### PR TITLE
Added the Account service report page to the cucumber reports.

### DIFF
--- a/assembly/src/main/descriptors/kapua-cucumber-report.xml
+++ b/assembly/src/main/descriptors/kapua-cucumber-report.xml
@@ -23,6 +23,11 @@
         </fileSet>
 
         <fileSet>
+            <outputDirectory>/account-service</outputDirectory>
+            <directory>../service/account/internal/target/cucumber</directory>
+        </fileSet>
+
+        <fileSet>
             <outputDirectory>/user-service</outputDirectory>
             <directory>../service/user/internal/target/cucumber</directory>
         </fileSet>

--- a/assembly/src/main/resources/html/cucumber/index.html
+++ b/assembly/src/main/resources/html/cucumber/index.html
@@ -50,6 +50,7 @@
                   </p>
                   <ul>
                     <li><a href="user-service/index.html">User service</a></li>
+                    <li><a href="account-service/index.html">Account service</a></li>
                     <li><a href="device-registry-service/index.html">Device registry service</a></li>
                     <!--li>Other service</li-->
                   </ul>


### PR DESCRIPTION
## Account service test reports

The test report for the Account service was missing from the cucumber report page in the Hudson dashboard. 
Now the report for the Account service unit tests should be accessible along the User and Device Registry service reports.

### Implementation changes
There are no changes to either the service implementation or the service test code.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>