### PR TITLE
JavaDoc device modules

### DIFF
--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaAppChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaAppChannel.java
@@ -12,13 +12,42 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management;
 
+/**
+ * Kapua application message channel definition.<br>
+ * This object defines the common channel behavior for a Kapua request or response message.<br>
+ * The request message is used to perform interactive operations with the device (e.g. to send command to the device, to ask configurations...)
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaAppChannel extends KapuaControlChannel
 {
+
+    /**
+     * Get the application name
+     * 
+     * @return
+     */
     public KapuaAppProperties getAppName();
 
+    /**
+     * Set the application name
+     * 
+     * @param app
+     */
     public void setAppName(KapuaAppProperties app);
 
+    /**
+     * Get the application version
+     * 
+     * @return
+     */
     public KapuaAppProperties getVersion();
 
+    /**
+     * Set the application version
+     * 
+     * @param version
+     */
     public void setVersion(KapuaAppProperties version);
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaAppProperties.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaAppProperties.java
@@ -12,7 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management;
 
+/**
+ * Kapua application property definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaAppProperties
 {
+
+    /**
+     * Get the property value
+     * 
+     * @return
+     */
     public String getValue();
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaControlChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaControlChannel.java
@@ -14,6 +14,13 @@ package org.eclipse.kapua.service.device.management;
 
 import org.eclipse.kapua.message.KapuaChannel;
 
+/**
+ * Kapua control message channel definition. (Marker interface)<br>
+ * This is the marker interface used by all control message channel.
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaControlChannel extends KapuaChannel
 {
 

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaMethod.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaMethod.java
@@ -12,12 +12,37 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management;
 
+/**
+ * Kapua request/reply method definition.<br>
+ * This object defines the command types that should be supported by a Kapua device.
+ * 
+ * @since 1.0
+ *
+ */
 public enum KapuaMethod
 {
+    /**
+     * Read
+     */
     READ,
+    /**
+     * Create
+     */
     CREATE,
+    /**
+     * Write
+     */
     WRITE,
+    /**
+     * Delete
+     */
     DELETE,
+    /**
+     * Options
+     */
     OPTIONS,
+    /**
+     * Execute
+     */
     EXECUTE;
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/ResponseProperties.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/ResponseProperties.java
@@ -12,19 +12,42 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management;
 
+/**
+ * Kapua response message properties.
+ *
+ * @since 1.0
+ * 
+ */
 public enum ResponseProperties
 {
+
+    /**
+     * Exception message (if present)
+     */
     RESP_PROPERTY_EXCEPTION_MESSAGE("kapua.response.exception.message"),
+    /**
+     * Exception stack (if present)
+     */
     RESP_PROPERTY_EXCEPTION_STACK("kapua.response.exception.stack"),
     ;
 
     private String value;
 
+    /**
+     * Constructor
+     * 
+     * @param value
+     */
     ResponseProperties(String value)
     {
         this.value = value;
     }
 
+    /**
+     * Get the property value
+     * 
+     * @return
+     */
     public String getValue()
     {
         return value;

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestChannel.java
@@ -14,9 +14,28 @@ package org.eclipse.kapua.service.device.management.request;
 import org.eclipse.kapua.service.device.management.KapuaAppChannel;
 import org.eclipse.kapua.service.device.management.KapuaMethod;
 
+/**
+ * Kapua request message channel definition.<br>
+ * This object defines the channel for a Kapua request message.<br>
+ * The request message is used to perform interactive operations with the device (e.g. to send command to the device, to ask configurations...)
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaRequestChannel extends KapuaAppChannel
 {
+
+    /**
+     * Get the request method
+     * 
+     * @return
+     */
     public KapuaMethod getMethod();
 
+    /**
+     * Set the request method
+     * 
+     * @param method
+     */
     public void setMethod(KapuaMethod method);
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestMessage.java
@@ -17,9 +17,29 @@ import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
 
+/**
+ * Kapua request message definition.<br>
+ * This object defines the for a Kapua request message.<br>
+ * The request message is used to perform interactive operations with the device (e.g. to send command to the device, to ask configurations...)
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaRequestMessage<C extends KapuaRequestChannel, P extends KapuaRequestPayload> extends KapuaMessage<C, P>
 {
+
+    /**
+     * Get the request message class type
+     * 
+     * @return
+     */
     public <M extends KapuaRequestMessage<C, P>> Class<M> getRequestClass();
 
+    /**
+     * Get the response message class type
+     * 
+     * @return
+     */
     public <RSC extends KapuaResponseChannel, RSP extends KapuaResponsePayload, M extends KapuaResponseMessage<RSC, RSP>> Class<M> getResponseClass();
+
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestPayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestPayload.java
@@ -14,6 +14,14 @@ package org.eclipse.kapua.service.device.management.request;
 
 import org.eclipse.kapua.message.KapuaPayload;
 
+/**
+ * Kapua request message payload definition.<br>
+ * This object defines the payload for a Kapua request message.<br>
+ * The request message is used to perform interactive operations with the device (e.g. to send command to the device, to ask configurations...)
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaRequestPayload extends KapuaPayload
 {
 

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/response/KapuaResponseChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/response/KapuaResponseChannel.java
@@ -14,6 +14,14 @@ package org.eclipse.kapua.service.device.management.response;
 
 import org.eclipse.kapua.service.device.management.KapuaAppChannel;
 
+/**
+ * Kapua response message channel definition.<br>
+ * This object defines the channel for a Kapua response message.<br>
+ * The response message is used to perform interactive operations with the device (e.g. to send command to the device, to ask configurations...)
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaResponseChannel extends KapuaAppChannel
 {
 

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/response/KapuaResponseCode.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/response/KapuaResponseCode.java
@@ -12,11 +12,29 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.response;
 
+/**
+ * Request/reply message response code.
+ * 
+ * @since 1.0
+ *
+ */
 public enum KapuaResponseCode
 {
+    /**
+     * Accepted
+     */
     ACCEPTED, // 200
               // 204
+    /**
+     * Bad request
+     */
     BAD_REQUEST, // 400
+    /**
+     * Resource not found
+     */
     NOT_FOUND, // 404
+    /**
+     * Internal error
+     */
     INTERNAL_ERROR; // 500
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/response/KapuaResponseMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/response/KapuaResponseMessage.java
@@ -14,9 +14,28 @@ package org.eclipse.kapua.service.device.management.response;
 
 import org.eclipse.kapua.message.KapuaMessage;
 
+/**
+ * Kapua response message definition.<br>
+ * This object defines the for a Kapua response message.<br>
+ * The response message is used to perform interactive operations with the device (e.g. to send command to the device, to ask configurations...)
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaResponseMessage<C extends KapuaResponseChannel, P extends KapuaResponsePayload> extends KapuaMessage<C, P>
 {
+
+    /**
+     * Get the response code
+     * 
+     * @return
+     */
     public KapuaResponseCode getResponseCode();
 
+    /**
+     * Set the response code
+     * 
+     * @param responseCode
+     */
     public void setResponseCode(KapuaResponseCode responseCode);
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/response/KapuaResponsePayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/response/KapuaResponsePayload.java
@@ -14,13 +14,42 @@ package org.eclipse.kapua.service.device.management.response;
 
 import org.eclipse.kapua.message.KapuaPayload;
 
+/**
+ * Kapua response message payload definition.<br>
+ * This object defines the payload for a Kapua response message.<br>
+ * The response message is used to perform interactive operations with the device (e.g. to send command to the device, to ask configurations...)
+ * 
+ * @since 1.0
+ *
+ */
 public interface KapuaResponsePayload extends KapuaPayload
 {
+
+    /**
+     * Get the exception message (if present)
+     * 
+     * @return
+     */
     public String getExceptionMessage();
 
+    /**
+     * Set the exception message (if present)
+     * 
+     * @param setExecptionMessage
+     */
     public void setExceptionMessage(String setExecptionMessage);
 
+    /**
+     * Get the exception stack trace (if present)
+     * 
+     * @return
+     */
     public String getExceptionStack();
 
+    /**
+     * Set the exception stack trace (if present)
+     * 
+     * @param setExecptionStack
+     */
     public void setExceptionStack(String setExecptionStack);
 }

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
@@ -14,30 +14,78 @@ package org.eclipse.kapua.service.device.management.bundle;
 
 import javax.xml.bind.annotation.*;
 
+/**
+ * Device bundle entity definition.<br>
+ * This entity is used to get information about bundles installed in the device.
+ *
+ * @since 1.0
+ * 
+ */
 @XmlRootElement(name = "bundle")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(factoryClass = DeviceBundleXmlRegistry.class,
          factoryMethod = "newDeviceBundle")
 public interface DeviceBundle
 {
+
+    /**
+     * Get the bundle identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "id")
     public long getId();
 
+    /**
+     * Set the bundle identifier
+     * 
+     * @param id
+     */
     public void setId(long id);
 
+    /**
+     * Get the bundle name
+     * 
+     * @return
+     */
     @XmlElement(name = "name")
     public String getName();
 
+    /**
+     * Set the bundle name
+     * 
+     * @param name
+     */
     public void setName(String name);
 
+    /**
+     * Get the bundle state
+     * 
+     * @return
+     */
     @XmlElement(name = "state")
     public String getState();
 
+    /**
+     * Set the bundle state
+     * 
+     * @param state
+     */
     public void setState(String state);
 
+    /**
+     * Get the bundle version
+     * 
+     * @return
+     */
     @XmlElement(name = "version")
     public String getVersion();
 
+    /**
+     * Set the bundle version
+     * 
+     * @param version
+     */
     public void setVersion(String version);
 
 }

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
@@ -2,9 +2,26 @@ package org.eclipse.kapua.service.device.management.bundle;
 
 import org.eclipse.kapua.model.KapuaObjectFactory;
 
+/**
+ * Device bundle entity service factory definition.
+ *
+ * @since 1.0
+ * 
+ */
 public interface DeviceBundleFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new device bundle list
+     * 
+     * @return
+     */
     public DeviceBundles newBundleListResult();
 
+    /**
+     * Create a new {@link DeviceBundle}
+     * 
+     * @return
+     */
     public DeviceBundle newDeviceBundle();
 }

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
@@ -16,14 +16,48 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 
+/**
+ * Device bundle service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceBundleManagementService extends KapuaService
 {
+
+    /**
+     * Get the device bundles list for the given device identifier
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param timeout timeout waiting for the device response
+     * @return
+     * @throws KapuaException
+     */
     public DeviceBundles get(KapuaId scopeId, KapuaId deviceId, Long timeout)
         throws KapuaException;
 
+    /**
+     * Start the device bundle identified by the given device identifier and device bundle identifier
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param bundleId
+     * @param timeout timeout waiting for the device response
+     * @throws KapuaException
+     */
     public void start(KapuaId scopeId, KapuaId deviceId, String bundleId, Long timeout)
         throws KapuaException;
 
+    /**
+     * Stop the device bundle identified by the given device identifier and device bundle identifier
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param bundleId
+     * @param timeout timeout waiting for the device response
+     * @throws KapuaException
+     */
     public void stop(KapuaId scopeId, KapuaId deviceId, String bundleId, Long timeout)
         throws KapuaException;
 }

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
@@ -14,11 +14,35 @@ package org.eclipse.kapua.service.device.management.bundle;
 
 import org.eclipse.kapua.locator.KapuaLocator;
 
+/**
+ * Device bundle xml factory class
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceBundleXmlRegistry {
+
     private final KapuaLocator locator = KapuaLocator.getInstance();
+
     private final DeviceBundleFactory factory = locator.getFactory(DeviceBundleFactory.class);
 
-    public DeviceBundles newBundleListResult() { return factory.newBundleListResult(); }
+    /**
+     * Creates a new device bundles list
+     * 
+     * @return
+     */
+    public DeviceBundles newBundleListResult()
+    {
+        return factory.newBundleListResult();
+    }
 
-    public DeviceBundle newDeviceBundle() { return factory.newDeviceBundle(); }
+    /**
+     * Creates a new device bundle
+     * 
+     * @return
+     */
+    public DeviceBundle newDeviceBundle()
+    {
+        return factory.newDeviceBundle();
+    }
 }

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
@@ -15,13 +15,24 @@ package org.eclipse.kapua.service.device.management.bundle;
 import javax.xml.bind.annotation.*;
 import java.util.List;
 
-
+/**
+ * Device bundles list entity definition.
+ * 
+ * @since 1.0
+ * 
+ */
 @XmlType(propOrder = { "bundles" },
         factoryClass = DeviceBundleXmlRegistry.class,
         factoryMethod = "newBundleListResult")
 @XmlRootElement(name = "bundles")
 public interface DeviceBundles
 {
+
+    /**
+     * Get the device bundles list
+     * 
+     * @return
+     */
     @XmlElement(name = "bundle", namespace = "http://eurotech.com/esf/2.0")
     public <B extends DeviceBundle> List<B> getBundles();
 }

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleAppProperties.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleAppProperties.java
@@ -14,9 +14,21 @@ package org.eclipse.kapua.service.device.management.bundle.internal;
 
 import org.eclipse.kapua.service.device.management.KapuaAppProperties;
 
+/**
+ * Device bundle properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceBundleAppProperties implements KapuaAppProperties
 {
+    /**
+     * Application name
+     */
 	APP_NAME("BUNDLE"),
+    /**
+     * Version
+     */
     APP_VERSION("1.0.0"),
     ;
 

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleFactoryImpl.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleFactoryImpl.java
@@ -4,6 +4,12 @@ import org.eclipse.kapua.service.device.management.bundle.DeviceBundle;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundles;
 
+/**
+ * Device bundle entity service factory implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceBundleFactoryImpl implements DeviceBundleFactory
 {
 

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleImpl.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleImpl.java
@@ -1,60 +1,69 @@
 package org.eclipse.kapua.service.device.management.bundle.internal;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundle;
 
+/**
+ * Device bundle entity implementation.
+ *
+ * @since 1.0
+ *
+ */
 public class DeviceBundleImpl implements DeviceBundle
 {
     public long id;
-
     public String name;
-
     public String version;
-
     public String state;
 
+    /**
+     * Constructor
+     */
     public DeviceBundleImpl()
     {}
 
+    @Override
     public long getId()
     {
         return id;
     }
 
+    @Override
     public void setId(long id)
     {
         this.id = id;
     }
 
+    @Override
     public String getName()
     {
         return name;
     }
 
+    @Override
     public void setName(String name)
     {
         this.name = name;
     }
 
+    @Override
     public String getVersion()
     {
         return version;
     }
 
+    @Override
     public void setVersion(String version)
     {
         this.version = version;
     }
 
+    @Override
     public String getState()
     {
         return state;
     }
 
+    @Override
     public void setState(String state)
     {
         this.state = state;

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
@@ -40,6 +40,12 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 
+/**
+ * Device bundle service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceBundleManagementServiceImpl implements DeviceBundleManagementService {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundlesImpl.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundlesImpl.java
@@ -17,6 +17,12 @@ import java.util.List;
 
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundles;
 
+/**
+ * Device bundles list entity implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceBundlesImpl implements DeviceBundles
 {
     private List<DeviceBundleImpl> bundles;

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestChannel.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestChannel.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.service.device.management.KapuaMethod;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
 
+/**
+ * Device bundle information request channel.
+ * 
+ * @since 1.0
+ * 
+ */
 public class BundleRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel
 {
     private KapuaMethod method;
@@ -34,21 +40,41 @@ public class BundleRequestChannel extends KapuaAppChannelImpl implements KapuaRe
         this.method = method;
     }
 
+    /**
+     * Get the bundle identifier
+     * 
+     * @return
+     */
     public String getBundleId()
     {
         return bundleId;
     }
 
+    /**
+     * Set the bundle identifier
+     * 
+     * @param bundleId
+     */
     public void setBundleId(String bundleId)
     {
         this.bundleId = bundleId;
     }
 
+    /**
+     * Check if the bundle is started
+     * 
+     * @return
+     */
     public boolean isStart()
     {
         return start;
     }
 
+    /**
+     * Set the bundle start flag
+     * 
+     * @param start
+     */
     public void setStart(boolean start)
     {
         this.start = start;

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestMessage.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestMessage.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.bundle.message.internal;
 import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
 
+/**
+ * Device bundle information request message.
+ * 
+ * @since 1.0
+ * 
+ */
 public class BundleRequestMessage extends KapuaMessageImpl<BundleRequestChannel, BundleRequestPayload>
                                          implements KapuaRequestMessage<BundleRequestChannel, BundleRequestPayload>
 {

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestPayload.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestPayload.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.bundle.message.internal;
 import org.eclipse.kapua.message.internal.KapuaPayloadImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
 
+/**
+ * Device bundle information request payload.
+ * 
+ * @since 1.0
+ * 
+ */
 public class BundleRequestPayload extends KapuaPayloadImpl implements KapuaRequestPayload
 {
 

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.bundle.message.internal;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
+/**
+ * Device bundle information response channel.
+ * 
+ * @since 1.0
+ * 
+ */
 public class BundleResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel
 {
 

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseMessage.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseMessage.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 
+/**
+ * Device bundle information response message.
+ * 
+ * @since 1.0
+ * 
+ */
 public class BundleResponseMessage extends KapuaMessageImpl<BundleResponseChannel, BundleResponsePayload>
                                           implements KapuaResponseMessage<BundleResponseChannel, BundleResponsePayload>
 {

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponsePayload.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponsePayload.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.bundle.message.internal;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaResponsePayloadImpl;
 
+/**
+ * Device bundle information response payload.
+ * 
+ * @since 1.0
+ * 
+ */
 public class BundleResponsePayload extends KapuaResponsePayloadImpl implements KapuaPayload
 {
 

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCall.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCall.java
@@ -17,26 +17,90 @@ import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestMessage;
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponseMessage;
 
+/**
+ * Device call definition.
+ *
+ * @param <RQ> device request message type
+ * @param <RS> device response message type
+ * 
+ * @since 1.0
+ * 
+ */
 @SuppressWarnings("rawtypes")
 public interface DeviceCall<RQ extends DeviceRequestMessage, RS extends DeviceResponseMessage>
 {
+
+    /**
+     * Executes a 'read command'
+     * 
+     * @param requestMessage
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public RS read(RQ requestMessage, Long timeout)
         throws KapuaException;
 
+    /**
+     * Executes a 'create command'
+     * 
+     * @param requestMessage
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public RS create(RQ requestMessage, Long timeout)
         throws KapuaException;
 
+    /**
+     * Executes a 'write command'
+     * 
+     * @param requestMessage
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public RS write(RQ requestMessage, Long timeout)
         throws KapuaException;
 
+    /**
+     * Executes a 'delete command'
+     * 
+     * @param requestMessage
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public RS delete(RQ requestMessage, Long timeout)
         throws KapuaException;
 
+    /**
+     * Executes an 'execute command'
+     * 
+     * @param requestMessage
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public RS execute(RQ requestMessage, Long timeout)
         throws KapuaException;
 
+    /**
+     * Executes an 'options command'
+     * 
+     * @param requestMessage
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public RS options(RQ requestMessage, Long timeout)
         throws KapuaException;
 
+    /**
+     * Get the device base message type
+     * 
+     * @return
+     */
     public <M extends DeviceMessage> Class<M> getBaseMessageClass();
+
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallFactory.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallFactory.java
@@ -14,8 +14,21 @@ package org.eclipse.kapua.service.device.call;
 
 import org.eclipse.kapua.model.KapuaObjectFactory;
 
+/**
+ * Device call service factory definition.
+ * 
+ * @since 1.0
+ * 
+ */
 @SuppressWarnings("rawtypes")
 public interface DeviceCallFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new {@link DeviceCall}
+     * 
+     * @return
+     */
     public DeviceCall newDeviceCall();
+
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallback.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallback.java
@@ -14,10 +14,28 @@ package org.eclipse.kapua.service.device.call;
 
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 
+/**
+ * Device callback definition
+ * 
+ * @param <RSM> response message type
+ * 
+ * @since 1.0
+ * 
+ */
 @SuppressWarnings("rawtypes")
 public interface DeviceCallback<RSM extends DeviceMessage>
 {
+
+    /**
+     * Action to be invoked on response received
+     * 
+     * @param response
+     */
     public void responseReceived(RSM response);
 
+    /**
+     * Action to be invoked on timed out
+     */
     public void timedOut();
+
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceMessageFactory.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceMessageFactory.java
@@ -20,19 +20,56 @@ import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestCh
 import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestMessage;
 import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestPayload;
 
+/**
+ * Device message service factory definition.
+ * 
+ * @since 1.0
+ *
+ */
 @SuppressWarnings("rawtypes")
 public interface DeviceMessageFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new device message
+     * 
+     * @return
+     */
     public DeviceMessage newMessage();
 
+    /**
+     * Creates a new device request message
+     * 
+     * @return
+     */
     public DeviceRequestMessage newRequestMessage();
 
+    /**
+     * Creates a new device channel
+     * 
+     * @return
+     */
     public DeviceChannel newChannel();
 
+    /**
+     * Creates a new device request channel
+     * 
+     * @return
+     */
     public DeviceRequestChannel newRequestChannel();
 
+    /**
+     * Creates a new device payload
+     * 
+     * @return
+     */
     public DevicePayload newPayload();
 
+    /**
+     * Creates a new device request payload
+     * 
+     * @return
+     */
     public DeviceRequestPayload newRequestPayload();
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceMethod.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceMethod.java
@@ -12,6 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call;
 
+/**
+ * Device method definition (Marker interface).<br>
+ * This object defines the command methods supported by a device.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceMethod
 {
 

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DeviceChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DeviceChannel.java
@@ -14,17 +14,59 @@ package org.eclipse.kapua.service.device.call.message;
 
 import org.eclipse.kapua.message.Channel;
 
+/**
+ * Device channel definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceChannel extends Channel
 {
+
+    /**
+     * Get the message classification.<br>
+     * This field it is used to distinguish between command messages and "standard" messages such as telemetry messages.<br>
+     * The domain values can be customized via configuration parameter.
+     * 
+     * @return
+     */
     public String getMessageClassification();
 
+    /**
+     * Set the message classification.<br>
+     * This field it is used to distinguish between command messages and "standard" messages such as telemetry messages.<br>
+     * The domain values can be customized via configuration parameter.
+     * 
+     * @param messageClassification
+     */
     public void setMessageClassification(String messageClassification);
 
+    /**
+     * Get the message scope
+     * 
+     * @return
+     */
     public String getScope();
 
+    /**
+     * Set th emessage scope
+     * 
+     * @param scope
+     */
     public void setScope(String scope);
 
+    /**
+     * Get the client identifier
+     * 
+     * @return
+     */
     public String getClientId();
 
+    /**
+     * Set the client identifier
+     * 
+     * @param clientId
+     */
     public void setClientId(String clientId);
+
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DeviceMessage.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DeviceMessage.java
@@ -16,11 +16,36 @@ import java.util.Date;
 
 import org.eclipse.kapua.message.Message;
 
+/**
+ * Device message definition.
+ * 
+ * @param <C> channel type
+ * @param <P> payload type
+ * 
+ * @since 1.0
+ * 
+ */
 public interface DeviceMessage<C extends DeviceChannel, P extends DevicePayload> extends Message
 {
+
+    /**
+     * Get the channel associated to the message
+     * 
+     * @return
+     */
     public C getChannel();
 
+    /**
+     * Get the payload associated to the message
+     * 
+     * @return
+     */
     public P getPayload();
 
+    /**
+     * Get the message timestamp
+     * 
+     * @return
+     */
     public Date getTimestamp();
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DevicePayload.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DevicePayload.java
@@ -18,21 +18,60 @@ import java.util.Map;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.message.Payload;
 
+/**
+ * Device payload definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DevicePayload extends Payload
 {
+
+    /**
+     * Get the message timestamp
+     * 
+     * @return
+     */
     public Date getTimestamp();
 
+    /**
+     * Get the device position
+     * 
+     * @return
+     */
     public DevicePosition getPosition();
 
+    /**
+     * Get the metrics (if defined)
+     * 
+     * @return
+     */
     public Map<String, Object> getMetrics();
 
+    /**
+     * Get the message body (if defined)
+     * 
+     * @return
+     */
     public byte[] getBody();
 
     //
     // Encode/Decode stuff
     //
+    /**
+     * Convert the message to a well formed byte array
+     * 
+     * @return
+     */
     public byte[] toByteArray();
 
+    /**
+     * Read and instantiate a message from well formed byte array
+     * 
+     * @param rawPayload
+     * @throws KapuaException
+     */
     public void readFromByteArray(byte[] rawPayload)
         throws KapuaException;
+
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DevicePosition.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DevicePosition.java
@@ -16,41 +16,139 @@ import java.util.Date;
 
 import org.eclipse.kapua.message.Position;
 
+/**
+ * Device position entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DevicePosition extends Position
 {
+
+    /**
+     * Get the device position longitude
+     * 
+     * @return
+     */
     public Double getLongitude();
 
+    /**
+     * Set the device position longitude
+     * 
+     * @param longitude
+     */
     public void setLongitude(Double longitude);
 
+    /**
+     * Get the device position latitude
+     * 
+     * @return
+     */
     public Double getLatitude();
 
+    /**
+     * Set the device position latitude
+     * 
+     * @param latitude
+     */
     public void setLatitude(Double latitude);
 
+    /**
+     * Get the device position altitude
+     * 
+     * @return
+     */
     public Double getAltitude();
 
+    /**
+     * Set the device position altitude
+     * 
+     * @param altitude
+     */
     public void setAltitude(Double altitude);
 
+    /**
+     * Get the device precision
+     * 
+     * @return
+     */
     public Double getPrecision();
 
+    /**
+     * Set the device precision
+     * 
+     * @param precision
+     */
     public void setPrecision(Double precision);
 
+    /**
+     * Get the device heading
+     * 
+     * @return
+     */
     public Double getHeading();
 
+    /**
+     * Set the device heading
+     * 
+     * @param heading
+     */
     public void setHeading(Double heading);
 
+    /**
+     * Get the device speed
+     * 
+     * @return
+     */
     public Double getSpeed();
 
+    /**
+     * Set the device speed
+     * 
+     * @param speed
+     */
     public void setSpeed(Double speed);
 
+    /**
+     * Get the timestamp
+     * 
+     * @return
+     */
     public Date getTimestamp();
 
+    /**
+     * Set the timestamp
+     * 
+     * @param timestamp
+     */
     public void setTimestamp(Date timestamp);
 
+    /**
+     * Get the satellites count
+     * 
+     * @return
+     */
     public Integer getSatellites();
 
+    /**
+     * Set the satellites count
+     * 
+     * @param satellites
+     */
     public void setSatellites(Integer satellites);
 
+    /**
+     * Get the device status
+     * 
+     * @return
+     */
     public Integer getStatus();
 
+    /**
+     * Set the device status
+     * 
+     * @param status
+     */
     public void setStatus(Integer status);
+
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/DeviceAppChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/DeviceAppChannel.java
@@ -14,9 +14,27 @@ package org.eclipse.kapua.service.device.call.message.app;
 
 import org.eclipse.kapua.service.device.call.message.DeviceChannel;
 
+/**
+ * Device application channel definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceAppChannel extends DeviceChannel
 {
+
+    /**
+     * Get the application identifier
+     * 
+     * @return
+     */
     public String getAppId();
 
+    /**
+     * Set the application identifier
+     * 
+     * @param appId
+     */
     public void setAppId(String appId);
+
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestChannel.java
@@ -15,22 +15,71 @@ package org.eclipse.kapua.service.device.call.message.app.request;
 import org.eclipse.kapua.service.device.call.DeviceMethod;
 import org.eclipse.kapua.service.device.call.message.app.DeviceAppChannel;
 
+/**
+ * Device request channel definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceRequestChannel extends DeviceAppChannel
 {
+
+    /**
+     * Get the request method
+     * 
+     * @return
+     */
     public DeviceMethod getMethod();
 
+    /**
+     * Set the request method
+     * 
+     * @param method
+     */
     public void setMethod(DeviceMethod method);
 
+    /**
+     * Get the request resources
+     * 
+     * @return
+     */
     public String[] getResources();
 
+    /**
+     * Set the request resources
+     * 
+     * @param resources
+     */
     public void setResources(String[] resources);
 
+    /**
+     * Get the request identifier
+     * 
+     * @return
+     */
     public String getRequestId();
 
+    /**
+     * Set the request identifier
+     * 
+     * @param requestId
+     */
     public void setRequestId(String requestId);
 
+    /**
+     * Get the requester client identifier.<br>
+     * May be useful to reply only to the requester
+     * 
+     * @return
+     */
     public String getRequesterClientId();
 
+    /**
+     * Set the requester client identifier.<br>
+     * May be useful to reply only to the requester
+     * 
+     * @param requesterClientId
+     */
     public void setRequesterClientId(String requesterClientId);
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestMessage.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestMessage.java
@@ -14,6 +14,13 @@ package org.eclipse.kapua.service.device.call.message.app.request;
 
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 
+/**
+ * Device request message definition.<br>
+ * It is used to send a request to a device.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceRequestMessage<D extends DeviceRequestChannel, P extends DeviceRequestPayload> extends DeviceMessage<D, P>
 {
 

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestPayload.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestPayload.java
@@ -14,13 +14,42 @@ package org.eclipse.kapua.service.device.call.message.app.request;
 
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 
+/**
+ * Device request payload definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceRequestPayload extends DevicePayload
 {
+
+    /**
+     * Get the request identifier
+     * 
+     * @return
+     */
     public String getRequestId();
 
+    /**
+     * Set the request identifier
+     * 
+     * @param requestId
+     */
     public void setRequestId(String requestId);
 
+    /**
+     * Get the requester client identifier.<br>
+     * May be useful to reply only to the requester
+     * 
+     * @return
+     */
     public String getRequesterClientId();
 
+    /**
+     * Set the requester client identifier.<br>
+     * May be useful to reply only to the requester
+     * 
+     * @param requesterId
+     */
     public void setRequesterClientId(String requesterId);
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseChannel.java
@@ -14,13 +14,40 @@ package org.eclipse.kapua.service.device.call.message.app.response;
 
 import org.eclipse.kapua.service.device.call.message.app.DeviceAppChannel;
 
+/**
+ * Device response channel definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceResponseChannel extends DeviceAppChannel
 {
+
+    /**
+     * Get the reply part
+     * 
+     * @return
+     */
     public String getReplyPart();
 
+    /**
+     * Set the reply part
+     * 
+     * @param replyPart
+     */
     public void setReplyPart(String replyPart);
 
+    /**
+     * Get the request identifier
+     * 
+     * @return
+     */
     public String getRequestId();
 
+    /**
+     * Set the request identifier
+     * 
+     * @param requestId
+     */
     public void setRequestId(String requestId);
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseCode.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseCode.java
@@ -12,6 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.message.app.response;
 
+/**
+ * Device response code definition.<br>
+ * It is used to define a short result for the command response received by a device.
+ * 
+ * @since 1.0
+ * 
+ */
 public interface DeviceResponseCode
 {
 

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseMessage.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseMessage.java
@@ -14,6 +14,13 @@ package org.eclipse.kapua.service.device.call.message.app.response;
 
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 
+/**
+ * Device response message definition.<br>
+ * It is used to get a response (to a previous request) from a device.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceResponseMessage<D extends DeviceResponseChannel, P extends DeviceResponsePayload> extends DeviceMessage<D, P>
 {
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponsePayload.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponsePayload.java
@@ -14,13 +14,41 @@ package org.eclipse.kapua.service.device.call.message.app.response;
 
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 
+/**
+ * Device response payload definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceResponsePayload extends DevicePayload
 {
+
+    /**
+     * Get the command response code
+     * 
+     * @return
+     */
     public <C extends DeviceResponseCode> C getResponseCode();
 
+    /**
+     * Get the command exception message
+     * 
+     * @return
+     */
     public String getExceptionMessage();
 
+    /**
+     * Get the command exception stack
+     * 
+     * @return
+     */
     public String getExceptionStack();
 
+    /**
+     * Get the command response body
+     * 
+     * @return
+     */
     public byte[] getResponseBody();
+
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/data/DeviceDataChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/data/DeviceDataChannel.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.call.message.data;
 
 import org.eclipse.kapua.service.device.call.message.DeviceChannel;
 
+/**
+ * Device data message channel definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceDataChannel extends DeviceChannel
 {
 

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallFactoryImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallFactoryImpl.java
@@ -13,6 +13,12 @@ package org.eclipse.kapua.service.device.call.kura;
 
 import org.eclipse.kapua.service.device.call.DeviceCallFactory;
 
+/**
+ * Kura device call service factory implementation.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraDeviceCallFactoryImpl implements DeviceCallFactory
 {
 

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallImpl.java
@@ -29,6 +29,12 @@ import org.eclipse.kapua.transport.TransportClientFactory;
 import org.eclipse.kapua.transport.TransportFacade;
 import org.eclipse.kapua.transport.message.TransportMessage;
 
+/**
+ * Kura device call implementation.
+ *
+ * @since 1.0
+ * 
+ */
 @SuppressWarnings("rawtypes")
 public class KuraDeviceCallImpl implements DeviceCall<KuraRequestMessage, KuraResponseMessage>
 {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallback.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallback.java
@@ -14,10 +14,21 @@ package org.eclipse.kapua.service.device.call.kura;
 import org.eclipse.kapua.service.device.call.DeviceCallback;
 import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseMessage;
 
+/**
+ * Kura device callback implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraDeviceCallback implements DeviceCallback<KuraResponseMessage>
 {
     private KuraDeviceResponseContainer responseContainer;
 
+    /**
+     * Constructor
+     * 
+     * @param responseContainer
+     */
     public KuraDeviceCallback(KuraDeviceResponseContainer responseContainer)
     {
         this.responseContainer = responseContainer;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceResponseContainer.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceResponseContainer.java
@@ -16,10 +16,19 @@ import java.util.ArrayList;
 import org.eclipse.kapua.service.device.call.DeviceCallback;
 import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseMessage;
 
+/**
+ * Kura device callback implementation.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraDeviceResponseContainer extends ArrayList<KuraResponseMessage> implements DeviceCallback<KuraResponseMessage>
 {
     private static final long serialVersionUID = -6909761350290400843L;
 
+    /**
+     * Constructor
+     */
     public KuraDeviceResponseContainer()
     {
         super();

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraMessageFactoryImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraMessageFactoryImpl.java
@@ -23,6 +23,12 @@ import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraReques
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura device message service factory implementation.
+ * 
+ * @since 1.0
+ *
+ */
 @SuppressWarnings("rawtypes")
 public class KuraMessageFactoryImpl implements DeviceMessageFactory
 {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraMethod.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraMethod.java
@@ -13,11 +13,33 @@ package org.eclipse.kapua.service.device.call.kura;
 
 import org.eclipse.kapua.service.device.call.DeviceMethod;
 
+/**
+ * Kura device method definition.<br>
+ * This object defines the command methods supported by a Kura device.
+ * 
+ * @since 1.0
+ *
+ */
 public enum KuraMethod implements DeviceMethod
 {
+    /**
+     * Get command
+     */
     GET,
+    /**
+     * Post command
+     */
     POST,
+    /**
+     * Put command
+     */
     PUT,
+    /**
+     * Delete command
+     */
     DEL,
+    /**
+     * Execute command
+     */
     EXEC
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/BundleMetrics.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/BundleMetrics.java
@@ -11,9 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.app;
 
+/**
+ * Bundle metrics properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum BundleMetrics
 {
+
+    /**
+     * Application identifier
+     */
     APP_ID("DEPLOY"),
+    /**
+     * Application version
+     */
     APP_VERSION("V2"),
     ;
 
@@ -24,6 +37,11 @@ public enum BundleMetrics
         this.value = value;
     }
 
+    /**
+     * Get a value property associated to this specific enumeration key.
+     * 
+     * @return
+     */
     public String getValue()
     {
         return value;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/CommandMetrics.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/CommandMetrics.java
@@ -11,25 +11,73 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.app;
 
+/**
+ * Command metrics properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum CommandMetrics
 {
+    /**
+     * Application identifier
+     */
     APP_ID("CMD"),
+    /**
+     * Application version
+     */
     APP_VERSION("V1"),
 
     // Request
+    /**
+     * Command
+     */
     APP_METRIC_CMD("command.command"),
+    /**
+     * ARGUMENT
+     */
     APP_METRIC_ARG("command.argument"),
+    /**
+     * Environment
+     */
     APP_METRIC_ENVP("command.environment.pair"),
+    /**
+     * Working directory
+     */
     APP_METRIC_DIR("command.working.directory"),
+    /**
+     * Standard input
+     */
     APP_METRIC_STDIN("command.stdin"),
+    /**
+     * Command timeout
+     */
     APP_METRIC_TOUT("command.timeout"),
+    /**
+     * Asynchronous running
+     */
     APP_METRIC_ASYNC("command.run.async"),
+    /**
+     * Password
+     */
     APP_METRIC_PASSWORD("command.password"),
 
     // Response
+    /**
+     * Standard error
+     */
     APP_METRIC_STDERR("command.stderr"),
+    /**
+     * Standard output
+     */
     APP_METRIC_STDOUT("command.stdout"),
+    /**
+     * Command exit code
+     */
     APP_METRIC_EXIT_CODE("command.exit.code"),
+    /**
+     * Command timed out flag
+     */
     APP_METRIC_TIMED_OUT("command.timedout"),
     ;
 
@@ -40,6 +88,11 @@ public enum CommandMetrics
         this.value = value;
     }
 
+    /**
+     * Get a value property associated to this specific enumeration key.
+     * 
+     * @return
+     */
     public String getValue()
     {
         return value;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/ConfigurationMetrics.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/ConfigurationMetrics.java
@@ -11,9 +11,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.app;
 
+/**
+ * Bundle metrics properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum ConfigurationMetrics
 {
+    /**
+     * Application identifier
+     */
     APP_ID("CONF"), 
+    /**
+     * Application version
+     */
     APP_VERSION("V1"),
     ;
 
@@ -24,6 +36,11 @@ public enum ConfigurationMetrics
         this.value = value;
     }
 
+    /**
+     * Get a value property associated to this specific enumeration key.
+     * 
+     * @return
+     */
     public String getValue()
     {
         return value;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/PackageMetrics.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/PackageMetrics.java
@@ -11,35 +11,96 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.app;
 
+/**
+ * Bundle metrics properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum PackageMetrics {
-    APP_ID("DEPLOY"),//
-    APP_VERSION("V2"), //
+
+    /**
+     * Application identifier
+     */
+    APP_ID("DEPLOY"),
+    /**
+     * Application version
+     */
+    APP_VERSION("V2"),
 
     // Commons metrics
-    APP_METRIC_PACKAGE_OPERATION_ID("job.id"), //
-    APP_METRIC_PACKAGE_REBOOT("dp.reboot"), //
-    APP_METRIC_PACKAGE_REBOOT_DELAY("dp.reboot.delay"), //
+    /**
+     * Operation identifier
+     */
+    APP_METRIC_PACKAGE_OPERATION_ID("job.id"),
+    /**
+     * Device reboot
+     */
+    APP_METRIC_PACKAGE_REBOOT("dp.reboot"),
+    /**
+     * Reboot delay
+     */
+    APP_METRIC_PACKAGE_REBOOT_DELAY("dp.reboot.delay"),
 
     // Request exec download
-    APP_METRIC_PACKAGE_DOWNLOAD_PACKAGE_URI("dp.uri"), //
-    APP_METRIC_PACKAGE_DOWNLOAD_PACKAGE_NAME("dp.name"), //
-    APP_METRIC_PACKAGE_DOWNLOAD_PACKAGE_VERSION("dp.version"), //
-    APP_METRIC_PACKAGE_DOWNLOAD_PROTOCOL("dp.download.protocol"), //
-    APP_METRIC_PACKAGE_DOWNLOAD_INSTALL("dp.install"), //
+    /**
+     * Download package uri
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_PACKAGE_URI("dp.uri"),
+    /**
+     * Download package name
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_PACKAGE_NAME("dp.name"),
+    /**
+     * Download package version
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_PACKAGE_VERSION("dp.version"),
+    /**
+     * Download package protocol
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_PROTOCOL("dp.download.protocol"),
+    /**
+     * Install downloaded package
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_INSTALL("dp.install"),
 
     // Response get download
-    APP_METRIC_PACKAGE_DOWNLOAD_SIZE("dp.download.size"), //
-    APP_METRIC_PACKAGE_DOWNLOAD_STATUS("dp.download.status"), //
-    APP_METRIC_PACKAGE_DOWNLOAD_PROGRESS("dp.download.progress"), //
+    /**
+     * Download package already downloaded
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_SIZE("dp.download.size"),
+    /**
+     * Download package status
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_STATUS("dp.download.status"),
+    /**
+     * Download package progress
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_PROGRESS("dp.download.progress"),
 
     // Request exec install
-    APP_METRIC_PACKAGE_INSTALL_PACKAGE_NAME("dp.name"), //
-    APP_METRIC_PACKAGE_INSTALL_PACKAGE_VERSION("dp.version"), //
-    APP_METRIC_PACKAGE_INSTALL_SYS_UPDATE("dp.install.system.update"), //
+    /**
+     * Install package name
+     */
+    APP_METRIC_PACKAGE_INSTALL_PACKAGE_NAME("dp.name"),
+    /**
+     * Install package version
+     */
+    APP_METRIC_PACKAGE_INSTALL_PACKAGE_VERSION("dp.version"),
+    /**
+     * Install system update package
+     */
+    APP_METRIC_PACKAGE_INSTALL_SYS_UPDATE("dp.install.system.update"),
 
     // Request exec uninstall
-    APP_METRIC_PACKAGE_UNINSTALL_PACKAGE_NAME("dp.name"), //
-    APP_METRIC_PACKAGE_UNINSTALL_PACKAGE_VERSION("dp.version"), //
+    /**
+     * Uninstall package name
+     */
+    APP_METRIC_PACKAGE_UNINSTALL_PACKAGE_NAME("dp.name"),
+    /**
+     * Uninstall package version
+     */
+    APP_METRIC_PACKAGE_UNINSTALL_PACKAGE_VERSION("dp.version"),
 
     ;
 
@@ -49,6 +110,11 @@ public enum PackageMetrics {
         this.value = value;
     }
 
+    /**
+     * Get a value property associated to this specific enumeration key.
+     * 
+     * @return
+     */
     public String getValue() {
         return value;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/RequestMetrics.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/RequestMetrics.java
@@ -11,9 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.app;
 
+/**
+ * Request metrics properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum RequestMetrics
 {
+
+    /**
+     * Request identifier
+     */
     REQ_METRIC_REQUEST_ID("request.id"),
+    /**
+     * Requester client identifier
+     */
     REQ_METRIC_REQUESTER_CLIENT_ID("requester.client.id"),
     ;
 
@@ -24,6 +37,11 @@ public enum RequestMetrics
         this.value = value;
     }
 
+    /**
+     * Get a value property associated to this specific enumeration key.
+     * 
+     * @return
+     */
     public String getValue()
     {
         return value;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/ResponseMetrics.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/ResponseMetrics.java
@@ -11,10 +11,25 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.app;
 
+/**
+ * Response metrics properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum ResponseMetrics
 {
+    /**
+     * Response exit code
+     */
     RESP_METRIC_EXIT_CODE("response.code"),
+    /**
+     * Response exception message
+     */
     RESP_METRIC_EXCEPTION_MESSAGE("response.exception.message"),
+    /**
+     * Response exception stack trace
+     */
     RESP_METRIC_EXCEPTION_STACK("response.exception.stack"),
     ;
 
@@ -25,6 +40,11 @@ public enum ResponseMetrics
         this.value = value;
     }
 
+    /**
+     * Get a value property associated to this specific enumeration key.
+     * 
+     * @return
+     */
     public String getValue()
     {
         return value;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/SnapshotMetrics.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/SnapshotMetrics.java
@@ -11,9 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.app;
 
+/**
+ * Snapshot metrics properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum SnapshotMetrics
 {
-    APP_ID("CONF"), APP_VERSION("V1"),;
+    /**
+     * Application identifier
+     */
+    APP_ID("CONF"),
+    /**
+     * Application version
+     */
+    APP_VERSION("V1"),;
 
     private String value;
 
@@ -22,6 +35,11 @@ public enum SnapshotMetrics
         this.value = value;
     }
 
+    /**
+     * Get a value property associated to this specific enumeration key.
+     * 
+     * @return
+     */
     public String getValue()
     {
         return value;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/exception/KuraMqttDeviceCallErrorCodes.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/exception/KuraMqttDeviceCallErrorCodes.java
@@ -14,12 +14,33 @@ package org.eclipse.kapua.service.device.call.kura.exception;
 
 import org.eclipse.kapua.KapuaErrorCode;
 
+/**
+ * Kura-mqtt device call error codes.
+ *
+ * @since 1.0
+ *
+ */
 public enum KuraMqttDeviceCallErrorCodes implements KapuaErrorCode
 {
+    /**
+     * Call error
+     */
     CALL_ERROR,
+    /**
+     * Call timeout
+     */
     CALL_TIMEOUT,
+    /**
+     * Borrow client form the pool error
+     */
     CLIENT_BORROW_ERROR,
+    /**
+     * Return client to the pool error
+     */
     CLIENT_RETURN_ERROR,
+    /**
+     * Send call error
+     */
     CLIENT_SEND_ERROR,
     ;
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/exception/KuraMqttDeviceCallException.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/exception/KuraMqttDeviceCallException.java
@@ -14,22 +14,46 @@ package org.eclipse.kapua.service.device.call.kura.exception;
 
 import org.eclipse.kapua.KapuaException;
 
+/**
+ * Kura-mqtt device call exception.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraMqttDeviceCallException extends KapuaException
 {
     private static final long   serialVersionUID     = -6207605695086240243L;
 
     private static final String KAPUA_ERROR_MESSAGES = "device-call-service-error-messages";
 
+    /**
+     * Constructor
+     * 
+     * @param code
+     */
     public KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes code)
     {
         super(code);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param code
+     * @param arguments
+     */
     public KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes code, Object... arguments)
     {
         super(code, arguments);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param code
+     * @param cause
+     * @param arguments
+     */
     public KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes code, Throwable cause, Object... arguments)
     {
         super(code, cause, arguments);

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
@@ -18,11 +18,18 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * Kura bundle definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name="bundle")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder= {"name","version","id","state"})
 public class KuraBundle
 {
+
     @XmlElement(name="name")
     public String name;
 
@@ -32,44 +39,82 @@ public class KuraBundle
     @XmlElement(name="id")
     public long id;
 
-    @XmlElement(name="state")
+    @XmlElement(name = "state")
     public String state;
 
+    /**
+     * Get bundle name
+     */
     public String getName()
     {
         return name;
     }
 
+    /**
+     * Set bundle name
+     * 
+     * @param name
+     */
     public void setName(String name)
     {
         this.name = name;
     }
 
+    /**
+     * Get bundle version
+     * 
+     * @return
+     */
     public String getVersion()
     {
         return version;
     }
 
+    /**
+     * Set bundle version
+     * 
+     * @param version
+     */
     public void setVersion(String version)
     {
         this.version = version;
     }
 
+    /**
+     * Get bundle identifier
+     * 
+     * @return
+     */
     public long getId()
     {
         return id;
     }
 
+    /**
+     * Set bundle identifier
+     * 
+     * @param id
+     */
     public void setId(long id)
     {
         this.id = id;
     }
 
+    /**
+     * Get bundle state
+     * 
+     * @return
+     */
     public String getState()
     {
         return state;
     }
 
+    /**
+     * Set bundle state
+     * 
+     * @param state
+     */
     public void setState(String state)
     {
         this.state = state;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
@@ -17,6 +17,12 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+/**
+ * Kura bundles list definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name="bundles")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class KuraBundles
@@ -24,11 +30,21 @@ public class KuraBundles
     @XmlElement(name="bundle")
     public KuraBundle[] bundles;
 
+    /**
+     * Get the bundles list
+     * 
+     * @return
+     */
     public KuraBundle[] getBundles()
     {
         return bundles;
     }
 
+    /**
+     * Set the bundles list
+     * 
+     * @param bundles
+     */
     public void setBundles(KuraBundle[] bundles)
     {
         this.bundles = bundles;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
@@ -25,13 +25,14 @@ import org.eclipse.kapua.commons.configuration.metatype.TocdImpl;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 
 /**
- * Describes the configuration of an OSGi Component.
- * The Component configuration groups all the information related to the configuration of a Component.
- * It provides access to parsed ObjectClassDefintion associated to this Component.
- * The configuration does not reuse the OSGi ObjectClassDefinition as the latter
- * does not provide access to certain aspects such as the required attribute,
- * the min and max values. Instead it returns the raw ObjectClassDefintion as parsed
- * from the MetaType Information XML resource associated to this Component.
+ * Describes the configuration of an OSGi Component.<br>
+ * The Component configuration groups all the information related to the configuration of a Component.<br>
+ * It provides access to parsed ObjectClassDefintion associated to this Component.<br>
+ * The configuration does not reuse the OSGi ObjectClassDefinition as the latter does not provide access to certain aspects such as the required attribute, the min and max values.<br>
+ * Instead it returns the raw ObjectClassDefintion as parsed from the MetaType Information XML resource associated to this Component.
+ * 
+ * @since 1.0
+ * 
  */
 @XmlRootElement(name = "configuration")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -39,7 +40,7 @@ public class KuraDeviceComponentConfiguration
 {
     /**
      * The PID (service's persistent identity) of the OSGi Component
-     * associated to this configuration.
+     * associated to this configuration.<br>
      * The service's persistent identity is defined as the name attribute of the
      * Component Descriptor XML file; at runtime, the same value is also available
      * in the component.name and in the service.pid attributes of the Component Configuration.
@@ -65,31 +66,69 @@ public class KuraDeviceComponentConfiguration
     public KuraDeviceComponentConfiguration()
     {}
 
+    /**
+     * Get the component identifier.<br>
+     * The PID (service's persistent identity) of the OSGi Component
+     * associated to this configuration.<br>
+     * The service's persistent identity is defined as the name attribute of the
+     * Component Descriptor XML file; at runtime, the same value is also available
+     * in the component.name and in the service.pid attributes of the Component Configuration.
+     * 
+     * @return
+     */
     public String getComponentId()
     {
         return componentId;
     }
 
+    /**
+     * Set the component identifier. Please refer to {@link KuraDeviceComponentConfiguration#getComponentId}
+     * 
+     * @param componentId
+     */
     public void setComponentId(String componentId)
     {
         this.componentId = componentId;
     }
 
+    /**
+     * Get the class definition.<br>
+     * The raw ObjectClassDefinition as parsed from the MetaType
+     * Information XML resource associated to this Component.
+     * 
+     * @return
+     */
     public KapuaTocd getDefinition()
     {
         return definition;
     }
 
+    /**
+     * Set the class definition. Please refer to {@link KuraDeviceComponentConfiguration#getDefinition}
+     * 
+     * @param definition
+     */
     public void setDefinition(KapuaTocd definition)
     {
         this.definition = (TocdImpl) definition;
     }
 
+    /**
+     * Get configuration properties.<br>
+     * The Dictionary of properties currently used by this component.
+     * 
+     * @return
+     */
     public Map<String, Object> getProperties()
     {
         return properties;
     }
 
+    /**
+     * Set configuration properties. Please refer to {@link KuraDeviceComponentConfiguration#getProperties}
+     * 
+     * @param properties
+     */
     public void setProperties(Map<String, Object> properties)
     {
         this.properties = properties;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
@@ -21,6 +21,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * A container for a list of OSGi component configurations.
+ * 
+ * @since 1.0
+ * 
  */
 @XmlRootElement(name = "configurations")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -30,15 +33,29 @@ public class KuraDeviceConfiguration
     private List<KuraDeviceComponentConfiguration> configurations;
 
     // Required by JAXB
+    /**
+     * Constructor
+     */
     public KuraDeviceConfiguration()
     {}
 
+    /**
+     * Constructor
+     * 
+     * @param accountName
+     * @param clientId
+     */
     public KuraDeviceConfiguration(String accountName, String clientId)
     {
         this();
         configurations = new ArrayList<>();
     }
 
+    /**
+     * Get the device component configuration list
+     * 
+     * @return
+     */
     public List<KuraDeviceComponentConfiguration> getConfigurations()
     {
         if (configurations == null) {
@@ -48,6 +65,11 @@ public class KuraDeviceConfiguration
         return configurations;
     }
 
+    /**
+     * Set the device component configuration list
+     * 
+     * @param configurations
+     */
     public void setConfigurations(List<KuraDeviceComponentConfiguration> configurations)
     {
         this.configurations = configurations;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraPassword.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraPassword.java
@@ -11,16 +11,32 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura.model.configuration;
 
+/**
+ * Kura password
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraPassword
 {
     private String password;
 
+    /**
+     * Constructor
+     * 
+     * @param password
+     */
     public KuraPassword(String password)
     {
         super();
         this.password = password;
     }
 
+    /**
+     * Get the password
+     * 
+     * @return
+     */
     public String getPassword()
     {
         return password;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraXmlConfigPropertiesAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraXmlConfigPropertiesAdapted.java
@@ -17,6 +17,9 @@ import javax.xml.bind.annotation.XmlElement;
 
 /**
  * A container for XmlConfigPropertyAdapted organized into an array.
+ * 
+ * @since 1.0
+ * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class KuraXmlConfigPropertiesAdapted
@@ -24,13 +27,26 @@ public class KuraXmlConfigPropertiesAdapted
     @XmlElement(name="property")
     private XmlConfigPropertyAdapted[] properties;
 
+    /**
+     * Constructor
+     */
     public KuraXmlConfigPropertiesAdapted() {
     }
 
+    /**
+     * Get the adapted configuration properties array
+     * 
+     * @return
+     */
     public XmlConfigPropertyAdapted[] getProperties() {
         return properties;
     }
 
+    /**
+     * Set the adapted configuration properties array
+     * 
+     * @param properties
+     */
     public void setProperties(XmlConfigPropertyAdapted[] properties) {
         this.properties = properties;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraXmlConfigPropertiesAdapter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraXmlConfigPropertiesAdapter.java
@@ -22,6 +22,12 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 import org.eclipse.kapua.commons.util.CryptoUtil;
 import org.eclipse.kapua.service.device.call.kura.model.configuration.XmlConfigPropertyAdapted.ConfigPropertyType;
 
+/**
+ * Xml Kura configuration properties adapter. It marshal and unmarshal configuration properties in a proper way.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraXmlConfigPropertiesAdapter extends XmlAdapter<KuraXmlConfigPropertiesAdapted, Map<String, Object>>
 {
 

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/XmlConfigPropertyAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/XmlConfigPropertyAdapted.java
@@ -19,10 +19,13 @@ import javax.xml.bind.annotation.XmlEnum;
 import javax.xml.bind.annotation.XmlEnumValue;
 
 /**
- * Represents a typed property.
- * Various flags help in the interpretation and semantics of the property value.
+ * Represents a typed property.<br>
+ * Various flags help in the interpretation and semantics of the property value.<br>
  * For example, a property value might be an array or the property value might have been
  * encrypted.
+ * 
+ * @since 1.0
+ * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class XmlConfigPropertyAdapted
@@ -71,10 +74,19 @@ public class XmlConfigPropertyAdapted
     @XmlElement(name="value")
     private String[]           values;
 
-
+    /**
+     * Constructor
+     */
     public XmlConfigPropertyAdapted() {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param name
+     * @param type
+     * @param values
+     */
     public XmlConfigPropertyAdapted(String name,
                                     ConfigPropertyType type,
                                     String[] values) {
@@ -85,42 +97,92 @@ public class XmlConfigPropertyAdapted
         this.encrypted = false;
     }
 
+    /**
+     * Get the property name
+     * 
+     * @return
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Set the property name
+     * 
+     * @param name
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Get the is array flag property
+     * 
+     * @return
+     */
     public boolean getArray() {
         return array;
     }
 
+    /**
+     * Set the is array flag property
+     * 
+     * @param array
+     */
     public void setArray(boolean array) {
         this.array = array;
     }
 
+    /**
+     * Get the property type
+     * 
+     * @return
+     */
     public ConfigPropertyType getType() {
         return type;
     }
 
+    /**
+     * Set the property type
+     * 
+     * @param type
+     */
     public void setType(ConfigPropertyType type) {
         this.type = type;
     }
 
+    /**
+     * Get the is encrypted flag property
+     * 
+     * @return
+     */
     public boolean isEncrypted() {
         return encrypted;
     }
 
+    /**
+     * Set the is encrypted flag property
+     * 
+     * @param encrypted
+     */
     public void setEncrypted(boolean encrypted) {
         this.encrypted = encrypted;
     }
 
+    /**
+     * Get property values
+     * 
+     * @return
+     */
     public String[] getValues() {
         return values;
     }
 
+    /**
+     * Set property values
+     * 
+     * @param values
+     */
     public void setValues(String[] values) {
         this.values = values;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
@@ -18,6 +18,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * Kura bundle information.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name="bundleInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder= {"name","version"})
@@ -29,21 +35,41 @@ public class KuraBundleInfo
     @XmlElement(name="version")
     public String version;
 
+    /**
+     * Get the bundle name
+     * 
+     * @return
+     */
     public String getName()
     {
         return name;
     }
 
+    /**
+     * Set the bundle name
+     * 
+     * @param name
+     */
     public void setName(String name)
     {
         this.name = name;
     }
 
+    /**
+     * Get the bundle version
+     * 
+     * @return
+     */
     public String getVersion()
     {
         return version;
     }
 
+    /**
+     * Set the bundle version
+     * 
+     * @param version
+     */
     public void setVersion(String version)
     {
         this.version = version;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
@@ -7,6 +7,12 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * Kura deployment package.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "package")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder = { "name", "version", "bundleInfos" })
@@ -22,31 +28,61 @@ public class KuraDeploymentPackage
     @XmlElement(name = "bundle")
     public KuraBundleInfo[] bundleInfos;
 
+    /**
+     * Get the deployment package name
+     * 
+     * @return
+     */
     public String getName()
     {
         return name;
     }
 
+    /**
+     * Set the deployment package name
+     * 
+     * @param name
+     */
     public void setName(String name)
     {
         this.name = name;
     }
 
+    /**
+     * Get the deployment package version
+     * 
+     * @return
+     */
     public String getVersion()
     {
         return version;
     }
 
+    /**
+     * Set the deployment package version
+     * 
+     * @param version
+     */
     public void setVersion(String version)
     {
         this.version = version;
     }
 
+    /**
+     * Get the bundle information array
+     * 
+     * @return
+     */
     public KuraBundleInfo[] getBundleInfos()
     {
         return bundleInfos;
     }
 
+    /**
+     * Set the bundle information array
+     * 
+     * @param bundleInfos
+     */
     public void setBundleInfos(KuraBundleInfo[] bundleInfos)
     {
         this.bundleInfos = bundleInfos;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
@@ -5,6 +5,12 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+/**
+ * Kura deployment packages.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "packages")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class KuraDeploymentPackages
@@ -12,11 +18,21 @@ public class KuraDeploymentPackages
     @XmlElement(name = "package")
     public KuraDeploymentPackage[] deploymentPackages;
 
+    /**
+     * Get the deployment package array
+     * 
+     * @return
+     */
     public KuraDeploymentPackage[] getDeploymentPackages()
     {
         return deploymentPackages;
     }
 
+    /**
+     * Set the deployment package array
+     * 
+     * @param deploymentPackages
+     */
     public void setDeploymentPackages(KuraDeploymentPackage[] deploymentPackages)
     {
         this.deploymentPackages = deploymentPackages;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/KuraSnapshotIds.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/KuraSnapshotIds.java
@@ -17,20 +17,36 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * Utility class to serialize a set of snapshot ids.
+ * 
+ * @since 1.0
+ * 
  */
 @XmlRootElement(name = "snapshot-ids")
 public class KuraSnapshotIds
 {
     private List<Long> snapshotIds;
 
+    /**
+     * Constructor
+     */
     public KuraSnapshotIds()
     {}
 
+    /**
+     * Get the snapshot identifiers list
+     * 
+     * @return
+     */
     public List<Long> getSnapshotIds()
     {
         return snapshotIds;
     }
 
+    /**
+     * Set the snapshot identifiers list
+     * 
+     * @param snapshotIds
+     */
     public void setSnapshotIds(List<Long> snapshotIds)
     {
         this.snapshotIds = snapshotIds;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/kura/KuraAppChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/kura/KuraAppChannel.java
@@ -15,20 +15,42 @@ package org.eclipse.kapua.service.device.call.message.app.kura;
 import org.eclipse.kapua.service.device.call.message.app.DeviceAppChannel;
 import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
 
+/**
+ * Kura application message channel.
+ * 
+ * @since 1.0
+ *
+ */
 public abstract class KuraAppChannel extends KuraChannel implements DeviceAppChannel
 {
     protected String appId;
 
+    /**
+     * Constructor
+     */
     public KuraAppChannel()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraAppChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param controlDestinationPrefix
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraAppChannel(String controlDestinationPrefix, String scopeNamespace, String clientId)
     {
         super(controlDestinationPrefix, scopeNamespace, clientId);

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/kura/KuraRequestChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/kura/KuraRequestChannel.java
@@ -17,6 +17,12 @@ import org.eclipse.kapua.service.device.call.kura.KuraMethod;
 import org.eclipse.kapua.service.device.call.message.app.kura.KuraAppChannel;
 import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestChannel;
 
+/**
+ * Kura command request message channel.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraRequestChannel extends KuraAppChannel implements DeviceRequestChannel
 {
     private KuraMethod method;
@@ -24,16 +30,32 @@ public class KuraRequestChannel extends KuraAppChannel implements DeviceRequestC
     private String     requestId;
     private String     requesterClientId;
 
+    /**
+     * Constructor
+     */
     public KuraRequestChannel()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraRequestChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param controlDestinationPrefix
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraRequestChannel(String controlDestinationPrefix, String scopeNamespace, String clientId)
     {
         super(controlDestinationPrefix, scopeNamespace, clientId);

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/kura/KuraRequestMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/kura/KuraRequestMessage.java
@@ -17,13 +17,30 @@ import java.util.Date;
 import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestMessage;
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
+/**
+ * Kura command request message.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraRequestMessage extends KuraMessage<KuraRequestChannel, KuraRequestPayload> implements DeviceRequestMessage<KuraRequestChannel, KuraRequestPayload>
 {
+
+    /**
+     * Constructor
+     */
     public KuraRequestMessage()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraRequestMessage(KuraRequestChannel channel, Date timestamp, KuraRequestPayload payload)
     {
         super(channel, timestamp, payload);

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/kura/KuraRequestPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/kura/KuraRequestPayload.java
@@ -17,6 +17,12 @@ import org.eclipse.kapua.service.device.call.kura.app.RequestMetrics;
 import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestPayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura command request message payload.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraRequestPayload extends KuraPayload implements DeviceRequestPayload
 {
     @Override

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponseChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponseChannel.java
@@ -15,16 +15,35 @@ package org.eclipse.kapua.service.device.call.message.app.response.kura;
 import org.eclipse.kapua.service.device.call.message.app.kura.KuraAppChannel;
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponseChannel;
 
+/**
+ * Kura command response message channel.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraResponseChannel extends KuraAppChannel implements DeviceResponseChannel
 {
     private String replyPart;
     private String requestId;
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraResponseChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param controlDestinationPrefix
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraResponseChannel(String controlDestinationPrefix, String scopeNamespace, String clientId)
     {
         super(controlDestinationPrefix, scopeNamespace, clientId);

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponseCode.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponseCode.java
@@ -14,30 +14,70 @@ package org.eclipse.kapua.service.device.call.message.app.response.kura;
 
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponseCode;
 
+/**
+ * Kura device response code definition.
+ * 
+ * @since 1.0
+ * 
+ */
 public enum KuraResponseCode implements DeviceResponseCode
 {
+    /**
+     * Accepted request
+     */
     ACCEPTED(200),
+    /**
+     * Bad request
+     */
     BAD_REQUEST(400),
+    /**
+     * Resource not found
+     */
     NOT_FOUND(404),
+    /**
+     * Internal error
+     */
     INTERNAL_ERROR(500);
 
     private int code;
 
+    /**
+     * Constructor
+     * 
+     * @param code
+     */
     KuraResponseCode(int code)
     {
         this.code = code;
     }
 
+    /**
+     * Get the response code
+     * 
+     * @return
+     */
     public int getCode()
     {
         return code;
     }
 
+    /**
+     * Constructs a {@link KuraResponseCode} from a string representation
+     * 
+     * @param responseCode
+     * @return
+     */
     public static KuraResponseCode fromResponseCode(String responseCode)
     {
         return fromResponseCode(Integer.valueOf(responseCode));
     }
 
+    /**
+     * Constructs a {@link KuraResponseCode} from an integer representation
+     * 
+     * @param responseCode
+     * @return
+     */
     public static KuraResponseCode fromResponseCode(int responseCode)
     {
         KuraResponseCode result = null;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponseMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponseMessage.java
@@ -17,8 +17,22 @@ import java.util.Date;
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponseMessage;
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
+/**
+ * Kura command response message.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraResponseMessage extends KuraMessage<KuraResponseChannel, KuraResponsePayload> implements DeviceResponseMessage<KuraResponseChannel, KuraResponsePayload>
 {
+
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraResponseMessage(KuraResponseChannel channel, Date timestamp, KuraResponsePayload payload)
     {
         super(channel, timestamp, payload);

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponsePayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponsePayload.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponsePayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura command response message payload.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraResponsePayload extends KuraPayload implements DeviceResponsePayload
 {
     @SuppressWarnings("unchecked")

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraChannel.java
@@ -19,6 +19,12 @@ import org.eclipse.kapua.service.device.call.message.DeviceChannel;
 import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSetting;
 import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSettingKeys;
 
+/**
+ * Kura device channel implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraChannel implements DeviceChannel
 {
     protected static final String DESTINATION_CONTROL_PREFIX = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
@@ -27,15 +33,31 @@ public class KuraChannel implements DeviceChannel
     protected String              scopeNamespace;
     protected String              clientId;
 
+    /**
+     * Constructor
+     */
     public KuraChannel()
     {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param messageClassification
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraChannel(String messageClassification, String scopeNamespace, String clientId)
     {
         this.messageClassification = messageClassification;
@@ -43,26 +65,31 @@ public class KuraChannel implements DeviceChannel
         this.clientId = clientId;
     }
 
+    @Override
     public String getMessageClassification()
     {
         return messageClassification;
     }
 
+    @Override
     public void setMessageClassification(String messageClassification)
     {
         this.messageClassification = messageClassification;
     }
 
+    @Override
     public String getScope()
     {
         return scopeNamespace;
     }
 
+    @Override
     public void setScope(String scope)
     {
         this.scopeNamespace = scope;
     }
 
+    @Override
     public String getClientId()
     {
         return clientId;
@@ -74,6 +101,12 @@ public class KuraChannel implements DeviceChannel
         this.clientId = clientId;
     }
 
+    /**
+     * Get the semantic tokens list.<br>
+     * The semantic part, of a channel, describes an action or a destination inside a domain (eg a scope identifier and a client identifier)
+     * 
+     * @return
+     */
     public List<String> getSemanticChannelParts()
     {
         return new ArrayList<>();

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraMessage.java
@@ -16,17 +16,33 @@ import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 
+/**
+ * Kura device message implementation.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraMessage<C extends KuraChannel, P extends KuraPayload> implements DeviceMessage<C, P>
 {
     protected C    channel;
     protected Date timestamp;
     protected P    payload;
 
+    /**
+     * Constructor
+     */
     public KuraMessage()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraMessage(C channel, Date timestamp, P payload)
     {
         this();
@@ -53,6 +69,11 @@ public class KuraMessage<C extends KuraChannel, P extends KuraPayload> implement
         return timestamp;
     }
 
+    /**
+     * Set the message timestamp
+     * 
+     * @param timestamp
+     */
     public void setTimestamp(Date timestamp)
     {
         this.timestamp = timestamp;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraPayload.java
@@ -30,6 +30,12 @@ import org.slf4j.LoggerFactory;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+/**
+ * Kura device payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraPayload implements DevicePayload
 {
     private static final Logger s_logger = LoggerFactory.getLogger(KuraPayload.class);
@@ -39,16 +45,25 @@ public class KuraPayload implements DevicePayload
     protected Map<String, Object> metrics;
     protected byte[]              body;
 
+    /**
+     * Constructor
+     */
     public KuraPayload()
     {
         metrics = new HashMap<>();
     }
 
+    @Override
     public Date getTimestamp()
     {
         return timestamp;
     }
 
+    /**
+     * Get the message timestamp
+     * 
+     * @param timestamp
+     */
     public void setTimestamp(Date timestamp)
     {
         this.timestamp = timestamp;
@@ -60,6 +75,11 @@ public class KuraPayload implements DevicePayload
         return position;
     }
 
+    /**
+     * Set the device position
+     * 
+     * @param position
+     */
     public void setPosition(DevicePosition position)
     {
         this.position = position;
@@ -71,11 +91,17 @@ public class KuraPayload implements DevicePayload
         return metrics;
     }
 
+    @Override
     public byte[] getBody()
     {
         return body;
     }
 
+    /**
+     * Set the message body
+     * 
+     * @param body
+     */
     public void setBody(byte[] body)
     {
         this.body = body;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraPosition.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraPosition.java
@@ -18,6 +18,12 @@ import javax.xml.bind.annotation.XmlElement;
 
 import org.eclipse.kapua.service.device.call.message.DevicePosition;
 
+/**
+ * Kura device position implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraPosition implements DevicePosition
 {
     /**
@@ -75,97 +81,119 @@ public class KuraPosition implements DevicePosition
     @XmlElement(name = "status")
     private Integer status;
 
+    /**
+     * Constructor
+     */
     public KuraPosition()
     {
     }
 
+    @Override
     public Double getLongitude()
     {
         return longitude;
     }
 
+    @Override
     public void setLongitude(Double longitude)
     {
         this.longitude = longitude;
     }
 
+    @Override
     public Double getLatitude()
     {
         return latitude;
     }
 
+    @Override
     public void setLatitude(Double latitude)
     {
         this.latitude = latitude;
     }
 
+    @Override
     public Double getAltitude()
     {
         return altitude;
     }
 
+    @Override
     public void setAltitude(Double altitude)
     {
         this.altitude = altitude;
     }
 
+    @Override
     public Double getPrecision()
     {
         return precision;
     }
 
+    @Override
     public void setPrecision(Double precision)
     {
         this.precision = precision;
     }
 
+    @Override
     public Double getHeading()
     {
         return heading;
     }
 
+    @Override
     public void setHeading(Double heading)
     {
         this.heading = heading;
     }
 
+    @Override
     public Double getSpeed()
     {
         return speed;
     }
 
+    @Override
     public void setSpeed(Double speed)
     {
         this.speed = speed;
     }
 
+    @Override
     public Date getTimestamp()
     {
         return timestamp;
     }
 
+    @Override
     public void setTimestamp(Date timestamp)
     {
         this.timestamp = timestamp;
     }
 
+    @Override
     public Integer getSatellites()
     {
         return satellites;
     }
 
+    @Override
     public void setSatellites(Integer satellites)
     {
         this.satellites = satellites;
     }
 
+    @Override
     public Integer getStatus()
     {
         return status;
     }
 
+    @Override
     public void setStatus(Integer status)
     {
         this.status = status;
     }
+    
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataChannel.java
@@ -17,6 +17,12 @@ import java.util.List;
 import org.eclipse.kapua.service.device.call.message.data.DeviceDataChannel;
 import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
 
+/**
+ * Kura data message channel.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraDataChannel extends KuraChannel implements DeviceDataChannel
 {
 
@@ -28,6 +34,11 @@ public class KuraDataChannel extends KuraChannel implements DeviceDataChannel
         return semanticChannelParts;
     }
 
+    /**
+     * Set the semantic channel tokens. {@link KuraChannel#getSemanticChannelParts() getSemanticChannelParts} for more detail.
+     * 
+     * @param semanticChannelParts
+     */
     public void setSemanticChannelParts(List<String> semanticChannelParts)
     {
         this.semanticChannelParts = semanticChannelParts;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataMessage.java
@@ -16,17 +16,33 @@ import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 
+/**
+ * Kura device message implementation.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraDataMessage implements DeviceMessage<KuraDataChannel, KuraDataPayload>
 {
     protected KuraDataChannel  channel;
     protected Date             timestamp;
     protected KuraDataPayload  payload;
 
+    /**
+     * Constructor
+     */
     public KuraDataMessage()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraDataMessage(KuraDataChannel channel, Date timestamp, KuraDataPayload payload)
     {
         this();
@@ -53,6 +69,11 @@ public class KuraDataMessage implements DeviceMessage<KuraDataChannel, KuraDataP
         return timestamp;
     }
 
+    /**
+     * Set the message timestamp
+     * 
+     * @param timestamp
+     */
     public void setTimestamp(Date timestamp)
     {
         this.timestamp = timestamp;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataPayload.java
@@ -31,6 +31,12 @@ import org.slf4j.LoggerFactory;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+/**
+ * Kura device payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraDataPayload implements DevicePayload
 {
     private static final Logger s_logger = LoggerFactory.getLogger(KuraDataPayload.class);
@@ -40,6 +46,9 @@ public class KuraDataPayload implements DevicePayload
     protected Map<String, Object> metrics;
     protected byte[]              body;
 
+    /**
+     * Constructor
+     */
     public KuraDataPayload()
     {
         metrics = new HashMap<>();
@@ -51,6 +60,11 @@ public class KuraDataPayload implements DevicePayload
         return timestamp;
     }
 
+    /**
+     * Set the message timestamp
+     * 
+     * @param timestamp
+     */
     public void setTimestamp(Date timestamp)
     {
         this.timestamp = timestamp;
@@ -62,6 +76,11 @@ public class KuraDataPayload implements DevicePayload
         return position;
     }
 
+    /**
+     * Set the device position
+     * 
+     * @param position
+     */
     public void setPosition(DevicePosition position)
     {
         this.position = position;
@@ -79,6 +98,11 @@ public class KuraDataPayload implements DevicePayload
         return body;
     }
 
+    /**
+     * St the message body
+     * 
+     * @param body
+     */
     public void setBody(byte[] body)
     {
         this.body = body;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraAppsChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraAppsChannel.java
@@ -14,18 +14,40 @@ package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
 
+/**
+ * Kura device application channel implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraAppsChannel extends KuraChannel
 {
 
+    /**
+     * Constructor
+     */
 	public KuraAppsChannel()
     {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraAppsChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param messageClassification
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraAppsChannel(String messageClassification, String scopeNamespace, String clientId)
     {
         this.messageClassification = messageClassification;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraAppsMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraAppsMessage.java
@@ -16,14 +16,31 @@ import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
+/**
+ * Kura device application message implementation.<br>
+ * The application message is sent by the device to update the platform knowledge about its available features.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraAppsMessage extends KuraMessage<KuraAppsChannel, KuraAppsPayload>
 {
 
+    /**
+     * Constructor
+     */
     public KuraAppsMessage()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraAppsMessage(KuraAppsChannel channel, 
     		Date timestamp,
             KuraAppsPayload payload) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraAppsPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraAppsPayload.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura device application message payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraAppsPayload extends KuraPayload implements DevicePayload
 {
     private final static String UPTIME                 = "uptime";
@@ -47,11 +53,44 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload
     private final static String MODEM_IMSI             = "modem_imsi";
     private final static String MODEM_ICCID            = "modem_iccid";
 
+    /**
+     * Constructor
+     */
     public KuraAppsPayload()
     {
     	super();
     }
     
+    /**
+     * Constructor
+     * 
+     * @param uptime
+     * @param displayName
+     * @param modelName
+     * @param modelId
+     * @param partNumber
+     * @param serialNumber
+     * @param firmwareVersion
+     * @param biosVersion
+     * @param os
+     * @param osVersion
+     * @param jvmName
+     * @param jvmVersion
+     * @param jvmProfile
+     * @param esfkuraVersion
+     * @param connectionInterface
+     * @param connectionIp
+     * @param acceptEncoding
+     * @param applicationIdentifiers
+     * @param availableProcessors
+     * @param totalMemory
+     * @param osArch
+     * @param osgiFramework
+     * @param osgiFrameworkVersion
+     * @param modemImei
+     * @param modemImsi
+     * @param modemIccid
+     */
     public KuraAppsPayload(String uptime,
                             String displayName,
                             String modelName,
@@ -161,151 +200,301 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload
         }
     }
 
+    /**
+     * Get the device uptime
+     * 
+     * @return
+     */
     public String getUptime()
     {
         return (String) getMetrics().get(UPTIME);
     }
 
+    /**
+     * Get the device display name
+     * 
+     * @return
+     */
     public String getDisplayName()
     {
         return (String) getMetrics().get(DISPLAY_NAME);
     }
 
+    /**
+     * Get the model name
+     * 
+     * @return
+     */
     public String getModelName()
     {
         return (String) getMetrics().get(MODEL_NAME);
     }
 
+    /**
+     * Get the model identifier
+     * 
+     * @return
+     */
     public String getModelId()
     {
         return (String) getMetrics().get(MODEL_ID);
     }
 
+    /**
+     * Get the part number
+     * 
+     * @return
+     */
     public String getPartNumber()
     {
         return (String) getMetrics().get(PART_NUMBER);
     }
 
+    /**
+     * Get the serial number
+     * 
+     * @return
+     */
     public String getSerialNumber()
     {
         return (String) getMetrics().get(SERIAL_NUMBER);
     }
 
+    /**
+     * Get the firmware
+     * 
+     * @return
+     */
     public String getFirmware()
     {
         return (String) getMetrics().get(FIRMWARE_VERSION);
     }
 
+    /**
+     * Get the firmware version
+     * 
+     * @return
+     */
     public String getFirmwareVersion()
     {
         return (String) getMetrics().get(FIRMWARE_VERSION);
     }
 
+    /**
+     * Get the bios
+     * 
+     * @return
+     */
     public String getBios()
     {
         return (String) getMetrics().get(BIOS_VERSION);
     }
 
+    /**
+     * Get the biuos version
+     * 
+     * @return
+     */
     public String getBiosVersion()
     {
         return (String) getMetrics().get(BIOS_VERSION);
     }
 
+    /**
+     * Get the operating system
+     * 
+     * @return
+     */
     public String getOs()
     {
         return (String) getMetrics().get(OS);
     }
 
+    /**
+     * Get the operating system version
+     * 
+     * @return
+     */
     public String getOsVersion()
     {
         return (String) getMetrics().get(OS_VERSION);
     }
 
+    /**
+     * Get the java virtual machine
+     * 
+     * @return
+     */
     public String getJvm()
     {
         return (String) getMetrics().get(JVM_NAME);
     }
 
+    /**
+     * Get the java virtual machine version
+     * 
+     * @return
+     */
     public String getJvmVersion()
     {
         return (String) getMetrics().get(JVM_VERSION);
     }
 
+    /**
+     * Get the java virtual machine profile
+     * 
+     * @return
+     */
     public String getJvmProfile()
     {
         return (String) getMetrics().get(JVM_PROFILE);
     }
 
+    /**
+     * Get the container framework
+     * 
+     * @return
+     */
     public String getContainerFramework()
     {
         return (String) getMetrics().get(OSGI_FRAMEWORK);
     }
 
+    /**
+     * Get the container framework version
+     * 
+     * @return
+     */
     public String getContainerFrameworkVersion()
     {
         return (String) getMetrics().get(OSGI_FRAMEWORK_VERSION);
     }
 
+    /**
+     * Get the application framework
+     * 
+     * @return
+     */
     public String getApplicationFramework()
     {
         return (String) getMetrics().get(ESFKURA_VERSION);
     }
 
+    /**
+     * Get the application framework version
+     * 
+     * @return
+     */
     public String getApplicationFrameworkVersion()
     {
         return (String) getMetrics().get(ESFKURA_VERSION);
     }
 
+    /**
+     * Get connection interface
+     * 
+     * @return
+     */
     public String getConnectionInterface()
     {
         return (String) getMetrics().get(CONNECTION_INTERFACE);
     }
 
+    /**
+     * Get the connection interface ip
+     * 
+     * @return
+     */
     public String getConnectionIp()
     {
         return (String) getMetrics().get(CONNECTION_IP);
     }
 
+    /**
+     * Get accept encoding
+     * 
+     * @return
+     */
     public String getAcceptEncoding()
     {
         return (String) getMetrics().get(ACCEPT_ENCODING);
     }
 
+    /**
+     * Get application identifiers
+     * 
+     * @return
+     */
     public String getApplicationIdentifiers()
     {
         return (String) getMetrics().get(APPLICATION_IDS);
     }
 
+    /**
+     * Get available processor
+     * 
+     * @return
+     */
     public String getAvailableProcessors()
     {
         return (String) getMetrics().get(AVAILABLE_PROCESSORS);
     }
 
+    /**
+     * Get total memory
+     * 
+     * @return
+     */
     public String getTotalMemory()
     {
         return (String) getMetrics().get(TOTAL_MEMORY);
     }
 
+    /**
+     * Get operating system architecture
+     * 
+     * @return
+     */
     public String getOsArch()
     {
         return (String) getMetrics().get(OS_ARCH);
     }
 
+    /**
+     * Get modem imei
+     * 
+     * @return
+     */
     public String getModemImei()
     {
         return (String) getMetrics().get(MODEM_IMEI);
     }
 
+    /**
+     * Get modem imsi
+     * 
+     * @return
+     */
     public String getModemImsi()
     {
         return (String) getMetrics().get(MODEM_IMSI);
     }
 
+    /**
+     * Get modem iccid
+     * 
+     * @return
+     */
     public String getModemIccid()
     {
         return (String) getMetrics().get(MODEM_ICCID);
     }
 
+    /**
+     * Returns a displayable representation string
+     * 
+     * @return
+     */
     public String toDisplayString()
     {
         return new StringBuilder().append("[ getUptime()=").append(getUptime())

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraBirthChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraBirthChannel.java
@@ -16,19 +16,41 @@ import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
 import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSetting;
 import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSettingKeys;
 
+/**
+ * Kura device birth message channel implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraBirthChannel extends KuraChannel
 {
     protected static final String DESTINATION_CONTROL_PREFIX = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
 
+    /**
+     * Constructor
+     */
     public KuraBirthChannel()
     {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraBirthChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param messageClassification
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraBirthChannel(String messageClassification, String scopeNamespace, String clientId)
     {
         this.messageClassification = messageClassification;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraBirthMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraBirthMessage.java
@@ -16,14 +16,31 @@ import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
+/**
+ * Kura device birth message implementation.<br>
+ * The birth message is sent by the device to notify to the platform that it is available.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraBirthMessage extends KuraMessage<KuraBirthChannel, KuraBirthPayload>
 {
 
+    /**
+     * Constructor
+     */
     public KuraBirthMessage()
     {
         super();
     }
     
+    /**
+     * Contructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraBirthMessage(KuraBirthChannel channel, 
     		Date timestamp,
             KuraBirthPayload payload) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraBirthPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraBirthPayload.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura device unmatched message payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraBirthPayload extends KuraPayload implements DevicePayload
 {
     private final static String UPTIME                 = "uptime";
@@ -47,10 +53,43 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload
     private final static String MODEM_IMSI             = "modem_imsi";
     private final static String MODEM_ICCID            = "modem_iccid";
     
+    /**
+     * Constructor
+     */
     public KuraBirthPayload() {
 		super();
 	}
 
+    /**
+     * Constructor
+     * 
+     * @param uptime
+     * @param displayName
+     * @param modelName
+     * @param modelId
+     * @param partNumber
+     * @param serialNumber
+     * @param firmwareVersion
+     * @param biosVersion
+     * @param os
+     * @param osVersion
+     * @param jvmName
+     * @param jvmVersion
+     * @param jvmProfile
+     * @param esfkuraVersion
+     * @param connectionInterface
+     * @param connectionIp
+     * @param acceptEncoding
+     * @param applicationIdentifiers
+     * @param availableProcessors
+     * @param totalMemory
+     * @param osArch
+     * @param osgiFramework
+     * @param osgiFrameworkVersion
+     * @param modemImei
+     * @param modemImsi
+     * @param modemIccid
+     */
     public KuraBirthPayload(String uptime,
                             String displayName,
                             String modelName,
@@ -160,151 +199,301 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload
         }
     }
 
+    /**
+     * Get the device uptime
+     * 
+     * @return
+     */
 	public String getUptime()
     {
         return (String) getMetrics().get(UPTIME);
     }
 
+    /**
+     * Get the device display name
+     * 
+     * @return
+     */
     public String getDisplayName()
     {
         return (String) getMetrics().get(DISPLAY_NAME);
     }
 
+    /**
+     * Get the model name
+     * 
+     * @return
+     */
     public String getModelName()
     {
         return (String) getMetrics().get(MODEL_NAME);
     }
 
+    /**
+     * Get the model identifier
+     * 
+     * @return
+     */
     public String getModelId()
     {
         return (String) getMetrics().get(MODEL_ID);
     }
 
+    /**
+     * Get the part number
+     * 
+     * @return
+     */
     public String getPartNumber()
     {
         return (String) getMetrics().get(PART_NUMBER);
     }
 
+    /**
+     * Get the serial number
+     * 
+     * @return
+     */
     public String getSerialNumber()
     {
         return (String) getMetrics().get(SERIAL_NUMBER);
     }
 
+    /**
+     * Get the firmware
+     * 
+     * @return
+     */
     public String getFirmware()
     {
         return (String) getMetrics().get(FIRMWARE_VERSION);
     }
 
+    /**
+     * Get the firmware version
+     * 
+     * @return
+     */
     public String getFirmwareVersion()
     {
         return (String) getMetrics().get(FIRMWARE_VERSION);
     }
 
+    /**
+     * Get the bios
+     * 
+     * @return
+     */
     public String getBios()
     {
         return (String) getMetrics().get(BIOS_VERSION);
     }
 
+    /**
+     * Get the biuos version
+     * 
+     * @return
+     */
     public String getBiosVersion()
     {
         return (String) getMetrics().get(BIOS_VERSION);
     }
 
+    /**
+     * Get the operating system
+     * 
+     * @return
+     */
     public String getOs()
     {
         return (String) getMetrics().get(OS);
     }
 
+    /**
+     * Get the operating system version
+     * 
+     * @return
+     */
     public String getOsVersion()
     {
         return (String) getMetrics().get(OS_VERSION);
     }
 
+    /**
+     * Get the java virtual machine
+     * 
+     * @return
+     */
     public String getJvm()
     {
         return (String) getMetrics().get(JVM_NAME);
     }
 
+    /**
+     * Get the java virtual machine version
+     * 
+     * @return
+     */
     public String getJvmVersion()
     {
         return (String) getMetrics().get(JVM_VERSION);
     }
 
+    /**
+     * Get the java virtual machine profile
+     * 
+     * @return
+     */
     public String getJvmProfile()
     {
         return (String) getMetrics().get(JVM_PROFILE);
     }
 
+    /**
+     * Get the container framework
+     * 
+     * @return
+     */
     public String getContainerFramework()
     {
         return (String) getMetrics().get(OSGI_FRAMEWORK);
     }
 
+    /**
+     * Get the container framework version
+     * 
+     * @return
+     */
     public String getContainerFrameworkVersion()
     {
         return (String) getMetrics().get(OSGI_FRAMEWORK_VERSION);
     }
 
+    /**
+     * Get the application framework
+     * 
+     * @return
+     */
     public String getApplicationFramework()
     {
         return (String) getMetrics().get(ESFKURA_VERSION);
     }
 
+    /**
+     * Get the application framework version
+     * 
+     * @return
+     */
     public String getApplicationFrameworkVersion()
     {
         return (String) getMetrics().get(ESFKURA_VERSION);
     }
 
+    /**
+     * Get connection interface
+     * 
+     * @return
+     */
     public String getConnectionInterface()
     {
         return (String) getMetrics().get(CONNECTION_INTERFACE);
     }
 
+    /**
+     * Get the connection interface ip
+     * 
+     * @return
+     */
     public String getConnectionIp()
     {
         return (String) getMetrics().get(CONNECTION_IP);
     }
 
+    /**
+     * Get accept encoding
+     * 
+     * @return
+     */
     public String getAcceptEncoding()
     {
         return (String) getMetrics().get(ACCEPT_ENCODING);
     }
 
+    /**
+     * Get application identifiers
+     * 
+     * @return
+     */
     public String getApplicationIdentifiers()
     {
         return (String) getMetrics().get(APPLICATION_IDS);
     }
 
+    /**
+     * Get available processor
+     * 
+     * @return
+     */
     public String getAvailableProcessors()
     {
         return (String) getMetrics().get(AVAILABLE_PROCESSORS);
     }
 
+    /**
+     * Get total memory
+     * 
+     * @return
+     */
     public String getTotalMemory()
     {
         return (String) getMetrics().get(TOTAL_MEMORY);
     }
 
+    /**
+     * Get operating system architecture
+     * 
+     * @return
+     */
     public String getOsArch()
     {
         return (String) getMetrics().get(OS_ARCH);
     }
 
+    /**
+     * Get modem imei
+     * 
+     * @return
+     */
     public String getModemImei()
     {
         return (String) getMetrics().get(MODEM_IMEI);
     }
 
+    /**
+     * Get modem imsi
+     * 
+     * @return
+     */
     public String getModemImsi()
     {
         return (String) getMetrics().get(MODEM_IMSI);
     }
 
+    /**
+     * Get modem iccid
+     * 
+     * @return
+     */
     public String getModemIccid()
     {
         return (String) getMetrics().get(MODEM_ICCID);
     }
 
+    /**
+     * Returns a displayable representation string
+     * 
+     * @return
+     */
     public String toDisplayString()
     {
         return new StringBuilder().append("[ getUptime()=").append(getUptime())

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraDisconnectChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraDisconnectChannel.java
@@ -14,18 +14,40 @@ package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
 
+/**
+ * Kura device disconnect message channel implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraDisconnectChannel extends KuraChannel
 {
 
+    /**
+     * Constructor
+     */
     public KuraDisconnectChannel()
     {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraDisconnectChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param messageClassification
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraDisconnectChannel(String messageClassification, String scopeNamespace, String clientId)
     {
         this.messageClassification = messageClassification;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraDisconnectMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraDisconnectMessage.java
@@ -16,14 +16,31 @@ import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
+/**
+ * Kura device disconnect message implementation.<br>
+ * The disconnect message is sent by the device to notify to the platform that it is no more available.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraDisconnectMessage extends KuraMessage<KuraDisconnectChannel, KuraDisconnectPayload>
 {
 
+    /**
+     * Constructor
+     */
     public KuraDisconnectMessage()
     {
         super();
     }
     
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraDisconnectMessage(KuraDisconnectChannel channel, 
     		Date timestamp,
             KuraDisconnectPayload payload) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraDisconnectPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraDisconnectPayload.java
@@ -15,16 +15,38 @@ package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura device unmatched message payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraDisconnectPayload extends KuraPayload implements DevicePayload
 {
+
+    /**
+     * Uptime metric name
+     */
     private final static String UPTIME       = "uptime";
+    /**
+     * Uptime device displayble name metric name
+     */
     private final static String DISPLAY_NAME = "display_name";
 
+    /**
+     * Constructor
+     */
     public KuraDisconnectPayload() 
     {
     	super();
     }
 
+    /**
+     * Returns a displayable representation string
+     * 
+     * @param uptime
+     * @param displayName
+     */
     public KuraDisconnectPayload(String uptime, String displayName)
     {
         super();
@@ -33,16 +55,31 @@ public class KuraDisconnectPayload extends KuraPayload implements DevicePayload
         getMetrics().put(DISPLAY_NAME, displayName);
     }
 
+    /**
+     * Ge tthe device uptime
+     * 
+     * @return
+     */
     public String getUptime()
     {
         return (String) getMetrics().get(UPTIME);
     }
 
+    /**
+     * Get the device displayable name
+     * 
+     * @return
+     */
     public String getDisplayName()
     {
         return (String) getMetrics().get(DISPLAY_NAME);
     }
 
+    /**
+     * Returns a displayable representation string
+     * 
+     * @return
+     */
     public String toDisplayString()
     {
         return new StringBuilder().append("[ getUptime()=").append(getUptime())

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraMissingChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraMissingChannel.java
@@ -14,18 +14,40 @@ package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
 
+/**
+ * Kura device missing message channel implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraMissingChannel extends KuraChannel
 {
 
+    /**
+     * Constructor
+     */
 	public KuraMissingChannel()
     {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraMissingChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param messageClassification
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraMissingChannel(String messageClassification, String scopeNamespace, String clientId)
     {
         this.messageClassification = messageClassification;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraMissingMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraMissingMessage.java
@@ -16,14 +16,31 @@ import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
+/**
+ * Kura device missing message implementation.<br>
+ * The missing message is sent by the platform to notify that a device is no more available (likely due to network error).
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraMissingMessage extends KuraMessage<KuraMissingChannel, KuraMissingPayload>
 {
 
+    /**
+     * Constructor
+     */
     public KuraMissingMessage()
     {
         super();
     }
     
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraMissingMessage(KuraMissingChannel channel, 
     		Date timestamp,
             KuraMissingPayload payload) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraMissingPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraMissingPayload.java
@@ -17,13 +17,28 @@ import java.util.Iterator;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura device unmatched message payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraMissingPayload extends KuraPayload implements DevicePayload
 {
+
+    /**
+     * Constructor
+     */
     public KuraMissingPayload() 
     {
     	super();
     }
 
+    /**
+     * Returns a displayable representation string
+     * 
+     * @return
+     */
     public String toDisplayString()
     {
     	StringBuilder sb = new StringBuilder();

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraNotifyChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraNotifyChannel.java
@@ -14,18 +14,40 @@ package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
 
+/**
+ * Kura device notification message channel implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraNotifyChannel extends KuraChannel
 {
 
+    /**
+     * Constructor
+     */
 	public KuraNotifyChannel()
     {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraNotifyChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param messageClassification
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraNotifyChannel(String messageClassification, String scopeNamespace, String clientId)
     {
         this.messageClassification = messageClassification;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraNotifyMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraNotifyMessage.java
@@ -16,14 +16,31 @@ import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
+/**
+ * Kura device notify message implementation.<br>
+ * The missing message is sent by the device to notify the platform about a task progress.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraNotifyMessage extends KuraMessage<KuraNotifyChannel, KuraNotifyPayload>
 {
 
+    /**
+     * Constructor
+     */
     public KuraNotifyMessage()
     {
         super();
     }
     
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraNotifyMessage(KuraNotifyChannel channel,
                              Date timestamp, KuraNotifyPayload payload)
     {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraNotifyPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraNotifyPayload.java
@@ -17,13 +17,28 @@ import java.util.Iterator;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura device notification message payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraNotifyPayload extends KuraPayload implements DevicePayload
 {
+    
+    /**
+     * Constructor
+     */
     public KuraNotifyPayload() 
     {
     	super();
     }
 
+    /**
+     * Returns a displayable representation string
+     * 
+     * @return
+     */
     public String toDisplayString()
     {
     	StringBuilder sb = new StringBuilder();

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraPayload.java
@@ -30,6 +30,12 @@ import org.slf4j.LoggerFactory;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+/**
+ * Kura device payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraPayload implements DevicePayload
 {
     private static final Logger   s_logger = LoggerFactory.getLogger(KuraPayload.class);
@@ -39,16 +45,25 @@ public class KuraPayload implements DevicePayload
     protected Map<String, Object> metrics;
     protected byte[]              body;
 
+    /**
+     * Constructor
+     */
     public KuraPayload()
     {
         metrics = new HashMap<>();
     }
 
+    @Override
     public Date getTimestamp()
     {
         return timestamp;
     }
 
+    /**
+     * Set the message timestamp
+     * 
+     * @param timestamp
+     */
     public void setTimestamp(Date timestamp)
     {
         this.timestamp = timestamp;
@@ -60,6 +75,11 @@ public class KuraPayload implements DevicePayload
         return position;
     }
 
+    /**
+     * Set the device position
+     * 
+     * @param position
+     */
     public void setPosition(DevicePosition position)
     {
         this.position = position;
@@ -71,11 +91,17 @@ public class KuraPayload implements DevicePayload
         return metrics;
     }
 
+    @Override
     public byte[] getBody()
     {
         return body;
     }
 
+    /**
+     * Set the message body
+     * 
+     * @param body
+     */
     public void setBody(byte[] body)
     {
         this.body = body;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraUnmatchedChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraUnmatchedChannel.java
@@ -14,18 +14,40 @@ package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
 
+/**
+ * Kura device unmatched message channel implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraUnmatchedChannel extends KuraChannel
 {
 
+    /**
+     * Constructor
+     */
 	public KuraUnmatchedChannel()
     {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraUnmatchedChannel(String scopeNamespace, String clientId)
     {
         this(null, scopeNamespace, clientId);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param messageClassification
+     * @param scopeNamespace
+     * @param clientId
+     */
     public KuraUnmatchedChannel(String messageClassification, String scopeNamespace, String clientId)
     {
         this.messageClassification = messageClassification;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraUnmatchedMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraUnmatchedMessage.java
@@ -16,14 +16,32 @@ import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
+/**
+ * Kura device unmatched message implementation.<br>
+ * The unmatched messages aren't elaborated by the system.<br>
+ * In that category fall all the messages that aren't categorized in the others life cycle message groups.
+ * 
+ * @since 1.0
+ * 
+ */
 public class KuraUnmatchedMessage extends KuraMessage<KuraUnmatchedChannel, KuraUnmatchedPayload>
 {
 
+    /**
+     * Constructor
+     */
     public KuraUnmatchedMessage()
     {
         super();
     }
     
+    /**
+     * Constructor
+     * 
+     * @param channel
+     * @param timestamp
+     * @param payload
+     */
     public KuraUnmatchedMessage(KuraUnmatchedChannel channel,
                                 Date timestamp, KuraUnmatchedPayload payload)
     {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraUnmatchedPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraUnmatchedPayload.java
@@ -17,13 +17,28 @@ import java.util.Iterator;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 
+/**
+ * Kura device unmatched message payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KuraUnmatchedPayload extends KuraPayload implements DevicePayload
 {
+
+    /**
+     * Constructor
+     */
     public KuraUnmatchedPayload() 
     {
     	super();
     }
 
+    /**
+     * Returns a displayable representation string
+     * 
+     * @return
+     */
     public String toDisplayString()
     {
     	StringBuilder sb = new StringBuilder();

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/proto/KuraPayloadProto.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/proto/KuraPayloadProto.java
@@ -13,6 +13,12 @@
 // source: kurapayload.proto
 package org.eclipse.kapua.service.device.call.message.kura.proto;
 
+/**
+ * Kura payload protobuf definition
+ * 
+ * @since 1.0
+ *
+ */
 @SuppressWarnings("unused")
 public final class KuraPayloadProto
 {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/setting/DeviceCallSetting.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/setting/DeviceCallSetting.java
@@ -14,17 +14,37 @@ package org.eclipse.kapua.service.device.call.message.kura.setting;
 
 import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
 
+/**
+ * Class that offers access to device call settings
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceCallSetting extends AbstractKapuaSetting<DeviceCallSettingKeys>
 {
+
+    /**
+     * Resource file from which source properties.
+     * 
+     */
     private static final String            DEVICE_CALL_SETTING_RESOURCE = "device-call-setting.properties";
 
     private static final DeviceCallSetting instance              = new DeviceCallSetting();
 
+    /**
+     * Initialize the {@link AbstractKapuaSetting} with the {@link DeviceCallSetting#DEVICE_CALL_SETTING_RESOURCE} value.
+     * 
+     */
     private DeviceCallSetting()
     {
         super(DEVICE_CALL_SETTING_RESOURCE);
     }
 
+    /**
+     * Gets a singleton instance of {@link DeviceCallSetting}.
+     * 
+     * @return A singleton instance of DeviceCallSetting.
+     */
     public static DeviceCallSetting getInstance()
     {
         return instance;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/setting/DeviceCallSettingKeys.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/setting/DeviceCallSettingKeys.java
@@ -13,11 +13,25 @@
 package org.eclipse.kapua.service.device.call.message.kura.setting;
 
 import org.eclipse.kapua.commons.setting.SettingKey;
+import org.eclipse.kapua.service.device.call.message.DeviceChannel;
 
+/**
+ * Available settings key for device call service
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceCallSettingKeys implements SettingKey
 {
+
+    /**
+     * Destination message classifier. {@link DeviceChannel#getMessageClassification} for more detail
+     */
     DESTINATION_MESSAGE_CLASSIFIER("destination.message.classifier"),
 
+    /**
+     * Destination reply part
+     */
     DESTINATION_REPLY_PART("destination.reply.part");
 
     private String key;
@@ -27,6 +41,7 @@ public enum DeviceCallSettingKeys implements SettingKey
         this.key = key;
     }
 
+    @Override
     public String key()
     {
         return key;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/utils/GZIPUtils.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/utils/GZIPUtils.java
@@ -18,9 +18,21 @@ import java.io.IOException;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+/**
+ * Gzip utilities.
+ * 
+ * @since 1.0
+ *
+ */
 public class GZIPUtils
 {
 
+    /**
+     * Check if the byte array represents compressed data
+     * 
+     * @param bytes
+     * @return
+     */
     public static boolean isCompressed(byte[] bytes)
     {
         if ((bytes == null) || (bytes.length < 2)) {
@@ -31,6 +43,13 @@ public class GZIPUtils
         }
     }
 
+    /**
+     * Returns the compressed provided data
+     * 
+     * @param source
+     * @return
+     * @throws IOException
+     */
     public static byte[] compress(byte[] source)
         throws IOException
     {
@@ -57,6 +76,13 @@ public class GZIPUtils
         return baos.toByteArray();
     }
 
+    /**
+     * Returns the decompressed provided data
+     * 
+     * @param source
+     * @return
+     * @throws IOException
+     */
     public static byte[] decompress(byte[] source)
         throws IOException
     {

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandFactory.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandFactory.java
@@ -14,9 +14,26 @@ package org.eclipse.kapua.service.device.management.command;
 
 import org.eclipse.kapua.model.KapuaObjectFactory;
 
+/**
+ * Device command entity service factory definition.
+ *
+ * @since 1.0
+ * 
+ */
 public interface DeviceCommandFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new {@link DeviceCommandInput}
+     * 
+     * @return
+     */
     public DeviceCommandInput newCommandInput();
 
+    /**
+     * Create a new {@link DeviceCommandOutput}
+     * 
+     * @return
+     */
     public DeviceCommandOutput newCommandOutput();
 }

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
@@ -22,6 +22,12 @@ import org.eclipse.kapua.model.KapuaEntity;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 
+/**
+ * Device command input entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "commandInput")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = {
@@ -36,49 +42,140 @@ import javax.xml.bind.annotation.XmlElementWrapper;
         "stdin"
 }, factoryClass = DeviceCommandXmlRegistry.class, factoryMethod = "newCommandInput")
 public interface DeviceCommandInput extends KapuaEntity {
+
+    /**
+     * Get the device command
+     * 
+     * @return
+     */
     @XmlElement(name = "command")
     public String getCommand();
     
+    /**
+     * Set the device command
+     * 
+     * @param command
+     */
     public void setCommand(String command);
 
+    /**
+     * Get the device password
+     * 
+     * @return
+     */
     @XmlElement(name = "password")
     public String getPassword();
     
+    /**
+     * Set the device password
+     * 
+     * @param password
+     */
     public void setPassword(String password);    
 
+    /**
+     * Get command arguments
+     * 
+     * @return
+     */
     @XmlElementWrapper(name = "arguments")
     @XmlElement(name = "argument")
     public String[] getArguments();
     
+    /**
+     * Set command arguments
+     * 
+     * @param arguments
+     */
     public void setArguments(String[] arguments);    
 
+    /**
+     * Get the command timeout
+     * 
+     * @return
+     */
     @XmlElement(name = "timeout")
     public Integer getTimeout();
     
+    /**
+     * Set the command timeout
+     * 
+     * @param timeout
+     */
     public void setTimeout(Integer timeout);
 
+    /**
+     * Get the working directory
+     * 
+     * @return
+     */
     @XmlElement(name = "workingDir")
     public String getWorkingDir();
     
+    /**
+     * Set the working directory
+     * 
+     * @param workingDir
+     */
     public void setWorkingDir(String workingDir);
 
+    /**
+     * Get the command input body
+     * 
+     * @return
+     */
     @XmlElement(name = "body")
     public byte[] getBody();
     
+    /**
+     * Set the command input body
+     * 
+     * @param bytes
+     */
     public void setBody(byte[] bytes);    
 
+    /**
+     * Get the environment attributes
+     * 
+     * @return
+     */
     @XmlElement(name = "environment")
     public String[] getEnvironment();
     
+    /**
+     * Set the environment attributes
+     * 
+     * @param environment
+     */
     public void setEnvironment(String[] environment);
     
+    /**
+     * Get the asynchronous run flag
+     * 
+     * @return
+     */
     @XmlElement(name = "runAsynch")
     public boolean isRunAsynch();
     
+    /**
+     * Set the asynchronous run flag
+     * 
+     * @param runAsync
+     */
     public void setRunAsynch(boolean runAsync);
 
+    /**
+     * Get the device standard input
+     * 
+     * @return
+     */
     @XmlElement(name = "stdin")
     public String getStdin();
     
+    /**
+     * Set the device standard input
+     * 
+     * @param stdin
+     */
     public void setStdin(String stdin);
 }

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
@@ -16,8 +16,25 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 
+/**
+ * Device command service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceCommandManagementService extends KapuaService
 {
+
+    /**
+     * Execute the given device command with the provided options
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param commandInput
+     * @param timeout command timeout
+     * @return
+     * @throws KapuaException
+     */
     public DeviceCommandOutput exec(KapuaId scopeId, KapuaId deviceId, DeviceCommandInput commandInput, Long timeout)
         throws KapuaException;
 }

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
@@ -20,6 +20,12 @@ import javax.xml.bind.annotation.XmlType;
 
 import org.eclipse.kapua.KapuaSerializable;
 
+/**
+ * Device command output entity definition.
+ * 
+ * @since 1.0
+ * 
+ */
 @XmlRootElement(name = "commandOutput")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = {
@@ -32,33 +38,93 @@ import org.eclipse.kapua.KapuaSerializable;
 }, factoryClass = DeviceCommandXmlRegistry.class, factoryMethod = "newCommandOutput")
 public interface DeviceCommandOutput extends KapuaSerializable
 {
+    /**
+     * Get the standard error
+     * 
+     * @return
+     */
     @XmlElement(name = "stderr")
     public String getStderr();
 
+    /**
+     * Set the standard error
+     * 
+     * @param stderr
+     */
     public void setStderr(String stderr);
 
+    /**
+     * Get the standard output
+     * 
+     * @return
+     */
     @XmlElement(name = "stdout")
     public String getStdout();
 
+    /**
+     * Set the standard output
+     * 
+     * @param stdout
+     */
     public void setStdout(String stdout);
 
+    /**
+     * Get the command execution exception message
+     * 
+     * @return
+     */
     @XmlElement(name = "exceptionMessage")
     public String getExceptionMessage();
 
+    /**
+     * Set the command execution exception message
+     * 
+     * @param exceptionMessage
+     */
     public void setExceptionMessage(String exceptionMessage);
 
+    /**
+     * Get the command execution exception stack
+     * 
+     * @return
+     */
     @XmlElement(name = "exceptionStack")
     public String getExceptionStack();
 
+    /**
+     * Set the command execution exception stack
+     * 
+     * @param exceptionStack
+     */
     public void setExceptionStack(String exceptionStack);
 
+    /**
+     * Get the command execution exit code
+     * 
+     * @return
+     */
     @XmlElement(name = "exitCode")
     public Integer getExitCode();
 
+    /**
+     * Set the command execution exit code
+     * 
+     * @param exitCode
+     */
     public void setExitCode(Integer exitCode);
 
+    /**
+     * Get the command execution timed out flag
+     * 
+     * @return
+     */
     @XmlElement(name = "hasTimedout")
     public Boolean getHasTimedout();
 
+    /**
+     * Set the command execution timed out flag
+     * 
+     * @param hasTimedout
+     */
     public void setHasTimedout(Boolean hasTimedout);
 }

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandXmlRegistry.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandXmlRegistry.java
@@ -4,18 +4,35 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 import org.eclipse.kapua.locator.KapuaLocator;
 
+/**
+ * Device bundle xml factory class
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRegistry
 public class DeviceCommandXmlRegistry {
     private final KapuaLocator locator = KapuaLocator.getInstance();
     private final DeviceCommandFactory factory = locator.getFactory(DeviceCommandFactory.class);
     
+    /**
+     * Creates a new device command input
+     * 
+     * @return
+     */
     public DeviceCommandInput newCommandInput()
     {
         return factory.newCommandInput();
     }
     
+    /**
+     * Creates a new device command output
+     * 
+     * @return
+     */
     public DeviceCommandOutput newCommandOutput()
     {
         return factory.newCommandOutput();
     }
+
 }

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/CommandAppProperties.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/CommandAppProperties.java
@@ -14,25 +14,73 @@ package org.eclipse.kapua.service.device.management.command.internal;
 
 import org.eclipse.kapua.service.device.management.KapuaAppProperties;
 
+/**
+ * Device command properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum CommandAppProperties implements KapuaAppProperties
 {
+    /**
+     * Application name
+     */
     APP_NAME("COMMAND"),
+    /**
+     * Application version
+     */
     APP_VERSION("1.0.0"),
 
     // Request
+    /**
+     * Command
+     */
     APP_PROPERTY_CMD("kapua.cmd.command"),
+    /**
+     * Arguments
+     */
     APP_PROPERTY_ARG("kapua.cmd.arguments"),
+    /**
+     * Environment
+     */
     APP_PROPERTY_ENVP("kapua.cmd.environment.pair"),
+    /**
+     * Working directory
+     */
     APP_PROPERTY_DIR("kapua.cmd.working.directory"),
+    /**
+     * Standard input
+     */
     APP_PROPERTY_STDIN("kapua.cmd.stdin"),
+    /**
+     * Command timeout
+     */
     APP_PROPERTY_TOUT("kapua.cmd.timeout"),
+    /**
+     * Asynchronous running
+     */
     APP_PROPERTY_ASYNC("kapua.cmd.run.async"),
+    /**
+     * Password
+     */
     APP_PROPERTY_PASSWORD("kapua.cmd.password"),
 
     // Response
+    /**
+     * Standard error
+     */
     APP_PROPERTY_STDERR("kapua.cmd.stderr"),
+    /**
+     * Standard output
+     */
     APP_PROPERTY_STDOUT("kapua.cmd.stdout"),
+    /**
+     * Command exit code
+     */
     APP_PROPERTY_EXIT_CODE("kapua.cmd.exit.code"),
+    /**
+     * Command timed out flag
+     */
     APP_PROPERTY_TIMED_OUT("kapua.cmd.timed.out"),
     ;
 

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandFactoryImpl.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandFactoryImpl.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.service.device.management.command.DeviceCommandFactory;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandInput;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandOutput;
 
+/**
+ * Device command entity service factory implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceCommandFactoryImpl implements DeviceCommandFactory
 {
 

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandInputImpl.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandInputImpl.java
@@ -17,6 +17,12 @@ import java.util.Date;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandInput;
 
+/**
+ * Device command input entity implementation.
+ *
+ * @since 1.0
+ *
+ */
 public class DeviceCommandInputImpl implements DeviceCommandInput {
 
 	private String command;

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
@@ -35,6 +35,12 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 
+/**
+ * Device command service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceCommandManagementServiceImpl implements DeviceCommandManagementService
 {
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandOutputImpl.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandOutputImpl.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.management.command.internal;
 
 import org.eclipse.kapua.service.device.management.command.DeviceCommandOutput;
 
+/**
+ * Device command output entity implementation.
+ *
+ * @since 1.0
+ *
+ */
 public class DeviceCommandOutputImpl implements DeviceCommandOutput
 {
 	

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestChannel.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestChannel.java
@@ -15,6 +15,12 @@ import org.eclipse.kapua.service.device.management.KapuaMethod;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
 
+/**
+ * Device command request channel.
+ * 
+ * @since 1.0
+ * 
+ */
 public class CommandRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel
 {
 

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestMessage.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestMessage.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.command.message.internal;
 import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
 
+/**
+ * Device command request message.
+ * 
+ * @since 1.0
+ * 
+ */
 public class CommandRequestMessage extends KapuaMessageImpl<CommandRequestChannel, CommandRequestPayload> implements KapuaRequestMessage<CommandRequestChannel, CommandRequestPayload>
 {
     @SuppressWarnings("unchecked")

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestPayload.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestPayload.java
@@ -18,8 +18,20 @@ import org.eclipse.kapua.message.internal.KapuaPayloadImpl;
 import org.eclipse.kapua.service.device.management.command.internal.CommandAppProperties;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
 
+/**
+ * Device command request payload.
+ * 
+ * @since 1.0
+ * 
+ */
 public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequestPayload
 {
+
+    /**
+     * Get the command argument list
+     * 
+     * @return
+     */
     public String[] getArguments()
     {
         List<String> argumentsList = new ArrayList<>();
@@ -42,6 +54,11 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Set the command argument list
+     * 
+     * @param arguments
+     */
     public void setArguments(String[] arguments)
     {
         if (arguments != null) {
@@ -51,6 +68,11 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the environment pairs
+     * 
+     * @return
+     */
     public String[] getEnvironmentPairs()
     {
         List<String> v = new ArrayList<>();
@@ -73,6 +95,11 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Set the environment pairs
+     * 
+     * @param environmentPairs
+     */
     public void setEnvironmentPairs(String[] environmentPairs)
     {
         if (environmentPairs != null) {
@@ -82,11 +109,21 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the working directory
+     * 
+     * @return
+     */
     public String getWorkingDir()
     {
         return (String) getProperties().get(CommandAppProperties.APP_PROPERTY_DIR.getValue());
     }
 
+    /**
+     * Set the working directory
+     * 
+     * @param workingDir
+     */
     public void setWorkingDir(String workingDir)
     {
         if (workingDir != null) {
@@ -94,11 +131,21 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the standard input
+     * 
+     * @return
+     */
     public String getStdin()
     {
         return (String) getProperties().get(CommandAppProperties.APP_PROPERTY_STDIN.getValue());
     }
 
+    /**
+     * Set the standard input
+     * 
+     * @param stdin
+     */
     public void setStdin(String stdin)
     {
         if (stdin != null) {
@@ -106,41 +153,81 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the command timeout
+     * 
+     * @return
+     */
     public Integer getTimeout()
     {
         return (Integer) getProperties().get(CommandAppProperties.APP_PROPERTY_TOUT.getValue());
     }
 
+    /**
+     * Set the command timeout
+     * 
+     * @param timeout
+     */
     public void setTimeout(int timeout)
     {
         getProperties().put(CommandAppProperties.APP_PROPERTY_TOUT.getValue(), Integer.valueOf(timeout));
     }
 
+    /**
+     * Get the run asynchronously flag
+     * 
+     * @return
+     */
     public Boolean isRunAsync()
     {
         return (Boolean) getProperties().get(CommandAppProperties.APP_PROPERTY_ASYNC.getValue());
     }
 
+    /**
+     * Set the run asynchronously flag
+     * 
+     * @param runAsync
+     */
     public void setRunAsync(boolean runAsync)
     {
         getProperties().put(CommandAppProperties.APP_PROPERTY_ASYNC.getValue(), Boolean.valueOf(runAsync));
     }
 
+    /**
+     * Set the command
+     * 
+     * @param cmd
+     */
     public void setCommand(String cmd)
     {
         getProperties().put(CommandAppProperties.APP_PROPERTY_CMD.getValue(), cmd);
     }
 
+    /**
+     * Get the command
+     * 
+     * @return
+     */
     public String getCommand()
     {
         return (String) getProperties().get(CommandAppProperties.APP_PROPERTY_CMD.getValue());
     }
 
+    /**
+     * Set the password
+     * 
+     * @param password
+     */
     public void setPassword(String password)
     {
         getProperties().put(CommandAppProperties.APP_PROPERTY_PASSWORD.getValue(), password);
     }
 
+    /**
+     * Get the password
+     * 
+     * @return
+     */
     public String getPassword()
     {
         return (String) getProperties().get(CommandAppProperties.APP_PROPERTY_PASSWORD.getValue());

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.command.message.internal;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
+/**
+ * Device command response channel.
+ * 
+ * @since 1.0
+ * 
+ */
 public class CommandResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel
 {
 

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseMessage.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseMessage.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 
+/**
+ * Device command response message.
+ * 
+ * @since 1.0
+ * 
+ */
 public class CommandResponseMessage extends KapuaMessageImpl<CommandResponseChannel, CommandResponsePayload> implements KapuaResponseMessage<CommandResponseChannel, CommandResponsePayload>
 {
     private KapuaResponseCode responseCode;

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
@@ -15,48 +15,109 @@ package org.eclipse.kapua.service.device.management.command.message.internal;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaResponsePayloadImpl;
 
+/**
+ * Device command response payload.
+ * 
+ * @since 1.0
+ * 
+ */
 public class CommandResponsePayload extends KapuaResponsePayloadImpl implements KapuaPayload
 {
+    /**
+     * Standard error application property
+     */
     public static final String APP_PROPERTY_STDERR    = "kapua.cmd.stderr";
+
+    /**
+     * Standard output application property
+     */
     public static final String APP_PROPERTY_STDOUT    = "kapua.cmd.stdout";
+
+    /**
+     * Command exit code application property
+     */
     public static final String APP_PROPERTY_EXIT_CODE = "kapua.cmd.exit.code";
+
+    /**
+     * Command timed out application property
+     */
     public static final String APP_PROPERTY_TIMEDOUT  = "kapua.cmd.timedout";
 
+    /**
+     * Get the command standard error
+     * 
+     * @return
+     */
     public String getStderr()
     {
         return (String) getProperties().get(APP_PROPERTY_STDERR);
     }
 
+    /**
+     * Set the command standard error
+     * 
+     * @param stderr
+     */
     public void setStderr(String stderr)
     {
         getProperties().put(APP_PROPERTY_STDERR, stderr);
     }
 
+    /**
+     * Get the command standard output
+     * 
+     * @return
+     */
     public String getStdout()
     {
         return (String) getProperties().get(APP_PROPERTY_STDOUT);
     }
 
+    /**
+     * Set the command standard output
+     * 
+     * @param stdout
+     */
     public void setStdout(String stdout)
     {
         getProperties().put(APP_PROPERTY_STDOUT, stdout);
     }
 
+    /**
+     * Get the command exit code
+     * 
+     * @return
+     */
     public Integer getExitCode()
     {
         return (Integer) getProperties().get(APP_PROPERTY_EXIT_CODE);
     }
 
+    /**
+     * Get the command exit code
+     * 
+     * @param exitCode
+     */
     public void setExitCode(Integer exitCode)
     {
         getProperties().put(APP_PROPERTY_EXIT_CODE, exitCode);
     }
 
+    /**
+     * Get the command execution timed out flag
+     * 
+     * @return
+     */
     public Boolean hasTimedout()
     {
         return (Boolean) getProperties().get(APP_PROPERTY_TIMEDOUT);
     }
 
+    /**
+     * Set the command execution timed out flag
+     * 
+     * @param timedout
+     */
     public void setTimedout(boolean timedout)
     {
         getProperties().put(APP_PROPERTY_TIMEDOUT, timedout);

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceManagementDestinationBuilder.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceManagementDestinationBuilder.java
@@ -12,6 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.commons;
 
+/**
+ * Device management destination builder.
+ * 
+ * 
+ * @since 1.0
+ *
+ * @param <T> destination type
+ */
 @SuppressWarnings("unchecked")
 public class DeviceManagementDestinationBuilder<T>
 {
@@ -20,30 +28,60 @@ public class DeviceManagementDestinationBuilder<T>
     protected String assetId;
     protected String appId;
 
+    /**
+     * Add the topic prefix to the destination
+     * 
+     * @param topicPrefix
+     * @return
+     */
     public T withTopicPrefix(String topicPrefix)
     {
         this.topicPrefix = topicPrefix;
         return (T) this;
     }
 
+    /**
+     * Add the account name to the destination
+     * 
+     * @param accountName
+     * @return
+     */
     public T withAccountName(String accountName)
     {
         this.accountName = accountName;
         return (T) this;
     }
 
+    /**
+     * Add the asset identifier to the destination
+     * 
+     * @param assetId
+     * @return
+     */
     public T withAssetId(String assetId)
     {
         this.assetId = assetId;
         return (T) this;
     }
 
+    /**
+     * Add the application identifier to the destination
+     * 
+     * @param appId
+     * @return
+     */
     public T withAppId(String appId)
     {
         this.appId = appId;
         return (T) this;
     }
 
+    /**
+     * Provides a destination builder for the device request messages.
+     * 
+     * @since 1.0
+     *
+     */
     public static class Request extends DeviceManagementDestinationBuilder<Request>
     {
         /**
@@ -63,18 +101,35 @@ public class DeviceManagementDestinationBuilder<T>
         private String              method;
         private String[]            resources;
 
+        /**
+         * Add the request method to the destination
+         * 
+         * @param method
+         * @return
+         */
         public Request withMethod(String method)
         {
             this.method = method;
             return this;
         }
 
+        /**
+         * Add the resources to the destination
+         * 
+         * @param resources
+         * @return
+         */
         public Request withResources(String[] resources)
         {
             this.resources = resources;
             return this;
         }
 
+        /**
+         * Build the destination
+         * 
+         * @return
+         */
         public String build()
         {
             String resourcesToString = buildResourcesString();

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceManagementDomain.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceManagementDomain.java
@@ -12,8 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.commons;
 
+/**
+ * Device management domain
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceManagementDomain {
 	
+    /**
+     * Device management
+     */
     String DEVICE_MANAGEMENT = "device_management";
 
 }

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceManagementRequestTopic.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceManagementRequestTopic.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.commons;
 
+/**
+ * Device management request topic. (Marker interface)
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceManagementRequestTopic
 {
 

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/AbstractDeviceApplicationCallResponseHandler.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/AbstractDeviceApplicationCallResponseHandler.java
@@ -18,8 +18,25 @@ import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraRespo
 import org.eclipse.kapua.service.device.management.commons.exception.DeviceManagementErrorCodes;
 import org.eclipse.kapua.service.device.management.commons.exception.DeviceManagementException;
 
+/**
+ * Device application call response handler.<br>
+ * This handler gets the call response from a device and convert it to the expected object type.
+ * 
+ * @param <T> expected response type
+ * 
+ * @since 1.0
+ * 
+ */
 public abstract class AbstractDeviceApplicationCallResponseHandler<T>
 {
+
+    /**
+     * Handle the device reply and convert it to the proper type
+     * 
+     * @param responseMessage
+     * @return
+     * @throws DeviceManagementException
+     */
     @SuppressWarnings("rawtypes")
     public T handle(DeviceResponseMessage responseMessage)
         throws DeviceManagementException
@@ -55,10 +72,23 @@ public abstract class AbstractDeviceApplicationCallResponseHandler<T>
         return responseObject;
     }
 
+    /**
+     * Handle an accepted request reply
+     * 
+     * @param responseMessage
+     * @return
+     * @throws DeviceManagementException
+     */
     @SuppressWarnings("rawtypes")
     protected abstract T handleAcceptedRequest(DeviceResponseMessage responseMessage)
         throws DeviceManagementException;
 
+    /**
+     * Handle a bad request reply
+     * 
+     * @param responseMessage
+     * @throws DeviceManagementException
+     */
     @SuppressWarnings("rawtypes")
     protected void handleBadRequestReply(DeviceResponseMessage responseMessage)
         throws DeviceManagementException
@@ -73,6 +103,12 @@ public abstract class AbstractDeviceApplicationCallResponseHandler<T>
                                                            responsePayload.getExceptionStack() });
     }
 
+    /**
+     * Handle an internal error reply
+     * 
+     * @param responseMessage
+     * @throws DeviceManagementException
+     */
     @SuppressWarnings("rawtypes")
     protected void handleDeviceInternalErrorReply(DeviceResponseMessage responseMessage)
         throws DeviceManagementException
@@ -87,6 +123,12 @@ public abstract class AbstractDeviceApplicationCallResponseHandler<T>
                                                            responsePayload.getExceptionStack() });
     }
 
+    /**
+     * Handle a resource not found reply
+     * 
+     * @param responseMessage
+     * @throws DeviceManagementException
+     */
     @SuppressWarnings("rawtypes")
     protected void handleNotFoundReply(DeviceResponseMessage responseMessage)
         throws DeviceManagementException

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallExecutor.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallExecutor.java
@@ -28,23 +28,52 @@ import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 import org.eclipse.kapua.translator.Translator;
 
+/**
+ * Device call executor definition.<br>
+ * This object executes call, collecting the response from the device.
+ * 
+ * @param <C> request channel type
+ * @param <P> request payload type
+ * @param <RQ> request message type
+ * @param <RS> response message type
+ * 
+ * @since 1.0
+ * 
+ */
 @SuppressWarnings("rawtypes")
 public class DeviceCallExecutor<C extends KapuaRequestChannel, P extends KapuaRequestPayload, RQ extends KapuaRequestMessage<C, P>, RS extends KapuaResponseMessage>
 {
     private RQ   requestMessage;
     private Long timeout;
 
+    /**
+     * Constructor
+     * 
+     * @param requestMessage
+     */
     public DeviceCallExecutor(RQ requestMessage)
     {
         this(requestMessage, null);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param requestMessage
+     * @param timeout
+     */
     public DeviceCallExecutor(RQ requestMessage, Long timeout)
     {
         this.requestMessage = requestMessage;
         this.timeout = timeout;
     }
 
+    /**
+     * Performs the device call
+     * 
+     * @return
+     * @throws KapuaException
+     */
     @SuppressWarnings({ "unchecked" })
     public RS send()
         throws KapuaException

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementErrorCodes.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementErrorCodes.java
@@ -14,14 +14,38 @@ package org.eclipse.kapua.service.device.management.commons.exception;
 
 import org.eclipse.kapua.KapuaErrorCode;
 
+/**
+ * Device management error codes.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceManagementErrorCodes implements KapuaErrorCode
 {
+    /**
+     * Request exception
+     */
     REQUEST_EXCEPTION,
+    /**
+     * Bad request method
+     */
     REQUEST_BAD_METHOD,
 
+    /**
+     * Response parse exception
+     */
     RESPONSE_PARSE_EXCEPTION,
 
+    /**
+     * Bad request
+     */
     RESPONSE_BAD_REQUEST,
+    /**
+     * Response not found
+     */
     RESPONSE_NOT_FOUND,
+    /**
+     * Response internal error
+     */
     RESPONSE_INTERNAL_ERROR;
 }

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementException.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementException.java
@@ -14,22 +14,46 @@ package org.eclipse.kapua.service.device.management.commons.exception;
 
 import org.eclipse.kapua.KapuaException;
 
+/**
+ * Device management exception.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceManagementException extends KapuaException
 {
     private static final long   serialVersionUID     = -6207605695086240243L;
 
     private static final String KAPUA_ERROR_MESSAGES = "device-management-service-error-messages";
 
+    /**
+     * Constructor
+     * 
+     * @param code
+     */
     public DeviceManagementException(DeviceManagementErrorCodes code)
     {
         super(code);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param code
+     * @param arguments
+     */
     public DeviceManagementException(DeviceManagementErrorCodes code, Object... arguments)
     {
         super(code, arguments);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param code
+     * @param cause
+     * @param arguments
+     */
     public DeviceManagementException(DeviceManagementErrorCodes code, Throwable cause, Object... arguments)
     {
         super(code, cause, arguments);

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaAppChannelImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaAppChannelImpl.java
@@ -17,6 +17,12 @@ import java.util.List;
 import org.eclipse.kapua.service.device.management.KapuaAppChannel;
 import org.eclipse.kapua.service.device.management.KapuaAppProperties;
 
+/**
+ * Kapua application message channel implementation.<br>
+ * 
+ * @since 1.0
+ *
+ */
 public abstract class KapuaAppChannelImpl implements KapuaAppChannel
 {
 

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.message.internal.KapuaPayloadImpl;
 import org.eclipse.kapua.service.device.management.ResponseProperties;
 import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
 
+/**
+ * Kapua response message payload implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class KapuaResponsePayloadImpl extends KapuaPayloadImpl implements KapuaResponsePayload
 {
 

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSetting.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSetting.java
@@ -14,17 +14,36 @@ package org.eclipse.kapua.service.device.management.commons.setting;
 
 import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
 
+/**
+ * Class that offers access to device management settings
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceManagementSetting extends AbstractKapuaSetting<DeviceManagementSettingKey>
 {
+
+    /**
+     * Resource file from which source properties.
+     * 
+     */
     private static final String                  DEVICE_MANAGEMENT_SETTING_RESOURCE = "device-management-setting.properties";
 
     private static final DeviceManagementSetting instance                           = new DeviceManagementSetting();
 
+    /**
+     * Constructor
+     */
     private DeviceManagementSetting()
     {
         super(DEVICE_MANAGEMENT_SETTING_RESOURCE);
     }
 
+    /**
+     * Get a singleton instance of {@link DeviceManagementSetting}.
+     * 
+     * @return
+     */
     public static DeviceManagementSetting getInstance()
     {
         return instance;

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
@@ -14,19 +14,38 @@ package org.eclipse.kapua.service.device.management.commons.setting;
 
 import org.eclipse.kapua.commons.setting.SettingKey;
 
+/**
+ * Available settings key for device management service
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceManagementSettingKey implements SettingKey
 {
+
+    /**
+     * Character encoding
+     */
     CHAR_ENCODING("character.encoding"),
 
+    /**
+     * Request timeout
+     */
     REQUEST_TIMEOUT("request.timeout");
 
     private String key;
 
+    /**
+     * Constructor
+     * 
+     * @param key
+     */
     private DeviceManagementSettingKey(String key)
     {
         this.key = key;
     }
 
+    @Override
     public String key()
     {
         return key;

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
@@ -20,6 +20,12 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.eclipse.kapua.commons.configuration.metatype.XmlConfigPropertiesAdapter;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 
+/**
+ * Device component configuration entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "configuration")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = {
@@ -30,24 +36,64 @@ import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 }, factoryClass = DeviceConfigurationXmlRegistry.class, factoryMethod = "newComponentConfiguration")
 public interface DeviceComponentConfiguration
 {
+    /**
+     * Get device configuration component identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "id")
     public String getId();
 
+    /**
+     * Set device configuration component identifier
+     * 
+     * @param Id
+     */
     public void setId(String Id);
 
+    /**
+     * Get device configuration component name
+     * 
+     * @return
+     */
     @XmlAttribute(name = "name")
     public String getName();
 
+    /**
+     * Set device configuration component name
+     * 
+     * @param unescapedComponentName
+     */
     public void setName(String unescapedComponentName);
 
+    /**
+     * Get device configuration component definition
+     * 
+     * @return
+     */
     @XmlElement(name = "definition")
     public KapuaTocd getDefinition();
 
+    /**
+     * Set device configuration component definition
+     * 
+     * @param definition
+     */
     public void setDefinition(KapuaTocd definition);
 
+    /**
+     * Get device configuration component properties
+     * 
+     * @return
+     */
     @XmlElement(name = "properties")
     @XmlJavaTypeAdapter(XmlConfigPropertiesAdapter.class)
     public Map<String, Object> getProperties();
 
+    /**
+     * Set device configuration component properties
+     * 
+     * @param properties
+     */
     public void setProperties(Map<String, Object> properties);
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
@@ -22,10 +22,22 @@ import javax.xml.bind.annotation.XmlElement;
 
 import org.eclipse.kapua.KapuaSerializable;
 
+/**
+ * Device configuration entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "configurations")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceConfigurationXmlRegistry.class, factoryMethod = "newConfiguration")
 public interface DeviceConfiguration extends KapuaSerializable {
+
+    /**
+     * Get the device component configuration list
+     * 
+     * @return
+     */
     @XmlElement(name = "configuration")
     public <C extends DeviceComponentConfiguration> List<C> getComponentConfigurations();
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
@@ -14,9 +14,26 @@ package org.eclipse.kapua.service.device.management.configuration;
 
 import org.eclipse.kapua.model.KapuaObjectFactory;
 
+/**
+ * Device configuration entity service factory definition.
+ *
+ * @since 1.0
+ * 
+ */
 public interface DeviceConfigurationFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new {@link DeviceComponentConfiguration} using the given component configuration identifier
+     * 
+     * @return
+     */
     public DeviceComponentConfiguration newComponentConfigurationInstance(String componentConfigurationId);
 
+    /**
+     * Creates a new {@link DeviceConfiguration}
+     * 
+     * @return
+     */
     public DeviceConfiguration newConfigurationInstance();
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
@@ -16,8 +16,26 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 
+/**
+ * Device configuration service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceConfigurationManagementService extends KapuaService
 {
+
+    /**
+     * Get the device configuration for the given device identifier and configuration identifier
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param configurationId
+     * @param configurationComponentPid
+     * @param timeout timeout waiting for the device response
+     * @return
+     * @throws KapuaException
+     */
     public DeviceConfiguration get(KapuaId scopeId,
                                    KapuaId deviceId,
                                    String configurationId,
@@ -25,12 +43,39 @@ public interface DeviceConfigurationManagementService extends KapuaService
                                    Long timeout)
         throws KapuaException;
 
-    public void put(KapuaId scopeId, KapuaId deviceId, String deviceConfig, Long timeout)
+    /**
+     * Put the provided configuration to the device identified by the provided device identifier
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param xmlDeviceConfig xml marshalled device configuration
+     * @param timeout timeout waiting for the device response
+     * @throws KapuaException
+     */
+    public void put(KapuaId scopeId, KapuaId deviceId, String xmlDeviceConfig, Long timeout)
         throws KapuaException;
 
+    /**
+     * Put the provided configuration to the device identified by the provided device identifier
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param deviceConfig
+     * @param timeout timeout waiting for the device response
+     * @throws KapuaException
+     */
     public void put(KapuaId scopeId, KapuaId deviceId, DeviceConfiguration deviceConfig, Long timeout)
         throws KapuaException;
 
+    /**
+     * Put the provided configuration to the device identified by the provided device identifier
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param deviceComponentConfig
+     * @param timeout timeout waiting for the device response
+     * @throws KapuaException
+     */
     public void put(KapuaId scopeId, KapuaId deviceId, DeviceComponentConfiguration deviceComponentConfig, Long timeout)
         throws KapuaException;
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
@@ -4,16 +4,33 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 import org.eclipse.kapua.locator.KapuaLocator;
 
+/**
+ * Device bundle xml factory class
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRegistry
 public class DeviceConfigurationXmlRegistry {
+
     private final KapuaLocator locator = KapuaLocator.getInstance();
     private final DeviceConfigurationFactory factory = locator.getFactory(DeviceConfigurationFactory.class);
 
+    /**
+     * Creates a new device configuration
+     * 
+     * @return
+     */
     public DeviceConfiguration newConfiguration()
     {
         return factory.newConfigurationInstance();
     }
     
+    /**
+     * Creates a new device component configuration
+     * 
+     * @return
+     */
     public DeviceComponentConfiguration newComponentConfiguration()
     {
         return factory.newComponentConfigurationInstance(null);

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
@@ -19,6 +19,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * Device snapshot entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "snapshot")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "id", 
@@ -27,13 +33,33 @@ import javax.xml.bind.annotation.XmlType;
         factoryMethod = "newDeviceSnapshot")
 public interface DeviceSnapshot {
     
+    /**
+     * Get the snapshot identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "id")
     public String getId();
     
+    /**
+     * Set the snapshot identifier
+     * 
+     * @param id
+     */
     public void setId(String id);
 
+    /**
+     * Get the snapshot timestamp
+     * 
+     * @return
+     */
     @XmlElement(name = "timestamp")
     public Long getTimestamp();
     
+    /**
+     * Set the snapshot timestamp
+     * 
+     * @param timestamp
+     */
     public void setTimestamp(Long timestamp);
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotFactory.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotFactory.java
@@ -14,9 +14,26 @@ package org.eclipse.kapua.service.device.management.snapshot;
 
 import org.eclipse.kapua.model.KapuaObjectFactory;
 
+/**
+ * Device snapshot entity service factory definition.
+ *
+ * @since 1.0
+ * 
+ */
 public interface DeviceSnapshotFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new {@link DeviceSnapshot}
+     * 
+     * @return
+     */
     public DeviceSnapshot newDeviceSnapshot();
 
+    /**
+     * Creates a new {@link DeviceSnapshots}
+     * 
+     * @return
+     */
     public DeviceSnapshots newDeviceSnapshots();
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotManagementService.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotManagementService.java
@@ -16,11 +16,36 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 
+/**
+ * Device snapshot service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceSnapshotManagementService extends KapuaService
 {
+
+    /**
+     * Get the device snapshots list for the the provided device identifier
+     * 
+     * @param scopeId
+     * @param deviceid
+     * @param timeout timeout waiting for the device response
+     * @return
+     * @throws KapuaException
+     */
     public DeviceSnapshots get(KapuaId scopeId, KapuaId deviceid, Long timeout)
         throws KapuaException;
 
+    /**
+     * Rollback the device configuration to the device snapshot identified by the provided snapshot identifier
+     * 
+     * @param scopeId
+     * @param deviceid
+     * @param snapshotId
+     * @param timeout timeout waiting for the device response
+     * @throws KapuaException
+     */
     public void rollback(KapuaId scopeId, KapuaId deviceid, String snapshotId, Long timeout)
         throws KapuaException;
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
@@ -4,15 +4,32 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 import org.eclipse.kapua.locator.KapuaLocator;
 
+/**
+ * Device bundle xml factory class
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRegistry
 public class DeviceSnapshotXmlRegistry {
+
     private final KapuaLocator locator = KapuaLocator.getInstance();
     private final DeviceSnapshotFactory factory = locator.getFactory(DeviceSnapshotFactory.class);
     
+    /**
+     * Creates a new device snapshots list
+     * 
+     * @return
+     */
     public DeviceSnapshots newDeviceSnapshots() {
         return factory.newDeviceSnapshots();
     }
     
+    /**
+     * Creates a new device snapshot
+     * 
+     * @return
+     */
     public DeviceSnapshot newDeviceSnapshot() {
         return factory.newDeviceSnapshot();
     }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
@@ -22,6 +22,13 @@ import javax.xml.bind.annotation.XmlType;
 
 import org.eclipse.kapua.KapuaSerializable;
 
+/**
+ * Device snapshots entity definition.<br>
+ * This entity manages a list of {@link DeviceSnapshot}
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "snapshots")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "snapshots" },
@@ -29,6 +36,12 @@ import org.eclipse.kapua.KapuaSerializable;
         factoryMethod = "newDeviceSnapshots")
 public interface DeviceSnapshots extends KapuaSerializable
 {
+
+    /**
+     * Get the device snapshot list
+     * 
+     * @return
+     */
     @XmlElement(name="snapshotId")
     public List<DeviceSnapshot> getSnapshots();
 }

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceComponentConfigurationImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceComponentConfigurationImpl.java
@@ -14,18 +14,16 @@ package org.eclipse.kapua.service.device.management.configuration.internal;
 
 import java.util.Map;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementRef;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import org.eclipse.kapua.commons.configuration.metatype.TocdImpl;
-import org.eclipse.kapua.commons.configuration.metatype.XmlConfigPropertiesAdapter;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.service.device.management.configuration.DeviceComponentConfiguration;
 
+/**
+ * Device component configuration entity implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceComponentConfigurationImpl implements DeviceComponentConfiguration
 {
     private String              id;
@@ -33,10 +31,18 @@ public class DeviceComponentConfigurationImpl implements DeviceComponentConfigur
     private TocdImpl            definition;
     private Map<String, Object> properties;
 
+    /**
+     * Constructor
+     */
     public DeviceComponentConfigurationImpl()
     {
     }
 
+    /**
+     * Constructor
+     * 
+     * @param id
+     */
     public DeviceComponentConfigurationImpl(String id)
     {
         this.id = id;

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationAppProperties.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationAppProperties.java
@@ -14,9 +14,22 @@ package org.eclipse.kapua.service.device.management.configuration.internal;
 
 import org.eclipse.kapua.service.device.management.KapuaAppProperties;
 
+/**
+ * /**
+ * Device application configuration properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceConfigurationAppProperties implements KapuaAppProperties
 {
-    APP_NAME("CONFIGURATION"), 
+    /**
+     * Application name
+     */
+    APP_NAME("CONFIGURATION"),
+    /**
+     * Application version
+     */
     APP_VERSION("1.0.0"),
     ;
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationFactoryImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationFactoryImpl.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.service.device.management.configuration.DeviceComponent
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory;
 
+/**
+ * Device configuration entity service factory implementation.
+ *
+ * @since 1.0
+ * 
+ */
 public class DeviceConfigurationFactoryImpl implements DeviceConfigurationFactory
 {
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationImpl.java
@@ -15,11 +15,14 @@ package org.eclipse.kapua.service.device.management.configuration.internal;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration;
 
+/**
+ * Device configuration entity implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceConfigurationImpl implements DeviceConfiguration
 {
     private List<DeviceComponentConfigurationImpl> configurations;

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -49,6 +49,12 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 import org.xml.sax.SAXException;
 
+/**
+ * Device configuration service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceConfigurationManagementServiceImpl implements DeviceConfigurationManagementService {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestChannel.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestChannel.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.service.device.management.KapuaMethod;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
 
+/**
+ * Device configuration request channel.
+ * 
+ * @since 1.0
+ * 
+ */
 public class ConfigurationRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel
 {
     private KapuaMethod method;
@@ -34,21 +40,41 @@ public class ConfigurationRequestChannel extends KapuaAppChannelImpl implements 
         this.method = method;
     }
 
+    /**
+     * Get the device configuration identifier
+     * 
+     * @return
+     */
     public String getConfigurationId()
     {
         return configurationId;
     }
 
+    /**
+     * Set the device configuration identifier
+     * 
+     * @param configurationId
+     */
     public void setConfigurationId(String configurationId)
     {
         this.configurationId = configurationId;
     }
 
+    /**
+     * Get the device configuration component identifier
+     * 
+     * @return
+     */
     public String getComponentId()
     {
         return componentId;
     }
 
+    /**
+     * Set the device configuration component identifier
+     * 
+     * @param componentId
+     */
     public void setComponentId(String componentId)
     {
         this.componentId = componentId;

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestMessage.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestMessage.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.configuration.message.intern
 import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
 
+/**
+ * Device configuration request message.
+ * 
+ * @since 1.0
+ * 
+ */
 public class ConfigurationRequestMessage extends KapuaMessageImpl<ConfigurationRequestChannel, ConfigurationRequestPayload>
                                          implements KapuaRequestMessage<ConfigurationRequestChannel, ConfigurationRequestPayload>
 {

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestPayload.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestPayload.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.configuration.message.intern
 import org.eclipse.kapua.message.internal.KapuaPayloadImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
 
+/**
+ * Device configuration request payload.
+ * 
+ * @since 1.0
+ * 
+ */
 public class ConfigurationRequestPayload extends KapuaPayloadImpl implements KapuaRequestPayload
 {
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.configuration.message.intern
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
+/**
+ * Device configuration response channel.
+ * 
+ * @since 1.0
+ * 
+ */
 public class ConfigurationResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel
 {
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseMessage.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseMessage.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 
+/**
+ * Device configuration response message.
+ * 
+ * @since 1.0
+ * 
+ */
 public class ConfigurationResponseMessage extends KapuaMessageImpl<ConfigurationResponseChannel, ConfigurationResponsePayload>
                                           implements KapuaResponseMessage<ConfigurationResponseChannel, ConfigurationResponsePayload>
 {

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponsePayload.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponsePayload.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.configuration.message.intern
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaResponsePayloadImpl;
 
+/**
+ * Device configuration response payload.
+ * 
+ * @since 1.0
+ * 
+ */
 public class ConfigurationResponsePayload extends KapuaResponsePayloadImpl implements KapuaPayload
 {
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotRequestChannel.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotRequestChannel.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.service.device.management.KapuaMethod;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
 
+/**
+ * Device snapshot request channel.
+ * 
+ * @since 1.0
+ * 
+ */
 public class SnapshotRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel
 {
     private KapuaMethod method;
@@ -33,11 +39,21 @@ public class SnapshotRequestChannel extends KapuaAppChannelImpl implements Kapua
         this.method = method;
     }
 
+    /**
+     * Get the snapshot identifier
+     * 
+     * @return
+     */
     public String getSnapshotId()
     {
         return snapshotId;
     }
 
+    /**
+     * Set the snapshot identifier
+     * 
+     * @param snapshotId
+     */
     public void setSnapshotId(String snapshotId)
     {
         this.snapshotId = snapshotId;

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotRequestMessage.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotRequestMessage.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.configuration.snapshot.inter
 import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
 
+/**
+ * Device snapshot request message.
+ * 
+ * @since 1.0
+ * 
+ */
 public class SnapshotRequestMessage extends KapuaMessageImpl<SnapshotRequestChannel, SnapshotRequestPayload>implements KapuaRequestMessage<SnapshotRequestChannel, SnapshotRequestPayload>
 {
     @SuppressWarnings("unchecked")

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotRequestPayload.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotRequestPayload.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.configuration.snapshot.inter
 import org.eclipse.kapua.message.internal.KapuaPayloadImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
 
+/**
+ * Device snapshot request payload.
+ * 
+ * @since 1.0
+ * 
+ */
 public class SnapshotRequestPayload extends KapuaPayloadImpl implements KapuaRequestPayload
 {
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotResponseChannel.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotResponseChannel.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.configuration.snapshot.inter
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
+/**
+ * Device snapshot response channel.
+ * 
+ * @since 1.0
+ * 
+ */
 public class SnapshotResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel
 {
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotResponseMessage.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotResponseMessage.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 
+/**
+ * Device snapshot response message.
+ * 
+ * @since 1.0
+ * 
+ */
 public class SnapshotResponseMessage extends KapuaMessageImpl<SnapshotResponseChannel, SnapshotResponsePayload>implements KapuaResponseMessage<SnapshotResponseChannel, SnapshotResponsePayload>
 {
     private KapuaResponseCode responseCode;

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotResponsePayload.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotResponsePayload.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.management.configuration.snapshot.inter
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaResponsePayloadImpl;
 
+/**
+ * Device snapshot response payload.
+ * 
+ * @since 1.0
+ * 
+ */
 public class SnapshotResponsePayload extends KapuaResponsePayloadImpl implements KapuaPayload
 {
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotAppProperties.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotAppProperties.java
@@ -14,9 +14,21 @@ package org.eclipse.kapua.service.device.management.snapshot.internal;
 
 import org.eclipse.kapua.service.device.management.KapuaAppProperties;
 
+/**
+ * Device snapshot properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceSnapshotAppProperties implements KapuaAppProperties
 {
+    /**
+     * Application name
+     */
 	APP_NAME("SNAPSHOT"),
+    /**
+     * Application version
+     */
     APP_VERSION("1.0.0"),
     ;
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotFactoryImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotFactoryImpl.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshot;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshots;
 
+/**
+ * Device snapshot entity service factory implementation.
+ *
+ * @since 1.0
+ * 
+ */
 public class DeviceSnapshotFactoryImpl implements DeviceSnapshotFactory
 {
 

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotImpl.java
@@ -15,7 +15,14 @@ package org.eclipse.kapua.service.device.management.snapshot.internal;
 
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshot;
 
+/**
+ * Device snapshot entity implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceSnapshotImpl implements DeviceSnapshot {
+
     private String id;
     private Long timestamp;
     

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
@@ -41,6 +41,12 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 
+/**
+ * Device snapshot service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceSnapshotManagementServiceImpl implements DeviceSnapshotManagementService {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotsImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotsImpl.java
@@ -21,12 +21,21 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshot;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshots;
 
+/**
+ * Device snapshots entity implementation.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "snapshotIds")
 public class DeviceSnapshotsImpl implements DeviceSnapshots
 {
     @XmlElement(name = "snapshotId")
     List<DeviceSnapshot> snapshotIds;
 
+    /**
+     * Constructor
+     */
     public DeviceSnapshotsImpl()
     {
         super();

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageFactory.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageFactory.java
@@ -9,25 +9,66 @@ import org.eclipse.kapua.service.device.management.packages.model.download.Devic
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 
+/**
+ * Device package service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DevicePackageFactory extends KapuaObjectFactory {
 
+    /**
+     * Creates a new {@link DevicePackages}
+     * 
+     * @return
+     */
     public DevicePackages newDeviceDeploymentPackages();
 
+    /**
+     * Creates a new {@link DevicePackage}
+     * 
+     * @return
+     */
     public DevicePackage newDeviceDeploymentPackage();
 
+    /**
+     * Creates a new device package bundle information
+     * 
+     * @return
+     */
     public DevicePackageBundleInfo newDevicePackageBundleInfo();
     
+    /**
+     * Creates a new device package bundle informations
+     * 
+     * @return
+     */
     public DevicePackageBundleInfos newDevicePackageBundleInfos();
 
     //
     // Download operation
     //
+    /**
+     * Creates a new device package download request
+     * 
+     * @return
+     */
     public DevicePackageDownloadRequest newPackageDownloadRequest();
 
+    /**
+     * Creates a new device package download operation
+     * 
+     * @return
+     */
     public DevicePackageDownloadOperation newPackageDownloadOperation();
 
     //
     // Uninstall operation
     //
+    /**
+     * Creates a new device package uninstall request
+     * 
+     * @return
+     */
     public DevicePackageUninstallRequest newPackageUninstallRequest();
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
@@ -23,29 +23,107 @@ import org.eclipse.kapua.service.device.management.packages.model.install.Device
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOperation;
 
+/**
+ * Device package service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DevicePackageManagementService extends KapuaService
 {
+
+    /**
+     * Get the installed packages list
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public DevicePackages getInstalled(KapuaId scopeId, KapuaId deviceId, Long timeout)
         throws KapuaException;
 
+    /**
+     * Starts a download package operation
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param packageDownloadRequest
+     * @param timeout
+     * @throws KapuaException
+     */
     public void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, Long timeout)
         throws KapuaException;
 
+    /**
+     * Interrupt a download package operation
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param timeout
+     * @throws KapuaException
+     */
     public void downloadStop(KapuaId scopeId, KapuaId deviceId, Long timeout)
         throws KapuaException;
 
+    /**
+     * Gets the download package status
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public DevicePackageDownloadOperation downloadStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
         throws KapuaException;
 
+    /**
+     * Installs a package
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param packageInstallRequest
+     * @param timeout
+     * @throws KapuaException
+     */
     public void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, Long timeout)
         throws KapuaException;
 
+    /**
+     * Gets the package installation status
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public DevicePackageInstallOperation installStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
         throws KapuaException;
 
+    /**
+     * Uninstalls a package
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param packageUninstallRequest
+     * @param timeout
+     * @throws KapuaException
+     */
     public void uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, Long timeout)
         throws KapuaException;
 
+    /**
+     * Gets the package uninstallation status
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param timeout
+     * @return
+     * @throws KapuaException
+     */
     public DevicePackageUninstallOperation uninstallStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
         throws KapuaException;
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.model;
 
-import org.eclipse.kapua.KapuaSerializable;
-
 import java.util.Date;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -22,6 +20,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * Device package definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "devicePackage")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "name",
@@ -30,21 +34,56 @@ import javax.xml.bind.annotation.XmlType;
         "installDate" }, factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newDevicePackage")
 public interface DevicePackage {
 
+    /**
+     * Get the package name
+     * 
+     * @return
+     */
     @XmlElement(name = "name")
     public String getName();
 
+    /**
+     * Set the package name
+     * 
+     * @param dpName
+     */
     public void setName(String dpName);
 
+    /**
+     * Get the package version
+     * 
+     * @return
+     */
     @XmlElement(name = "version")
     public String getVersion();
 
+    /**
+     * Set the package version
+     * 
+     * @param dpVersion
+     */
     public void setVersion(String dpVersion);
 
+    /**
+     * Get device package bundle informations
+     * 
+     * @return
+     */
     @XmlElement(name = "bundleInfos")
     public <B extends DevicePackageBundleInfos> B getBundleInfos();
 
+    /**
+     * Get the installation date
+     * 
+     * @return
+     */
     @XmlElement(name = "installDate")
     public Date getInstallDate();
 
+    /**
+     * Set the installation date
+     * 
+     * @param installDate
+     */
     public void setInstallDate(Date installDate);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfo.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfo.java
@@ -6,18 +6,44 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * Device package bundle information definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "devicePackageBundleInfo")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newDevicePackageBundleInfo")
 public interface DevicePackageBundleInfo {
 
+    /**
+     * Get the package bundle name
+     * 
+     * @return
+     */
     @XmlElement(name = "name")
     public String getName();
 
+    /**
+     * Set the package bundle name
+     * 
+     * @param name
+     */
     public void setName(String name);
 
+    /**
+     * Get the package bundle version
+     * 
+     * @return
+     */
     @XmlElement(name = "version")
     public String getVersion();
 
+    /**
+     * Set the package bundle version
+     * 
+     * @param version
+     */
     public void setVersion(String version);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfos.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfos.java
@@ -4,9 +4,21 @@ import java.util.List;
 
 import javax.xml.bind.annotation.*;
 
+/**
+ * Package bundle informations list container definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newDevicePackageBundleInfos")
 public interface DevicePackageBundleInfos {
+
+    /**
+     * Get the device package bundle informations
+     * 
+     * @return
+     */
     @XmlElement(name = "bundleInfo")
     public <B extends DevicePackageBundleInfo> List<B> getBundlesInfos();
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageXmlRegistry.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageXmlRegistry.java
@@ -20,28 +20,71 @@ import org.eclipse.kapua.service.device.management.packages.DevicePackageFactory
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 
+/**
+ * Device package xml factory class
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRegistry
 public class DevicePackageXmlRegistry {
+
     private final KapuaLocator locator = KapuaLocator.getInstance();
     private final DevicePackageFactory factory = locator.getFactory(DevicePackageFactory.class);
     
+    /**
+     * Creates a new device package instance
+     * 
+     * @return
+     */
     public DevicePackage newDevicePackage() {
         return factory.newDeviceDeploymentPackage();
     }
     
+    /**
+     * Creates a new device packages instance
+     * 
+     * @return
+     */
     public DevicePackages newDevicePackages() {
         return factory.newDeviceDeploymentPackages();
     }
     
+    /**
+     * Creates a new device package bundle information instance
+     * 
+     * @return
+     */
     public DevicePackageBundleInfo newDevicePackageBundleInfo() {
         return factory.newDevicePackageBundleInfo();
     }
     
+    /**
+     * Creates a new device package bundle informations instance
+     * 
+     * @return
+     */
     public DevicePackageBundleInfos newDevicePackageBundleInfos() {
         return factory.newDevicePackageBundleInfos();
     }
 
-    public DevicePackageDownloadRequest newDevicePackageDownloadRequest() { return factory.newPackageDownloadRequest(); }
+    /**
+     * Creates a new device package download request instance
+     * 
+     * @return
+     */
+    public DevicePackageDownloadRequest newDevicePackageDownloadRequest()
+    {
+        return factory.newPackageDownloadRequest();
+    }
 
-    public DevicePackageUninstallRequest newDevicePackageUninstallRequest() { return factory.newPackageUninstallRequest(); }
+    /**
+     * Creates a new device package uninstall request instance
+     * 
+     * @return
+     */
+    public DevicePackageUninstallRequest newDevicePackageUninstallRequest()
+    {
+        return factory.newPackageUninstallRequest();
+    }
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackages.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackages.java
@@ -22,10 +22,22 @@ import javax.xml.bind.annotation.XmlType;
 
 import java.util.List;
 
+/**
+ * Device packages list container definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "devicePackages")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newDevicePackages")
 public interface DevicePackages extends KapuaSerializable {
+
+    /**
+     * Get the device package list
+     * 
+     * @return
+     */
     @XmlElement(name = "devicePackage")
     public <D extends DevicePackage> List<D> getPackages();
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
@@ -2,21 +2,68 @@ package org.eclipse.kapua.service.device.management.packages.model.download;
 
 import org.eclipse.kapua.model.id.KapuaId;
 
+/**
+ * Device download package operation entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DevicePackageDownloadOperation {
 
+    /**
+     * Get the download package identifier
+     * 
+     * @return
+     */
     public KapuaId getId();
 
+    /**
+     * Set the download package identifier
+     * 
+     * @param id
+     */
     public void setId(KapuaId id);
 
+    /**
+     * Get the package size
+     * 
+     * @return
+     */
     public Integer getSize();
 
+    /**
+     * Set the package size
+     * 
+     * @param downloadSize
+     */
     public void setSize(Integer downloadSize);
 
+    /**
+     * Get the download progress
+     * 
+     * @return
+     */
     public Integer getProgress();
 
+    /**
+     * Set the download progress
+     * 
+     * @param downloadProgress
+     */
     public void setProgress(Integer downloadProgress);
 
+    /**
+     * Get the download status
+     * 
+     * @return
+     */
     public DevicePackageDownloadStatus getStatus();
 
+    /**
+     * Set the download status
+     * 
+     * @param status
+     */
     public void setStatus(DevicePackageDownloadStatus status);
+
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadRequest.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadRequest.java
@@ -5,6 +5,12 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackageX
 import javax.xml.bind.annotation.*;
 import java.net.URI;
 
+/**
+ * Device package download request definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "downloadRequest")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = {
@@ -18,33 +24,94 @@ import java.net.URI;
         factoryMethod = "newDevicePackageDownloadRequest")
 public interface DevicePackageDownloadRequest
 {
+
+    /**
+     * Get the download URI
+     * 
+     * @return
+     */
     @XmlElement(name = "uri")
     public URI getURI();
 
+    /**
+     * Set the download URI
+     * 
+     * @param uri
+     */
     public void setURI(URI uri);
 
+    /**
+     * Get the package name
+     * 
+     * @return
+     */
     @XmlElement(name = "name")
     public String getName();
 
+    /**
+     * Set the package name
+     * 
+     * @param name
+     */
     public void setName(String name);
 
+    /**
+     * Get the package version
+     * 
+     * @return
+     */
     @XmlElement(name = "version")
     public String getVersion();
 
+    /**
+     * Set the package version
+     * 
+     * @param version
+     */
     public void setVersion(String version);
 
+    /**
+     * Get the package installed flag
+     * 
+     * @return
+     */
     @XmlElement(name = "install")
     public Boolean isInstall();
 
+    /**
+     * Set the package installed flag
+     * 
+     * @param install
+     */
     public void setInstall(Boolean install);
 
+    /**
+     * Get the device reboot flag
+     * 
+     * @return
+     */
     @XmlElement(name = "reboot")
     public Boolean isReboot();
 
+    /**
+     * Set the device reboot flag
+     * 
+     * @param reboot
+     */
     public void setReboot(Boolean reboot);
 
+    /**
+     * Get the reboot delay
+     * 
+     * @return
+     */
     @XmlElement(name = "rebootDelay")
     public Integer getRebootDelay();
 
+    /**
+     * Set the reboot delay
+     * 
+     * @param rebootDelay
+     */
     public void setRebootDelay(Integer rebootDelay);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadStatus.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadStatus.java
@@ -1,8 +1,23 @@
 package org.eclipse.kapua.service.device.management.packages.model.download;
 
+/**
+ * Device package download status.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DevicePackageDownloadStatus
 {
+    /**
+     * In progress
+     */
     IN_PROGRESS,
+    /**
+     * Completed
+     */
     COMPLETED,
+    /**
+     * Failed
+     */
     FAILED
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
@@ -2,21 +2,67 @@ package org.eclipse.kapua.service.device.management.packages.model.install;
 
 import org.eclipse.kapua.model.id.KapuaId;
 
+/**
+ * Device package install operation entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DevicePackageInstallOperation {
 
+    /**
+     * Get the package identifier
+     * 
+     * @return
+     */
     public KapuaId getId();
 
+    /**
+     * Set the package identifier
+     * 
+     * @param id
+     */
     public void setId(KapuaId id);
 
+    /**
+     * Get the package name
+     * 
+     * @return
+     */
     public String getName();
 
+    /**
+     * Set the package name
+     * 
+     * @param packageName
+     */
     public void setName(String packageName);
 
+    /**
+     * Get the package version
+     * 
+     * @return
+     */
     public String getVersion();
 
+    /**
+     * Set the package version
+     * 
+     * @param version
+     */
     public void setVersion(String version);
 
+    /**
+     * Get the package install status
+     * 
+     * @return
+     */
     public DevicePackageInstallStatus getStatus();
 
+    /**
+     * Set the package install status
+     * 
+     * @param status
+     */
     public void setStatus(DevicePackageInstallStatus status);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
@@ -1,20 +1,66 @@
 package org.eclipse.kapua.service.device.management.packages.model.install;
 
+/**
+ * Device package install request definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DevicePackageInstallRequest {
 
+    /**
+     * Get the package name
+     * 
+     * @return
+     */
     public String getName();
 
+    /**
+     * Set the package name
+     * 
+     * @param name
+     */
     public void setName(String name);
 
+    /**
+     * Get the package version
+     * 
+     * @return
+     */
     public String getVersion();
 
+    /**
+     * Set the package version
+     * 
+     * @param version
+     */
     public void setVersion(String version);
 
+    /**
+     * Get the device reboot flag
+     * 
+     * @return
+     */
     public Boolean isReboot();
 
+    /**
+     * Set the device reboot flag
+     * 
+     * @param reboot
+     */
     public void setReboot(Boolean reboot);
 
+    /**
+     * Get the reboot delay
+     * 
+     * @return
+     */
     public Integer getRebootDelay();
 
+    /**
+     * Set the reboot delay
+     * 
+     * @param rebootDelay
+     */
     public void setRebootDelay(Integer rebootDelay);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallStatus.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallStatus.java
@@ -1,8 +1,23 @@
 package org.eclipse.kapua.service.device.management.packages.model.install;
 
+/**
+ * Device package install status.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DevicePackageInstallStatus
 {
+    /**
+     * In progress
+     */
     IN_PROGRESS,
+    /**
+     * Completed
+     */
     COMPLETED,
+    /**
+     * Failed
+     */
     FAILED
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
@@ -2,21 +2,67 @@ package org.eclipse.kapua.service.device.management.packages.model.uninstall;
 
 import org.eclipse.kapua.model.id.KapuaId;
 
+/**
+ * Device package uninstall operation entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DevicePackageUninstallOperation {
 
+    /**
+     * Get the package identifier
+     * 
+     * @return
+     */
     public KapuaId getId();
 
+    /**
+     * Set the package identifier
+     * 
+     * @param id
+     */
     public void setId(KapuaId id);
 
+    /**
+     * Get the package name
+     * 
+     * @return
+     */
     public String getName();
 
+    /**
+     * Set the package name
+     * 
+     * @param packageName
+     */
     public void setName(String packageName);
 
+    /**
+     * Get the package version
+     * 
+     * @return
+     */
     public String getVersion();
 
+    /**
+     * Set the package version
+     * 
+     * @param version
+     */
     public void setVersion(String version);
 
+    /**
+     * Get the package uninstall status
+     * 
+     * @return
+     */
     public DevicePackageUninstallStatus getStatus();
 
+    /**
+     * Set the package uninstall status
+     * 
+     * @param status
+     */
     public void setStatus(DevicePackageUninstallStatus status);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
@@ -4,6 +4,12 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackageX
 
 import javax.xml.bind.annotation.*;
 
+/**
+ * Device package uninstall request definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "uninstallRequest")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = {
@@ -15,23 +21,63 @@ import javax.xml.bind.annotation.*;
         factoryMethod = "newDevicePackageUninstallRequest")
 public interface DevicePackageUninstallRequest {
 
+    /**
+     * Get package name
+     * 
+     * @return
+     */
     @XmlElement(name = "name")
     public String getName();
 
+    /**
+     * Set package name
+     * 
+     * @param name
+     */
     public void setName(String name);
 
+    /**
+     * Get package version
+     * 
+     * @return
+     */
     @XmlElement(name = "version")
     public String getVersion();
 
+    /**
+     * Set package version
+     * 
+     * @param version
+     */
     public void setVersion(String version);
 
+    /**
+     * Get the device reboot flag
+     * 
+     * @return
+     */
     @XmlElement(name = "reboot")
     public Boolean isReboot();
 
+    /**
+     * Set the device reboot flag
+     * 
+     * @param reboot
+     */
     public void setReboot(Boolean reboot);
 
+    /**
+     * Get the reboot delay
+     * 
+     * @return
+     */
     @XmlElement(name = "rebootDelay")
     public Integer getRebootDelay();
 
+    /**
+     * Set the reboot delay
+     * 
+     * @param rebootDelay
+     */
     public void setRebootDelay(Integer rebootDelay);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallStatus.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallStatus.java
@@ -1,8 +1,23 @@
 package org.eclipse.kapua.service.device.management.packages.model.uninstall;
 
+/**
+ * Device package uninstall status.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DevicePackageUninstallStatus
 {
+    /**
+     * In progress
+     */
     IN_PROGRESS,
+    /**
+     * Completed
+     */
     COMPLETED,
+    /**
+     * Failed
+     */
     FAILED
 }

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.service.device.management.packages.model.internal.Devic
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.internal.DevicePackageUninstallRequestImpl;
 
+/**
+ * Device package service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePackageFactoryImpl implements DevicePackageFactory {
 
     @Override

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -53,6 +53,12 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 import org.eclipse.kapua.service.generator.id.IdGeneratorService;
 
+/**
+ * Device package service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePackageManagementServiceImpl implements DevicePackageManagementService {
 
     @Override

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageAppProperties.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageAppProperties.java
@@ -2,33 +2,88 @@ package org.eclipse.kapua.service.device.management.packages.message.internal;
 
 import org.eclipse.kapua.service.device.management.KapuaAppProperties;
 
+/**
+ * Device application properties definition.
+ * 
+ * @since 1.0
+ *
+ */
 public enum PackageAppProperties implements KapuaAppProperties {
-    APP_NAME("DEPLOY"), //
-    APP_VERSION("1.0.0"), //
+
+    /**
+     * Application name
+     */
+    APP_NAME("DEPLOY"),
+    /**
+     * Application version
+     */
+    APP_VERSION("1.0.0"),
 
     // Commons exec properties
-    APP_PROPERTY_PACKAGE_OPERATION_ID("kapua.package.operation.id"), //
-    APP_PROPERTY_PACKAGE_REBOOT("kapua.package.reboot"), //
-    APP_PROPERTY_PACKAGE_REBOOT_DELAY("kapua.package.reboot.delay"), //
+    /**
+     * Operation identifier
+     */
+    APP_PROPERTY_PACKAGE_OPERATION_ID("kapua.package.operation.id"),
+    /**
+     * Device reboot
+     */
+    APP_PROPERTY_PACKAGE_REBOOT("kapua.package.reboot"),
+    /**
+     * Reboot delay
+     */
+    APP_PROPERTY_PACKAGE_REBOOT_DELAY("kapua.package.reboot.delay"),
 
     // Request exec download
-    APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_URI("kapua.package.download.uri"), //
-    APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_NAME("kapua.package.download.name"), //
-    APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_VERSION("kapua.package.download.version"), //
-    APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL("kapua.package.download.install"), //
+    /**
+     * Package uri
+     */
+    APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_URI("kapua.package.download.uri"),
+    /**
+     * Package name
+     */
+    APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_NAME("kapua.package.download.name"),
+    /**
+     * Package version
+     */
+    APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_VERSION("kapua.package.download.version"),
+    /**
+     * Package install
+     */
+    APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL("kapua.package.download.install"),
 
     // Response get download
-    APP_PROPERTY_PACKAGE_DOWNLOAD_SIZE("kapua.package.download.size"), //
-    APP_PROPERTY_PACKAGE_DOWNLOAD_STATUS("kapua.package.download.status"), //
-    APP_PROPERTY_PACKAGE_DOWNLOAD_PROGRESS("kapua.package.download.progress"), //
+    /**
+     * Package download size
+     */
+    APP_PROPERTY_PACKAGE_DOWNLOAD_SIZE("kapua.package.download.size"),
+    /**
+     * Package download status
+     */
+    APP_PROPERTY_PACKAGE_DOWNLOAD_STATUS("kapua.package.download.status"),
+    /**
+     * Package download progress
+     */
+    APP_PROPERTY_PACKAGE_DOWNLOAD_PROGRESS("kapua.package.download.progress"),
 
     // Request exec install
-    APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_NAME("kapua.package.install.name"), //
-    APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_VERSION("kapua.package.install.version"), //
+    /**
+     * Package install name
+     */
+    APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_NAME("kapua.package.install.name"),
+    /**
+     * Package install version
+     */
+    APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_VERSION("kapua.package.install.version"),
 
     // Request exec uninstall
-    APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_NAME("kapua.package.uninstall.name"), //
-    APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_VERSION("kapua.package.uninstall.version"), //
+    /**
+     * Package uninstall name
+     */
+    APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_NAME("kapua.package.uninstall.name"),
+    /**
+     * Package uninstall version
+     */
+    APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_VERSION("kapua.package.uninstall.version"),
 
     ;
 

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
@@ -4,6 +4,12 @@ import org.eclipse.kapua.service.device.management.KapuaMethod;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
 
+/**
+ * Package request message channel.
+ * 
+ * @since 1.0
+ *
+ */
 public class PackageRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel
 {
     private KapuaMethod     method;
@@ -21,11 +27,21 @@ public class PackageRequestChannel extends KapuaAppChannelImpl implements KapuaR
         this.method = method;
     }
 
+    /**
+     * Get package resource
+     * 
+     * @return
+     */
     public PackageResource getResource()
     {
         return packageResource;
     }
 
+    /**
+     * Set package resource
+     * 
+     * @param packageResource
+     */
     public void setPackageResource(PackageResource packageResource)
     {
         this.packageResource = packageResource;

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestMessage.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestMessage.java
@@ -3,6 +3,12 @@ package org.eclipse.kapua.service.device.management.packages.message.internal;
 import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
 
+/**
+ * Package request message.
+ * 
+ * @since 1.0
+ *
+ */
 public class PackageRequestMessage extends KapuaMessageImpl<PackageRequestChannel, PackageRequestPayload>
         implements KapuaRequestMessage<PackageRequestChannel, PackageRequestPayload> {
 

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
@@ -6,13 +6,30 @@ import org.eclipse.kapua.message.internal.KapuaPayloadImpl;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
 
+/**
+ * Package request message payload.
+ * 
+ * @since 1.0
+ *
+ */
 public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequestPayload
 {
+
+    /**
+     * Get the operation identifier
+     * 
+     * @return
+     */
     public KapuaId getOperationId()
     {
         return (KapuaId) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue());
     }
 
+    /**
+     * Set the operation identifier
+     * 
+     * @param operationId
+     */
     public void setOperationId(KapuaId operationId)
     {
         if (operationId != null) {
@@ -20,11 +37,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the device reboot flag
+     * 
+     * @return
+     */
     public Boolean isReboot()
     {
         return (Boolean) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT.getValue());
     }
 
+    /**
+     * Set the device reboot flag
+     * 
+     * @param reboot
+     */
     public void setReboot(Boolean reboot)
     {
         if (reboot != null) {
@@ -32,11 +59,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the device reboot flag
+     * 
+     * @return
+     */
     public Integer getRebootDelay()
     {
         return (Integer) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT_DELAY.getValue());
     }
 
+    /**
+     * Set the device reboot flag
+     * 
+     * @param rebootDelay
+     */
     public void setRebootDelay(Integer rebootDelay)
     {
         if (rebootDelay != null) {
@@ -47,11 +84,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     //
     // Download
     //
+    /**
+     * Get the package download URI
+     * 
+     * @return
+     */
     public URI getPackageDownloadURI()
     {
         return (URI) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_URI.getValue());
     }
 
+    /**
+     * Set the package download URI
+     * 
+     * @param uri
+     */
     public void setPackageDownloadURI(URI uri)
     {
         if (uri != null) {
@@ -59,11 +106,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the package name
+     * 
+     * @return
+     */
     public String getPackageDownloadName()
     {
         return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_NAME.getValue());
     }
 
+    /**
+     * Set the package name
+     * 
+     * @param packageName
+     */
     public void setPackageDownloadName(String packageName)
     {
         if (packageName != null) {
@@ -71,11 +128,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the package version
+     * 
+     * @return
+     */
     public String getPackageDownloadVersion()
     {
         return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_VERSION.getValue());
     }
 
+    /**
+     * Set the package version
+     * 
+     * @param packageVersion
+     */
     public void setPackageDownloadVersion(String packageVersion)
     {
         if (packageVersion != null) {
@@ -83,11 +150,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the is a download package and install flag
+     * 
+     * @return
+     */
     public Boolean isPackageDownloadnstall()
     {
         return (Boolean) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL.getValue());
     }
 
+    /**
+     * Set the is a download package and install flag
+     * 
+     * @param packageDownloadnstall
+     */
     public void setPackageDownloadnstall(Boolean packageDownloadnstall)
     {
         if (packageDownloadnstall != null) {
@@ -98,11 +175,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     //
     // Install
     //
+    /**
+     * Get the package install name
+     * 
+     * @return
+     */
     public String getPackageInstallName()
     {
         return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_NAME.getValue());
     }
 
+    /**
+     * Set the package install name
+     * 
+     * @param packageName
+     */
     public void setPackageInstallName(String packageName)
     {
         if (packageName != null) {
@@ -110,11 +197,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the package install version
+     * 
+     * @return
+     */
     public String getPackageInstallVersion()
     {
         return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_VERSION.getValue());
     }
 
+    /**
+     * Set the package install version
+     * 
+     * @param packageVersion
+     */
     public void setPackageInstallVersion(String packageVersion)
     {
         if (packageVersion != null) {
@@ -125,11 +222,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     //
     // Uninstall
     //
+    /**
+     * Get the package uninstall name
+     * 
+     * @return
+     */
     public String getPackageUninstallName()
     {
         return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_NAME.getValue());
     }
 
+    /**
+     * Set the package uninstall name
+     * 
+     * @param packageName
+     */
     public void setPackageUninstallName(String packageName)
     {
         if (packageName != null) {
@@ -137,11 +244,21 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         }
     }
 
+    /**
+     * Get the package uninstall version
+     * 
+     * @return
+     */
     public String getPackageUninstallVersion()
     {
         return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_VERSION.getValue());
     }
 
+    /**
+     * Set the package uninstall version
+     * 
+     * @param packageVersion
+     */
     public void setPackageUninstallVersion(String packageVersion)
     {
         if (packageVersion != null) {
@@ -152,16 +269,31 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     //
     // Utility methods
     //
+    /**
+     * Get the is a download request flag
+     * 
+     * @return
+     */
     public boolean isDownloadRequest()
     {
         return getPackageDownloadName() != null;
     }
 
+    /**
+     * Get the is an install request flag
+     * 
+     * @return
+     */
     public boolean isInstallRequest()
     {
         return getPackageInstallName() != null;
     }
 
+    /**
+     * Get the is an uninstall request flag
+     * 
+     * @return
+     */
     public boolean isUninstallRequest()
     {
         return getPackageUninstallName() != null;

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResource.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResource.java
@@ -1,8 +1,23 @@
 package org.eclipse.kapua.service.device.management.packages.message.internal;
 
+/**
+ * Packages resource operation type.
+ * 
+ * @since 1.0
+ *
+ */
 public enum PackageResource
 {
+    /**
+     * Download
+     */
     DOWNLOAD,
+    /**
+     * Install
+     */
     INSTALL,
+    /**
+     * Uninstall
+     */
     UNINSTALL
 }

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
@@ -3,6 +3,12 @@ package org.eclipse.kapua.service.device.management.packages.message.internal;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
+/**
+ * Package response message channel.
+ * 
+ * @since 1.0
+ *
+ */
 public class PackageResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel
 {
 

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseMessage.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseMessage.java
@@ -4,6 +4,12 @@ import org.eclipse.kapua.message.internal.KapuaMessageImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 
+/**
+ * Package response message.
+ * 
+ * @since 1.0
+ *
+ */
 public class PackageResponseMessage extends KapuaMessageImpl<PackageResponseChannel, PackageResponsePayload>
                                    implements KapuaResponseMessage<PackageResponseChannel, PackageResponsePayload>
 {

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
@@ -5,44 +5,90 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.commons.message.response.KapuaResponsePayloadImpl;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadStatus;
 
+/**
+ * Package response message payload.
+ * 
+ * @since 1.0
+ *
+ */
 public class PackageResponsePayload extends KapuaResponsePayloadImpl implements KapuaPayload {
 
+    /**
+     * Set the package download operation identifier
+     * 
+     * @param operationId
+     */
     public void setPackageDownloadOperationId(KapuaId operationId) {
         if (operationId != null) {
             getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue(), operationId);
         }
     }
 
+    /**
+     * Get the package download operation identifier
+     * 
+     * @return
+     */
     public KapuaId getPackageDownloadOperationId() {
         return (KapuaId) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue());
     }
 
+    /**
+     * Set the package download operation status
+     * 
+     * @param status
+     */
     public void setPackageDownloadOperationStatus(DevicePackageDownloadStatus status) {
         if (status != null) {
             getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_STATUS.getValue(), status);
         }
     }
 
+    /**
+     * Get the package download operation status
+     * 
+     * @return
+     */
     public DevicePackageDownloadStatus getPackageDownloadOperationStatus() {
         return (DevicePackageDownloadStatus) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_STATUS.getValue());
     }
 
+    /**
+     * Get the package download size
+     * 
+     * @param size
+     */
     public void setPackageDownloadOperationSize(Integer size) {
         if (size != null) {
             getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_SIZE.getValue(), size);
         }
     }
 
+    /**
+     * Set the package download size
+     * 
+     * @return
+     */
     public Integer getPackageDownloadOperationSize() {
         return (Integer) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_SIZE.getValue());
     }
 
+    /**
+     * Set the package download progress
+     * 
+     * @param progress
+     */
     public void setPackageDownloadOperationProgress(Integer progress) {
         if (progress != null) {
             getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PROGRESS.getValue(), progress);
         }
     }
 
+    /**
+     * Get the package download progress
+     * 
+     * @return
+     */
     public Integer getPackageDownloadOperationProgress() {
         return (Integer) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PROGRESS.getValue());
     }

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOperationImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOperationImpl.java
@@ -8,6 +8,12 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOperation;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadStatus;
 
+/**
+ * Device download package operation entity.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "packageDownloadOperation")
 public class DevicePackageDownloadOperationImpl implements DevicePackageDownloadOperation {
 
@@ -23,6 +29,9 @@ public class DevicePackageDownloadOperationImpl implements DevicePackageDownload
     @XmlElement(name = "status")
     private DevicePackageDownloadStatus status;
 
+    /**
+     * Constructor
+     */
     public DevicePackageDownloadOperationImpl() {
     }
 

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadRequestImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadRequestImpl.java
@@ -4,6 +4,12 @@ import java.net.URI;
 
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
 
+/**
+ * Device package download request.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePackageDownloadRequestImpl implements DevicePackageDownloadRequest
 {
     public URI    uri;
@@ -15,61 +21,73 @@ public class DevicePackageDownloadRequestImpl implements DevicePackageDownloadRe
     public Boolean reboot;
     public Integer rebootDelay;
 
+    @Override
     public URI getURI()
     {
         return uri;
     }
 
+    @Override
     public void setURI(URI uri)
     {
         this.uri = uri;
     }
 
+    @Override
     public String getName()
     {
         return name;
     }
 
+    @Override
     public void setName(String name)
     {
         this.name = name;
     }
 
+    @Override
     public String getVersion()
     {
         return version;
     }
 
+    @Override
     public void setVersion(String version)
     {
         this.version = version;
     }
 
+    @Override
     public Boolean isInstall()
     {
         return install;
     }
 
+    @Override
     public void setInstall(Boolean install)
     {
         this.install = install;
     }
 
+    @Override
     public Boolean isReboot()
     {
         return reboot;
     }
 
+    @Override
     public void setReboot(Boolean reboot)
     {
         this.reboot = reboot;
     }
 
+    @Override
     public Integer getRebootDelay()
     {
         return rebootDelay;
     }
 
+    @Override
     public void setRebootDelay(Integer rebootDelay)
     {
         this.rebootDelay = rebootDelay;

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOperationImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOperationImpl.java
@@ -8,6 +8,12 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallOperation;
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallStatus;
 
+/**
+ * Device package install operation entity.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "packageInstallOperation")
 public class DevicePackageInstallOperationImpl implements DevicePackageInstallOperation {
 
@@ -35,26 +41,32 @@ public class DevicePackageInstallOperationImpl implements DevicePackageInstallOp
         }
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public String getVersion() {
         return version;
     }
 
+    @Override
     public void setVersion(String version) {
         this.version = version;
     }
 
+    @Override
     public DevicePackageInstallStatus getStatus() {
         return status;
     }
 
+    @Override
     public void setStatus(DevicePackageInstallStatus status) {
         this.status = status;
     }

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallRequestImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallRequestImpl.java
@@ -2,6 +2,12 @@ package org.eclipse.kapua.service.device.management.packages.model.install.inter
 
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallRequest;
 
+/**
+ * Device package install request.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePackageInstallRequestImpl implements DevicePackageInstallRequest {
 
     private String name;
@@ -9,34 +15,42 @@ public class DevicePackageInstallRequestImpl implements DevicePackageInstallRequ
     private Boolean reboot;
     private Integer rebootDelay;
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public String getVersion() {
         return version;
     }
 
+    @Override
     public void setVersion(String version) {
         this.version = version;
     }
 
+    @Override
     public Boolean isReboot() {
         return reboot;
     }
 
+    @Override
     public void setReboot(Boolean reboot) {
         this.reboot = reboot;
     }
 
+    @Override
     public Integer getRebootDelay() {
         return rebootDelay;
     }
 
+    @Override
     public void setRebootDelay(Integer rebootDelay) {
         this.rebootDelay = rebootDelay;
     }

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
@@ -8,6 +8,12 @@ import javax.xml.bind.annotation.XmlType;
 
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageBundleInfo;
 
+/**
+ * Device package bundle information.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "bundleInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder = { "name", "version" })

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfosImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfosImpl.java
@@ -10,6 +10,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageBundleInfos;
 
+/**
+ * Package bundle informations list container.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "bundleInfos")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class DevicePackageBundleInfosImpl implements DevicePackageBundleInfos

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageImpl.java
@@ -2,14 +2,14 @@ package org.eclipse.kapua.service.device.management.packages.model.internal;
 
 import java.util.Date;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackage;
 
+/**
+ * Device package.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePackageImpl implements DevicePackage
 {
     private String name;
@@ -20,26 +20,31 @@ public class DevicePackageImpl implements DevicePackage
 
     private Date installDate;
 
+    @Override
     public String getName()
     {
         return name;
     }
 
+    @Override
     public void setName(String name)
     {
         this.name = name;
     }
 
+    @Override
     public String getVersion()
     {
         return version;
     }
 
+    @Override
     public void setVersion(String version)
     {
         this.version = version;
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public DevicePackageBundleInfosImpl getBundleInfos()
     {
@@ -49,11 +54,13 @@ public class DevicePackageImpl implements DevicePackage
         return bundleInfos;
     }
 
+    @Override
     public Date getInstallDate()
     {
         return installDate;
     }
 
+    @Override
     public void setInstallDate(Date installDate)
     {
         this.installDate = installDate;

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackagesImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackagesImpl.java
@@ -3,13 +3,14 @@ package org.eclipse.kapua.service.device.management.packages.model.internal;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackages;
 
+/**
+ * Device packages list container.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePackagesImpl implements DevicePackages
 {
     public List<DevicePackageImpl> deploymentPackages;

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOperationImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOperationImpl.java
@@ -7,6 +7,12 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOperation;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallStatus;
 
+/**
+ * Device package uninstall operation entity.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePackageUninstallOperationImpl implements DevicePackageUninstallOperation {
 
     @XmlElement(name = "id")
@@ -33,26 +39,32 @@ public class DevicePackageUninstallOperationImpl implements DevicePackageUninsta
         }
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public String getVersion() {
         return version;
     }
 
+    @Override
     public void setVersion(String version) {
         this.version = version;
     }
 
+    @Override
     public DevicePackageUninstallStatus getStatus() {
         return status;
     }
 
+    @Override
     public void setStatus(DevicePackageUninstallStatus status) {
         this.status = status;
     }

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallRequestImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallRequestImpl.java
@@ -2,6 +2,12 @@ package org.eclipse.kapua.service.device.management.packages.model.uninstall.int
 
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 
+/**
+ * Device package uninstall request.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePackageUninstallRequestImpl implements DevicePackageUninstallRequest {
 
     public String name;
@@ -10,34 +16,42 @@ public class DevicePackageUninstallRequestImpl implements DevicePackageUninstall
     public Boolean reboot;
     public Integer rebootDelay;
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public String getVersion() {
         return version;
     }
 
+    @Override
     public void setVersion(String version) {
         this.version = version;
     }
 
+    @Override
     public Boolean isReboot() {
         return reboot;
     }
 
+    @Override
     public void setReboot(Boolean reboot) {
         this.reboot = reboot;
     }
 
+    @Override
     public Integer getRebootDelay() {
         return rebootDelay;
     }
 
+    @Override
     public void setRebootDelay(Integer rebootDelay) {
         this.rebootDelay = rebootDelay;
     }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
@@ -24,8 +24,11 @@ import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 
 /**
- * Device is an object representing a device or gateway connected to the Kapua platform.
+ * Device is an object representing a device or gateway connected to the Kapua platform.<br>
  * The Device object contains several attributes regarding the Device itself and its software configuration.
+ * 
+ * @since 1.0
+ * 
  */
 @XmlRootElement(name = "device")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -77,134 +80,398 @@ public interface Device extends KapuaUpdatableEntity {
         return TYPE;
     }
 
+    /**
+     * Get the client identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "clientId")
     public String getClientId();
 
+    /**
+     * Set the client identifier
+     * 
+     * @param clientId
+     */
     public void setClientId(String clientId);
 
+    /**
+     * Get the connection identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "connectionId")
     public KapuaId getConnectionId();
 
+    /**
+     * Set the connection identifier
+     * 
+     * @param connectionId
+     */
     public void setConnectionId(KapuaId connectionId);
 
+    /**
+     * Get the connection status
+     * 
+     * @return
+     */
     @XmlElement(name = "status")
     public DeviceStatus getStatus();
 
+    /**
+     * Set the connection status
+     * 
+     * @param status
+     */
     public void setStatus(DeviceStatus status);
 
+    /**
+     * Get the display name
+     * 
+     * @return
+     */
     @XmlElement(name = "displayName")
     public String getDisplayName();
 
+    /**
+     * Set the display name
+     * 
+     * @param diplayName
+     */
     public void setDisplayName(String diplayName);
 
+    /**
+     * Get the last event on
+     * 
+     * @return
+     */
     @XmlElement(name = "lastEventOn")
     public Date getLastEventOn();
 
+    /**
+     * Set the last event on
+     * 
+     * @param lastEventOn
+     */
     public void setLastEventOn(Date lastEventOn);
 
+    /**
+     * Get the last event type
+     * 
+     * @return
+     */
     @XmlElement(name = "lastEventType")
     public DeviceEventType getLastEventType();
 
+    /**
+     * Set the last event type
+     * 
+     * @param lastEventType
+     */
     public void setLastEventType(DeviceEventType lastEventType);
 
+    /**
+     * Get the serial number
+     * 
+     * @return
+     */
     @XmlElement(name = "serialNumber")
     public String getSerialNumber();
 
+    /**
+     * Set the serial number
+     * 
+     * @param serialNumber
+     */
     public void setSerialNumber(String serialNumber);
 
+    /**
+     * Get the model identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "modelId")
     public String getModelId();
 
+    /**
+     * Set the model identifier
+     * 
+     * @param modelId
+     */
     public void setModelId(String modelId);
 
+    /**
+     * Get the imei
+     * 
+     * @return
+     */
     @XmlElement(name = "imei")
     public String getImei();
 
+    /**
+     * Set the imei
+     * 
+     * @param imei
+     */
     public void setImei(String imei);
 
+    /**
+     * Get the imsi
+     * 
+     * @return
+     */
     @XmlElement(name = "imsi")
     public String getImsi();
 
+    /**
+     * Set the imsi
+     * 
+     * @param imsi
+     */
     public void setImsi(String imsi);
 
+    /**
+     * Get the iccid
+     * 
+     * @return
+     */
     @XmlElement(name = "iccid")
     public String getIccid();
 
+    /**
+     * Set the iccid
+     * 
+     * @param iccid
+     */
     public void setIccid(String iccid);
 
+    /**
+     * Get bios version
+     * 
+     * @return
+     */
     @XmlElement(name = "biosVersion")
     public String getBiosVersion();
 
+    /**
+     * Set bios version
+     * 
+     * @param biosVersion
+     */
     public void setBiosVersion(String biosVersion);
 
+    /**
+     * Get firmware version
+     * 
+     * @return
+     */
     @XmlElement(name = "firmwareVersion")
     public String getFirmwareVersion();
 
+    /**
+     * Set firmware version
+     * 
+     * @param firmwareVersion
+     */
     public void setFirmwareVersion(String firmwareVersion);
 
+    /**
+     * Get os version
+     * 
+     * @return
+     */
     @XmlElement(name = "osVersion")
     public String getOsVersion();
 
+    /**
+     * Set os version
+     * 
+     * @param osVersion
+     */
     public void setOsVersion(String osVersion);
 
+    /**
+     * Get jvm version
+     * 
+     * @return
+     */
     @XmlElement(name = "jvmVersion")
     public String getJvmVersion();
 
+    /**
+     * Set jvm version
+     * 
+     * @param jvmVersion
+     */
     public void setJvmVersion(String jvmVersion);
 
+    /**
+     * Get osgi framework version
+     * 
+     * @return
+     */
     @XmlElement(name = "osgiFrameworkVersion")
     public String getOsgiFrameworkVersion();
 
+    /**
+     * Set osgi framework version
+     * 
+     * @param osgiFrameworkVersion
+     */
     public void setOsgiFrameworkVersion(String osgiFrameworkVersion);
 
+    /**
+     * Get application framework version
+     * 
+     * @return
+     */
     @XmlElement(name = "applicationFrameworkVersion")
     public String getApplicationFrameworkVersion();
 
+    /**
+     * Set application framework version
+     * 
+     * @param appFrameworkVersion
+     */
     public void setApplicationFrameworkVersion(String appFrameworkVersion);
 
+    /**
+     * Get application identifiers
+     * 
+     * @return
+     */
     @XmlElement(name = "applicationIdentifiers")
     public String getApplicationIdentifiers();
 
+    /**
+     * Set application identifiers
+     * 
+     * @param applicationIdentifiers
+     */
     public void setApplicationIdentifiers(String applicationIdentifiers);
 
+    /**
+     * Get accept encoding flag
+     * 
+     * @return
+     */
     @XmlElement(name = "acceptEncoding")
     public String getAcceptEncoding();
 
+    /**
+     * Set accept encoding flag
+     * 
+     * @param acceptEncoding
+     */
     public void setAcceptEncoding(String acceptEncoding);
 
+    /**
+     * Get custom attribute 1
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute1")
     public String getCustomAttribute1();
 
+    /**
+     * Set custom attribute 1
+     * 
+     * @param customAttribute1
+     */
     public void setCustomAttribute1(String customAttribute1);
 
+    /**
+     * Get custom attribute 2
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute2")
     public String getCustomAttribute2();
 
+    /**
+     * Set custom attribute 2
+     * 
+     * @param customAttribute2
+     */
     public void setCustomAttribute2(String customAttribute2);
 
+    /**
+     * Get custom attribute 3
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute3")
     public String getCustomAttribute3();
 
+    /**
+     * Set custom attribute 3
+     * 
+     * @param customAttribute3
+     */
     public void setCustomAttribute3(String customAttribute3);
 
+    /**
+     * Get custom attribute 4
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute4")
     public String getCustomAttribute4();
 
+    /**
+     * Set custom attribute 4
+     * 
+     * @param customAttribute4
+     */
     public void setCustomAttribute4(String customAttribute4);
 
+    /**
+     * Get custom attribute 5
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute5")
     public String getCustomAttribute5();
 
+    /**
+     * Set custom attribute 5
+     * 
+     * @param customAttribute5
+     */
     public void setCustomAttribute5(String customAttribute5);
 
+    /**
+     * Get credentials mode.<br>
+     * The device credential mode sets a security level for the devices, setting a specific user connection policy between the available policies.
+     * 
+     * @return
+     */
     @XmlElement(name = "devoceCredentialsMode")
     public DeviceCredentialsMode getCredentialsMode();
 
+    /**
+     * Set credentials mode.<br>
+     * The device credential mode sets a security level for the devices, setting a specific user connection policy between the available policies.
+     * 
+     * @param credentialsMode
+     */
     public void setCredentialsMode(DeviceCredentialsMode credentialsMode);
 
+    /**
+     * Get preferred user identifier.<br>
+     * Set the preferred user identifier that can connect to this device.
+     * 
+     * @return
+     */
     @XmlElement(name = "preferredUserId")
     public KapuaId getPreferredUserId();
 
+    /**
+     * Set preferred user identifier.<br>
+     * Set the preferred user identifier that can connect to this device.
+     * 
+     * @param deviceUserId
+     */
     public void setPreferredUserId(KapuaId deviceUserId);
 
     /*

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
@@ -22,12 +22,14 @@ import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 
 /**
- * DeviceCreator encapsulates all the information needed to create a new Device in the system.
- * The data provided will be used to seed the new Device and its related information.
- * The fields of the DeviceCreator presents the attributes that are searchable for a given device.
+ * DeviceCreator encapsulates all the information needed to create a new Device in the system.<br>
+ * The data provided will be used to seed the new Device and its related information.<br>
+ * The fields of the DeviceCreator presents the attributes that are searchable for a given device.<br>
  * The DeviceCreator Properties field can be used to provide additional properties associated to the Device;
- * those properties will not be searchable through Device queries.
+ * those properties will not be searchable through Device queries.<br>
  * The clientId field of the Device is used to store the MAC address of the primary network interface of the device.
+ * 
+ * @since 1.0
  */
 @XmlRootElement(name = "deviceCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -56,118 +58,352 @@ import org.eclipse.kapua.model.id.KapuaId;
         "preferredUserId" }, factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDeviceCreator")
 public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
 
+    /**
+     * Get the client identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "clientId")
     public String getClientId();
 
+    /**
+     * Set the client identifier
+     * 
+     * @param clientId
+     */
     public void setClientId(String clientId);
 
+    /**
+     * Get the connection identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "connectionId")
     public KapuaId getConnectionId();
 
+    /**
+     * Set the connection identifier
+     * 
+     * @param connectionId
+     */
     public void setConnectionId(KapuaId connectionId);
 
+    /**
+     * Get the display name
+     * 
+     * @return
+     */
     @XmlElement(name = "displayName")
     public String getDisplayName();
 
+    /**
+     * Set the display name
+     * 
+     * @param displayName
+     */
     public void setDisplayName(String displayName);
 
+    /**
+     * Get the serial number
+     * 
+     * @return
+     */
     @XmlElement(name = "serialNumber")
     public String getSerialNumber();
 
+    /**
+     * Set the serial number
+     * 
+     * @param serialNumber
+     */
     public void setSerialNumber(String serialNumber);
 
+    /**
+     * Get the model identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "modelId")
     public String getModelId();
 
+    /**
+     * Set the model identifier
+     * 
+     * @param modelId
+     */
     public void setModelId(String modelId);
 
+    /**
+     * Get the imei
+     * 
+     * @return
+     */
     @XmlElement(name = "imei")
     public String getImei();
 
+    /**
+     * Set the imei
+     * 
+     * @param imei
+     */
     public void setImei(String imei);
 
+    /**
+     * Get the imsi
+     * 
+     * @return
+     */
     @XmlElement(name = "imsi")
     public String getImsi();
 
+    /**
+     * Set the imsi
+     * 
+     * @param imsi
+     */
     public void setImsi(String imsi);
 
+    /**
+     * Get the iccid
+     * 
+     * @return
+     */
     @XmlElement(name = "iccid")
     public String getIccid();
 
+    /**
+     * Set the iccid
+     * 
+     * @param iccid
+     */
     public void setIccid(String iccid);
 
+    /**
+     * Get bios version
+     * 
+     * @return
+     */
     @XmlElement(name = "biosVersion")
     public String getBiosVersion();
 
+    /**
+     * Set bios version
+     * 
+     * @param biosVersion
+     */
     public void setBiosVersion(String biosVersion);
 
+    /**
+     * Get firmware version
+     * 
+     * @return
+     */
     @XmlElement(name = "firmwareVersion")
     public String getFirmwareVersion();
 
+    /**
+     * Set firmware version
+     * 
+     * @param firmwareVersion
+     */
     public void setFirmwareVersion(String firmwareVersion);
 
+    /**
+     * Get os version
+     * 
+     * @return
+     */
     @XmlElement(name = "osVersion")
     public String getOsVersion();
 
+    /**
+     * Set os version
+     * 
+     * @param osVersion
+     */
     public void setOsVersion(String osVersion);
 
+    /**
+     * Get jvm version
+     * 
+     * @return
+     */
     @XmlElement(name = "jvmVersion")
     public String getJvmVersion();
 
+    /**
+     * Set jvm version
+     * 
+     * @param jvmVersion
+     */
     public void setJvmVersion(String jvmVersion);
 
+    /**
+     * Get osgi framework version
+     * 
+     * @return
+     */
     @XmlElement(name = "osgiFrameworkVersion")
     public String getOsgiFrameworkVersion();
 
+    /**
+     * Set osgi framework version
+     * 
+     * @param osgiFrameworkVersion
+     */
     public void setOsgiFrameworkVersion(String osgiFrameworkVersion);
 
+    /**
+     * Get application framework version
+     * 
+     * @return
+     */
     @XmlElement(name = "applicationFrameworkVersion")
     public String getApplicationFrameworkVersion();
 
+    /**
+     * Set application framework version
+     * 
+     * @param appFrameworkVersion
+     */
     public void setApplicationFrameworkVersion(String appFrameworkVersion);
 
+    /**
+     * Get application identifiers
+     * 
+     * @return
+     */
     @XmlElement(name = "applicationIdentifiers")
     public String getApplicationIdentifiers();
 
+    /**
+     * Set application identifiers
+     * 
+     * @param applicationIdentifiers
+     */
     public void setApplicationIdentifiers(String applicationIdentifiers);
 
+    /**
+     * Get accept encoding flag
+     * 
+     * @return
+     */
     @XmlElement(name = "acceptEncoding")
     public String getAcceptEncoding();
 
+    /**
+     * Set accept encoding flag
+     * 
+     * @param acceptEncoding
+     */
     public void setAcceptEncoding(String acceptEncoding);
 
+    /**
+     * Get custom attribute 1
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute1")
     public String getCustomAttribute1();
 
+    /**
+     * Set custom attribute 1
+     * 
+     * @param customAttribute1
+     */
     public void setCustomAttribute1(String customAttribute1);
 
+    /**
+     * Get custom attribute 2
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute2")
     public String getCustomAttribute2();
 
+    /**
+     * Set custom attribute 2
+     * 
+     * @param customAttribute2
+     */
     public void setCustomAttribute2(String customAttribute2);
 
+    /**
+     * Get custom attribute 3
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute3")
     public String getCustomAttribute3();
 
+    /**
+     * Set custom attribute 3
+     * 
+     * @param customAttribute3
+     */
     public void setCustomAttribute3(String customAttribute3);
 
+    /**
+     * Get custom attribute 4
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute4")
     public String getCustomAttribute4();
 
+    /**
+     * Set custom attribute 4
+     * 
+     * @param customAttribute4
+     */
     public void setCustomAttribute4(String customAttribute4);
 
+    /**
+     * Get custom attribute 5
+     * 
+     * @return
+     */
     @XmlElement(name = "customAttribute5")
     public String getCustomAttribute5();
 
+    /**
+     * Set custom attribute 5
+     * 
+     * @param customAttribute5
+     */
     public void setCustomAttribute5(String customAttribute5);
 
+    /**
+     * Get credentials mode.<br>
+     * The device credential mode sets a security level for the devices, setting a specific user connection policy between the available policies.
+     * 
+     * @return
+     */
     @XmlElement(name = "credentialsMode")
     public DeviceCredentialsMode getCredentialsMode();
 
+    /**
+     * Set credentials mode.<br>
+     * The device credential mode sets a security level for the devices, setting a specific user connection policy between the available policies.
+     * 
+     * @param credentialsMode
+     */
     public void setCredentialsMode(DeviceCredentialsMode credentialsMode);
 
+    /**
+     * Get preferred user identifier.<br>
+     * Set the preferred user identifier that can connect to this device.
+     * 
+     * @return
+     */
     @XmlElement(name = "preferredUserId")
     public KapuaId getPreferredUserId();
 
+    /**
+     * Set preferred user identifier.<br>
+     * Set the preferred user identifier that can connect to this device.
+     * 
+     * @param preferredUserId
+     */
     public void setPreferredUserId(KapuaId preferredUserId);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCredentialsMode.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCredentialsMode.java
@@ -14,6 +14,9 @@ package org.eclipse.kapua.service.device.registry;
 
 /**
  * Defines the strategy to validate credentials during device login.
+ * 
+ * @since 1.0
+ * 
  */
 public enum DeviceCredentialsMode
 {
@@ -42,6 +45,9 @@ public enum DeviceCredentialsMode
 
     private boolean usableAsAccountDefault;
 
+    /**
+     * Constructor
+     */
     DeviceCredentialsMode()
     {
         this(true);

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceEventType.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceEventType.java
@@ -12,25 +12,88 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
+/**
+ * Device event types
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceEventType
 {
+    /**
+     * Connected (network layer)
+     */
     CONNECTED,
+    /**
+     * Birth
+     */
     BIRTH,
+    /**
+     * Disconnected (network layer)
+     */
     DC,
+    /**
+     * Disconnected
+     */
     DISCONNECTED,
+    /**
+     * Missing (gthe device doesn't reply to the ping request from the broker)
+     */
     MISSING,
+    /**
+     * Configuration component updated
+     */
     CONF_COMP_UPDATED,
+    /**
+     * Configuration updated
+     */
     CONF_UPDATED,
+    /**
+     * Configuration rollbacked
+     */
     CONF_ROLLEDBACK,
+    /**
+     * Deploy package downloaded
+     */
     DEPLOY_DOWNLOADED,
+    /**
+     * Deploy package installed
+     */
     DEPLOY_INSTALLED,
+    /**
+     * Deploy package uninstalled
+     */
     DEPLOY_UNINSTALLED,
+    /**
+     * Command executed
+     */
     CMD_EXECUTED,
+    /**
+     * Applications updated
+     */
     APPS_UPDATED,
+    /**
+     * Bundle started
+     */
     BUNDLE_STARTED,
+    /**
+     * Bundle stopped
+     */
     BUNDLE_STOPPED,
+    /**
+     * Device provisioned
+     */
     PROVISIONED,
+    /**
+     * Certificate updated
+     */
     CERTIFICATE_UPDATED,
+    /**
+     * Certificate revoked
+     */
     CERTIFICATE_REVOKED,
+    /**
+     * Certificate update error
+     */
     CERTIFICATE_UPDATE_ERROR
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceFactory.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceFactory.java
@@ -15,13 +15,43 @@ package org.eclipse.kapua.service.device.registry;
 import org.eclipse.kapua.model.KapuaObjectFactory;
 import org.eclipse.kapua.model.id.KapuaId;
 
+/**
+ * Device service factory definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new device creator
+     * 
+     * @param scopeId
+     * @param clientId
+     * @return
+     */
     public DeviceCreator newCreator(KapuaId scopeId, String clientId);
 
+    /**
+     * Creates a new {@link Device}
+     * 
+     * @return
+     */
     public Device newDevice();
     
+    /**
+     * Creates a new device query base on provided scoper identifier
+     * 
+     * @param scopeId
+     * @return
+     */
     public DeviceQuery newQuery(KapuaId scopeId);
     
+    /**
+     * Creates a new device list result
+     * 
+     * @return
+     */
     public DeviceListResult newDeviceListResult();
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceListResult.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.registry;
 
 import org.eclipse.kapua.model.query.KapuaListResult;
 
+/**
+ * Device list result definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceListResult extends KapuaListResult<Device>
 {
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DevicePredicates.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DevicePredicates.java
@@ -12,33 +12,120 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
+/**
+ * Device query predicates.
+ * 
+ * @since 1.0
+ *
+ */
 public class DevicePredicates
 {
+    /**
+     * Client identifier
+     */
     public static final String CLIENT_ID                     = "clientId";
+    /**
+     * Display name
+     */
     public static final String DISPLAY_NAME                  = "displayName";
+    /**
+     * Serial number
+     */
     public static final String SERIAL_NUMBER                 = "serialNumber";
+    /**
+     * Imei
+     */
     public static final String IMEI                          = "imei";
+    /**
+     * Imsi
+     */
     public static final String IMSI                          = "imsi";
+    /**
+     * Iccd
+     */
     public static final String ICCID                         = "iccid";
+    /**
+     * Model identifier
+     */
     public static final String MODEL_ID                      = "modelId";
+    /**
+     * Bios version
+     */
     public static final String BIOS_VERSION                  = "biosVersion";
+    /**
+     * Firmware version
+     */
     public static final String FIRMWARE_VERSION              = "firmwareVersion";
+    /**
+     * Operating system version
+     */
     public static final String OS_VERSION                    = "osVersion";
+    /**
+     * Jvm version
+     */
     public static final String JVM_VERSION                   = "jvmVersion";
+    /**
+     * Osgi framework version
+     */
     public static final String OSGI_FRAMEWORK_VERSION        = "osgiFrameworkVersion";
+    /**
+     * Application framework version
+     */
     public static final String APPLICATION_FRAMEWORK_VERSION = "applicationFrameworkVersion";
+    /**
+     * Application identifier
+     */
     public static final String APPLICATION_IDENTIFIERS       = "applicationIdentifiers";
+    /**
+     * Custom attribute 1
+     */
     public static final String CUSTOM_ATTRIBUTE_1            = "customAttribute1";
+    /**
+     * Custom attribute 2
+     */
     public static final String CUSTOM_ATTRIBUTE_2            = "customAttribute2";
+    /**
+     * Custom attribute 3
+     */
     public static final String CUSTOM_ATTRIBUTE_3            = "customAttribute3";
+    /**
+     * Custom attribute 4
+     */
     public static final String CUSTOM_ATTRIBUTE_4            = "customAttribute4";
+    /**
+     * Custom attribute 5
+     */
     public static final String CUSTOM_ATTRIBUTE_5            = "customAttribute5";
+    /**
+     * Accept encoding
+     */
     public static final String ACCEPT_ENCODING               = "acceptEncoding";
+    /**
+     * Gps longitude
+     */
     public static final String GPS_LONGITUDE                 = "gpsLongitude";
+    /**
+     * Gps latitude
+     */
     public static final String GPS_LATITUDE                  = "gpsLatitude";
+    /**
+     * Connection ip
+     */
     public static final String CONNECTION_STATUS             = "connectionIp";
+    /**
+     * Device status
+     */
     public static final String STATUS                        = "status";
+    /**
+     * Credentials mode
+     */
     public static final String CREDENTIALS_MODE              = "credentialsMode";
+    /**
+     * Preferred user identifier
+     */
     public static final String PREFERRED_USER_ID             = "preferredUserId";
+    /**
+     * Last event on
+     */
     public static final String LAST_EVENT_ON                 = "lastEventOn";
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceQuery.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.registry;
 
 import org.eclipse.kapua.model.query.KapuaQuery;
 
+/**
+ * Device query definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceQuery extends KapuaQuery<Device>
 {
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
@@ -17,11 +17,22 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
 
+/**
+ * Device registry service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceRegistryService extends KapuaEntityService<Device, DeviceCreator>,
                                        KapuaUpdatableEntityService<Device>
 {
     /**
      * Finds a device by its unique clientId and loads it with all its properties.
+     * 
+     * @param scopeId
+     * @param clientId
+     * @return
+     * @throws KapuaException
      */
     public Device findByClientId(KapuaId scopeId, String clientId)
         throws KapuaException;

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceStatus.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceStatus.java
@@ -12,8 +12,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
+/**
+ * Device status.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceStatus
 {
+    /**
+     * Enabled
+     */
     ENABLED,
+    /**
+     * Disabled
+     */
     DISABLED
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
@@ -16,22 +16,43 @@ import javax.xml.bind.annotation.XmlRegistry;
 
 import org.eclipse.kapua.locator.KapuaLocator;
 
+/**
+ * Device xml factory class
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRegistry
 public class DeviceXmlRegistry {
 
     private final KapuaLocator locator = KapuaLocator.getInstance();
     private final DeviceFactory factory = locator.getFactory(DeviceFactory.class);
     
+    /**
+     * Creates a new {@link Device}
+     * 
+     * @return
+     */
     public Device newDevice()
     {
         return factory.newDevice();
     }
 
+    /**
+     * Creates a new device creator
+     * 
+     * @return
+     */
     public DeviceCreator newDeviceCreator()
     {
         return factory.newCreator(null, null);
     }
 
+    /**
+     * Creates a new device list result
+     * 
+     * @return
+     */
     public DeviceListResult newDeviceListResult()
     {
         return factory.newDeviceListResult();

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
@@ -15,6 +15,12 @@ package org.eclipse.kapua.service.device.registry.connection;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 
+/**
+ * Device connection entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceConnection extends KapuaUpdatableEntity
 {
     public static final String TYPE = "deviceConnection";
@@ -24,27 +30,87 @@ public interface DeviceConnection extends KapuaUpdatableEntity
         return TYPE;
     }
 
+    /**
+     * Get the device connection status
+     * 
+     * @return
+     */
     public DeviceConnectionStatus getStatus();
 
+    /**
+     * Set the device connection status
+     * 
+     * @param connectionStatus
+     */
     public void setStatus(DeviceConnectionStatus connectionStatus);
 
+    /**
+     * Get the client identifier
+     * 
+     * @return
+     */
     public String getClientId();
 
+    /**
+     * Set the client identifier
+     * 
+     * @param clientId
+     */
     public void setClientId(String clientId);
 
+    /**
+     * Get the user identifier
+     * 
+     * @return
+     */
     public KapuaId getUserId();
 
+    /**
+     * Set the user identifier
+     * 
+     * @param userId
+     */
     public void setUserId(KapuaId userId);
 
+    /**
+     * Get the device protocol
+     * 
+     * @return
+     */
     public String getProtocol();
 
+    /**
+     * Set the device protocol
+     * 
+     * @param protocol
+     */
     public void setProtocol(String protocol);
 
+    /**
+     * Get the client ip
+     * 
+     * @return
+     */
     public String getClientIp();
 
+    /**
+     * Set the client ip
+     * 
+     * @param clientIp
+     */
     public void setClientIp(String clientIp);
 
+    /**
+     * Get the server ip
+     * 
+     * @return
+     */
     public String getServerIp();
 
+    /**
+     * Set the server ip
+     * 
+     * @param serverIp
+     */
     public void setServerIp(String serverIp);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
@@ -15,25 +15,82 @@ package org.eclipse.kapua.service.device.registry.connection;
 import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 
+/**
+ * Device connection creator service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<DeviceConnection>
 {
+
+    /**
+     * Get the client identifier
+     * 
+     * @return
+     */
     public String getClientId();
 
+    /**
+     * Set the client identifier
+     * 
+     * @param clientId
+     */
     public void setClientId(String clientId);
 
+    /**
+     * Get the user identifier
+     * 
+     * @return
+     */
     public KapuaId getUserId();
 
+    /**
+     * Set the user identifier
+     * 
+     * @param userId
+     */
     public void setUserId(KapuaId userId);
 
+    /**
+     * Get the device protocol
+     * 
+     * @return
+     */
     public String getProtocol();
 
+    /**
+     * Set the device protocol
+     * 
+     * @param protocol
+     */
     public void setProtocol(String protocol);
 
+    /**
+     * Get the client ip
+     * 
+     * @return
+     */
     public String getClientIp();
 
+    /**
+     * Set the client ip
+     * 
+     * @param clientIp
+     */
     public void setClientIp(String clientIp);
 
+    /**
+     * Get the server ip
+     * 
+     * @return
+     */
     public String getServerIp();
 
+    /**
+     * Set the server ip
+     * 
+     * @param serverIp
+     */
     public void setServerIp(String serverIp);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionFactory.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionFactory.java
@@ -15,12 +15,36 @@ package org.eclipse.kapua.service.device.registry.connection;
 import org.eclipse.kapua.model.KapuaObjectFactory;
 import org.eclipse.kapua.model.id.KapuaId;
 
+/**
+ * Device connection service factory definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceConnectionFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new device connection creator
+     * 
+     * @param scopeId
+     * @return
+     */
     public DeviceConnectionCreator newCreator(KapuaId scopeId);
 
+    /**
+     * Creates a new device connection query for the specified scope identifier
+     * 
+     * @param scopeId
+     * @return
+     */
     public DeviceConnectionQuery newQuery(KapuaId scopeId);
 
+    /**
+     * Creates a new device connection summary
+     * 
+     * @return
+     */
     public DeviceConnectionSummary newConnectionSummary();
 
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionListResult.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.registry.connection;
 
 import org.eclipse.kapua.model.query.KapuaListResult;
 
+/**
+ * Device connection list definition.
+ *
+ * @since 1.0
+ *
+ */
 public interface DeviceConnectionListResult extends KapuaListResult<DeviceConnection>
 {
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionPredicates.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionPredicates.java
@@ -12,8 +12,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection;
 
+/**
+ * Device connection query predicates.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceConnectionPredicates
 {
+    /**
+     * Client identifier
+     */
     public final static String CLIENT_ID         = "clientId";
+    /**
+     * Connection status
+     */
     public final static String CONNECTION_STATUS = "connectionStatus";
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionQuery.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.registry.connection;
 
 import org.eclipse.kapua.model.query.KapuaQuery;
 
+/**
+ * Device connection query definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceConnectionQuery extends KapuaQuery<DeviceConnection>
 {
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
@@ -20,10 +20,22 @@ import org.eclipse.kapua.service.KapuaUpdatableEntityService;
 /**
  * DeviceConnectionService exposes APIs to retrieve Device connections under a scope.
  * It includes APIs to find, list, and update devices connections associated with a scope.
+ * 
+ * @since 1.0
+ * 
  */
 public interface DeviceConnectionService extends KapuaEntityService<DeviceConnection, DeviceConnectionCreator>,
                                          KapuaUpdatableEntityService<DeviceConnection>
 {
+
+    /**
+     * Find the connection by client identifier
+     * 
+     * @param scopeId
+     * @param clientId
+     * @return
+     * @throws KapuaException
+     */
     public DeviceConnection findByClientId(KapuaId scopeId, String clientId)
         throws KapuaException;
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionStatus.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionStatus.java
@@ -12,9 +12,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection;
 
+/**
+ * Device connection status.
+ * 
+ * @since 1.0
+ *
+ */
 public enum DeviceConnectionStatus
 {
+    /**
+     * Connected
+     */
     CONNECTED,
+    /**
+     * Disconnected
+     */
     DISCONNECTED,
+    /**
+     * Missing
+     */
     MISSING
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionSummary.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionSummary.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.KapuaSerializable;
 
 import javax.xml.bind.annotation.*;
 
+/**
+ * Device connection summary definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "connectionSummary")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "connected",
@@ -26,28 +32,78 @@ import javax.xml.bind.annotation.*;
 public interface DeviceConnectionSummary extends KapuaSerializable
 {
 
+    /**
+     * Get the connected count
+     * 
+     * @return
+     */
     @XmlElement(name = "connected")
     public long getConnected();
 
+    /**
+     * Set the connected count
+     * 
+     * @param connected
+     */
     public void setConnected(long connected);
 
+    /**
+     * Get the disconnected count
+     * 
+     * @return
+     */
     @XmlElement(name = "disconnected")
     public long getDisconnected();
 
+    /**
+     * Set the disconnected count
+     * 
+     * @param disconnected
+     */
     public void setDisconnected(long disconnected);
 
+    /**
+     * Get the missing count
+     * 
+     * @return
+     */
     @XmlElement(name = "missing")
     public long getMissing();
 
+    /**
+     * Set the missing count
+     * 
+     * @param missing
+     */
     public void setMissing(long missing);
 
+    /**
+     * Get the enabled count
+     * 
+     * @return
+     */
     @XmlElement(name = "enabled")
     public long getEnabled();
 
+    /**
+     * Set the enabled count
+     * 
+     * @param enabled
+     */
     public void setEnabled(long enabled);
 
+    /**
+     * Get the disabled count
+     * 
+     * @return
+     */
     @XmlElement(name = "disabled")
     public long getDisabled();
 
+    /**
+     * Set the disabled count
+     * 
+     * @param disabled
+     */
     public void setDisabled(long disabled);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
@@ -16,12 +16,23 @@ import org.eclipse.kapua.locator.KapuaLocator;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+/**
+ * Device connection xml factory class
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRegistry
 public class DeviceConnectionXmlRegistry
 {
     private final KapuaLocator            locator = KapuaLocator.getInstance();
     private final DeviceConnectionFactory factory = locator.getFactory(DeviceConnectionFactory.class);
 
+    /**
+     * Creates a new connection summary
+     * 
+     * @return
+     */
     public DeviceConnectionSummary newConnectionSummary()
     {
         return factory.newConnectionSummary();

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
@@ -22,6 +22,12 @@ import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 
 import javax.xml.bind.annotation.*;
 
+/**
+ * Device event entity definition.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement(name = "event")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "deviceId",
@@ -43,44 +49,124 @@ public interface DeviceEvent extends KapuaEntity
         return TYPE;
     }
 
+    /**
+     * Get the device identifier
+     * 
+     * @return
+     */
     @XmlElement(name = "deviceId")
     public KapuaId getDeviceId();
 
+    /**
+     * Set the device identifier
+     * 
+     * @param deviceId
+     */
     public void setDeviceId(KapuaId deviceId);
 
+    /**
+     * Get the sent on date
+     * 
+     * @return
+     */
     @XmlElement(name = "sentOn")
     public Date getSentOn();
 
+    /**
+     * Set the sent on date
+     * 
+     * @param sentOn
+     */
     public void setSentOn(Date sentOn);
 
+    /**
+     * Get the received on date
+     * 
+     * @return
+     */
     @XmlElement(name = "receivedOn")
     public Date getReceivedOn();
 
+    /**
+     * Set the received on date
+     * 
+     * @param receivedOn
+     */
     public void setReceivedOn(Date receivedOn);
 
+    /**
+     * Get the device position
+     * 
+     * @return
+     */
     @XmlElement(name = "position")
     public KapuaPosition getPosition();
 
+    /**
+     * Set the device position
+     * 
+     * @param position
+     */
     public void setPosition(KapuaPosition position);
 
+    /**
+     * Get resource
+     * 
+     * @return
+     */
     @XmlElement(name = "resource")
     public String getResource();
 
+    /**
+     * Set resource
+     * 
+     * @param resource
+     */
     public void setResource(String resource);
 
+    /**
+     * Get action
+     * 
+     * @return
+     */
     @XmlElement(name = "action")
     public KapuaMethod getAction();
 
+    /**
+     * Set action
+     * 
+     * @param action
+     */
     public void setAction(KapuaMethod action);
 
+    /**
+     * Get response code
+     * 
+     * @return
+     */
     @XmlElement(name = "responseCode")
     public KapuaResponseCode getResponseCode();
 
+    /**
+     * Set the response code
+     * 
+     * @param responseCode
+     */
     public void setResponseCode(KapuaResponseCode responseCode);
 
+    /**
+     * Get event message
+     * 
+     * @return
+     */
     @XmlElement(name = "eventMessage")
     public String getEventMessage();
 
+    /**
+     * Set the event message
+     * 
+     * @param eventMessage
+     */
     public void setEventMessage(String eventMessage);
 
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
@@ -20,37 +20,124 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.KapuaMethod;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 
+/**
+ * Device event creator service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent>
 {
+
+    /**
+     * Get the device identifier
+     * 
+     * @return
+     */
     public KapuaId getDeviceId();
 
+    /**
+     * Set the device identifier
+     * 
+     * @param deviceId
+     */
     public void setDeviceId(KapuaId deviceId);
 
+    /**
+     * Get the sent on date
+     * 
+     * @return
+     */
     public Date getSentOn();
 
+    /**
+     * Set the sent on date
+     * 
+     * @param sentOn
+     */
     public void setSentOn(Date sentOn);
 
+    /**
+     * Get the received on date
+     * 
+     * @return
+     */
     public Date getReceivedOn();
 
+    /**
+     * Set the received on date
+     * 
+     * @param receivedOn
+     */
     public void setReceivedOn(Date receivedOn);
 
+    /**
+     * Get device position
+     * 
+     * @return
+     */
     public KapuaPosition getPosition();
 
+    /**
+     * Set device position
+     * 
+     * @param position
+     */
     public void setPosition(KapuaPosition position);
 
+    /**
+     * Get resource
+     * 
+     * @return
+     */
     public String getResource();
 
+    /**
+     * Set resource
+     * 
+     * @param resource
+     */
     public void setResource(String resource);
 
+    /**
+     * GHet action
+     * 
+     * @return
+     */
     public KapuaMethod getAction();
 
+    /**
+     * Set action
+     * 
+     * @param action
+     */
     public void setAction(KapuaMethod action);
 
+    /**
+     * Get response code
+     * 
+     * @return
+     */
     public KapuaResponseCode getResponseCode();
 
+    /**
+     * Set response code
+     * 
+     * @param responseCode
+     */
     public void setResponseCode(KapuaResponseCode responseCode);
 
+    /**
+     * Get event message
+     * 
+     * @return
+     */
     public String getEventMessage();
 
+    /**
+     * Set event message
+     * 
+     * @param eventMessage
+     */
     public void setEventMessage(String eventMessage);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventFactory.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventFactory.java
@@ -17,13 +17,45 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 import java.util.Date;
 
+/**
+ * Device event factory service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceEventFactory extends KapuaObjectFactory
 {
+
+    /**
+     * Creates a new device event creator
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @param receivedOn
+     * @param resource
+     * @return
+     */
     DeviceEventCreator newCreator(KapuaId scopeId, KapuaId deviceId, Date receivedOn, String resource);
 
+    /**
+     * Creates a new device event query based on provided scope identifier
+     * 
+     * @param scopeId
+     * @return
+     */
     DeviceEventQuery newQuery(KapuaId scopeId);
 
+    /**
+     * Creates a new {@link DeviceEvent}
+     * 
+     * @return
+     */
     DeviceEvent newDeviceEvent();
 
+    /**
+     * Creates a new device event list result
+     * 
+     * @return
+     */
     DeviceEventListResult newDeviceListResult();
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventListResult.java
@@ -19,6 +19,12 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * Device event list definition.
+ * 
+ * @since 1.0
+ * 
+ */
 @XmlRootElement(name = "accountListResult")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceEventXmlRegistry.class,factoryMethod = "newDeviceListResult")

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventPredicates.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventPredicates.java
@@ -12,10 +12,28 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.event;
 
+/**
+ * Device event predicates.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceEventPredicates {
 
+    /**
+     * Device identifier
+     */
     public static final String DEVICE_ID = "deviceId";
+    /**
+     * Received on
+     */
     public static final String RECEIVED_ON = "receivedOn";
+    /**
+     * Sent on
+     */
     public static final String SENT_ON = "sentOn";
+    /**
+     * Event type
+     */
     public static final String EVENT_TYPE = "resource";
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventQuery.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.registry.event;
 
 import org.eclipse.kapua.model.query.KapuaQuery;
 
+/**
+ * Device event query definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceEventQuery extends KapuaQuery<DeviceEvent>
 {
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.registry.event;
 
 import org.eclipse.kapua.service.KapuaEntityService;
 
+/**
+ * Device event service definition.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceEventService extends KapuaEntityService<DeviceEvent, DeviceEventCreator>
 {
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
@@ -16,15 +16,31 @@ import org.eclipse.kapua.locator.KapuaLocator;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
+/**
+ * Device event xml factory class.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRegistry
 public class DeviceEventXmlRegistry {
 
     private final KapuaLocator locator = KapuaLocator.getInstance();
     private final DeviceEventFactory factory = locator.getFactory(DeviceEventFactory.class);
     
+    /**
+     * Creates a new device event
+     * 
+     * @return
+     */
     public DeviceEvent newDeviceEvent() {
         return factory.newDeviceEvent();
     }
 
+    /**
+     * Creates a new device event list result
+     * 
+     * @return
+     */
     public DeviceEventListResult newDeviceListResult() { return factory.newDeviceListResult(); }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifeCycleService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifeCycleService.java
@@ -20,11 +20,21 @@ import org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 
+/**
+ * Device life cycle service definition.<br>
+ * This service handles the life cycle messages coming from the device.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceLifeCycleService extends KapuaService
 {
+
     /**
      * Processes a birth certificate for a device, creating or updating the device footprint with the information supplied.
      * 
+     * @param connectionId
+     * @param message
      * @throws KapuaException
      */
     public <M extends KapuaBirthMessage> void birth(KapuaId connectionId, M message)
@@ -33,6 +43,8 @@ public interface DeviceLifeCycleService extends KapuaService
     /**
      * Processes a death certificate for a device, updating the device footprint with the information supplied.
      * 
+     * @param connectionId
+     * @param message
      * @throws KapuaException
      */
     public <M extends KapuaDisconnectMessage> void death(KapuaId connectionId, M message)
@@ -41,6 +53,8 @@ public interface DeviceLifeCycleService extends KapuaService
     /**
      * Processes a last-will testament for a device, updating the device footprint with the information supplied.
      * 
+     * @param connectionId
+     * @param message
      * @throws KapuaException
      */
     public <M extends KapuaMissingMessage> void missing(KapuaId connectionId, M message)
@@ -49,6 +63,8 @@ public interface DeviceLifeCycleService extends KapuaService
     /**
      * Processes a birth certificate for a device, creating or updating the device footprint with the information supplied.
      * 
+     * @param connectionId
+     * @param message
      * @throws KapuaException
      */
     public <M extends KapuaAppsMessage> void applications(KapuaId connectionId, M message)

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifecycleDomain.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifecycleDomain.java
@@ -12,8 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.lifecycle;
 
+/**
+ * Device life cycle domain.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceLifecycleDomain {
 	
+    /**
+     * Device life cycle
+     */
 	String DEVICE_LIFECYCLE = "device_lifecycle";
 
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidation.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidation.java
@@ -25,6 +25,9 @@ import org.eclipse.kapua.service.device.registry.internal.DeviceDomain;
 
 /**
  * Provides logic used to validate preconditions required to execute the device service operation.
+ * 
+ * @since 1.0
+ * 
  */
 public final class DeviceValidation {
 
@@ -32,11 +35,24 @@ public final class DeviceValidation {
 
     private final AuthorizationService authorizationService;
 
+    /**
+     * Constructs
+     * 
+     * @param permissionFactory
+     * @param authorizationService
+     */
     public DeviceValidation(PermissionFactory permissionFactory, AuthorizationService authorizationService) {
         this.permissionFactory = permissionFactory;
         this.authorizationService = authorizationService;
     }
 
+    /**
+     * Validates the device creates precondition
+     * 
+     * @param deviceCreator
+     * @return
+     * @throws KapuaException
+     */
     public DeviceCreator validateCreatePreconditions(DeviceCreator deviceCreator) throws KapuaException {
         ArgumentValidator.notNull(deviceCreator, "deviceCreator");
         ArgumentValidator.notNull(deviceCreator.getScopeId(), "deviceCreator.scopeId");
@@ -47,6 +63,13 @@ public final class DeviceValidation {
         return deviceCreator;
     }
 
+    /**
+     * Validates the device updates precondition
+     * 
+     * @param device
+     * @return
+     * @throws KapuaException
+     */
     public Device validateUpdatePreconditions(Device device) throws KapuaException {
         ArgumentValidator.notNull(device, "device");
         ArgumentValidator.notNull(device.getId(), "device.id");
@@ -57,6 +80,13 @@ public final class DeviceValidation {
         return device;
     }
 
+    /**
+     * Validates the find device precondition
+     * 
+     * @param scopeId
+     * @param entityId
+     * @throws KapuaException
+     */
     public void validateFindPreconditions(KapuaId scopeId, KapuaId entityId) throws KapuaException {
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(entityId, "entityId");
@@ -64,6 +94,12 @@ public final class DeviceValidation {
         authorizationService.checkPermission(permissionFactory.newPermission(DeviceDomain.DEVICE, Actions.read, scopeId));
     }
 
+    /**
+     * Validates the device query precondition
+     * 
+     * @param query
+     * @throws KapuaException
+     */
     public void validateQueryPreconditions(KapuaQuery<Device> query) throws KapuaException {
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
@@ -71,6 +107,12 @@ public final class DeviceValidation {
         authorizationService.checkPermission(permissionFactory.newPermission(DeviceDomain.DEVICE, Actions.read, query.getScopeId()));
     }
 
+    /**
+     * Validates the device count precondition
+     * 
+     * @param query
+     * @throws KapuaException
+     */
     public void validateCountPreconditions(KapuaQuery<Device> query) throws KapuaException {
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
@@ -78,6 +120,13 @@ public final class DeviceValidation {
         authorizationService.checkPermission(permissionFactory.newPermission(DeviceDomain.DEVICE, Actions.read, query.getScopeId()));
     }
 
+    /**
+     * Validates the device delete precondition
+     * 
+     * @param scopeId
+     * @param deviceId
+     * @throws KapuaException
+     */
     public void validateDeletePreconditions(KapuaId scopeId, KapuaId deviceId) throws KapuaException {
         ArgumentValidator.notNull(deviceId, "device.id");
         ArgumentValidator.notNull(scopeId, "device.scopeId");
@@ -85,6 +134,13 @@ public final class DeviceValidation {
         authorizationService.checkPermission(permissionFactory.newPermission(DeviceDomain.DEVICE, Actions.delete, scopeId));
     }
 
+    /**
+     * Validates the device find by identifier precondition
+     * 
+     * @param scopeId
+     * @param clientId
+     * @throws KapuaException
+     */
     public void validateFindByClientIdPreconditions(KapuaId scopeId, String clientId) throws KapuaException {
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notEmptyOrNull(clientId, "clientId");

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionCreatorImpl.java
@@ -19,6 +19,12 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
 
+/**
+ * Device connection creator service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceConnectionCreatorImpl extends AbstractKapuaEntityCreator<DeviceConnection> implements DeviceConnectionCreator
 {
     private static final long serialVersionUID = 2740394157765904615L;
@@ -38,36 +44,47 @@ public class DeviceConnectionCreatorImpl extends AbstractKapuaEntityCreator<Devi
     @XmlElement(name = "serverIp")
     private String            serverIp;
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     public DeviceConnectionCreatorImpl(KapuaId scopeId)
     {
         super(scopeId);
     }
 
+    @Override
     public String getClientId()
     {
         return clientId;
     }
 
+    @Override
     public void setClientId(String clientId)
     {
         this.clientId = clientId;
     }
 
+    @Override
     public KapuaId getUserId()
     {
         return userId;
     }
 
+    @Override
     public void setUserId(KapuaId userId)
     {
         this.userId = userId;
     }
 
+    @Override
     public String getProtocol()
     {
         return protocol;
     }
 
+    @Override
     public void setProtocol(String protocol)
     {
         this.protocol = protocol;
@@ -78,16 +95,19 @@ public class DeviceConnectionCreatorImpl extends AbstractKapuaEntityCreator<Devi
         return clientIp;
     }
 
+    @Override
     public void setClientIp(String clientIp)
     {
         this.clientIp = clientIp;
     }
 
+    @Override
     public String getServerIp()
     {
         return serverIp;
     }
 
+    @Override
     public void setServerIp(String serverIp)
     {
         this.serverIp = serverIp;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
@@ -22,9 +22,22 @@ import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCrea
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionListResult;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionStatus;
 
+/**
+ * Device connection DAO
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceConnectionDAO extends ServiceDAO
 {
 
+    /**
+     * Create a new device connection
+     * 
+     * @param em
+     * @param deviceConnectionCreator
+     * @return
+     */
     public static DeviceConnection create(EntityManager em, DeviceConnectionCreator deviceConnectionCreator)
     {
         DeviceConnection deviceConnection = new DeviceConnectionImpl(deviceConnectionCreator.getScopeId());
@@ -38,6 +51,14 @@ public class DeviceConnectionDAO extends ServiceDAO
         return ServiceDAO.create(em, deviceConnection);
     }
 
+    /**
+     * Update the provided device connection
+     * 
+     * @param em
+     * @param deviceConnection
+     * @return
+     * @throws KapuaException
+     */
     public static DeviceConnection update(EntityManager em, DeviceConnection deviceConnection)
         throws KapuaException
     {
@@ -45,23 +66,52 @@ public class DeviceConnectionDAO extends ServiceDAO
         return ServiceDAO.update(em, DeviceConnectionImpl.class, deviceConnectionImpl);
     }
 
+    /**
+     * Find the device connection by device connection identifier
+     * 
+     * @param em
+     * @param deviceConnectionId
+     * @return
+     */
     public static DeviceConnection find(EntityManager em, KapuaId deviceConnectionId)
     {
         return em.find(DeviceConnectionImpl.class, deviceConnectionId);
     }
 
+    /**
+     * Return the device connection list matching the provided query
+     * 
+     * @param em
+     * @param query
+     * @return
+     * @throws KapuaException
+     */
     public static DeviceConnectionListResult query(EntityManager em, KapuaQuery<DeviceConnection> query)
         throws KapuaException
     {
         return ServiceDAO.query(em, DeviceConnection.class, DeviceConnectionImpl.class, new DeviceConnectionListResultImpl(), query);
     }
 
+    /**
+     * Return the device connection count matching the provided query
+     * 
+     * @param em
+     * @param query
+     * @return
+     * @throws KapuaException
+     */
     public static long count(EntityManager em, KapuaQuery<DeviceConnection> query)
         throws KapuaException
     {
         return ServiceDAO.count(em, DeviceConnection.class, DeviceConnectionImpl.class, query);
     }
 
+    /**
+     * Delete the device connection by device connection identifier
+     * 
+     * @param em
+     * @param deviceConnectionId
+     */
     public static void delete(EntityManager em, KapuaId deviceConnectionId)
     {
         ServiceDAO.delete(em, DeviceConnectionImpl.class, deviceConnectionId);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDomain.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDomain.java
@@ -12,8 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection.internal;
 
+/**
+ * Device connection domain
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceConnectionDomain {
 	
+    /**
+     * Device connection
+     */
     String DEVICE_CONNECTION = "device_connection";
 
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionFactoryImpl.java
@@ -18,6 +18,12 @@ import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFact
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionQuery;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionSummary;
 
+/**
+ * Device connection service factory implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceConnectionFactoryImpl implements DeviceConnectionFactory
 {
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionImpl.java
@@ -32,6 +32,12 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionStatus;
 
+/**
+ * Device connection entity.
+ * 
+ * @since 1.0
+ *
+ */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 @Entity(name = "DeviceConnection")
@@ -72,71 +78,91 @@ public class DeviceConnectionImpl extends AbstractKapuaUpdatableEntity implement
     @Column(name = "server_ip")
     private String                 serverIp;
 
+    /**
+     * Constructor
+     */
     protected DeviceConnectionImpl()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     public DeviceConnectionImpl(KapuaId scopeId)
     {
         super(scopeId);
     }
 
+    @Override
     public DeviceConnectionStatus getStatus()
     {
         return connectionStatus;
     }
 
+    @Override
     public void setStatus(DeviceConnectionStatus connectionStatus)
     {
         this.connectionStatus = connectionStatus;
     }
 
+    @Override
     public String getClientId()
     {
         return clientId;
     }
 
+    @Override
     public void setClientId(String clientId)
     {
         this.clientId = clientId;
     }
 
+    @Override
     public KapuaId getUserId()
     {
         return userId;
     }
 
+    @Override
     public void setUserId(KapuaId userId)
     {
         this.userId = (KapuaEid) userId;
     }
 
+    @Override
     public String getProtocol()
     {
         return protocol;
     }
 
+    @Override
     public void setProtocol(String protocol)
     {
         this.protocol = protocol;
     }
 
+    @Override
     public String getClientIp()
     {
         return clientIp;
     }
 
+    @Override
     public void setClientIp(String clientIp)
     {
         this.clientIp = clientIp;
     }
 
+    @Override
     public String getServerIp()
     {
         return serverIp;
     }
 
+    @Override
     public void setServerIp(String serverIp)
     {
         this.serverIp = serverIp;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionListResultImpl.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionListResult;
 
+/**
+ * Device connection list.
+ *
+ * @since 1.0
+ *
+ */
 public class DeviceConnectionListResultImpl extends KapuaListResultImpl<DeviceConnection> implements DeviceConnectionListResult
 {
     private static final long serialVersionUID = -4450707993798807403L;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionQueryImpl.java
@@ -17,13 +17,28 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionQuery;
 
+/**
+ * Device connection query.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceConnectionQueryImpl extends AbstractKapuaQuery<DeviceConnection> implements DeviceConnectionQuery
 {
+
+    /**
+     * Constructor
+     */
     private DeviceConnectionQueryImpl()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     public DeviceConnectionQueryImpl(KapuaId scopeId)
     {
         this();

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -35,6 +35,9 @@ import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFac
 /**
  * DeviceConnectionService exposes APIs to retrieve Device connections under a scope.
  * It includes APIs to find, list, and update devices connections associated with a scope.
+ * 
+ * @since 1.0
+ * 
  */
 public class DeviceConnectionServiceImpl implements DeviceConnectionService
 {

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionSummaryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionSummaryImpl.java
@@ -14,6 +14,12 @@ package org.eclipse.kapua.service.device.registry.connection.internal;
 
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionSummary;
 
+/**
+ * Device connection summary.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceConnectionSummaryImpl implements DeviceConnectionSummary
 {
     private long connected;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventCreatorImpl.java
@@ -24,6 +24,12 @@ import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
 
+/**
+ * Device event creator service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceEventCreatorImpl extends AbstractKapuaEntityCreator<DeviceEvent> implements DeviceEventCreator
 {
     private static final long serialVersionUID = -3982569213440658172L;
@@ -52,6 +58,11 @@ public class DeviceEventCreatorImpl extends AbstractKapuaEntityCreator<DeviceEve
     @XmlElement(name = "eventMessage")
     private String            eventMessage;
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     protected DeviceEventCreatorImpl(KapuaId scopeId)
     {
         super(scopeId);
@@ -117,21 +128,25 @@ public class DeviceEventCreatorImpl extends AbstractKapuaEntityCreator<DeviceEve
         this.resource = resource;
     }
 
+    @Override
     public KapuaMethod getAction()
     {
         return action;
     }
 
+    @Override
     public void setAction(KapuaMethod action)
     {
         this.action = action;
     }
 
+    @Override
     public KapuaResponseCode getResponseCode()
     {
         return responseCode;
     }
 
+    @Override
     public void setResponseCode(KapuaResponseCode responseCode)
     {
         this.responseCode = responseCode;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDAO.java
@@ -21,9 +21,22 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
 
+/**
+ * Device event DAO
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceEventDAO extends ServiceDAO
 {
 
+    /**
+     * Create a new device event
+     * 
+     * @param em
+     * @param deviceEventCreator
+     * @return
+     */
     public static DeviceEvent create(EntityManager em, DeviceEventCreator deviceEventCreator)
     {
         DeviceEvent deviceEvent = new DeviceEventImpl(deviceEventCreator.getScopeId());
@@ -39,6 +52,14 @@ public class DeviceEventDAO extends ServiceDAO
         return ServiceDAO.create(em, deviceEvent);
     }
 
+    /**
+     * Update the provided device event
+     * 
+     * @param em
+     * @param deviceConnection
+     * @return
+     * @throws KapuaException
+     */
     public static DeviceEvent update(EntityManager em, DeviceEvent deviceConnection)
         throws KapuaException
     {
@@ -48,23 +69,52 @@ public class DeviceEventDAO extends ServiceDAO
         return null;
     }
 
+    /**
+     * Find the device event by device event identifier
+     * 
+     * @param em
+     * @param deviceEventId
+     * @return
+     */
     public static DeviceEvent find(EntityManager em, KapuaId deviceEventId)
     {
         return em.find(DeviceEventImpl.class, deviceEventId);
     }
 
+    /**
+     * Return the device event list matching the provided query
+     * 
+     * @param em
+     * @param query
+     * @return
+     * @throws KapuaException
+     */
     public static DeviceEventListResult query(EntityManager em, KapuaQuery<DeviceEvent> query)
         throws KapuaException
     {
         return ServiceDAO.query(em, DeviceEvent.class, DeviceEventImpl.class, new DeviceEventListResultImpl(), query);
     }
 
+    /**
+     * Return the device event count matching the provided query
+     * 
+     * @param em
+     * @param query
+     * @return
+     * @throws KapuaException
+     */
     public static long count(EntityManager em, KapuaQuery<DeviceEvent> query)
         throws KapuaException
     {
         return ServiceDAO.count(em, DeviceEvent.class, DeviceEventImpl.class, query);
     }
 
+    /**
+     * Delete the device event by device event identifier
+     * 
+     * @param em
+     * @param deviceEventId
+     */
     public static void delete(EntityManager em, KapuaId deviceEventId)
     {
         ServiceDAO.delete(em, DeviceEventImpl.class, deviceEventId);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDomain.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDomain.java
@@ -12,8 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.event.internal;
 
+/**
+ * Device event domain.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceEventDomain  {
-	
+
+    /**
+     * Device event
+     */
     String DEVICE_EVENT = "device_event";
 
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventFactoryImpl.java
@@ -18,8 +18,16 @@ import org.eclipse.kapua.service.device.registry.event.*;
 
 import java.util.Date;
 
+/**
+ * Device event factory service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceEventFactoryImpl implements DeviceEventFactory
 {
+
+    @Override
     public DeviceEventCreator newCreator(KapuaId scopeId, KapuaId deviceId, Date receivedOn, String resource) {
     	DeviceEventCreatorImpl creator = new DeviceEventCreatorImpl(scopeId);
         creator.setDeviceId(deviceId);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventImpl.java
@@ -36,6 +36,12 @@ import org.eclipse.kapua.service.device.management.KapuaMethod;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 
+/**
+ * Device event entity.
+ * 
+ * @since 1.0
+ *
+ */
 @Entity
 @Table(name = "dvc_device_event")
 public class DeviceEventImpl extends AbstractKapuaEntity implements DeviceEvent
@@ -86,11 +92,19 @@ public class DeviceEventImpl extends AbstractKapuaEntity implements DeviceEvent
     @Column(name = "event_message", updatable = false, nullable = false)
     private String            eventMessage;
 
+    /**
+     * Constructor
+     */
     protected DeviceEventImpl()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     public DeviceEventImpl(KapuaId scopeId)
     {
         super(scopeId);
@@ -167,21 +181,25 @@ public class DeviceEventImpl extends AbstractKapuaEntity implements DeviceEvent
         this.resource = resource;
     }
 
+    @Override
     public KapuaMethod getAction()
     {
         return action;
     }
 
+    @Override
     public void setAction(KapuaMethod action)
     {
         this.action = action;
     }
 
+    @Override
     public KapuaResponseCode getResponseCode()
     {
         return responseCode;
     }
 
+    @Override
     public void setResponseCode(KapuaResponseCode responseCode)
     {
         this.responseCode = responseCode;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventListResultImpl.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
 import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
 
+/**
+ * Device event list.
+ * 
+ * @since 1.0
+ * 
+ */
 public class DeviceEventListResultImpl extends KapuaListResultImpl<DeviceEvent> implements DeviceEventListResult
 {
     private static final long serialVersionUID = 6537888946643944463L;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventQueryImpl.java
@@ -17,13 +17,28 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventQuery;
 
+/**
+ * Device event query.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceEventQueryImpl extends AbstractKapuaQuery<DeviceEvent> implements DeviceEventQuery
 {
+
+    /**
+     * Constructor
+     */
     private DeviceEventQueryImpl()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     public DeviceEventQueryImpl(KapuaId scopeId)
     {
         this();

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceImpl.java
@@ -30,6 +30,12 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFactory;
 
+/**
+ * Device event service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceEventServiceImpl implements DeviceEventService {
 
     private final AuthorizationService authorizationService;
@@ -38,6 +44,12 @@ public class DeviceEventServiceImpl implements DeviceEventService {
 
     private final EntityManagerSession entityManagerSession;
 
+    /**
+     * Constructor
+     * 
+     * @param authorizationService
+     * @param permissionFactory
+     */
     public DeviceEventServiceImpl(AuthorizationService authorizationService, PermissionFactory permissionFactory) {
         this.authorizationService = authorizationService;
         this.permissionFactory = permissionFactory;
@@ -45,6 +57,9 @@ public class DeviceEventServiceImpl implements DeviceEventService {
         this.entityManagerSession = new EntityManagerSession(DeviceEntityManagerFactory.instance());
     }
 
+    /**
+     * Constructor
+     */
     public DeviceEventServiceImpl() {
         KapuaLocator locator = KapuaLocator.getInstance();
         authorizationService = locator.getService(AuthorizationService.class);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
@@ -19,12 +19,15 @@ import org.eclipse.kapua.service.device.registry.DeviceCreator;
 import org.eclipse.kapua.service.device.registry.DeviceCredentialsMode;
 
 /**
- * DeviceCreator encapsulates all the information needed to create a new Device in the system.
- * The data provided will be used to seed the new Device and its related information.
- * The fields of the DeviceCreator presents the attributes that are searchable for a given device.
+ * DeviceCreator encapsulates all the information needed to create a new Device in the system.<br>
+ * The data provided will be used to seed the new Device and its related information.<br>
+ * The fields of the DeviceCreator presents the attributes that are searchable for a given device.<br>
  * The DeviceCreator Properties field can be used to provide additional properties associated to the Device;
- * those properties will not be searchable through Device queries.
+ * those properties will not be searchable through Device queries.<br>
  * The clientId field of the Device is used to store the MAC address of the primary network interface of the device.
+ * 
+ * @since 1.0
+ * 
  */
 public class DeviceCreatorImpl extends AbstractKapuaEntityCreator<Device> implements DeviceCreator
 {
@@ -55,16 +58,23 @@ public class DeviceCreatorImpl extends AbstractKapuaEntityCreator<Device> implem
     private DeviceCredentialsMode deviceCredentialsMode;
     private KapuaId               preferredUserId;
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     protected DeviceCreatorImpl(KapuaId scopeId)
     {
         super(scopeId);
     }
 
+    @Override
     public String getClientId()
     {
         return clientId;
     }
 
+    @Override
     public void setClientId(String clientId)
     {
         this.clientId = clientId;
@@ -82,231 +92,287 @@ public class DeviceCreatorImpl extends AbstractKapuaEntityCreator<Device> implem
         this.connectionId = connectionId;
     }
 
+    @Override
     public String getDisplayName()
     {
         return displayName;
     }
 
+    @Override
     public void setDisplayName(String displayName)
     {
         this.displayName = displayName;
     }
 
+    @Override
     public String getSerialNumber()
     {
         return serialNumber;
     }
 
+    @Override
     public void setSerialNumber(String serialNumber)
     {
         this.serialNumber = serialNumber;
     }
 
+    @Override
     public String getModelId()
     {
         return modelId;
     }
 
+    @Override
     public void setModelId(String modelId)
     {
         this.modelId = modelId;
     }
 
+    @Override
     public String getImei()
     {
         return imei;
     }
 
+    @Override
     public void setImei(String imei)
     {
         this.imei = imei;
     }
 
+    @Override
     public String getImsi()
     {
         return imsi;
     }
 
+    @Override
     public void setImsi(String imsi)
     {
         this.imsi = imsi;
     }
 
+    @Override
     public String getIccid()
     {
         return iccid;
     }
 
+    @Override
     public void setIccid(String iccid)
     {
         this.iccid = iccid;
     }
 
+    @Override
     public String getBiosVersion()
     {
         return biosVersion;
     }
 
+    @Override
     public void setBiosVersion(String biosVersion)
     {
         this.biosVersion = biosVersion;
     }
 
+    @Override
     public String getFirmwareVersion()
     {
         return firmwareVersion;
     }
 
+    @Override
     public void setFirmwareVersion(String firmwareVersion)
     {
         this.firmwareVersion = firmwareVersion;
     }
 
+    @Override
     public String getOsVersion()
     {
         return osVersion;
     }
 
+    @Override
     public void setOsVersion(String osVersion)
     {
         this.osVersion = osVersion;
     }
 
+    @Override
     public String getJvmVersion()
     {
         return jvmVersion;
     }
 
+    @Override
     public void setJvmVersion(String jvmVersion)
     {
         this.jvmVersion = jvmVersion;
     }
 
+    @Override
     public String getOsgiFrameworkVersion()
     {
         return osgiFrameworkVersion;
     }
 
+    @Override
     public void setOsgiFrameworkVersion(String osgiFrameworkVersion)
     {
         this.osgiFrameworkVersion = osgiFrameworkVersion;
     }
 
+    @Override
     public String getApplicationFrameworkVersion()
     {
         return applicationFrameworkVersion;
     }
 
+    @Override
     public void setApplicationFrameworkVersion(String applicationFrameworkVersion)
     {
         this.applicationFrameworkVersion = applicationFrameworkVersion;
     }
 
+    @Override
     public String getApplicationIdentifiers()
     {
         return applicationIdentifiers;
     }
 
+    @Override
     public void setApplicationIdentifiers(String applicationIdentifiers)
     {
         this.applicationIdentifiers = applicationIdentifiers;
     }
 
+    @Override
     public String getAcceptEncoding()
     {
         return acceptEncoding;
     }
 
+    @Override
     public void setAcceptEncoding(String acceptEncoding)
     {
         this.acceptEncoding = acceptEncoding;
     }
 
+    /**
+     * Get the gps longitude
+     * 
+     * @return
+     */
     public Double getGpsLongitude()
     {
         return gpsLongitude;
     }
 
+    /**
+     * Set the gps longitude
+     * 
+     * @param gpsLongitude
+     */
     public void setGpsLongitude(Double gpsLongitude)
     {
         this.gpsLongitude = gpsLongitude;
     }
 
+    /**
+     * Get the gps latitude
+     * 
+     * @return
+     */
     public Double getGpsLatitude()
     {
         return gpsLatitude;
     }
 
+    /**
+     * Set the gps latitude
+     * 
+     * @param gpsLatitude
+     */
     public void setGpsLatitude(Double gpsLatitude)
     {
         this.gpsLatitude = gpsLatitude;
     }
-
+    @Override
     public String getCustomAttribute1()
     {
         return customAttribute1;
     }
-
+    @Override
     public void setCustomAttribute1(String customAttribute1)
     {
         this.customAttribute1 = customAttribute1;
     }
-
+    @Override
     public String getCustomAttribute2()
     {
         return customAttribute2;
     }
-
+    @Override
     public void setCustomAttribute2(String customAttribute2)
     {
         this.customAttribute2 = customAttribute2;
     }
-
+    @Override
     public String getCustomAttribute3()
     {
         return customAttribute3;
     }
-
+    @Override
     public void setCustomAttribute3(String customAttribute3)
     {
         this.customAttribute3 = customAttribute3;
     }
 
+    @Override
     public String getCustomAttribute4()
     {
         return customAttribute4;
     }
 
+    @Override
     public void setCustomAttribute4(String customAttribute4)
     {
         this.customAttribute4 = customAttribute4;
     }
 
+    @Override
     public String getCustomAttribute5()
     {
         return customAttribute5;
     }
 
+    @Override
     public void setCustomAttribute5(String customAttribute5)
     {
         this.customAttribute5 = customAttribute5;
     }
 
+    @Override
     public DeviceCredentialsMode getCredentialsMode()
     {
         return deviceCredentialsMode;
     }
 
+    @Override
     public void setCredentialsMode(DeviceCredentialsMode credentialsMode)
     {
         this.deviceCredentialsMode = credentialsMode;
     }
 
+    @Override
     public KapuaId getPreferredUserId()
     {
         return preferredUserId;
     }
 
+    @Override
     public void setPreferredUserId(KapuaId preferredUserId)
     {
         this.preferredUserId = preferredUserId;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
@@ -22,8 +22,21 @@ import org.eclipse.kapua.service.device.registry.DeviceCreator;
 import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DeviceStatus;
 
+/**
+ * Device DAO
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceDAO extends ServiceDAO {
 
+    /**
+     * Creates a new Device
+     * 
+     * @param em
+     * @param deviceCreator
+     * @return
+     */
     public static Device create(EntityManager em, DeviceCreator deviceCreator) {
         Device device = new DeviceImpl(deviceCreator.getScopeId());
 
@@ -59,25 +72,61 @@ public class DeviceDAO extends ServiceDAO {
         return ServiceDAO.create(em, device);
     }
 
+    /**
+     * Updates the provided device
+     * 
+     * @param em
+     * @param device
+     * @return
+     */
     public static Device update(EntityManager em, Device device) {
         DeviceImpl deviceImpl = (DeviceImpl) device;
         return ServiceDAO.update(em, DeviceImpl.class, deviceImpl);
     }
 
+    /**
+     * Finds the device by device identifier
+     * 
+     * @param em
+     * @param deviceId
+     * @return
+     */
     public static Device find(EntityManager em, KapuaId deviceId) {
         return em.find(DeviceImpl.class, deviceId);
     }
 
+    /**
+     * Returns the device list matching the provided query
+     * 
+     * @param em
+     * @param query
+     * @return
+     * @throws KapuaException
+     */
     public static DeviceListResult query(EntityManager em, KapuaQuery<Device> query)
             throws KapuaException {
         return ServiceDAO.query(em, Device.class, DeviceImpl.class, new DeviceListResultImpl(), query);
     }
 
+    /**
+     * Returns the device count matching the provided query
+     * 
+     * @param em
+     * @param query
+     * @return
+     * @throws KapuaException
+     */
     public static long count(EntityManager em, KapuaQuery<Device> query)
             throws KapuaException {
         return ServiceDAO.count(em, Device.class, DeviceImpl.class, query);
     }
 
+    /**
+     * Deletes the device by device identifier
+     * 
+     * @param em
+     * @param deviceId
+     */
     public static void delete(EntityManager em, KapuaId deviceId) {
         ServiceDAO.delete(em, DeviceImpl.class, deviceId);
     }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDomain.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDomain.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.internal;
 
+/**
+ * Device domanin.
+ * 
+ * @since 1.0
+ *
+ */
 public interface DeviceDomain {
 	
     String DEVICE = "device";

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceEntityManagerFactory.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceEntityManagerFactory.java
@@ -19,6 +19,12 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.jpa.AbstractEntityManagerFactory;
 import org.eclipse.kapua.commons.jpa.EntityManager;
 
+/**
+ * Entity manager factory for the device module.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceEntityManagerFactory extends AbstractEntityManagerFactory
 {
     private static final String               PERSISTENCE_UNIT_NAME = "kapua-device";
@@ -27,6 +33,9 @@ public class DeviceEntityManagerFactory extends AbstractEntityManagerFactory
 
     private static DeviceEntityManagerFactory instance              = new DeviceEntityManagerFactory();
 
+    /**
+     * Constructs a new entity manager factory and configure it to use the device persistence unit.
+     */
     private DeviceEntityManagerFactory()
     {
         super(PERSISTENCE_UNIT_NAME,
@@ -34,12 +43,22 @@ public class DeviceEntityManagerFactory extends AbstractEntityManagerFactory
               s_uniqueConstraints);
     }
 
+    /**
+     * Return a new {@link EntityManager} instance
+     * 
+     * @return
+     */
     public static EntityManager getEntityManager()
         throws KapuaException
     {
         return instance.createEntityManager();
     }
 
+    /**
+     * Return the {@link EntityManager} singleton instance
+     * 
+     * @return
+     */
     public static DeviceEntityManagerFactory instance() {
         return instance;
     }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceFactoryImpl.java
@@ -19,6 +19,12 @@ import org.eclipse.kapua.service.device.registry.DeviceFactory;
 import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DeviceQuery;
 
+/**
+ * Device service factory implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceFactoryImpl implements DeviceFactory
 {
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImpl.java
@@ -32,6 +32,12 @@ import org.eclipse.kapua.service.device.registry.DeviceCredentialsMode;
 import org.eclipse.kapua.service.device.registry.DeviceEventType;
 import org.eclipse.kapua.service.device.registry.DeviceStatus;
 
+/**
+ * Device object implementation.
+ * 
+ * @since 1.0
+ *
+ */
 @Entity(name = "Device")
 @Table(name = "dvc_device")
 public class DeviceImpl extends AbstractKapuaUpdatableEntity implements Device {
@@ -145,18 +151,28 @@ public class DeviceImpl extends AbstractKapuaUpdatableEntity implements Device {
     })
     private KapuaEid preferredUserId;
 
+    /**
+     * Constructor
+     */
     protected DeviceImpl() {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     public DeviceImpl(KapuaId scopeId) {
         super(scopeId);
     }
 
+    @Override
     public String getClientId() {
         return clientId;
     }
 
+    @Override
     public void setClientId(String clientId) {
         this.clientId = clientId;
     }
@@ -173,196 +189,244 @@ public class DeviceImpl extends AbstractKapuaUpdatableEntity implements Device {
         }
     }
 
+    @Override
     public DeviceStatus getStatus() {
         return status;
     }
 
+    @Override
     public void setStatus(DeviceStatus status) {
         this.status = status;
     }
 
+    @Override
     public String getDisplayName() {
         return displayName;
     }
 
+    @Override
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
     }
 
+    @Override
     public Date getLastEventOn() {
         return lastEventOn;
     }
 
+    @Override
     public void setLastEventOn(Date lastEventOn) {
         this.lastEventOn = lastEventOn;
     }
 
+    @Override
     public DeviceEventType getLastEventType() {
         return lastEventType;
     }
 
+    @Override
     public void setLastEventType(DeviceEventType lastEventType) {
         this.lastEventType = lastEventType;
     }
 
+    @Override
     public String getSerialNumber() {
         return serialNumber;
     }
 
+    @Override
     public void setSerialNumber(String serialNumber) {
         this.serialNumber = serialNumber;
     }
 
+    @Override
     public String getModelId() {
         return modelId;
     }
 
+    @Override
     public void setModelId(String modelId) {
         this.modelId = modelId;
     }
 
+    @Override
     public String getImei() {
         return imei;
     }
 
+    @Override
     public void setImei(String imei) {
         this.imei = imei;
     }
 
+    @Override
     public String getImsi() {
         return imsi;
     }
 
+    @Override
     public void setImsi(String imsi) {
         this.imsi = imsi;
     }
 
+    @Override
     public String getIccid() {
         return iccid;
     }
 
+    @Override
     public void setIccid(String iccid) {
         this.iccid = iccid;
     }
 
+    @Override
     public String getBiosVersion() {
         return biosVersion;
     }
 
+    @Override
     public void setBiosVersion(String biosVersion) {
         this.biosVersion = biosVersion;
     }
 
+    @Override
     public String getFirmwareVersion() {
         return firmwareVersion;
     }
 
+    @Override
     public void setFirmwareVersion(String firmwareVersion) {
         this.firmwareVersion = firmwareVersion;
     }
 
+    @Override
     public String getOsVersion() {
         return osVersion;
     }
 
+    @Override
     public void setOsVersion(String osVersion) {
         this.osVersion = osVersion;
     }
 
+    @Override
     public String getJvmVersion() {
         return jvmVersion;
     }
 
+    @Override
     public void setJvmVersion(String jvmVersion) {
         this.jvmVersion = jvmVersion;
     }
 
+    @Override
     public String getOsgiFrameworkVersion() {
         return osgiFrameworkVersion;
     }
 
+    @Override
     public void setOsgiFrameworkVersion(String osgiFrameworkVersion) {
         this.osgiFrameworkVersion = osgiFrameworkVersion;
     }
 
+    @Override
     public String getApplicationFrameworkVersion() {
         return applicationFrameworkVersion;
     }
 
+    @Override
     public void setApplicationFrameworkVersion(String applicationFrameworkVersion) {
         this.applicationFrameworkVersion = applicationFrameworkVersion;
     }
 
+    @Override
     public String getApplicationIdentifiers() {
         return applicationIdentifiers;
     }
 
+    @Override
     public void setApplicationIdentifiers(String applicationIdentifiers) {
         this.applicationIdentifiers = applicationIdentifiers;
     }
 
+    @Override
     public String getAcceptEncoding() {
         return acceptEncoding;
     }
 
+    @Override
     public void setAcceptEncoding(String acceptEncoding) {
         this.acceptEncoding = acceptEncoding;
     }
 
+    @Override
     public String getCustomAttribute1() {
         return customAttribute1;
     }
 
+    @Override
     public void setCustomAttribute1(String customAttribute1) {
         this.customAttribute1 = customAttribute1;
     }
 
+    @Override
     public String getCustomAttribute2() {
         return customAttribute2;
     }
 
+    @Override
     public void setCustomAttribute2(String customAttribute2) {
         this.customAttribute2 = customAttribute2;
     }
 
+    @Override
     public String getCustomAttribute3() {
         return customAttribute3;
     }
 
+    @Override
     public void setCustomAttribute3(String customAttribute3) {
         this.customAttribute3 = customAttribute3;
     }
 
+    @Override
     public String getCustomAttribute4() {
         return customAttribute4;
     }
 
+    @Override
     public void setCustomAttribute4(String customAttribute4) {
         this.customAttribute4 = customAttribute4;
     }
 
+    @Override
     public String getCustomAttribute5() {
         return customAttribute5;
     }
 
+    @Override
     public void setCustomAttribute5(String customAttribute5) {
         this.customAttribute5 = customAttribute5;
     }
 
+    @Override
     public DeviceCredentialsMode getCredentialsMode() {
         return deviceCredentialsMode != null ? DeviceCredentialsMode.valueOf(deviceCredentialsMode) : null;
     }
 
+    @Override
     public void setCredentialsMode(DeviceCredentialsMode deviceCredentialsMode) {
         if (deviceCredentialsMode != null) {
             this.deviceCredentialsMode = deviceCredentialsMode.name();
         }
     }
 
+    @Override
     public org.eclipse.kapua.model.id.KapuaId getPreferredUserId() {
         return preferredUserId;
     }
 
+    @Override
     public void setPreferredUserId(KapuaId preferredUserId) {
         this.preferredUserId = (KapuaEid) preferredUserId;
     }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceListResultImpl.java
@@ -16,6 +16,12 @@ import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceListResult;
 
+/**
+ * Device list result implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceListResultImpl extends KapuaListResultImpl<Device> implements DeviceListResult
 {
     private static final long serialVersionUID = -3870951363076544938L;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceQueryImpl.java
@@ -17,13 +17,28 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceQuery;
 
+/**
+ * Device query implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceQueryImpl extends AbstractKapuaQuery<Device> implements DeviceQuery
 {
+
+    /**
+     * Constructor
+     */
     private DeviceQueryImpl()
     {
         super();
     }
 
+    /**
+     * Constructor
+     * 
+     * @param scopeId
+     */
     public DeviceQueryImpl(KapuaId scopeId)
     {
         this();

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -28,22 +28,29 @@ import org.eclipse.kapua.service.device.registry.DevicePredicates;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 import org.eclipse.kapua.service.device.registry.common.DeviceValidation;
 
+/**
+ * Device registry service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceRegistryServiceImpl implements DeviceRegistryService {
 
     // Collaborator members
-
     private final AuthorizationService authorizationService;
-
     private final PermissionFactory permissionFactory;
-
     private final DeviceValidation deviceValidation;
-
     private final DeviceEntityManagerFactory deviceEntityManagerFactory;
-
     private final EntityManagerSession entityManagerSession;
 
     // Constructors
-
+    /**
+     * Constructor
+     * 
+     * @param authorizationService
+     * @param permissionFactory
+     * @param deviceEntityManagerFactory
+     */
     public DeviceRegistryServiceImpl(AuthorizationService authorizationService, PermissionFactory permissionFactory, DeviceEntityManagerFactory deviceEntityManagerFactory) {
         this.authorizationService = authorizationService;
         this.permissionFactory = permissionFactory;
@@ -52,6 +59,9 @@ public class DeviceRegistryServiceImpl implements DeviceRegistryService {
         this.entityManagerSession = new EntityManagerSession(deviceEntityManagerFactory);
     }
 
+    /**
+     * Constructor
+     */
     public DeviceRegistryServiceImpl() {
         KapuaLocator locator = KapuaLocator.getInstance();
         authorizationService = locator.getService(AuthorizationService.class);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
@@ -34,6 +34,12 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService;
 
+/**
+ * Device life cycle service implementation.
+ * 
+ * @since 1.0
+ *
+ */
 public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService
 {
     @Override


### PR DESCRIPTION
Added javadoc to all devices modules.

This should be the current list of missing javadoc modules:
- datastore-api
- datastore-internal
- console
- rest-api
