### PR TITLE
Added jacoco and cucumber reports to build

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -267,6 +267,20 @@
 							<appendAssemblyId>false</appendAssemblyId>
 						</configuration>
 					</execution>
+					<execution>
+						<id>kapua-cucumber-report</id>
+						<phase>package</phase>
+						<goals>
+							<goal>attached</goal>
+						</goals>
+						<configuration>
+							<descriptors>
+								<descriptor>src/main/descriptors/kapua-cucumber-report.xml</descriptor>
+							</descriptors>
+							<finalName>kapua-cucumber-report</finalName>
+							<appendAssemblyId>false</appendAssemblyId>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 

--- a/assembly/src/main/descriptors/kapua-cucumber-report.xml
+++ b/assembly/src/main/descriptors/kapua-cucumber-report.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+  -->
+<assembly>
+    <id>kapua-cucumber-report</id>
+
+    <formats>
+        <format>dir</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <outputDirectory>/</outputDirectory>
+            <directory>src/main/resources/html/cucumber</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>/user-service</outputDirectory>
+            <directory>../service/user/internal/target/cucumber</directory>
+        </fileSet>
+    </fileSets>
+
+</assembly>

--- a/assembly/src/main/resources/html/cucumber/index.html
+++ b/assembly/src/main/resources/html/cucumber/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Kapua Cucumber Reports</title>
+  </head>
+  <body>
+    <h1>Kapua Cucumber Reports</h1>
+    <h2>Functional tests</h2>
+    <ul>
+        <li><a href="user-service/index.html">User service</a></li>
+        <!--li>Other service</li-->
+    </ul>
+    <!-- Integration tests -->
+    
+    <!-- UI tests with Selenium -->
+    
+    <!-- REST tests-->
+  </body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,9 @@
         <docker-maven-plugin.version>0.17.2</docker-maven-plugin.version>
         <liquibase-plugin.version>3.0.5</liquibase-plugin.version>
 
+        <jacoco.version>0.7.4.201502262128</jacoco.version>
+        <surefire.version>2.12.4</surefire.version>
+
         <!-- -->
         <!-- Database configuration for local installs and tests -->
         <!-- Database host address is the one exported by the dev-tools/src/vagrant/Vagrantfile  -->        
@@ -212,6 +215,36 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <!-- no argLine here -->
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>


### PR DESCRIPTION
Jacoco plugin was added to master pom file. Jacoco coverage reports are generated
and later used in Hudson CI.

Cucumber reports are generated in test phase of build. Assembly of those reports was
added to assembly project. This assembly also has an index page that combines all
cucumber reports on a single page. This page is published with Hudson Html publishing
plugin.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>