### PR TITLE
Unit tests for the Device Registry validator helper.

### DIFF
--- a/assembly/src/main/descriptors/kapua-cucumber-report.xml
+++ b/assembly/src/main/descriptors/kapua-cucumber-report.xml
@@ -26,6 +26,11 @@
             <outputDirectory>/user-service</outputDirectory>
             <directory>../service/user/internal/target/cucumber</directory>
         </fileSet>
+
+        <fileSet>
+            <outputDirectory>/device-registry-service</outputDirectory>
+            <directory>../service/device/registry/internal/target/cucumber</directory>
+        </fileSet>
     </fileSets>
 
 </assembly>

--- a/assembly/src/main/resources/html/cucumber/index.html
+++ b/assembly/src/main/resources/html/cucumber/index.html
@@ -9,6 +9,7 @@
     <h2>Functional tests</h2>
     <ul>
         <li><a href="user-service/index.html">User service</a></li>
+        <li><a href="device-registry-service/index.html">Device registry service</a></li>
         <!--li>Other service</li-->
     </ul>
     <!-- Integration tests -->

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/common/DeviceRegistryValidationTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/common/DeviceRegistryValidationTestSteps.java
@@ -1,0 +1,390 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry.common;
+
+import static org.eclipse.kapua.service.device.registry.DeviceCredentialsMode.LOOSE;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+import java.math.BigInteger;
+import java.security.acl.Permission;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.device.registry.DeviceCreator;
+import org.eclipse.kapua.service.device.registry.DeviceFactory;
+import org.eclipse.kapua.service.device.registry.DeviceQuery;
+import org.eclipse.kapua.service.device.registry.DeviceStatus;
+import org.eclipse.kapua.service.device.registry.internal.DeviceCreatorImpl;
+import org.eclipse.kapua.service.device.registry.internal.DeviceFactoryImpl;
+import org.eclipse.kapua.service.device.registry.internal.DeviceImpl;
+import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.MockedLocator;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+
+/**
+ * Implementation of Gherkin steps used in DeviceRegistryValidation.feature scenarios.
+ *
+ * MockedLocator is used for Location Service. Mockito is used to mock other
+ * services that the Device Registry services dependent on. Dependent services are: -
+ * Authorization Service.
+ *
+ *
+ */
+
+public class DeviceRegistryValidationTestSteps extends KapuaTest {
+
+    KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
+
+    @SuppressWarnings("unused")
+    private static final Logger s_logger = LoggerFactory.getLogger(DeviceRegistryValidationTestSteps.class);
+
+    // Currently executing scenario.
+    Scenario scenario;
+
+    // Device validator object
+    DeviceValidation deviceValidator = null;
+
+    // Device registry related objects
+    DeviceFactory deviceFactory = new DeviceFactoryImpl();
+    DeviceCreator deviceCreator = null;
+    DeviceImpl device = null;
+    DeviceQuery query = null;
+
+    // Check if exception was fired in step.
+    boolean exceptionCaught = false;
+
+    // *************************************
+    // Definition of Cucumber scenario steps
+    // *************************************
+
+    // Setup and tear-down steps
+
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+        this.scenario = scenario;
+        exceptionCaught = false;
+
+        // Set up the mock locator
+        MockedLocator mockLocator = (MockedLocator) locator;
+
+        // Inject mocked Authorization Service method checkPermission
+        AuthorizationService mockedAuthorization = mock(AuthorizationService.class);
+        // TODO: Check why does this line needs an explicit cast!
+        Mockito.doNothing().when(mockedAuthorization).checkPermission(
+                (org.eclipse.kapua.service.authorization.permission.Permission) any(Permission.class));
+        mockLocator.setMockedService(org.eclipse.kapua.service.authorization.AuthorizationService.class,
+                mockedAuthorization);
+
+        // Inject mocked Permission Factory
+        PermissionFactory mockedPermissionFactory = mock(PermissionFactory.class);
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.authorization.permission.PermissionFactory.class,
+                mockedPermissionFactory);
+
+        // Instantiate the validation object
+        deviceValidator = new DeviceValidation(mockedPermissionFactory, mockedAuthorization);
+
+        // Set KapuaMetatypeFactory for Metatype configuration
+        mockLocator.setMockedFactory(org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory.class, new KapuaMetatypeFactoryImpl());
+
+        // All operations on database are performed using system user.
+        KapuaSession kapuaSession = new KapuaSession(null, new KapuaEid(BigInteger.ONE), new KapuaEid(BigInteger.ONE));
+        KapuaSecurityUtils.setSession(kapuaSession);
+    }
+
+    @After
+    public void afterScenario()
+            throws Exception {
+        KapuaSecurityUtils.clearSession();
+    }
+
+    // The Cucumber test steps
+
+    @Given("^A regular device creator$")
+    public void createARegularDeviceCreator()
+            throws KapuaException {
+        deviceCreator = prepareRegularDeviceCreator(rootScopeId, "testDev");
+    }
+
+    @Given("^A null device creator$")
+    public void createANullDeviceCreator()
+            throws KapuaException {
+        deviceCreator = null;
+    }
+
+    @Given("^A regular device$")
+    public void createRegularDevice()
+            throws KapuaException {
+        device = prepareRegularDevice(rootScopeId, new KapuaEid(BigInteger.valueOf(random.nextLong())));
+    }
+
+    @Given("^A null device$")
+    public void createANullDevice()
+            throws KapuaException {
+        device = null;
+    }
+
+    @Given("^A regular query$")
+    public void createRegularQuery() {
+        query = deviceFactory.newQuery(rootScopeId);
+    }
+
+    @Given("^A query with a null Scope ID$")
+    public void createQueryWithNullScopeId() {
+        query = deviceFactory.newQuery(null);
+    }
+
+    @Given("^A null query$")
+    public void createNullQuery() {
+        query = null;
+    }
+
+    @When("^I set the creator scope ID to null$")
+    public void setDeviceCreatorScopeToNull() {
+        deviceCreator.setScopeId(null);
+    }
+
+    @When("^I set the creator client ID to null$")
+    public void setDeviceCreatorClientToNull() {
+        deviceCreator.setClientId(null);
+    }
+
+    @When("^I set the device scope ID to null$")
+    public void setDeviceScopeToNull() {
+        device.setScopeId(null);
+    }
+
+    @When("^I set the device ID to null$")
+    public void setDeviceIdToNull() {
+        device.setId(null);
+    }
+
+    @When("^I validate the device creator$")
+    public void validateExistingDeviceCreator()
+            throws KapuaException {
+        try {
+            exceptionCaught = false;
+            deviceValidator.validateCreatePreconditions(deviceCreator);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I validate the device for updates$")
+    public void validateExistingDeviceForUpdates()
+            throws KapuaException {
+        try {
+            exceptionCaught = false;
+            deviceValidator.validateUpdatePreconditions(device);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^Validating a find operation for scope (.+) and device (.+)$")
+    public void validateDeviceSearch(String scopeId, String deviceId)
+            throws KapuaException {
+        KapuaId scope;
+        KapuaId dev;
+
+        if (scopeId.trim().toLowerCase().equals("null")) {
+            scope = null;
+        } else {
+            scope = new KapuaEid(new BigInteger(scopeId));
+        }
+
+        if (deviceId.trim().toLowerCase().equals("null")) {
+            dev = null;
+        } else {
+            dev = new KapuaEid(new BigInteger(deviceId));
+        }
+
+        try {
+            exceptionCaught = false;
+            deviceValidator.validateFindPreconditions(scope, dev);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^Validating a find operation for scope (.+) and client \"(.*)\"$")
+    public void validateDeviceSearchByClientId(String scopeId, String clientId)
+            throws KapuaException {
+        KapuaId scope;
+        String client;
+
+        if (scopeId.trim().toLowerCase().equals("null")) {
+            scope = null;
+        } else {
+            scope = new KapuaEid(new BigInteger(scopeId));
+        }
+
+        if (clientId.trim().toLowerCase().equals("null")) {
+            client = null;
+        } else {
+            client = clientId;
+        }
+
+        try {
+            exceptionCaught = false;
+            deviceValidator.validateFindByClientIdPreconditions(scope, client);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^Validating a delete operation for scope (.+) and device (.+)$")
+    public void validateDeviceDelete(String scopeId, String deviceId)
+            throws KapuaException {
+        KapuaId scope;
+        KapuaId dev;
+
+        if (scopeId.trim().toLowerCase().equals("null")) {
+            scope = null;
+        } else {
+            scope = new KapuaEid(new BigInteger(scopeId));
+        }
+
+        if (deviceId.trim().toLowerCase().equals("null")) {
+            dev = null;
+        } else {
+            dev = new KapuaEid(new BigInteger(deviceId));
+        }
+
+        try {
+            exceptionCaught = false;
+            deviceValidator.validateDeletePreconditions(scope, dev);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I validate a query operation$")
+    public void checkQueryOperation()
+            throws KapuaException {
+        try {
+            exceptionCaught = false;
+            deviceValidator.validateQueryPreconditions(query);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I validate a count operation$")
+    public void checkCountOperation()
+            throws KapuaException {
+        try {
+            exceptionCaught = false;
+            deviceValidator.validateCountPreconditions(query);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @Then("^No exception is thrown$")
+    public void checkThatNoExceptionWasCaught() {
+        assertFalse(exceptionCaught);
+    }
+
+    @Then("^An exception is thrown$")
+    public void checkThatAnExceptionWasCaught() {
+        assertTrue(exceptionCaught);
+    }
+
+    // *******************
+    // * Private Helpers *
+    // *******************
+
+    // Create a device creator object. The creator is pre-filled with default data.
+    private DeviceCreator prepareRegularDeviceCreator(KapuaId accountId, String client) {
+        DeviceCreatorImpl tmpDeviceCreator = (DeviceCreatorImpl) deviceFactory.newCreator(accountId, client);
+
+        tmpDeviceCreator.setClientId(client);
+        tmpDeviceCreator.setConnectionId(new KapuaEid(BigInteger.valueOf(random.nextLong())));
+        tmpDeviceCreator.setDisplayName("test_name");
+        tmpDeviceCreator.setSerialNumber("serialNumber");
+        tmpDeviceCreator.setModelId("modelId");
+        tmpDeviceCreator.setImei(String.valueOf(random.nextInt()));
+        tmpDeviceCreator.setImsi(String.valueOf(random.nextInt()));
+        tmpDeviceCreator.setIccid(String.valueOf(random.nextInt()));
+        tmpDeviceCreator.setBiosVersion("biosVersion");
+        tmpDeviceCreator.setFirmwareVersion("firmwareVersion");
+        tmpDeviceCreator.setOsVersion("osVersion");
+        tmpDeviceCreator.setJvmVersion("jvmVersion");
+        tmpDeviceCreator.setOsgiFrameworkVersion("osgiFrameworkVersion");
+        tmpDeviceCreator.setApplicationFrameworkVersion("kapuaVersion");
+        tmpDeviceCreator.setApplicationIdentifiers("applicationIdentifiers");
+        tmpDeviceCreator.setAcceptEncoding("acceptEncoding");
+        tmpDeviceCreator.setGpsLatitude(45.2);
+        tmpDeviceCreator.setGpsLongitude(26.3);
+        tmpDeviceCreator.setCustomAttribute1("customAttribute1");
+        tmpDeviceCreator.setCustomAttribute2("customAttribute2");
+        tmpDeviceCreator.setCustomAttribute3("customAttribute3");
+        tmpDeviceCreator.setCustomAttribute4("customAttribute4");
+        tmpDeviceCreator.setCustomAttribute5("customAttribute5");
+        tmpDeviceCreator.setCredentialsMode(LOOSE);
+        tmpDeviceCreator.setPreferredUserId(new KapuaEid(BigInteger.valueOf(random.nextLong())));
+        tmpDeviceCreator.setStatus(DeviceStatus.ENABLED);
+
+        return tmpDeviceCreator;
+    }
+
+    // Create a device object. The device is pre-filled with default data.
+    private DeviceImpl prepareRegularDevice(KapuaId accountId, KapuaId deviceId) {
+        DeviceImpl tmpDevice = (DeviceImpl) deviceFactory.newDevice();
+
+        tmpDevice.setScopeId(accountId);
+        tmpDevice.setId(deviceId);
+        tmpDevice.setConnectionId(new KapuaEid(BigInteger.valueOf(random.nextLong())));
+        tmpDevice.setDisplayName("test_name");
+        tmpDevice.setSerialNumber("serialNumber");
+        tmpDevice.setModelId("modelId");
+        tmpDevice.setImei(String.valueOf(random.nextInt()));
+        tmpDevice.setImsi(String.valueOf(random.nextInt()));
+        tmpDevice.setIccid(String.valueOf(random.nextInt()));
+        tmpDevice.setBiosVersion("biosVersion");
+        tmpDevice.setFirmwareVersion("firmwareVersion");
+        tmpDevice.setOsVersion("osVersion");
+        tmpDevice.setJvmVersion("jvmVersion");
+        tmpDevice.setOsgiFrameworkVersion("osgiFrameworkVersion");
+        tmpDevice.setApplicationFrameworkVersion("kapuaVersion");
+        tmpDevice.setApplicationIdentifiers("applicationIdentifiers");
+        tmpDevice.setAcceptEncoding("acceptEncoding");
+        tmpDevice.setCustomAttribute1("customAttribute1");
+        tmpDevice.setCustomAttribute2("customAttribute2");
+        tmpDevice.setCustomAttribute3("customAttribute3");
+        tmpDevice.setCustomAttribute4("customAttribute4");
+        tmpDevice.setCustomAttribute5("customAttribute5");
+        tmpDevice.setCredentialsMode(LOOSE);
+        tmpDevice.setPreferredUserId(new KapuaEid(BigInteger.valueOf(random.nextLong())));
+        tmpDevice.setStatus(DeviceStatus.ENABLED);
+
+        return tmpDevice;
+    }
+}

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
@@ -18,7 +18,13 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = "classpath:features", plugin = { "pretty", "html:target/cucumber",
-        "json:target/cucumber.json" }, monochrome = true)
+@CucumberOptions(features = "classpath:features", 
+                 glue = { "org.eclipse.kapua.service.device.registry.common", 
+                          "org.eclipse.kapua.service.device.registry.internal"},
+                 plugin = { "pretty", 
+                            "html:target/cucumber",
+                            "json:target/cucumber.json" }, 
+                 monochrome = true)
+
 public class RunTest {
 }

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistryValidation.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistryValidation.feature
@@ -1,0 +1,180 @@
+###############################################################################
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+Feature: Device Registry Validation Tests
+    The Device Registry Validation helper is responsible for validating parameters 
+    and permissions before any operation is performed on the database.
+
+Scenario: Validate a regular creator
+	Create a regular device creator. The validator should OK it.
+	
+	Given A regular device creator
+	When I validate the device creator
+	Then No exception is thrown
+
+Scenario: Validate a null creator
+	Create a null device creator. The validator should throw an exception.
+	
+	Given A null device creator
+	When I validate the device creator
+	Then An exception is thrown
+	
+Scenario: Validate a device creator with a null scope ID
+	Create a regular device creator. Assign a null scope ID. The validator
+	should throw an exception.
+	
+	Given A regular device creator
+	When I set the creator scope ID to null
+	And I validate the device creator
+	Then An exception is thrown
+	
+Scenario: Validate a device creator with a null client ID
+	Create a regular device creator. Assign a null client ID. The validator
+	should throw an exception.
+	
+	Given A regular device creator
+	When I set the creator client ID to null
+	And I validate the device creator
+	Then An exception is thrown	
+	
+Scenario: Validate a regular device
+	Create a regular device object. the update validator should OK it.
+	
+	Given A regular device
+	When I validate the device for updates	
+	Then No exception is thrown
+
+Scenario: Validate a null device
+	Create a null device object. The validator should throw an
+	exception.
+	
+	Given A null device
+	When I validate the device for updates	
+	Then An exception is thrown
+
+Scenario: Validate a regular device search
+	Validate the parameters for a device search. Both ScopeID and DeviceID 
+	are not null. The validator should be OK with it.
+	
+	When Validating a find operation for scope 15 and device 4321
+	Then No exception is thrown
+	
+Scenario: Validate a device search with a null device ID
+	Validate the parameters for a device search. ScopeID is valid, but the DeviceID 
+	is null. The validator should throw an exception.
+	
+	When Validating a find operation for scope 15 and device null
+	Then An exception is thrown
+	
+Scenario: Validate a device search with a null scope ID
+	Validate the parameters for a device search. DeviceID is valid, but ScopeID 
+	is null. The validator should throw an exception.
+	
+	When Validating a find operation for scope null and device 2
+	Then An exception is thrown
+	
+Scenario: Validate a regular device deletion
+	Validate the parameters for deleting a device. Both ScopeID and DeviceID 
+	are not null. The validator should be OK with it.
+	
+	When Validating a delete operation for scope 15 and device 4321
+	Then No exception is thrown
+	
+Scenario: Validate deleting a device with a null device ID
+	Validate the parameters for deleting a device. ScopeID is valid, but the DeviceID 
+	is null. The validator should throw an exception.
+	
+	When Validating a delete operation for scope 15 and device null
+	Then An exception is thrown
+	
+Scenario: Validate deleting a device with a null scope ID
+	Validate the parameters for deleting a device. DeviceID is valid, but ScopeID 
+	is null. The validator should throw an exception.
+	
+	When Validating a delete operation for scope null and device 2
+	Then An exception is thrown	
+	
+Scenario: Validate a regular device client search	
+	Validate the parameters for a client id based search. Both the Scope ID and the 
+	Client ID are valid. The validator should OK it.
+
+	When Validating a find operation for scope 42 and client "test_client"
+	Then No exception is thrown
+	
+Scenario: Validate a device client search with null scope	
+	Validate the parameters for a client id based search. The Scope ID is null and the 
+	Client ID is valid. The validator should throw an exception.
+
+	When Validating a find operation for scope null and client "test_client"
+	Then An exception is thrown	
+	
+Scenario: Validate a device client based search with a null client ID	
+	Validate the parameters for a client id based search. The Scope ID is valid but the 
+	Client ID is null. The validator should throw an exception.
+	Note: a string with the content 'null' is taken as a null string. Just a cucumber workaround.
+	
+	When Validating a find operation for scope 42 and client "null"
+	Then An exception is thrown	
+	
+Scenario: Validate a device client based search with an empty client ID	
+	Validate the parameters for a client id based search. The Scope ID is valid while the 
+	Client ID is an empty string. The validator should throw an exception.
+	
+	When Validating a find operation for scope 42 and client ""
+	Then An exception is thrown		
+	
+Scenario: Validate a regular device query
+	Validate the parameters for a regulat device query. Neither the query nor the query 
+	Scope ID is null. The validator should be OK with it.
+	
+	Given A regular query
+	When I validate a query operation
+	Then No exception is thrown
+
+Scenario: Validate a null device query
+	Validate a null device query. The validator should throw an exception.
+
+	Given A null query
+	When I validate a query operation
+	Then An exception is thrown
+
+Scenario: Validate a device query with a null Scope ID
+	Validate a faulty device query. The query is not null, but the query Scope ID 
+	is null. The validator should throw an exception.
+	
+	Given A query with a null Scope ID
+	When I validate a query operation
+	Then An exception is thrown
+
+Scenario: Validate a regular device count
+	Validate the parameters for a regulat device count. Neither the query nor the query 
+	Scope ID is null. The validator should be OK with it.
+	
+	Given A regular query
+	When I validate a count operation
+	Then No exception is thrown
+
+Scenario: Validate a null device count
+	Validate a device count with a null query. The validator should throw an exception.
+	
+	Given A null query
+	When I validate a count operation
+	Then An exception is thrown
+
+Scenario: Validate a device count with a null Scope ID
+	Validate a device count with a faulty query. The query is not null, but the query Scope ID is.
+	The validator should throw an exception.
+	
+	Given A query with a null Scope ID
+	When I validate a count operation
+	Then An exception is thrown	


### PR DESCRIPTION
## Unit tests for the Device Registry validation helper
This set of unit tests exercises the DeviceValidation class (package org.eclipse.kapua.service.device.registry.common). 
Also, entries have been added to the Assemblies project files to show the Device Registry test reports in the Hudson dashboard.

**Note**: This set of tests is a replacement for the existing jUnit tests (DeviceValidationTest.java). The obsoleted test class will be eventually removed.

### Changes to Maven pom files
The pom files have not been changed.

### Implementation changes
The implementation of the Device registry service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented to test the operations of the DeviceValidation class.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>