### PR TITLE
Avoid NPE on getConnectionId

### DIFF
--- a/console/src/main/java/org/eclipse/kapua/app/console/server/GwtDeviceServiceImpl.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/server/GwtDeviceServiceImpl.java
@@ -231,16 +231,17 @@ public class GwtDeviceServiceImpl extends KapuaRemoteServiceServlet implements G
                 GwtDevice gwtDevice = KapuaGwtConverter.convert(d);
 
                 // Connection info
-                DeviceConnection deviceConnection = deviceConnectionService.find(d.getScopeId(), d.getConnectionId());
-                if (deviceConnection != null) {
-                    gwtDevice.setConnectionIp(deviceConnection.getClientIp());
-                    gwtDevice.setGwtDeviceConnectionStatus(deviceConnection.getStatus().name());
-                    gwtDevice.setLastEventOn(deviceConnection.getModifiedOn());
-                    gwtDevice.setLastEventType(deviceConnection.getStatus().name());
-                } else {
-                    gwtDevice.setGwtDeviceConnectionStatus(GwtDeviceConnectionStatus.DISCONNECTED.name());
+                gwtDevice.setGwtDeviceConnectionStatus(GwtDeviceConnectionStatus.DISCONNECTED.name());
+                if (d.getConnectionId() != null) {
+                    DeviceConnection deviceConnection = deviceConnectionService.find(d.getScopeId(), d.getConnectionId());
+                    if (deviceConnection != null) {
+                        gwtDevice.setConnectionIp(deviceConnection.getClientIp());
+                        gwtDevice.setGwtDeviceConnectionStatus(deviceConnection.getStatus().name());
+                        gwtDevice.setLastEventOn(deviceConnection.getModifiedOn());
+                        gwtDevice.setLastEventType(deviceConnection.getStatus().name());
+                    }
                 }
-
+                
                 // Event infos
                 DeviceEventQuery eventQuery = deviceEventFactory.newQuery(deviceQuery.getScopeId());
                 eventQuery.setLimit(1);


### PR DESCRIPTION
This is to integrate #60 (which fixes #57), since `deviceConnectionService.find()` would throw an NPE if `d.getConnectionId()` returns `null`