### PR TITLE
Account service CRUD tests.

### DIFF
--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -1,86 +1,123 @@
 <?xml version="1.0"?>
 <!-- Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others All rights reserved. 
-	This program and the accompanying materials are made available under the 
-	terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-	and is available at http://www.eclipse.org/legal/epl-v10.html Contributors: 
-	Eurotech - initial API and implementation -->
+    This program and the accompanying materials are made available under the 
+    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
+    and is available at http://www.eclipse.org/legal/epl-v10.html Contributors: 
+    Eurotech - initial API and implementation -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.eclipse.kapua</groupId>
-		<artifactId>kapua-account</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
-	</parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua-account</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>kapua-account-internal</artifactId>
-	<name>${project.artifactId}</name>
+    <artifactId>kapua-account-internal</artifactId>
+    <name>${project.artifactId}</name>
 
-	<dependencies>
-		<!-- Implemented service interfaces -->
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-account-api</artifactId>
-		</dependency>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <locator.class.impl>org.eclipse.kapua.test.MockedLocator</locator.class.impl>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-		<!-- Required service interfaces -->
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-security-authorization-api</artifactId>
-		</dependency>
+    <dependencies>
+        <!-- Implemented service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-api</artifactId>
+        </dependency>
 
-		<!-- Internal dependencies -->
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-commons</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-guice</artifactId>
-		</dependency> 
+        <!-- Required service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-authorization-api</artifactId>
+        </dependency>
 
-		<!-- Test dependencies -->
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-guice</artifactId>
+        </dependency> 
 
-	<profiles>
-		<profile>
-			<id>sql</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>sql-maven-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>create-schema</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>execute</goal>
-								</goals>
-								<configuration>
-									<autocommit>true</autocommit>
-									<srcFiles>
-										<srcFile>src/main/sql/H2/act_account_drop.sql</srcFile>
-										<srcFile>src/main/sql/H2/act_account_create.sql</srcFile>
-										<srcFile>src/main/sql/H2/act_account_seed.sql</srcFile>
-									</srcFiles>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-core</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>sql</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>sql-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-schema</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <autocommit>true</autocommit>
+                                    <srcFiles>
+                                        <srcFile>src/main/sql/H2/act_account_drop.sql</srcFile>
+                                        <srcFile>src/main/sql/H2/act_account_create.sql</srcFile>
+                                        <srcFile>src/main/sql/H2/act_account_seed.sql</srcFile>
+                                    </srcFiles>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/service/account/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.account.AccountService.xml
+++ b/service/account/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.account.AccountService.xml
@@ -14,7 +14,7 @@
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kapua.service.account.AccountService"
-         name="UserService" 
+         name="AccountService" 
          description="This is the configuration for the kapua AccountService. ">
         
         <Icon resource="OSGI-INF/account-service.png" size="32"/>

--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
@@ -1,0 +1,628 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.account.internal;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+import java.math.BigInteger;
+import java.security.acl.Permission;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtils;
+import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.model.config.metatype.KapuaTocd;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountCreator;
+import org.eclipse.kapua.service.account.AccountFactory;
+import org.eclipse.kapua.service.account.AccountQuery;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.account.Organization;
+import org.eclipse.kapua.service.account.internal.setting.KapuaAccountSetting;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.MockedLocator;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+
+/**
+ * Implementation of Gherkin steps used in AccountService.feature scenarios.
+ *
+ * MockedLocator is used for Location Service. Mockito is used to mock other
+ * services that the Account services dependent on. Dependent services are: -
+ * Authorization Service -
+ *
+ *
+ */
+public class AccountServiceTestSteps extends KapuaTest {
+
+    public static String DEFAULT_PATH = "src/main/sql/H2";
+    public static String DEFAULT_COMMONS_PATH = "../../../commons";
+    public static String CREATE_ACCOUNT_TABLES = "act_*.sql";
+    public static String DROP_ACCOUNT_TABLES = "act_*_drop.sql";
+
+    KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
+
+    @SuppressWarnings("unused")
+    private static final Logger s_logger = LoggerFactory.getLogger(AccountServiceTestSteps.class);
+
+    // Account creator object used for creating new accounts.
+    AccountCreator accountCreator = null;
+    AccountService accountService = null;
+    AccountFactory accountFactory = null;
+
+    // Simple account objects used for creation and checks of account operations.
+    Account account;
+    Organization organization;
+    KapuaId accountId;
+
+    // Check if exception was fired in step.
+    boolean exceptionCaught = false;
+
+    // Currently executing scenario.
+    Scenario scenario;
+
+    // Metadata boolean value.
+    Boolean boolVal = null;
+
+    // Metadata integer value.
+    Integer intVal = null;
+
+    // Default constructor
+    public AccountServiceTestSteps() {
+    }
+
+    // *************************************
+    // Definition of Cucumber scenario steps
+    // *************************************
+
+    // Setup and tear-down steps
+
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+        this.scenario = scenario;
+        exceptionCaught = false;
+
+        // Create User Service tables
+        enableH2Connection();
+
+        // Create the account service tables
+        KapuaConfigurableServiceSchemaUtils.createSchemaObjects(DEFAULT_COMMONS_PATH);
+        scriptSession(AccountEntityManagerFactory.getInstance(), CREATE_ACCOUNT_TABLES);
+        XmlUtil.setContextProvider(new AccountsJAXBContextProvider());
+
+        MockedLocator mockLocator = (MockedLocator) locator;
+
+        // Inject mocked Authorization Service method checkPermission
+        AuthorizationService mockedAuthorization = mock(AuthorizationService.class);
+        // TODO: Check why does this line needs an explicit cast!
+        Mockito.doNothing().when(mockedAuthorization).checkPermission(
+                (org.eclipse.kapua.service.authorization.permission.Permission) any(Permission.class));
+        mockLocator.setMockedService(org.eclipse.kapua.service.authorization.AuthorizationService.class,
+                mockedAuthorization);
+
+        // Inject mocked Permission Factory
+        PermissionFactory mockedPermissionFactory = mock(PermissionFactory.class);
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.authorization.permission.PermissionFactory.class,
+                mockedPermissionFactory);
+
+        // Inject actual account related services
+        accountService = new AccountServiceImpl();
+        mockLocator.setMockedService(org.eclipse.kapua.service.account.AccountService.class, accountService);
+        accountFactory = new AccountFactoryImpl();
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.account.AccountFactory.class, accountFactory);
+
+        // Set KapuaMetatypeFactory for Metatype configuration
+        mockLocator.setMockedFactory(org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory.class, new KapuaMetatypeFactoryImpl());
+
+        // All operations on database are performed using system user.
+        KapuaSession kapuaSession = new KapuaSession(null, null, new KapuaEid(BigInteger.ONE), new KapuaEid(BigInteger.ONE), "kapua-sys");
+        KapuaSecurityUtils.setSession(kapuaSession);
+    }
+
+    @After
+    public void afterScenario() throws Exception {
+        // Drop the Account Service tables
+        scriptSession(AccountEntityManagerFactory.getInstance(), DROP_ACCOUNT_TABLES);
+        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
+        KapuaSecurityUtils.clearSession();
+    }
+
+    // The Cucumber test steps
+
+    @Given("^An account creator with the name \"(.*)\"$")
+    public void prepareTestAccountCreatorWithName(String name) {
+        accountCreator = prepareRegularAccountCreator(rootScopeId, name);
+    }
+
+    @Given("^An existing account with the name \"(.*)\"$")
+    public void createTestAccountWithName(String name)
+            throws KapuaException {
+        accountCreator = prepareRegularAccountCreator(rootScopeId, name);
+        account = accountService.create(accountCreator);
+        accountId = account.getId();
+    }
+
+    @Given("^I create (\\d+) childs for account with Id (\\d+)$")
+    public void createANumberOfAccounts(int num, int parentId)
+            throws KapuaException {
+        exceptionCaught = false;
+        for (int i = 0; i < num; i++) {
+            accountCreator = prepareRegularAccountCreator(new KapuaEid(BigInteger.valueOf(parentId)), "tmp_acc_" + String.format("%d", i));
+            try {
+                accountService.create(accountCreator);
+            } catch (KapuaException ex) {
+                exceptionCaught = true;
+                break;
+            }
+        }
+    }
+
+    @Given("^I create (\\d+) childs for account with name \"(.*)\"$")
+    public void createANumberOfChildrenForAccountWithName(int num, String name)
+            throws KapuaException {
+        Account tmpAcc = accountService.findByName(name);
+        exceptionCaught = false;
+        for (int i = 0; i < num; i++) {
+            accountCreator = prepareRegularAccountCreator(tmpAcc.getId(), "tmp_acc_" + String.format("%d", i));
+            try {
+                accountService.create(accountCreator);
+            } catch (KapuaException ex) {
+                exceptionCaught = true;
+                break;
+            }
+        }
+    }
+
+    @Given("^I create (\\d+) accounts with organization name \"(.*)\"$")
+    public void createANumberOfChildrenForAccountWithOrganizationName(int num, String name)
+            throws KapuaException {
+        exceptionCaught = false;
+        for (int i = 0; i < num; i++) {
+            accountCreator = prepareRegularAccountCreator(rootScopeId, "tmp_acc_" + String.format("%d", i));
+            accountCreator.setOrganizationName(name);
+            try {
+                accountService.create(accountCreator);
+            } catch (KapuaException ex) {
+                exceptionCaught = true;
+                break;
+            }
+        }
+    }
+
+    @When("^I create account \"(.*)\"$")
+    public void createAccount(String name)
+            throws Exception {
+        accountCreator = prepareRegularAccountCreator(rootScopeId, name);
+        account = accountService.create(accountCreator);
+        accountId = account.getId();
+    }
+
+    @When("^I create a duplicate account \"(.*)\"$")
+    public void createDuplicateAccount(String name)
+            throws Exception {
+        accountCreator = prepareRegularAccountCreator(rootScopeId, name);
+        try {
+            exceptionCaught = false;
+            account = accountService.create(accountCreator);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I create an account with a null name$")
+    public void createAccountWithNullName() {
+        accountCreator = prepareRegularAccountCreator(rootScopeId, null);
+        try {
+            exceptionCaught = false;
+            account = accountService.create(accountCreator);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I modify the account \"(.*)\"$")
+    public void changeAccountDetails(String name)
+            throws KapuaException {
+        account = accountService.findByName(name);
+        Organization tmpOrg = account.getOrganization();
+
+        // Change an organization detail
+        tmpOrg.setName(tmpOrg.getName() + "_xx");
+        tmpOrg.setCity(tmpOrg.getCity() + "_xx");
+        account.setOrganization(tmpOrg);
+
+        accountService.update(account);
+    }
+
+    @When("^I modify the current account$")
+    public void updateAccount() {
+        try {
+            exceptionCaught = false;
+            accountService.update(account);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I change the account \"(.*)\" name to \"(.*)\"$")
+    public void changeAccountName(String acc_name, String name)
+            throws KapuaException {
+        Account tmpAcc = accountService.findByName(acc_name);
+
+        tmpAcc.setName(name);
+        try {
+            exceptionCaught = false;
+            accountService.update(tmpAcc);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I change the parent path for account \"(.*)\"$")
+    public void changeParentPathForAccount(String name)
+            throws KapuaException {
+        Account tmpAcc = accountService.findByName(name);
+        String modParentPath = tmpAcc.getParentAccountPath() + "/mod";
+
+        tmpAcc.setParentAccountPath(modParentPath);
+        try {
+            exceptionCaught = false;
+            accountService.update(tmpAcc);
+        } catch (KapuaAccountException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I try to change the account \"(.*)\" scope Id to (\\d+)$")
+    public void changeAccountScopeId(String name, int newScopeId)
+            throws KapuaException {
+        AccountImpl tmpAcc = (AccountImpl) accountService.findByName(name);
+
+        tmpAcc.setScopeId(new KapuaEid(BigInteger.valueOf(newScopeId)));
+        try {
+            exceptionCaught = false;
+            accountService.update(tmpAcc);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I delete account \"(.*)\"$")
+    public void deleteAccountWithName(String name)
+            throws KapuaException {
+        Account tmpAcc = accountService.findByName(name);
+        accountService.delete(tmpAcc.getScopeId(), tmpAcc.getId());
+    }
+
+    @When("^I try to delete the system account$")
+    public void deleteSystemAccount()
+            throws KapuaException {
+        String adminUserName = SystemSetting.getInstance().getString(SystemSettingKey.SYS_ADMIN_ACCOUNT);
+        Account tmpAcc = accountService.findByName(adminUserName);
+
+        assertNotNull(tmpAcc);
+        assertNotNull(tmpAcc.getId());
+
+        try {
+            exceptionCaught = false;
+            accountService.delete(rootScopeId, tmpAcc.getId());
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I delete a random account$")
+    public void deleteRandomAccount() {
+        try {
+            exceptionCaught = false;
+            accountService.delete(rootScopeId, new KapuaEid(BigInteger.valueOf(new Random().nextLong())));
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I search for the account with name \"(.*)\"$")
+    public void findAccountByName(String name)
+            throws KapuaException {
+        account = accountService.findByName(name);
+    }
+
+    @When("^I search for the account with the remembered account Id$")
+    public void findAccountByStoredId()
+            throws KapuaException {
+        account = accountService.find(accountId);
+    }
+
+    @When("^I search for the account with the remembered parent and account Ids$")
+    public void findAccountByStoredScopeAndAccountIds()
+            throws KapuaException {
+        account = accountService.find(rootScopeId, accountId);
+    }
+
+    @When("^I search for a random account Id$")
+    public void findRandomAccountId()
+            throws KapuaException {
+        account = accountService.find(rootScopeId, new KapuaEid(BigInteger.valueOf(new Random().nextLong())));
+    }
+
+    @When("^I set the following parameters$")
+    public void setAccountParameters(List<StringTuple> paramList)
+            throws KapuaException {
+        Properties accProps = account.getEntityProperties();
+        for (StringTuple param : paramList) {
+            accProps.setProperty(param.getName(), param.getValue());
+        }
+        account.setEntityProperties(accProps);
+        account = accountService.update(account);
+    }
+
+    @When("^I configure \"(.*)\" item \"(.*)\" to \"(.*)\"$")
+    public void setConfigurationValue(String type, String name, String value)
+            throws KapuaException {
+        Map<String, Object> valueMap = new HashMap<>();
+
+        switch (type) {
+        case "integer":
+            valueMap.put(name, Integer.valueOf(value));
+            break;
+        case "string":
+            valueMap.put(name, value);
+            break;
+        default:
+            break;
+        }
+
+        try {
+            exceptionCaught = false;
+            accountService.setConfigValues(account.getId(), valueMap);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I add the unknown config item \"(.*)\" with value (\\d+)$")
+    public void addUnknownIntegerConfigurationValue(String name, int value)
+            throws KapuaException {
+        Map<String, Object> valuesRead = accountService.getConfigValues(account.getId());
+        valuesRead.put(name, value);
+        accountService.setConfigValues(account.getId(), valuesRead);
+    }
+
+    @When("^I query for all accounts that have the system account as parent$")
+    public void queryForNumberOfTopLevelAccounts()
+            throws KapuaException {
+        AccountQuery query = new AccountQueryImpl(rootScopeId);
+        KapuaListResult<Account> accList = accountService.query(query);
+        intVal = accList.getSize();
+    }
+
+    @Then("^The account matches the creator settings$")
+    public void checkCreatedAccountDefaults() {
+        assertNotNull(account);
+        assertNotNull(account.getId());
+        assertNotNull(account.getId().getId());
+        assertTrue(account.getOptlock() >= 0);
+        assertEquals(rootScopeId, account.getScopeId());
+        assertNotNull(account.getCreatedOn());
+        assertNotNull(account.getCreatedBy());
+        assertNotNull(account.getModifiedOn());
+        assertNotNull(account.getModifiedBy());
+        assertNotNull(account.getOrganization());
+        assertEquals(accountCreator.getOrganizationName(), account.getOrganization().getName());
+        assertEquals(accountCreator.getOrganizationPersonName(), account.getOrganization().getPersonName());
+        assertEquals(accountCreator.getOrganizationCountry(), account.getOrganization().getCountry());
+        assertEquals(accountCreator.getOrganizationStateProvinceCounty(), account.getOrganization().getStateProvinceCounty());
+        assertEquals(accountCreator.getOrganizationCity(), account.getOrganization().getCity());
+        assertEquals(accountCreator.getOrganizationAddressLine1(), account.getOrganization().getAddressLine1());
+        assertEquals(accountCreator.getOrganizationAddressLine2(), account.getOrganization().getAddressLine2());
+        assertEquals(accountCreator.getOrganizationEmail(), account.getOrganization().getEmail());
+        assertEquals(accountCreator.getOrganizationZipPostCode(), account.getOrganization().getZipPostCode());
+        assertEquals(accountCreator.getOrganizationPhoneNumber(), account.getOrganization().getPhoneNumber());
+    }
+
+    @Then("^Account \"(.*)\" exists$")
+    public void checkWhetherAccountExists(String name)
+            throws KapuaException {
+        Account tmpAcc = accountService.findByName(name);
+
+        assertNotNull(tmpAcc);
+    }
+
+    @Then("^Account \"(.*)\" is correctly modified$")
+    public void checkForAccountModifications(String name)
+            throws KapuaException {
+        Account tmpAcc = accountService.findByName(name);
+
+        assertEquals(account.getOrganization().getName(), tmpAcc.getOrganization().getName());
+        assertEquals(account.getOrganization().getCity(), tmpAcc.getOrganization().getCity());
+    }
+
+    @Then("^The account with Id (\\d+) has (\\d+) subaccounts$")
+    public void checkNumberOfAccounts(int parentId, int num)
+            throws KapuaException {
+        KapuaQuery<Account> query = accountFactory.newQuery(new KapuaEid(BigInteger.valueOf(parentId)));
+        long accountCnt = accountService.count(query);
+
+        assertEquals(num, accountCnt);
+    }
+
+    @Then("^Account \"(.*)\" has (\\d+) children$")
+    public void checkNumberOfChildrenForNamedAccount(String name, int num)
+            throws KapuaException {
+        Account tmpAcc = accountService.findByName(name);
+        KapuaQuery<Account> query = accountFactory.newQuery(tmpAcc.getId());
+        long accountCnt = accountService.count(query);
+
+        assertEquals(num, accountCnt);
+    }
+
+    @Then("^An exception is caught$")
+    public void checkThatAnExceptionWasCaught() {
+        assertTrue(exceptionCaught);
+    }
+
+    @Then("^The account does not exist$")
+    public void tryToFindInexistentAccount()
+            throws KapuaException {
+        assertNull(account);
+    }
+
+    @Then("^The System account exists$")
+    public void findSystemAccount()
+            throws KapuaException {
+        String adminUserName = SystemSetting.getInstance().getString(SystemSettingKey.SYS_ADMIN_ACCOUNT);
+        Account tmpAcc = accountService.findByName(adminUserName);
+
+        assertNotNull(tmpAcc);
+    }
+
+    @Then("^The account has the following parameters$")
+    public void checkAccountParameters(List<StringTuple> paramList)
+            throws KapuaException {
+        Properties accProps = account.getEntityProperties();
+        for (StringTuple param : paramList) {
+            assertEquals(param.getValue(), accProps.getProperty(param.getName()));
+        }
+    }
+
+    @Then("^The account has metadata$")
+    public void checkMetadataExistence()
+            throws KapuaException {
+        KapuaTocd metaData = accountService.getConfigMetadata();
+
+        assertNotNull(metaData);
+    }
+
+    @Then("^The default configuration for the account is set$")
+    public void checkDefaultAccountConfiguration()
+            throws KapuaException {
+        Map<String, Object> valuesRead = accountService.getConfigValues(account.getId());
+
+        assertTrue(valuesRead.containsKey("maxNumberChildAccounts"));
+        assertEquals(0, valuesRead.get("maxNumberChildAccounts"));
+    }
+
+    @Then("^The config item \"(.*)\" is set to \"(.*)\"$")
+    public void checkConfigValue(String name, String value)
+            throws KapuaException {
+        Map<String, Object> valuesRead = accountService.getConfigValues(account.getId());
+
+        assertTrue(valuesRead.containsKey(name));
+        assertEquals(value, valuesRead.get(name).toString());
+    }
+
+    @Then("^The config item \"(.*)\" is missing$")
+    public void checkMissingConfigItem(String name)
+            throws KapuaException {
+        Map<String, Object> valuesRead = accountService.getConfigValues(account.getId());
+
+        assertFalse(valuesRead.containsKey(name));
+    }
+
+    @Then("^The returned value is (\\d+)$")
+    public void checkIntegerReturnValue(int val)
+            throws KapuaException {
+        assertEquals(new Integer(val), intVal);
+    }
+
+    @Then("^Account service metadata is available$")
+    public void checkAccountServiceMetadataExistance()
+            throws KapuaException {
+        KapuaAccountSetting tmpAccountSettings = KapuaAccountSetting.getInstance();
+
+        assertNotNull("Account settings not configured.", tmpAccountSettings);
+    }
+
+    // *******************
+    // * Private Helpers *
+    // *******************
+
+    /**
+     * Create a user creator object. The creator is pre-filled with default data.
+     *
+     * @param parentId:
+     *            Id of the parent account
+     * @param name:
+     *            The name of the account
+     * @return The newly created account creator object.
+     */
+    private AccountCreator prepareRegularAccountCreator(KapuaId parentId, String name) {
+        AccountCreator tmpAccCreator = accountFactory.newAccountCreator(parentId, name);
+
+        tmpAccCreator.setAccountPassword("pp12345678$$QQ");
+        tmpAccCreator.setOrganizationName("org_" + name);
+        tmpAccCreator.setOrganizationPersonName(String.format("person_", name));
+        tmpAccCreator.setOrganizationCountry("home_country");
+        tmpAccCreator.setOrganizationStateProvinceCounty("home_province");
+        tmpAccCreator.setOrganizationCity("home_city");
+        tmpAccCreator.setOrganizationAddressLine1("address_line_1");
+        tmpAccCreator.setOrganizationAddressLine2("address_line_2");
+        tmpAccCreator.setOrganizationEmail("org_" + name + "@org.com");
+        tmpAccCreator.setOrganizationZipPostCode("1234");
+        tmpAccCreator.setOrganizationPhoneNumber("012/123-456-789");
+
+        return tmpAccCreator;
+    }
+
+    // *****************
+    // * Inner Classes *
+    // *****************
+
+    // Custom String tuple class for name/value pairs as given in the cucumber feature file
+    public class StringTuple {
+
+        private String name;
+        private String value;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/RunTest.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/RunTest.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.account.internal;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "classpath:features", plugin = { "pretty", "html:target/cucumber",
+        "json:target/cucumber.json" }, monochrome = true)
+public class RunTest {
+}

--- a/service/account/internal/src/test/resources/features/AccountService.feature
+++ b/service/account/internal/src/test/resources/features/AccountService.feature
@@ -1,0 +1,201 @@
+###############################################################################
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+Feature: User Account Service
+    The User Account Service is responsible for CRUD operations for user accounts in the Kapua
+    database.
+
+Scenario: Handle account creation
+	Create a test account and check whether it was created correctly.
+	
+	When I create account "test_acc"
+	Then The account matches the creator settings
+
+Scenario: Find all child accounts
+	Create a number of subaccounts. Check that the account has the correct number of subaccounts.
+
+	When I create 15 childs for account with Id 1
+	Then The account with Id 1 has 15 subaccounts
+
+Scenario: Handle duplicate account names
+	Accounts with duplicate names must not be created. When a duplicate account name is 
+	given, the account service should throw an exception.
+	
+	Given An existing account with the name "test_acc_1"
+	When I create a duplicate account "test_acc_1"
+	Then An exception is caught
+
+Scenario: Handle null account name
+	If an account name is null, the account service should throw an exception.
+	
+	When I create an account with a null name
+	Then An exception is caught
+
+Scenario: Find account by Id
+	The account service must be able to find the requested account entity by its Id.
+	
+	Given An existing account with the name "test_acc_42"
+	When I search for the account with the remembered account Id
+	Then The account matches the creator settings
+
+Scenario: Find account by Ids
+	The account service must be able to find the requested account entity by its 
+	parent and account Ids.
+	
+	Given An existing account with the name "test_acc_42"
+	When I search for the account with the remembered parent and account Ids
+	Then The account matches the creator settings
+
+Scenario: Find account by random Id
+	Search for an account that does not exist.
+	
+	When I search for a random account Id
+	Then The account does not exist
+
+Scenario: Find account by name
+	The account service must be able to find the requested account entity by its name.
+	
+	Given An existing account with the name "test_acc_42"
+	When I search for the account with name "test_acc_42"
+	Then The account matches the creator settings 
+
+Scenario: Find by name nonexisting account
+	Search for an account name that does not exist.
+	
+	When I search for the account with name "test_acc_unlikely_to_exist"
+	Then The account does not exist
+
+Scenario: Modify an existing account
+	Test that the account service correctly modifies an existing account. The modified 
+	account details must be correctly stored in the account database.
+	
+	Given An existing account with the name "test_acc_42"
+	When I modify the account "test_acc_42"
+	Then Account "test_acc_42" is correctly modified
+
+Scenario: Modify nonexisting account
+	Try to update an account that does not exist anymore. An exception should be thrown.
+
+	Given An existing account with the name "test_acc_42"
+	When I delete account "test_acc_42"
+	And I modify the current account
+	Then An exception is caught
+
+Scenario: Delete an existing account
+	Delete a previously created account. The account should be deleted from the database.
+	
+	Given An existing account with the name "test_acc_123"
+	When I delete account "test_acc_123"
+	And I search for the account with name "test_acc_123"
+	Then The account does not exist
+
+Scenario: Delete the Kapua system account
+	It must not be possible to delete the system account.
+
+	When I try to delete the system account
+	Then An exception is caught
+	And The System account exists
+
+Scenario: Delete nonexisting account
+	Try to delete an account with a a random Id. The operation should fail and an exception 
+	should be thrown.
+	
+	When I delete a random account
+	Then An exception is caught
+
+Scenario: Change the account parent Id
+	The account service must not allow the account parent Id to be changed.
+
+	Given An existing account with the name "test_acc_123"
+	When I try to change the account "test_acc_123" scope Id to 2
+	Then An exception is caught
+
+Scenario: Change the account parent path
+	It must not be possible to change the account parent path. Any try should result in an exception.
+
+	Given An existing account with the name "test_acc_11"
+	When I change the parent path for account "test_acc_11"
+	Then An exception is caught
+
+Scenario: Check account properties
+	It must be possible to set arbitrary account properties.
+	
+	Given An existing account with the name "test_acc_11"
+	When I set the following parameters
+		| name | value  |
+		| key1 | value1 |
+		| key2 | value2 |
+		| key3 | value3 |
+	Then The account has the following parameters
+		| name | value  |
+		| key1 | value1 |
+		| key2 | value2 |
+		| key3 | value3 |
+
+Scenario: Every account must have the default configuration items
+	Create a new account and check whether it has the default configuration items set.
+
+	Given An existing account with the name "test_acc_11"
+	Then The default configuration for the account is set
+
+Scenario: A newly created account must have some metadata
+	Create a new account. Check whether the account has some associated metadata.
+
+	Given An existing account with the name "test_acc_11"
+	Then The account has metadata
+
+Scenario: It is possible to change the configuration items
+	Values of the supported configurationm items must be modifiable.
+ 
+	Given An existing account with the name "test_acc_11"
+	When I configure "integer" item "maxNumberChildAccounts" to "5"
+	Then The config item "maxNumberChildAccounts" is set to "5"
+	
+Scenario: Unknown configuiration items are silently ignored
+	Unknown items must be ignored. No exception or error must be raised.
+
+	Given An existing account with the name "test_acc_11"
+	When I add the unknown config item "UnknownItem" with value 10
+	Then The config item "UnknownItem" is missing
+
+Scenario: Setting configuration without mandatory items must raise an error
+	Mandatory configuration items must always be set. Trying to set configuration items without 
+	specifying the mandatory items must raise an error.
+	
+	Given An existing account with the name "test_acc_11"
+	When I configure "integer" item "ArbitraryUnknownItem" to "5"
+	Then An exception is caught
+
+Scenario: Test account query
+	Perform a database query and find all the accounts that have the 'scopeId'
+	property set to '1' (children of the system account). This is the default query and
+	no additional parameter is needed to create it.
+	
+	Given I create 9 accounts with organization name "test_org"
+    When I query for all accounts that have the system account as parent
+    Then The returned value is 9
+    
+Scenario: Account service metadata
+	The Account service must have some associated configuration metadata. Check that the
+	metadata exists. No content checks will be performed.
+
+    Then Account service metadata is available
+
+Scenario: Account name must not be mutable
+	It must be impossible to change an existing account name. When tried, an exception must 
+	be thrown and the original account must be unchanged. 
+	
+	Given An existing account with the name "test_acc"
+	When I change the account "test_acc" name to "test_acc_new"
+	Then An exception is caught
+	And Account "test_acc" exists

--- a/service/account/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/internal/src/test/resources/kapua-environment-setting.properties
@@ -44,7 +44,7 @@ commons.db.pool.size.initial=5
 commons.db.pool.size.min=2
 commons.db.pool.size.max=30
 commons.db.pool.borrow.timeout=15000
-	
+
 #
 # Broker settings
 #
@@ -52,6 +52,12 @@ broker.scheme=tcp
 broker.host=localhost
 broker.port=1884
 
+#
+# Entity settings
+#
+commons.entity.key.size=8
+commons.entity.insert.max.retry=3
+
 character.encoding=UTF-8
-	
+
 commons.osgi.context=false


### PR DESCRIPTION
CRUD tests for the Account service
--------------------------
The majority of the basic functionality is exercised by these tests.

Changes to Maven pom files
----------------------------
Account Service implementation pom file is modified with additional Cucumber dependencies.
Surefire plugin is configured with the custom MockedLocator. This allows the Account service to be tested in isolation from other services (specially authorization and authentication services).

Implementation changes
----------------------------
There is no change in the Account service implementation.

Tests changes
----------------------------
A new set of Cucumber based tests is implemented to test CRUD operations on the Account service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>