### PR TITLE
CRUD tests for the Device Connection service.

### DIFF
--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceRegistryConnectionTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceRegistryConnectionTestSteps.java
@@ -1,0 +1,500 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry.connection.internal;
+
+import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsEqualTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+import java.math.BigInteger;
+import java.security.acl.Permission;
+import java.util.HashSet;
+import java.util.List;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtils;
+import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionListResult;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionQuery;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionStatus;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionSummary;
+import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFactory;
+import org.eclipse.kapua.service.device.registry.internal.DeviceRegistryServiceTestSteps;
+import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.MockedLocator;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+
+/**
+ * Implementation of Gherkin steps used in DeviceRegistryConnection.features scenarios.
+ *
+ * MockedLocator is used for Location Service. Mockito is used to mock other
+ * services that the Device Registry services dependent on. Dependent services are: -
+ * Authorization Service -
+ *
+ *
+ */
+
+public class DeviceRegistryConnectionTestSteps extends KapuaTest {
+
+    public static String DEFAULT_PATH = "src/main/sql/H2";
+    public static String DEFAULT_COMMONS_PATH = "../../../commons";
+    public static String CREATE_DEVICE_TABLES = "dvc_*_create.sql";
+    public static String DROP_DEVICE_TABLES = "dvc_*_drop.sql";
+
+    public static String CLIENT_NAME = "test_client";
+    public static String CLIENT_IP = "127.1.1.10";
+    public static String SERVER_IP = "127.1.1.100";
+
+    KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
+    KapuaId rootUserId = new KapuaEid(BigInteger.ONE);
+
+    @SuppressWarnings("unused")
+    private static final Logger s_logger = LoggerFactory.getLogger(DeviceRegistryServiceTestSteps.class);
+
+    // Currently executing scenario.
+    Scenario scenario;
+
+    // Various device connection related service references
+    DeviceConnectionService deviceConnectionService = null;
+    DeviceConnectionFactory deviceConnectionFactory = null;
+
+    // Device connection related objects
+    DeviceConnection connection = null;
+    DeviceConnectionListResult connectionList = null;
+
+    // Device registry related objects
+    DeviceConnectionCreator connectionCreator = null;
+    Device device = null;
+
+    // The registry IDs
+    KapuaId userId = null;
+    KapuaId scopeId = null;
+    KapuaId connectionId = null;
+    KapuaId deviceId = null;
+
+    // Scratchpad data
+    String stringVal = "";
+    int intVal = 0;
+    boolean boolVal = false;
+
+    // Check if exception was fired in step.
+    boolean exceptionCaught = false;
+
+    // *************************************
+    // Definition of Cucumber scenario steps
+    // *************************************
+
+    // Setup and tear-down steps
+
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+        this.scenario = scenario;
+        exceptionCaught = false;
+
+        // Create User Service tables
+        enableH2Connection();
+
+        // Create the account service tables
+        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
+        scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
+        KapuaConfigurableServiceSchemaUtils.createSchemaObjects(DEFAULT_COMMONS_PATH);
+        scriptSession(DeviceEntityManagerFactory.instance(), CREATE_DEVICE_TABLES);
+
+        MockedLocator mockLocator = (MockedLocator) locator;
+
+        // Inject mocked Authorization Service method checkPermission
+        AuthorizationService mockedAuthorization = mock(AuthorizationService.class);
+        // TODO: Check why does this line needs an explicit cast!
+        Mockito.doNothing().when(mockedAuthorization).checkPermission(
+                (org.eclipse.kapua.service.authorization.permission.Permission) any(Permission.class));
+        mockLocator.setMockedService(org.eclipse.kapua.service.authorization.AuthorizationService.class,
+                mockedAuthorization);
+
+        // Inject mocked Permission Factory
+        PermissionFactory mockedPermissionFactory = mock(PermissionFactory.class);
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.authorization.permission.PermissionFactory.class,
+                mockedPermissionFactory);
+
+        // Inject actual device registry related services
+        deviceConnectionService = new DeviceConnectionServiceImpl();
+        mockLocator.setMockedService(org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService.class,
+                deviceConnectionService);
+        deviceConnectionFactory = new DeviceConnectionFactoryImpl();
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory.class,
+                deviceConnectionFactory);
+
+        // Set KapuaMetatypeFactory for Metatype configuration
+        mockLocator.setMockedFactory(org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory.class, new KapuaMetatypeFactoryImpl());
+
+        // All operations on database are performed using system user.
+        KapuaSession kapuaSession = new KapuaSession(null, new KapuaEid(BigInteger.ONE), new KapuaEid(BigInteger.ONE));
+        KapuaSecurityUtils.setSession(kapuaSession);
+
+        // Default the scope ID to the root ID and the user ID to the system user ID
+        scopeId = rootScopeId;
+        userId = rootUserId;
+    }
+
+    @After
+    public void afterScenario()
+            throws Exception {
+        // Drop the Account Service tables
+        scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
+        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
+        KapuaSecurityUtils.clearSession();
+    }
+
+    // The Cucumber test steps
+
+    @Given("^UngaBunga$")
+    public void testUngaBunga()
+            throws KapuaException {
+        KapuaId tmpId1 = new KapuaEid(BigInteger.valueOf(-1));
+        KapuaId tmpId2 = new KapuaEid(BigInteger.valueOf(-2));
+        DeviceConnectionCreator tmpCreator = prepareRegularConnectionCreator(tmpId1, tmpId2);
+        connection = deviceConnectionService.create(tmpCreator);
+    }
+
+    @Given("^A regular connection creator$")
+    public void createRegularCreator() {
+        connectionCreator = prepareRegularConnectionCreator(rootScopeId,
+                new KapuaEid(BigInteger.valueOf(random.nextLong())));
+    }
+
+    @Given("^A connection for scope (d+)$")
+    public void createConnectionInScope(int scope)
+            throws KapuaException {
+        DeviceConnectionCreator tmpCreator = prepareRegularConnectionCreator(new KapuaEid(BigInteger.valueOf(scope)),
+                new KapuaEid(BigInteger.valueOf(random.nextLong())));
+        connection = deviceConnectionService.create(tmpCreator);
+    }
+
+    @Given("^A scope with id (\\d+)$")
+    public void setCustomScopeId(int scope) {
+        scopeId = new KapuaEid(BigInteger.valueOf(scope));
+        assertNotNull(scopeId);
+    }
+
+    @Given("^User (-?\\d+) in scope (-?\\d+)$")
+    public void setCustomUserAndScopeId(int user, int scope) {
+        userId = new KapuaEid(BigInteger.valueOf(user));
+        scopeId = new KapuaEid(BigInteger.valueOf(scope));
+        assertNotNull(userId);
+        assertNotNull(scopeId);
+    }
+
+    @Given("^I have the following connection(?:|s)$")
+    public void createConnections(List<DeviceConnectionImpl> connections)
+            throws KapuaException {
+        try {
+            exceptionCaught = false;
+            for (DeviceConnection connItem : connections) {
+                connectionCreator = new DeviceConnectionCreatorImpl(scopeId);
+                connectionCreator.setUserId(userId);
+                connectionCreator.setClientId(connItem.getClientId());
+                connectionCreator.setClientIp(connItem.getClientIp());
+                connectionCreator.setServerIp(connItem.getServerIp());
+                connectionCreator.setProtocol(connItem.getProtocol());
+                connection = deviceConnectionService.create(connectionCreator);
+                connectionId = connection.getId();
+            }
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @Given("^I modify the connection details to$")
+    public void updateConnectionDetails(List<DeviceConnectionImpl> connections)
+            throws KapuaException {
+        // Only a single connection must be specified for this test!
+        assertNotNull(connections);
+        assertEquals(1, connections.size());
+        try {
+            exceptionCaught = false;
+            // try to modify the existing connection
+            // Slight workaround for cucumber limitations: Remember the desired
+            // connection settings via the global connectionCreator variable
+            if (connections.get(0).getClientId() != null) {
+                connection.setClientId(connections.get(0).getClientId());
+                connectionCreator.setClientId(connections.get(0).getClientId());
+            }
+            if (connections.get(0).getClientIp() != null) {
+                connection.setClientIp(connections.get(0).getClientIp());
+                connectionCreator.setClientIp(connections.get(0).getClientIp());
+            }
+            if (connections.get(0).getServerIp() != null) {
+                connection.setServerIp(connections.get(0).getServerIp());
+                connectionCreator.setServerIp(connections.get(0).getServerIp());
+            }
+            if (connections.get(0).getProtocol() != null) {
+                connection.setProtocol(connections.get(0).getProtocol());
+                connectionCreator.setProtocol(connections.get(0).getProtocol());
+            }
+            connection = deviceConnectionService.update(connection);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I try to modify the connection client Id to \"(.+)\"$")
+    public void changeConnectionClientId(String client)
+            throws KapuaException {
+        // Remember the old client ID for later checking
+        stringVal = connection.getClientId();
+        // Update the connection client ID
+        connection.setClientId(client);
+        connection = deviceConnectionService.update(connection);
+    }
+
+    @When("^I try to modify the connection Id$")
+    public void changeConnectionIdRandomly()
+            throws KapuaException {
+        // Try to update the connection ID
+        KapuaId newId = new KapuaEid(BigInteger.valueOf(random.nextLong()));
+        connection.setId(newId);
+        try {
+            exceptionCaught = false;
+            connection = deviceConnectionService.update(connection);
+        } catch (KapuaException ex) {
+            // Since the ID is not updatable there should be an exception
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I create a new connection from the existing creator$")
+    public void createConnectionFromExistingCreator()
+            throws KapuaException {
+        connection = deviceConnectionService.create(connectionCreator);
+    }
+
+    @Then("^The connection object is regular$")
+    public void checkConnectionObject() {
+        assertNotNull(connection);
+        assertNotNull(connection.getId());
+    }
+
+    @Then("^The connection object matches the creator$")
+    public void checkConnectionObjectAgainstCreator()
+            throws KapuaException {
+        assertNotNull(connection);
+        assertNotNull(connectionCreator);
+        assertEquals(connectionCreator.getScopeId(), connection.getScopeId());
+        assertEquals(connectionCreator.getClientId(), connection.getClientId());
+        assertEquals(connectionCreator.getUserId(), connection.getUserId());
+        assertEquals(connectionCreator.getClientIp(), connection.getClientIp());
+        assertEquals(connectionCreator.getServerIp(), connection.getServerIp());
+        assertEquals(connectionCreator.getProtocol(), connection.getProtocol());
+    }
+
+    @Then("^The connection status is \"(.+)\"$")
+    public void checkConnectionStatus(String status) {
+        if (status.trim().toUpperCase().equals("CONNECTED")) {
+            assertEquals(DeviceConnectionStatus.CONNECTED, connection.getStatus());
+        } else if (status.trim().toUpperCase().equals("DISCONNECTED")) {
+            assertEquals(DeviceConnectionStatus.DISCONNECTED, connection.getStatus());
+        } else if (status.trim().toUpperCase().equals("MISSING")) {
+            assertEquals(DeviceConnectionStatus.MISSING, connection.getStatus());
+        } else {
+            fail();
+        }
+    }
+
+    @Then("^I count (\\d+) connections in scope (-?\\d+)$")
+    public void countConnectioncInScope(int target, int scope)
+            throws KapuaException {
+        DeviceConnectionQuery tmpQuery = new DeviceConnectionQueryImpl(new KapuaEid(BigInteger.valueOf(scope)));
+        long tmpCount = 0;
+
+        assertNotNull(tmpQuery);
+        tmpCount = deviceConnectionService.count(tmpQuery);
+        assertEquals(target, tmpCount);
+    }
+
+    @When("^I search for a connection by scope and connection IDs$")
+    public void findConnectionByScopeAndConnectionId()
+            throws KapuaException {
+        connection = deviceConnectionService.find(scopeId, connectionId);
+    }
+
+    @When("^I search for a random connection ID$")
+    public void searchForARandomConnectionId()
+            throws KapuaException {
+        KapuaId tmpConnId = new KapuaEid(BigInteger.valueOf(random.nextLong()));
+        connection = deviceConnectionService.find(scopeId, tmpConnId);
+    }
+
+    @When("^I search for a connection with the client ID \"(.+)\"$")
+    public void findConnectionByClientId(String client)
+            throws KapuaException {
+        connection = deviceConnectionService.findByClientId(scopeId, client);
+    }
+
+    @When("^I delete the existing connection$")
+    public void deleteExistingConnection()
+            throws KapuaException {
+        deviceConnectionService.delete(connection.getScopeId(), connection.getId());
+        connection = null;
+    }
+
+    @When("^I try to delete a random connection ID$")
+    public void deleteRandomConnection() {
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(random.nextLong()));
+        try {
+            exceptionCaught = false;
+            deviceConnectionService.delete(scopeId, tmpId);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @When("^I query for all connections with the parameter \"(.+)\" set to \"(.+)\"$")
+    public void cueryForConnections(String parameter, String value)
+            throws KapuaException {
+        DeviceConnectionQuery tmpQuery = new DeviceConnectionQueryImpl(scopeId);
+        tmpQuery.setPredicate(attributeIsEqualTo(parameter, value));
+
+        connectionList = (DeviceConnectionListResult) deviceConnectionService.query(tmpQuery);
+        assertNotNull(connectionList);
+    }
+
+    @Then("^I find (\\d+) connection(?:|s)$")
+    public void checkResultListLength(int num) {
+        assertNotNull(connectionList);
+        assertEquals(num, connectionList.getSize());
+    }
+
+    @Then("^The connection details match$")
+    public void checkConnectionDetails(List<DeviceConnectionImpl> connections)
+            throws KapuaException {
+        // Only a single connection must be specified for this test!
+        assertNotNull(connections);
+        assertEquals(1, connections.size());
+        // Slight workaround for cucumber limitations: The connection settings are
+        // remembered via the global connection variable
+        if (connections.get(0).getClientId() != null) {
+            assertEquals(connections.get(0).getClientId(), connection.getClientId());
+        }
+        if (connections.get(0).getClientIp() != null) {
+            assertEquals(connections.get(0).getClientIp(), connection.getClientIp());
+        }
+        if (connections.get(0).getServerIp() != null) {
+            assertEquals(connections.get(0).getServerIp(), connection.getServerIp());
+        }
+        if (connections.get(0).getProtocol() != null) {
+            assertEquals(connections.get(0).getProtocol(), connection.getProtocol());
+        }
+    }
+
+    @Then("^The connection client ID remains unchanged$")
+    public void checkThatClientIdHasNotChanged() {
+        assertEquals(stringVal, connection.getClientId());
+    }
+
+    @Then("^No connection was found$")
+    public void checkThatConnectionIsNull() {
+        assertNull(connection);
+    }
+
+    @Then("^An exception was thrown$")
+    public void checkThatExceptionWasThrown() {
+        assertTrue(exceptionCaught);
+    }
+
+    @Then("^No exception was thrown$")
+    public void checkThatExceptionWasNotThrown() {
+        assertFalse(exceptionCaught);
+    }
+
+    @Then("^All connection factory functions must return non null values$")
+    public void exerciseAllConnectionFactoryFunctions() {
+        DeviceConnectionCreator tmpCreator = null;
+        DeviceConnectionQuery tmpQuery = null;
+        DeviceConnectionSummary tmpSummary = null;
+
+        tmpCreator = deviceConnectionFactory.newCreator(rootScopeId);
+        tmpQuery = deviceConnectionFactory.newQuery(rootScopeId);
+        tmpSummary = deviceConnectionFactory.newConnectionSummary();
+
+        assertNotNull(tmpCreator);
+        assertNotNull(tmpQuery);
+        assertNotNull(tmpSummary);
+    }
+
+    @Then("^The device connection domain defaults are correctly initialized$")
+    public void checkConnectionDomainInitialization() {
+        DeviceConnectionDomain tmpDomain = new DeviceConnectionDomain();
+
+        assertEquals("device_connection", tmpDomain.getName());
+        assertEquals("DeviceConnectionService", tmpDomain.getServiceName());
+        assertEquals(3, tmpDomain.getActions().size());
+        assertTrue(tmpDomain.getActions().contains(Actions.read));
+        assertTrue(tmpDomain.getActions().contains(Actions.write));
+        assertTrue(tmpDomain.getActions().contains(Actions.delete));
+    }
+
+    @Then("^The device connection domain data can be updated$")
+    public void checkDeviceConnectionDomainUpdate() {
+        DeviceConnectionDomain tmpDomain = new DeviceConnectionDomain();
+
+        tmpDomain.setName("test_name");
+        tmpDomain.setServiceName("test_service_name");
+        tmpDomain.setActions(new HashSet<>(Lists.newArrayList(Actions.connect, Actions.execute)));
+
+        assertEquals("test_name", tmpDomain.getName());
+        assertEquals("test_service_name", tmpDomain.getServiceName());
+        assertEquals(2, tmpDomain.getActions().size());
+        assertTrue(tmpDomain.getActions().contains(Actions.connect));
+        assertTrue(tmpDomain.getActions().contains(Actions.execute));
+    }
+
+    // *******************
+    // * Private Helpers *
+    // *******************
+
+    // Create a connection creator object. The creator is pre-filled with default data.
+    DeviceConnectionCreator prepareRegularConnectionCreator(KapuaId scopeId, KapuaId userId) {
+        DeviceConnectionCreatorImpl tmpCreator = new DeviceConnectionCreatorImpl(scopeId);
+
+        tmpCreator.setUserId(userId);
+        tmpCreator.setClientId(CLIENT_NAME);
+        tmpCreator.setClientIp(CLIENT_IP);
+        tmpCreator.setServerIp(SERVER_IP);
+        tmpCreator.setProtocol("tcp");
+
+        return tmpCreator;
+    }
+}

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
@@ -18,9 +18,10 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = "classpath:features", 
-                 glue = { "org.eclipse.kapua.service.device.registry.common", 
-                          "org.eclipse.kapua.service.device.registry.internal"},
+@CucumberOptions(features = "classpath:features",
+                 glue = { "org.eclipse.kapua.service.device.registry.internal",
+                          "org.eclipse.kapua.service.device.registry.common",
+                          "org.eclipse.kapua.service.device.registry.connection.internal" },
                  plugin = { "pretty", 
                             "html:target/cucumber",
                             "json:target/cucumber.json" }, 

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistryConnection.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistryConnection.feature
@@ -1,0 +1,226 @@
+###############################################################################
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+Feature: Device Registry Connection tests
+    The Device Registry Connection service is responsible for performing CRUD operations 
+    regarding device connections on the Kapua database.
+    
+Scenario: Regular connection
+	It must be possible to create a device connection entry in the database. The centry 
+	must match the creator parameters. The connection status must also be 
+	implicitly set to CONNECTED. 
+
+	Given User 1 in scope 1
+	And I have the following connection
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	Then The connection object is regular
+	And The connection details match
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	And The connection status is "CONNECTED"
+
+Scenario: Device connection update
+	It must be possible to change the data of an existing device connection database 
+	entry.
+
+	Given User 1 in scope 1
+	And I have the following connection
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	When I modify the connection details to
+		| clientIp    | serverIp   | protocol |
+		| 127.0.0.109 | 127.0.0.25 | udp      |
+	Then No exception was thrown
+	And The connection details match
+		| clientIp    | serverIp   | protocol |
+		| 127.0.0.109 | 127.0.0.25 | udp      |
+
+Scenario: Try to modify the connection client ID
+	It must not be possible to change the client ID of an existing device connection.
+	Attempts to change the client ID must be silently ignored. No exceptions must 
+	be thrown.
+	
+	Given User 1 in scope 1
+	And I have the following connection
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	When I try to modify the connection client Id to "testClient2"
+	Then No exception was thrown
+	And The connection client ID remains unchanged
+
+Scenario: Count connections in scope
+	It must be possible to count all the connections in a given scope.
+
+	Given A scope with id 1
+	And I have the following connections
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      |
+		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      |
+		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      |
+		| testClient5 | 127.0.0.105 | 127.0.0.10 | tcp      |
+		| testClient6 | 127.0.0.106 | 127.0.0.10 | tcp      |
+		| testClient7 | 127.0.0.107 | 127.0.0.10 | tcp      |
+	Then No exception was thrown
+	And I count 7 connections in scope 1
+
+Scenario: Count connections in empty scope
+	Counting connections for an empty (nonexisting) scope must not raise any exception.
+	A regular result (in this case 0) must be returned.
+	
+	Given A scope with id 1
+	And I have the following connections
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      |
+		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      |
+		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      |
+		| testClient5 | 127.0.0.105 | 127.0.0.10 | tcp      |
+		| testClient6 | 127.0.0.106 | 127.0.0.10 | tcp      |
+		| testClient7 | 127.0.0.107 | 127.0.0.10 | tcp      |
+	Then I count 0 connections in scope 42
+
+Scenario: Try to change an existing connection ID
+	It must not be possible to change the ID of an existing connection. Trying to 
+	do so must result in an exception being thrown.
+	
+	Given User 1 in scope 1
+	And I have the following connection
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	When I try to modify the connection Id
+	Then An exception was thrown
+
+Scenario: Find a connection by its IDs
+	It must be possible to find a specific connection in the database based on 
+	its scope and entity IDs.
+
+	Given User 1 in scope 1
+	And I have the following connection
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	When I search for a connection by scope and connection IDs
+	Then The connection details match
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+
+Scenario: I try to find a non-existing connection
+	Searching for a non existing connection must not raise any exception. A null
+	reference must be returned instead.
+
+	Given User 1 in scope 1
+	And I have the following connection
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	When I search for a random connection ID
+	Then No connection was found
+
+Scenario: Find a connection by its client ID
+	It must be possible to find a specific connection in the database based on its
+	scope and client IDs.
+
+	Given User 1 in scope 1
+	And I have the following connections
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      |
+		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      |
+		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      |
+	When I search for a connection with the client ID "testClient3"
+	Then The connection details match
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      |	
+
+Scenario: Search for a non existent client ID
+	Searching for a non existing connection must not raise any exception. A null
+	reference must be returned instead.
+	
+	Given User 1 in scope 1
+	And I have the following connections
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      |
+		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      |
+		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      |
+	When I search for a connection with the client ID "nonexistentId"
+	Then No connection was found
+
+Scenario: The Client ID is case sensitive
+	Given User 1 in scope 1
+	And I have the following connections
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	When I search for a connection with the client ID "TESTClient1"
+	Then No connection was found
+	When I search for a connection with the client ID "testClient1"
+	Then The connection details match
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |	
+
+Scenario: Delete a connection from the database
+	It must be possible to delete a specific entry fron the connection database.
+
+	Given User 1 in scope 1
+	And I have the following connections
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      |
+		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      |
+		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      |
+	And I search for a connection with the client ID "testClient3"
+	And I delete the existing connection
+	When I search for a connection with the client ID "testClient3"
+	Then No connection was found
+
+Scenario: Delete a non existing cnnection
+	Trying to delete a non existent connection should result in an exception 
+	being thrown.
+	
+	Given User 1 in scope 1
+	And I have the following connection
+		| clientId    | clientIp    | serverIp   | protocol |
+		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      |
+	When I try to delete a random connection ID
+	Then An exception was thrown
+
+Scenario: Generic connection query
+	It must be possible to query for connections in the database based on various 
+	parameters.
+	
+	Given User 1 in scope 1
+	And I have the following connections
+		| clientId     | clientIp    | serverIp   | protocol |
+		| testClient01 | 127.0.0.101 | 127.0.0.10 | tcp      |
+		| testClient02 | 127.0.0.102 | 127.0.0.10 | tcp      |
+		| testClient03 | 127.0.0.103 | 127.0.0.10 | tcp      |
+		| testClient04 | 127.0.0.104 | 127.0.0.11 | tcp      |
+		| testClient05 | 127.0.0.104 | 127.0.0.11 | tcp      |
+		| testClient06 | 127.0.0.104 | 127.0.0.11 | tcp      |
+		| testClient07 | 127.0.0.104 | 127.0.0.11 | udp      |
+		| testClient08 | 127.0.0.104 | 127.0.0.10 | udp      |
+		| testClient09 | 127.0.0.104 | 127.0.0.10 | udp      |
+		| testClient10 | 127.0.0.104 | 127.0.0.10 | udp      |
+		| testClient11 | 127.0.0.104 | 127.0.0.10 | udp      |
+	When I query for all connections with the parameter "protocol" set to "udp"
+	Then I find 5 connections
+	When I query for all connections with the parameter "serverIp" set to "127.0.0.11"
+	Then I find 4 connections
+
+Scenario: Connection Service factory sanity checks
+	Then All connection factory functions must return non null values
+
+Scenario: Check the sanity of the Device Connection Domain data initialization
+	Then The device connection domain defaults are correctly initialized
+	
+Scenario: Check the Device Connection Domain data seetting
+	Then The device connection domain data can be updated


### PR DESCRIPTION
## CRUD tests for the Device Connection service
This first set of Device Connection service tests exercises the majority of the Device Connection service (package org.eclipse.kapua.service.device.registry.connection.internal).
**Note**: The existing jUnit tests for the Device Registry service packages are disabled (@Ignore). Mixing the preexisting jUnit and new cucumber based tests leads to failure of the jUnit tests (caused by the use of the MockedLocator). Eventually all jUnit tests will be replaced by suitable cucumber based tests.

### Changes to Maven pom files
No changes in the pom files.

### Implementation changes
The implementation of the Device Connection service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented to test CRUD operations on the Device Connection service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>