### PR TITLE
Basic unit tests for message module

### DIFF
--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -39,10 +39,33 @@
             <artifactId>validation-api</artifactId>
         </dependency>
 
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-shiro</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- External testing dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        KapuaMessageFactoryTest.class,
+        KapuaChannelTest.class,
+        KapuaMessageTest.class,
+        MessageExceptionTest.class,
+        KapuaPositionTest.class,
+        KapuaPayloadTest.class
+})
+public class BasicMessageTestSuite {
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.eclipse.kapua.message.internal.device.data.KapuaDeviceDataTest;
+import org.eclipse.kapua.message.internal.device.lifecycle.LifecycleTestSuite;
+import org.eclipse.kapua.message.internal.xml.MetricTestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        BasicMessageTestSuite.class,
+        MetricTestSuite.class,
+        KapuaDeviceDataTest.class,
+        LifecycleTestSuite.class
+
+})
+public class FullMessageTestSuite {
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.eclipse.kapua.message.KapuaChannel;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KapuaChannelTest extends Assert {
+
+    KapuaChannel kapuaChannel;
+
+    @Before
+    public void before() throws Exception {
+        kapuaChannel = new KapuaChannelImpl();
+    }
+
+    @Test
+    public void semanticParts() throws Exception {
+        List<String> semanticParts = new ArrayList<>();
+        semanticParts.add("part1");
+        semanticParts.add("part2");
+        semanticParts.add("part3");
+        kapuaChannel.setSemanticParts(semanticParts);
+        List<String> getSemanticParts = kapuaChannel.getSemanticParts();
+
+        assertEquals(semanticParts, getSemanticParts);
+    }
+
+    @Test
+    public void semanticPartsToString() throws Exception {
+        List<String> semanticParts = new ArrayList<>();
+        semanticParts.add("part1");
+        semanticParts.add("part2");
+        semanticParts.add("part3");
+        kapuaChannel.setSemanticParts(semanticParts);
+        String toString = kapuaChannel.toString();
+
+        assertEquals("part1/part2/part3/", toString);
+    }
+
+    @Test
+    public void semanticPartsToStringEmpty() throws Exception {
+        List<String> semanticParts = new ArrayList<>();
+
+        kapuaChannel.setSemanticParts(semanticParts);
+        String toString = kapuaChannel.toString();
+
+        assertEquals("NO semantic topic defined", toString);
+    }
+
+    @Test
+    public void semanticPartsToStringNull() throws Exception {
+
+        kapuaChannel.setSemanticParts(null);
+        String toString = kapuaChannel.toString();
+
+        assertEquals("NO semantic topic defined", toString);
+    }
+
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.message.*;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KapuaMessageFactoryTest extends Assert {
+
+    private KapuaMessageFactory kapuaMessageFactory;
+
+    @Before
+    public void before() throws KapuaException {
+        kapuaMessageFactory = new KapuaMessageFactoryImpl();
+    }
+
+    @Test
+    public void newMessage() throws Exception {
+        KapuaMessage message = kapuaMessageFactory.newMessage();
+
+        assertNotNull(message);
+    }
+
+    @Test
+    public void newChannel() throws Exception {
+        KapuaChannel channel = kapuaMessageFactory.newChannel();
+
+        assertNotNull(channel);
+    }
+
+    @Test
+    public void newPayload() throws Exception {
+        KapuaPayload payload = kapuaMessageFactory.newPayload();
+
+        assertNotNull(payload);
+    }
+
+    @Test
+    public void newPosition() throws Exception {
+        KapuaPosition position = kapuaMessageFactory.newPosition();
+
+        assertNotNull(position);
+    }
+
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.message.KapuaChannel;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.eclipse.kapua.message.internal.KapuaMessageUtil.*;
+
+public class KapuaMessageTest extends Assert {
+
+    private static final String KAPUA_MESSAGE_XML_STR = "missing";
+
+    private ZonedDateTime referenceDate = ZonedDateTime.of(2017, 1, 18, 13, 10, 46, 0, ZoneId.systemDefault());
+
+    private Date capturedDate = Date.from(referenceDate.toInstant());
+
+    private Date sentDate = Date.from(referenceDate.plusSeconds(10).toInstant());
+
+    private Date receivedDate = Date.from(referenceDate.plusMinutes(1).toInstant());
+
+    @Before
+    public void before() throws Exception {
+        XmlUtil.setContextProvider(new MessageJAXBContextProvider());
+    }
+
+    @Test
+    public void kapuaMessage() throws Exception {
+        KapuaChannel kapuaChannel = new KapuaChannelImpl();
+        KapuaPayload kapuaMetrics = new KapuaPayloadImpl();
+
+        populateChannel(kapuaChannel);
+        populatePayload(kapuaMetrics);
+        KapuaMessage kapuaMessage = new KapuaMessageImpl(kapuaChannel, kapuaMetrics);
+        populateKapuaMessage(kapuaMessage, referenceDate);
+
+        assertEquals(UUID.fromString("11111111-2222-3333-4444-555555555555"), kapuaMessage.getId());
+        assertEquals(new KapuaEid(BigInteger.ONE), kapuaMessage.getScopeId());
+        assertEquals(new KapuaEid(BigInteger.ONE), kapuaMessage.getDeviceId());
+        assertEquals(receivedDate, kapuaMessage.getReceivedOn());
+        assertEquals(sentDate, kapuaMessage.getSentOn());
+        assertEquals(capturedDate, kapuaMessage.getCapturedOn());
+        KapuaPosition position = new KapuaPositionImpl();
+        populatePosition(position, referenceDate);
+        assertEquals(position.toString(), kapuaMessage.getPosition().toString());
+        assertEquals(kapuaChannel, kapuaMessage.getChannel());
+        assertEquals(kapuaMetrics, kapuaMessage.getPayload());
+    }
+
+    @Test
+    public void setMessageChannelAndPayload() throws Exception {
+        KapuaChannel kapuaChannel = new KapuaChannelImpl();
+        KapuaPayload kapuaPayload = new KapuaPayloadImpl();
+
+        populateChannel(kapuaChannel);
+        populatePayload(kapuaPayload);
+        KapuaMessage kapuaMessage = new KapuaMessageImpl();
+        kapuaMessage.setChannel(kapuaChannel);
+        kapuaMessage.setPayload(kapuaPayload);
+
+        assertEquals(kapuaChannel, kapuaMessage.getChannel());
+        assertEquals(kapuaPayload, kapuaMessage.getPayload());
+    }
+
+    @Test
+    public void messageEquals() throws Exception {
+        KapuaMessage kapuaMessageFirst = new KapuaMessageImpl();
+        populateKapuaMessage(kapuaMessageFirst, referenceDate);
+        KapuaMessage kapuaMessageSecond = new KapuaMessageImpl();
+        populateKapuaMessage(kapuaMessageSecond, referenceDate);
+
+        assertEquals(0, ((KapuaMessageImpl) kapuaMessageFirst).
+                compareTo((KapuaMessageImpl) kapuaMessageSecond));
+    }
+
+    @Test
+    @Ignore("KapuaMessage marshaling not working")
+    public void marshallMessage() throws Exception {
+        KapuaChannel kapuaChannel = new KapuaChannelImpl();
+        KapuaPayload kapuaMetrics = new KapuaPayloadImpl();
+
+        populateChannel(kapuaChannel);
+        populatePayload(kapuaMetrics);
+        KapuaMessage kapuaMessage = new KapuaMessageImpl(kapuaChannel, kapuaMetrics);
+        populateKapuaMessage(kapuaMessage, referenceDate);
+
+        StringWriter strWriter = new StringWriter();
+        XmlUtil.marshal(kapuaMessage, strWriter);
+        assertEquals(KAPUA_MESSAGE_XML_STR, strWriter.toString());
+    }
+
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.message.KapuaChannel;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.KapuaPosition;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+/**
+ * Test Utility for repeating parts of code in Message moudule.
+ * Mostly for populating sturctures with random / semi random test data.
+ */
+public class KapuaMessageUtil {
+
+    private static ZoneId defaultZoneId = ZoneId.systemDefault();
+
+    /**
+     * Prepare payload data that contains two metrics and simple byte payload.
+     *
+     * @param kapuaPayload payload reference to fill with test data
+     */
+    public static void populatePayload(KapuaPayload kapuaPayload) {
+        Map<String, Object> metrics = new HashMap<>();
+        metrics.put("key1", "value1");
+        metrics.put("key2", "value2");
+        kapuaPayload.setProperties(metrics);
+        byte[] body = {'b', 'o', 'd', 'y'};
+        kapuaPayload.setBody(body);
+    }
+
+    /**
+     * Prepare payload data that contains metrics with all available types.
+     *
+     * @param kapuaPayload payload reference to fill with test data
+     */
+    public static void populatePayloadWithAllTypesOfMetrics(KapuaPayload kapuaPayload) {
+        Map<String, Object> metrics = new HashMap<>();
+        metrics.put("Float", new Float(42.42f));
+        metrics.put("Double", new Double(42.42d));
+        metrics.put("Integer", new Integer(42));
+        metrics.put("Long", new Long(43l));
+        metrics.put("Boolean", Boolean.TRUE);
+        metrics.put("String", "Big brown fox");
+        metrics.put("byte", new byte[]{'b', 'o', 'd', 'y', 0});
+        metrics.put("unknown", new BigDecimal("42.42"));
+        kapuaPayload.setProperties(metrics);
+    }
+
+    /**
+     * Prepare channel semantic parts with three part metric.
+     *
+     * @param kapuaChannel channel reference to fill with test data
+     */
+    public static void populateChannel(KapuaChannel kapuaChannel) {
+        List<String> semanticParts = new ArrayList<>();
+        semanticParts.add("part1");
+        semanticParts.add("part2");
+        semanticParts.add("part3");
+        kapuaChannel.setSemanticParts(semanticParts);
+    }
+
+    /**
+     * Prepare full KapuaMessage with fixed data. Data is not semantically correct, just
+     * tokens that fill all necessary fields.
+     *
+     * @param kapuaMessage  KapuaMessage reference to fill with test data
+     * @param referenceDate reference date on which all date fields are based
+     */
+    public static void populateKapuaMessage(KapuaMessage kapuaMessage, ZonedDateTime referenceDate) {
+        kapuaMessage.setId(UUID.fromString("11111111-2222-3333-4444-555555555555"));
+        kapuaMessage.setScopeId(new KapuaEid(BigInteger.ONE));
+        kapuaMessage.setDeviceId(new KapuaEid(BigInteger.ONE));
+        kapuaMessage.setReceivedOn(Date.from(referenceDate.plusMinutes(1).toInstant()));
+        kapuaMessage.setSentOn(Date.from(referenceDate.plusSeconds(10).toInstant()));
+        kapuaMessage.setCapturedOn(Date.from(referenceDate.toInstant()));
+        KapuaPosition position = new KapuaPositionImpl();
+        populatePosition(position, referenceDate);
+        kapuaMessage.setPosition(position);
+    }
+
+    /**
+     * Prepare position data with fixed values. Values are semantically correct.
+     *
+     * @param position      reference to position object that is filled with test data
+     * @param referenceDate reference date on which all date fields are based
+     */
+    public static void populatePosition(KapuaPosition position, ZonedDateTime referenceDate) {
+        position.setLongitude(Double.valueOf("45.1111"));
+        position.setLatitude(Double.valueOf("15.3333"));
+        position.setAltitude(Double.valueOf("430.30"));
+        position.setPrecision(Double.valueOf("12"));
+        position.setHeading(Double.valueOf("280"));
+        position.setSpeed(Double.valueOf("60.20"));
+        position.setTimestamp(Date.from(referenceDate.toInstant()));
+        position.setSatellites(5);
+        position.setStatus(4);
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.util.Map;
+
+import static org.eclipse.kapua.message.internal.KapuaMessageUtil.populatePayload;
+import static org.eclipse.kapua.message.internal.KapuaMessageUtil.populatePayloadWithAllTypesOfMetrics;
+
+public class KapuaPayloadTest extends Assert {
+
+    private static final int PAYLOAD_DISPLAY_STR_LEN = 109;
+
+    private static final String KAPUA_PAYLOAD_XML_STR = "missing";
+
+    @Before
+    public void before() throws Exception {
+        XmlUtil.setContextProvider(new MessageJAXBContextProvider());
+    }
+
+    @Test
+    public void payloadGetterSetters() throws Exception {
+        KapuaPayload kapuaPayload = new KapuaPayloadImpl();
+        populatePayload(kapuaPayload);
+
+        Map<String, Object> properties = kapuaPayload.getProperties();
+        byte[] body = kapuaPayload.getBody();
+        assertEquals("value1", properties.get("key1"));
+        assertEquals("value2", properties.get("key2"));
+        assertArrayEquals(new byte[]{'b', 'o', 'd', 'y'}, body);
+    }
+
+    @Test
+    public void displayString() throws Exception {
+        KapuaPayload kapuaPayload = new KapuaPayloadImpl();
+        populatePayloadWithAllTypesOfMetrics(kapuaPayload);
+
+        String displayStr = kapuaPayload.toDisplayString();
+        assertEquals("Length not equal, content probably too.", PAYLOAD_DISPLAY_STR_LEN, displayStr.length());
+    }
+
+    @Test
+    @Ignore("KapuaPayload marshaling not working")
+    public void marshallPayload() throws Exception {
+        KapuaPayload kapuaPayload = new KapuaPayloadImpl();
+        populatePayload(kapuaPayload);
+
+        StringWriter strWriter = new StringWriter();
+        XmlUtil.marshal(kapuaPayload, strWriter);
+        assertEquals(KAPUA_PAYLOAD_XML_STR, strWriter.toString());
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.eclipse.kapua.message.internal.KapuaMessageUtil.populatePosition;
+
+public class KapuaPositionTest extends Assert {
+
+    private static final String newline = System.lineSeparator();
+
+    private static final String POSITION_DISPLAY_STR = "^latitude=.*~~longitude=.*~~altitude=.*" +
+            "~~precision=.*~~heading=.*~~speed=.*~~timestamp=.*~~satellites=.*~~status=.*$";
+
+    private static final String DISPLAY_STR = "^\\{\"longitude\":.*, \"latitude\":.*, \"altitude\":.*" +
+            ", \"precision\":.*, \"heading\":.*, \"speed\":.*, \"timestamp\":.*, \"satellites\":.*, \"status\":.*\\}$";
+
+
+    private static ZonedDateTime referenceDate = ZonedDateTime.of(2017, 1, 18, 13, 10, 46, 0, ZoneId.systemDefault());
+
+    private static String referenceDateStr = referenceDate.
+            format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+
+    private static final String POSITION_XML_STR = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + newline +
+            "<altitude>430.3</altitude><heading>280.0</heading><latitude>15.3333</latitude>" +
+            "<longitude>45.1111</longitude><precision>12.0</precision><satellites>5</satellites>" +
+            "<speed>60.2</speed><status>4</status><timestamp>" + referenceDateStr + "</timestamp>" + newline;
+
+    @Before
+    public void before() throws Exception {
+        XmlUtil.setContextProvider(new MessageJAXBContextProvider());
+    }
+
+    @Test
+    public void positionGetterSetters() throws Exception {
+        KapuaPosition position = new KapuaPositionImpl();
+        populatePosition(position, referenceDate);
+
+        assertEquals(new Double("45.1111"), position.getLongitude());
+        assertEquals(new Double("15.3333"), position.getLatitude());
+        assertEquals(new Double("430.3"), position.getAltitude());
+        assertEquals(new Double("12.0"), position.getPrecision());
+        assertEquals(new Double("280.0"), position.getHeading());
+        assertEquals(new Double("60.2"), position.getSpeed());
+        assertNotNull(position.getTimestamp());
+        assertEquals(new Integer(5), position.getSatellites());
+        assertEquals(new Integer(4), position.getStatus());
+    }
+
+    @Test
+    public void displayString() throws Exception {
+        KapuaPosition position = new KapuaPositionImpl();
+        populatePosition(position, referenceDate);
+
+        String displayStr = position.toDisplayString();
+        assertTrue("\nExpected: " + POSITION_DISPLAY_STR +
+                        "\nActual:   " + displayStr,
+                displayStr.matches(POSITION_DISPLAY_STR));
+    }
+
+    @Test
+    public void displayEmptyPositionString() throws Exception {
+        KapuaPosition position = new KapuaPositionImpl();
+
+        String displayStr = position.toDisplayString();
+        assertNull(displayStr);
+    }
+
+    @Test
+    public void toStringValue() throws Exception {
+        KapuaPosition position = new KapuaPositionImpl();
+        populatePosition(position, referenceDate);
+
+        String toStr = position.toString();
+        assertTrue("\nExpected: " + DISPLAY_STR +
+                        "\nActual:   " + toStr,
+                toStr.matches(DISPLAY_STR));
+    }
+
+    @Test
+    public void marshallPosition() throws Exception {
+        KapuaPosition position = new KapuaPositionImpl();
+        populatePosition(position, referenceDate);
+
+        StringWriter strWriter = new StringWriter();
+        XmlUtil.marshal(position, strWriter);
+        assertEquals(POSITION_XML_STR, strWriter.toString());
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MessageExceptionTest extends Assert {
+
+    @Test
+    public void invalidDestinationText() throws Exception {
+        MessageException ex = new MessageException(MessageErrorCodes.INVALID_DESTINATION);
+        String message = ex.getLocalizedMessage();
+
+        assertEquals("Invalid destination", message);
+    }
+
+    @Test
+    public void invalidMessageText() throws Exception {
+        MessageException ex = new MessageException(MessageErrorCodes.INVALID_MESSAGE);
+        String message = ex.getLocalizedMessage();
+
+        assertEquals("Invalid message", message);
+    }
+
+    @Test
+    public void invalidMetricTypeText() throws Exception {
+        MessageException ex = new MessageException(MessageErrorCodes.INVALID_METRIC_TYPE, "int");
+        String message = ex.getLocalizedMessage();
+
+        assertEquals("Invalid metric type int", message);
+    }
+
+    @Test
+    public void invalidMetricValueText() throws Exception {
+        MessageException ex = new MessageException(MessageErrorCodes.INVALID_METRIC_VALUE,
+                new NullPointerException(),
+                0);
+        String message = ex.getLocalizedMessage();
+
+        assertEquals("Invalid metric value 0", message);
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageJAXBContextProvider.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageJAXBContextProvider.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageJAXBContextProvider.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
+import org.eclipse.kapua.message.KapuaChannel;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.internal.xml.KapuaMetric;
+import org.eclipse.kapua.message.internal.xml.KapuaMetricValue;
+import org.eclipse.kapua.message.internal.xml.KapuaMetricsMap;
+import org.eclipse.kapua.message.internal.xml.KapuaMetricsMapType;
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+public class MessageJAXBContextProvider implements JAXBContextProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(MessageJAXBContextProvider.class);
+
+    private JAXBContext context;
+
+    @Override
+    public JAXBContext getJAXBContext() throws KapuaException {
+        if (context == null) {
+            Class<?>[] classes = new Class<?>[]{
+                    KapuaMessage.class,
+                    KapuaChannel.class,
+                    KapuaPayload.class,
+                    KapuaPosition.class,
+                    KapuaMetric.class,
+                    KapuaMetricValue.class,
+                    KapuaMetricsMapType.class,
+                    KapuaMetricsMap.class
+            };
+            try {
+                context = JAXBContextFactory.createContext(classes, null);
+            } catch (JAXBException jaxbException) {
+                logger.warn("Error creating JAXBContext, tests will fail!");
+            }
+        }
+        return context;
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.data;
+
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KapuaDeviceDataTest extends Assert {
+
+    @Test
+    public void kapuaDataChannelGetterSetters() throws Exception {
+        KapuaDataChannelImpl kapuaDataChannel = new KapuaDataChannelImpl();
+
+        kapuaDataChannel.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaDataChannel.getClientId());
+    }
+
+    @Test
+    public void kapuaDataChanneltoString() throws Exception {
+        KapuaDataChannelImpl kapuaDataChannel = new KapuaDataChannelImpl();
+        List<String> semanticParts = new ArrayList<>();
+        semanticParts.add("part1");
+        semanticParts.add("part2");
+        semanticParts.add("part3");
+
+        kapuaDataChannel.setClientId("clientId-1");
+        kapuaDataChannel.setSemanticParts(semanticParts);
+        assertEquals("semantic topic 'part1/part2/part3/'", kapuaDataChannel.toString());
+    }
+
+    @Test
+    public void kapuaDataMesssageGetterSetters() {
+        KapuaDataMessage kapuaDataMessage = new KapuaDataMessageImpl();
+
+        kapuaDataMessage.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaDataMessage.getClientId());
+    }
+
+    @Test
+    public void kapuaDataPayloadDefaultConstructor() {
+        KapuaDataPayload kapuaDataPayload = new KapuaDataPayloadImpl();
+
+        assertNotNull(kapuaDataPayload);
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.lifecycle;
+
+import org.eclipse.kapua.message.device.lifecycle.KapuaAppsChannel;
+import org.eclipse.kapua.message.device.lifecycle.KapuaAppsPayload;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KapuaAppsMessageTest extends Assert {
+
+    private static final String PAYLOAD_DISPLAY_STR = "[ getUptime()=12" +
+            ", getDisplayName()=displayName" +
+            ", getModelName()=modelName" +
+            ", getModelId()=modelId-1" +
+            ", getPartNumber()=part-1" +
+            ", getSerialNumber()=SN-123" +
+            ", getFirmwareVersion()=firmwareV-1" +
+            ", getBiosVersion()=biosV-1" +
+            ", getOs()=Linux" +
+            ", getOsVersion()=osV-1" +
+            ", getJvmName()=Oracle HotSpot" +
+            ", getJvmVersion()=8" +
+            ", getJvmProfile()=desktop" +
+            ", getOsgiFramework()=containerFramework" +
+            ", getOsgiFrameworkVersion()=containerFrameworkV-1" +
+            ", getEsfKuraVersion()=applicationFrameworkV-1" +
+            ", getConnectionInterface()=connectionInterface" +
+            ", getConnectionIp()=192.168.1.1" +
+            ", getAcceptEncoding()=UTF-8" +
+            ", getApplicationIdentifiers()=applicationIdentifiers" +
+            ", getAvailableProcessors()=1" +
+            ", getTotalMemory()=4" +
+            ", getOsArch()=Linux x86" +
+            ", getModemImei()=49-015420-323751" +
+            ", getModemImsi()=359881234567890" +
+            ", getModemIccid()=8991101200003204510" +
+            "]";
+
+    @Test
+    public void kapuaAppsPayloadInitConstructor() {
+        KapuaAppsPayload kapuaAppsPayload = populateKapuaAppsPayload();
+
+        assertEquals("12", kapuaAppsPayload.getUptime());
+        assertEquals("displayName", kapuaAppsPayload.getDisplayName());
+        assertEquals("modelName", kapuaAppsPayload.getModelName());
+        assertEquals("modelId-1", kapuaAppsPayload.getModelId());
+        assertEquals("part-1", kapuaAppsPayload.getPartNumber());
+        assertEquals("SN-123", kapuaAppsPayload.getSerialNumber());
+        assertEquals("firmware-1", kapuaAppsPayload.getFirmware());
+        assertEquals("firmwareV-1", kapuaAppsPayload.getFirmwareVersion());
+        assertEquals("bios", kapuaAppsPayload.getBios());
+        assertEquals("biosV-1", kapuaAppsPayload.getBiosVersion());
+        assertEquals("Linux", kapuaAppsPayload.getOs());
+        assertEquals("osV-1", kapuaAppsPayload.getOsVersion());
+        assertEquals("Oracle HotSpot", kapuaAppsPayload.getJvm());
+        assertEquals("8", kapuaAppsPayload.getJvmVersion());
+        assertEquals("desktop", kapuaAppsPayload.getJvmProfile());
+        assertEquals("containerFramework", kapuaAppsPayload.getContainerFramework());
+        assertEquals("containerFrameworkV-1", kapuaAppsPayload.getContainerFrameworkVersion());
+        assertEquals("applicationFramework", kapuaAppsPayload.getApplicationFramework());
+        assertEquals("applicationFrameworkV-1", kapuaAppsPayload.getApplicationFrameworkVersion());
+        assertEquals("connectionInterface", kapuaAppsPayload.getConnectionInterface());
+        assertEquals("192.168.1.1", kapuaAppsPayload.getConnectionIp());
+        assertEquals("UTF-8", kapuaAppsPayload.getAcceptEncoding());
+        assertEquals("applicationIdentifiers", kapuaAppsPayload.getApplicationIdentifiers());
+        assertEquals("1", kapuaAppsPayload.getAvailableProcessors());
+        assertEquals("4", kapuaAppsPayload.getTotalMemory());
+        assertEquals("Linux x86", kapuaAppsPayload.getOsArch());
+        assertEquals("49-015420-323751", kapuaAppsPayload.getModemImei());
+        assertEquals("359881234567890", kapuaAppsPayload.getModemImsi());
+        assertEquals("8991101200003204510", kapuaAppsPayload.getModemIccid());
+    }
+
+    @Test
+    public void toDisplayString() throws Exception {
+        KapuaAppsPayload kapuaAppsPayload = populateKapuaAppsPayload();
+
+        // FIXME strings representing methods are not in sync with real method names
+        String displayStr = kapuaAppsPayload.toDisplayString();
+        assertEquals(PAYLOAD_DISPLAY_STR, displayStr);
+    }
+
+    @Test
+    public void kapuaAppsMessageConstructor() throws Exception {
+        KapuaAppsMessageImpl kapuaAppsMessage = new KapuaAppsMessageImpl();
+
+        assertNotNull(kapuaAppsMessage);
+    }
+
+    @Test
+    public void kapuaAppsChannelGetterSetters() throws Exception {
+        KapuaAppsChannel kapuaAppsChannel = new KapuaAppsChannelImpl();
+
+        kapuaAppsChannel.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaAppsChannel.getClientId());
+    }
+
+    /**
+     * Prepare Kapua Apps payload data, data is not necessary semantically correct.
+     *
+     * @return all KapuaAppsPayload fields populated with data.
+     */
+    private static KapuaAppsPayload populateKapuaAppsPayload() {
+        KapuaAppsPayload kapuaAppsPayload = new KapuaAppsPayloadImpl(
+                "12",
+                "displayName",
+                "modelName",
+                "modelId-1",
+                "part-1",
+                "SN-123",
+                "firmware-1",
+                "firmwareV-1",
+                "bios",
+                "biosV-1",
+                "Linux",
+                "osV-1",
+                "Oracle HotSpot",
+                "8",
+                "desktop",
+                "containerFramework",
+                "containerFrameworkV-1",
+                "applicationFramework",
+                "applicationFrameworkV-1",
+                "connectionInterface",
+                "192.168.1.1",
+                "UTF-8",
+                "applicationIdentifiers",
+                "1",
+                "4",
+                "Linux x86",
+                "49-015420-323751",
+                "359881234567890",
+                "8991101200003204510"
+        );
+
+        return kapuaAppsPayload;
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.lifecycle;
+
+import org.eclipse.kapua.message.device.lifecycle.KapuaBirthChannel;
+import org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage;
+import org.eclipse.kapua.message.device.lifecycle.KapuaBirthPayload;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KapuaBirthMessageTest extends Assert {
+
+    private static final String PAYLOAD_DISPLAY_STR = "[ getUptime()=12" +
+            ", getDisplayName()=displayName" +
+            ", getModelName()=modelName" +
+            ", getModelId()=modelId-1" +
+            ", getPartNumber()=part-1" +
+            ", getSerialNumber()=SN-123" +
+            ", getFirmwareVersion()=firmwareV-1" +
+            ", getBiosVersion()=biosV-1" +
+            ", getOs()=Linux" +
+            ", getOsVersion()=osV-1" +
+            ", getJvmName()=Oracle HotSpot" +
+            ", getJvmVersion()=8" +
+            ", getJvmProfile()=desktop" +
+            ", getOsgiFramework()=containerFramework" +
+            ", getOsgiFrameworkVersion()=containerFrameworkV-1" +
+            ", getEsfKuraVersion()=applicationFrameworkV-1" +
+            ", getConnectionInterface()=connectionInterface" +
+            ", getConnectionIp()=192.168.1.1" +
+            ", getAcceptEncoding()=UTF-8" +
+            ", getApplicationIdentifiers()=applicationIdentifiers" +
+            ", getAvailableProcessors()=1" +
+            ", getTotalMemory()=4" +
+            ", getOsArch()=Linux x86" +
+            ", getModemImei()=49-015420-323751" +
+            ", getModemImsi()=359881234567890" +
+            ", getModemIccid()=8991101200003204510" +
+            "]";
+
+    @Test
+    public void kapuaBirthPayloadInitConstructor() {
+        KapuaBirthPayload kapuaBirthPayload = populateKapuaBirthPayload();
+
+        assertEquals("12", kapuaBirthPayload.getUptime());
+        assertEquals("displayName", kapuaBirthPayload.getDisplayName());
+        assertEquals("modelName", kapuaBirthPayload.getModelName());
+        assertEquals("modelId-1", kapuaBirthPayload.getModelId());
+        assertEquals("part-1", kapuaBirthPayload.getPartNumber());
+        assertEquals("SN-123", kapuaBirthPayload.getSerialNumber());
+        assertEquals("firmware-1", kapuaBirthPayload.getFirmware());
+        assertEquals("firmwareV-1", kapuaBirthPayload.getFirmwareVersion());
+        assertEquals("bios", kapuaBirthPayload.getBios());
+        assertEquals("biosV-1", kapuaBirthPayload.getBiosVersion());
+        assertEquals("Linux", kapuaBirthPayload.getOs());
+        assertEquals("osV-1", kapuaBirthPayload.getOsVersion());
+        assertEquals("Oracle HotSpot", kapuaBirthPayload.getJvm());
+        assertEquals("8", kapuaBirthPayload.getJvmVersion());
+        assertEquals("desktop", kapuaBirthPayload.getJvmProfile());
+        assertEquals("containerFramework", kapuaBirthPayload.getContainerFramework());
+        assertEquals("containerFrameworkV-1", kapuaBirthPayload.getContainerFrameworkVersion());
+        assertEquals("applicationFramework", kapuaBirthPayload.getApplicationFramework());
+        assertEquals("applicationFrameworkV-1", kapuaBirthPayload.getApplicationFrameworkVersion());
+        assertEquals("connectionInterface", kapuaBirthPayload.getConnectionInterface());
+        assertEquals("192.168.1.1", kapuaBirthPayload.getConnectionIp());
+        assertEquals("UTF-8", kapuaBirthPayload.getAcceptEncoding());
+        assertEquals("applicationIdentifiers", kapuaBirthPayload.getApplicationIdentifiers());
+        assertEquals("1", kapuaBirthPayload.getAvailableProcessors());
+        assertEquals("4", kapuaBirthPayload.getTotalMemory());
+        assertEquals("Linux x86", kapuaBirthPayload.getOsArch());
+        assertEquals("49-015420-323751", kapuaBirthPayload.getModemImei());
+        assertEquals("359881234567890", kapuaBirthPayload.getModemImsi());
+        assertEquals("8991101200003204510", kapuaBirthPayload.getModemIccid());
+    }
+
+    @Test
+    public void toDisplayString() throws Exception {
+        KapuaBirthPayload kapuaBirthPayload = populateKapuaBirthPayload();
+
+        // FIXME strings representing methods are not in sync with real method names
+        String displayStr = kapuaBirthPayload.toDisplayString();
+        assertEquals(PAYLOAD_DISPLAY_STR, displayStr);
+    }
+
+    @Test
+    public void kapuaBirthMessageConstructor() throws Exception {
+        KapuaBirthMessageImpl kapuaBirthMessage = new KapuaBirthMessageImpl();
+
+        assertNotNull(kapuaBirthMessage);
+    }
+
+    @Test
+    public void kapuaBirthMessageGetterSetters() throws Exception {
+        KapuaBirthMessage kapuaBirthMessage = new KapuaBirthMessageImpl();
+
+        kapuaBirthMessage.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaBirthMessage.getClientId());
+    }
+
+    @Test
+    public void kapuaBirthChannelGetterSetters() throws Exception {
+        KapuaBirthChannel kapuaBirthChannel = new KapuaBirthChannelImpl();
+
+        kapuaBirthChannel.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaBirthChannel.getClientId());
+    }
+
+    /**
+     * Prepare Kapua Birth payload data, data is not necessary semantically correct.
+     *
+     * @return all KapuaBirthPayload fields populated with data.
+     */
+    private static KapuaBirthPayload populateKapuaBirthPayload() {
+        KapuaBirthPayload kapuaBirthPayload = new KapuaBirthPayloadImpl(
+                "12",
+                "displayName",
+                "modelName",
+                "modelId-1",
+                "part-1",
+                "SN-123",
+                "firmware-1",
+                "firmwareV-1",
+                "bios",
+                "biosV-1",
+                "Linux",
+                "osV-1",
+                "Oracle HotSpot",
+                "8",
+                "desktop",
+                "containerFramework",
+                "containerFrameworkV-1",
+                "applicationFramework",
+                "applicationFrameworkV-1",
+                "connectionInterface",
+                "192.168.1.1",
+                "UTF-8",
+                "applicationIdentifiers",
+                "1",
+                "4",
+                "Linux x86",
+                "49-015420-323751",
+                "359881234567890",
+                "8991101200003204510"
+        );
+
+        return kapuaBirthPayload;
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.lifecycle;
+
+import org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectChannel;
+import org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectMessage;
+import org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectPayload;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KapuaDisconnectMessageTest extends Assert {
+
+    private static final String PAYLOAD_DISPLAY_STR = "[ getUptime()=12" +
+            ", getDisplayName()=displayName" +
+            "]";
+
+    @Test
+    public void kapuaDisconnectPayloadInitConstructor() {
+        KapuaDisconnectPayload kapuaDisconnectPayload = populateKapuaDisconnectPayload();
+
+        assertEquals("12", kapuaDisconnectPayload.getUptime());
+        assertEquals("displayName", kapuaDisconnectPayload.getDisplayName());
+    }
+
+    @Test
+    public void toDisplayString() throws Exception {
+        KapuaDisconnectPayload kapuaDisconnectPayload = populateKapuaDisconnectPayload();
+
+        String displayStr = kapuaDisconnectPayload.toDisplayString();
+        assertEquals(PAYLOAD_DISPLAY_STR, displayStr);
+    }
+
+    @Test
+    public void kapuaDisconnectMessageConstructor() throws Exception {
+        KapuaDisconnectMessageImpl kapuaDisconnectMessage = new KapuaDisconnectMessageImpl();
+
+        assertNotNull(kapuaDisconnectMessage);
+    }
+
+    @Test
+    public void kapuaDisconnectMessageGetterSetters() throws Exception {
+        KapuaDisconnectMessage kapuaDisconnectMessage = new KapuaDisconnectMessageImpl();
+
+        kapuaDisconnectMessage.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaDisconnectMessage.getClientId());
+    }
+
+    @Test
+    public void kapuaDisconnectChannelGetterSetters() throws Exception {
+        KapuaDisconnectChannel kapuaDisconnectChannel = new KapuaDisconnectChannelImpl();
+
+        kapuaDisconnectChannel.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaDisconnectChannel.getClientId());
+    }
+
+    /**
+     * Prepare Kapua Disconnect payload data, data is not necessary semantically correct.
+     *
+     * @return all KapuaDisconnectPayload fields populated with data.
+     */
+    private static KapuaDisconnectPayload populateKapuaDisconnectPayload() {
+        KapuaDisconnectPayload kapuaDisconnectPayload = new KapuaDisconnectPayloadImpl(
+                "12",
+                "displayName"
+        );
+
+        return kapuaDisconnectPayload;
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.lifecycle;
+
+import org.eclipse.kapua.message.device.lifecycle.KapuaMissingChannel;
+import org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage;
+import org.eclipse.kapua.message.device.lifecycle.KapuaMissingPayload;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KapuaMissingMessageTest extends Assert {
+
+    @Test
+    public void kapuaMissingPayloadConstructor() {
+        KapuaMissingPayload kapuaMissingPayload = new KapuaMissingPayloadImpl();
+
+        assertNotNull(kapuaMissingPayload);
+    }
+
+    @Test
+    public void kapuaMissingMessageConstructor() throws Exception {
+        KapuaMissingMessage kapuaMissingMessage = new KapuaMissingMessageImpl();
+
+        assertNotNull(kapuaMissingMessage);
+    }
+
+    @Test
+    public void kapuaMissingChannelGetterSetters() throws Exception {
+        KapuaMissingChannel kapuaMissingChannel = new KapuaMissingChannelImpl();
+
+        kapuaMissingChannel.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaMissingChannel.getClientId());
+    }
+
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaNotifyMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaNotifyMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaNotifyMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaNotifyMessageTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.lifecycle;
+
+import org.eclipse.kapua.message.device.lifecycle.KapuaNotifyChannel;
+import org.eclipse.kapua.message.device.lifecycle.KapuaNotifyPayload;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KapuaNotifyMessageTest extends Assert {
+
+    private static final String NOTIFY_MSG_STR = "Client id 'clientId-1' - semantic topic 'part1/part2/part3/'";
+
+    @Test
+    public void kapuaNotifyPayloadConstructor() {
+        KapuaNotifyPayload kapuaNotifyPayload = new KapuaNotifyPayloadImpl();
+
+        assertNotNull(kapuaNotifyPayload);
+    }
+
+    @Test
+    public void kapuaNotifyMessageConstructor() throws Exception {
+        KapuaNotifyMessageImpl kapuaNotifyMessage = new KapuaNotifyMessageImpl();
+
+        assertNotNull(kapuaNotifyMessage);
+    }
+
+    @Test
+    public void kapuaNotifyChannelGetterSetters() throws Exception {
+        KapuaNotifyChannel kapuaNotifyChannel = new KapuaNotifyChannelImpl();
+
+        kapuaNotifyChannel.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaNotifyChannel.getClientId());
+    }
+
+    @Test
+    public void toStringValue() throws Exception {
+        KapuaNotifyChannel kapuaNotifyChannel = new KapuaNotifyChannelImpl();
+        List<String> semanticParts = new ArrayList<>();
+        semanticParts.add("part1");
+        semanticParts.add("part2");
+        semanticParts.add("part3");
+
+        kapuaNotifyChannel.setClientId("clientId-1");
+        kapuaNotifyChannel.setSemanticParts(semanticParts);
+        String displayStr = kapuaNotifyChannel.toString();
+        assertEquals(NOTIFY_MSG_STR, displayStr);
+    }
+
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaUnmatchedMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaUnmatchedMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaUnmatchedMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaUnmatchedMessageTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.lifecycle;
+
+import org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedChannel;
+import org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedPayload;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KapuaUnmatchedMessageTest extends Assert {
+
+    private static final String UNMATCHED_MSG_STR = "Client id 'clientId-1' - semantic topic 'part1/part2/part3/'";
+
+    @Test
+    public void kapuaNotifyPayloadConstructor() {
+        KapuaUnmatchedPayload kapuaUnmatchedPayload = new KapuaUnmatchedPayloadImpl();
+
+        assertNotNull(kapuaUnmatchedPayload);
+    }
+
+    @Test
+    public void kapuaUnmatchedMessageConstructor() throws Exception {
+        KapuaUnmatchedMessageImpl kapuaUnmatchedMessage = new KapuaUnmatchedMessageImpl();
+
+        assertNotNull(kapuaUnmatchedMessage);
+    }
+
+    @Test
+    public void kapuaUnmatchedChannelGetterSetters() throws Exception {
+        KapuaUnmatchedChannel kapuaUnmatchedChannel = new KapuaUnmatchedChannelImpl();
+
+        kapuaUnmatchedChannel.setClientId("clientId-1");
+        assertEquals("clientId-1", kapuaUnmatchedChannel.getClientId());
+    }
+
+    @Test
+    public void toStringValue() throws Exception {
+        KapuaUnmatchedChannel kapuaUnmatchedChannel = new KapuaUnmatchedChannelImpl();
+        List<String> semanticParts = new ArrayList<>();
+        semanticParts.add("part1");
+        semanticParts.add("part2");
+        semanticParts.add("part3");
+
+        kapuaUnmatchedChannel.setClientId("clientId-1");
+        kapuaUnmatchedChannel.setSemanticParts(semanticParts);
+        String displayStr = kapuaUnmatchedChannel.toString();
+        assertEquals(UNMATCHED_MSG_STR, displayStr);
+    }
+
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.lifecycle;
+
+import org.eclipse.kapua.message.internal.xml.KapuaMetricTest;
+import org.eclipse.kapua.message.internal.xml.KapuaMetricValueTest;
+import org.eclipse.kapua.message.internal.xml.KapuaMetricsMapAdapterTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        KapuaAppsMessageTest.class,
+        KapuaBirthMessageTest.class,
+        KapuaDisconnectMessageTest.class,
+        KapuaMissingMessageTest.class,
+        KapuaNotifyMessageTest.class,
+        KapuaUnmatchedMessageTest.class
+})
+public class LifecycleTestSuite {
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
@@ -1,0 +1,208 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.xml;
+
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.message.internal.MessageJAXBContextProvider;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.math.BigDecimal;
+
+public class KapuaMetricTest extends Assert {
+
+    private static final String newline = System.lineSeparator();
+
+    private static final byte[] BYTES = {'b', 'y', 't', 'e', 's'};
+
+    private static final String BASE64_BYTES = "Ynl0ZXM=";
+
+    private static final String METRIC_XML_STR = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + newline +
+            "<metric>" + newline +
+            "   <name>name</name>" + newline +
+            "   <type>string</type>" + newline +
+            "   <value>value</value>" + newline +
+            "</metric>" + newline;
+
+    @Before
+    public void before() throws Exception {
+        XmlUtil.setContextProvider(new MessageJAXBContextProvider());
+    }
+
+    @Test
+    public void defaultConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric();
+
+        assertNull(kapuaMetric.getName());
+        assertNull(kapuaMetric.getValue());
+    }
+
+    @Test
+    public void stringTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "string", "value");
+
+        assertEquals("name", kapuaMetric.getName());
+        assertEquals("value", kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof String);
+    }
+
+    @Test
+    public void doubleTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "double", "42.42");
+
+        assertEquals("name", kapuaMetric.getName());
+        assertEquals(new Double("42.42"), kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof Double);
+    }
+
+    @Test
+    public void intTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "int", "42");
+
+        assertEquals("name", kapuaMetric.getName());
+        assertEquals(new Integer(42), kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof Integer);
+    }
+
+    @Test
+    public void floatTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "float", "42.42");
+
+        assertEquals("name", kapuaMetric.getName());
+        assertEquals(new Float(42.42), kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof Float);
+    }
+
+    @Test
+    public void longTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "long", "42");
+
+        assertEquals("name", kapuaMetric.getName());
+        assertEquals(new Long(42), kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof Long);
+    }
+
+    @Test
+    public void booleanTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "boolean", "true");
+
+        assertEquals("name", kapuaMetric.getName());
+        assertEquals(Boolean.TRUE, kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof Boolean);
+    }
+
+    @Test
+    public void byteArrayTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "base64Binary", BASE64_BYTES);
+
+        assertEquals("name", kapuaMetric.getName());
+        assertArrayEquals(BYTES, (byte[]) kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof byte[]);
+    }
+
+    @Test
+    public void unknownTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "bigdecimal", "42.42");
+
+        assertEquals("name", kapuaMetric.getName());
+        assertEquals("42.42", kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof String);
+    }
+
+    @Test
+    public void initWithTypeConstructor() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", String.class, "value");
+
+        assertEquals("name", kapuaMetric.getName());
+        assertEquals("value", kapuaMetric.getValue());
+        assertTrue(kapuaMetric.getValue() instanceof String);
+    }
+
+    @Test
+    public void getMetricTypeString() throws Exception {
+
+        assertEquals("string", KapuaMetric.getMetricType(String.class));
+    }
+
+    @Test
+    public void getMetricTypeDouble() throws Exception {
+
+        assertEquals("double", KapuaMetric.getMetricType(Double.class));
+    }
+
+    @Test
+    public void getMetricTypeInteger() throws Exception {
+
+        assertEquals("int", KapuaMetric.getMetricType(Integer.class));
+    }
+
+    @Test
+    public void getMetricTypeFloat() throws Exception {
+
+        assertEquals("float", KapuaMetric.getMetricType(Float.class));
+    }
+
+    @Test
+    public void getMetricTypeLong() throws Exception {
+
+        assertEquals("long", KapuaMetric.getMetricType(Long.class));
+    }
+
+    @Test
+    public void getMetricTypeBoolean() throws Exception {
+
+        assertEquals("boolean", KapuaMetric.getMetricType(Boolean.class));
+    }
+
+    @Test
+    public void getMetricTypeByteArray() throws Exception {
+
+        assertEquals("base64Binary", KapuaMetric.getMetricType(BYTES.getClass()));
+    }
+
+    @Test
+    public void getMetricTypeUnknown() throws Exception {
+
+        // FIXME Unknown types should be hadeled
+        assertEquals("class java.math.BigDecimal", KapuaMetric.getMetricType(BigDecimal.class));
+    }
+
+    @Test
+    public void getMetricTypeNull() throws Exception {
+
+        assertNull(KapuaMetric.getMetricType(null));
+    }
+
+    @Test
+    public void getStringValueNull() throws Exception {
+
+        assertNull(KapuaMetric.getStringValue(null));
+    }
+
+    @Test
+    public void getStringValueOfByteArray() throws Exception {
+
+        assertEquals(BASE64_BYTES, KapuaMetric.getStringValue(BYTES));
+    }
+
+    @Test
+    public void marshallMetric() throws Exception {
+        KapuaMetric kapuaMetric = new KapuaMetric("name", "string", "value");
+
+        StringWriter strWriter = new StringWriter();
+        XmlUtil.marshal(kapuaMetric, strWriter);
+        assertEquals(METRIC_XML_STR, strWriter.toString());
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricValueTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricValueTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricValueTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricValueTest.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.xml;
+
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.message.internal.MessageJAXBContextProvider;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class KapuaMetricValueTest extends Assert {
+
+    private static final String newline = System.lineSeparator();
+
+    private static final ZoneId defaultZoneId = ZoneId.systemDefault();
+
+    private static final Long TIMESTAMP = ZonedDateTime.of(2017, 1, 18, 13, 10, 46, 0, ZoneId.systemDefault()).
+            toEpochSecond();
+
+    private static final String UUID = "11111111-2222-3333-4444-555555555555";
+
+    private static final byte[] BYTES = {'b', 'y', 't', 'e', 's'};
+
+    private static final String BASE64_BYTES = "Ynl0ZXM=";
+
+    private static final String METRIC_VALUE_XML_STR = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + newline +
+            "<metricValue>" + newline +
+            "   <timestamp>" + TIMESTAMP + "</timestamp>" + newline +
+            "   <value>value</value>" + newline +
+            "   <uuid>11111111-2222-3333-4444-555555555555</uuid>" + newline +
+            "</metricValue>" + newline;
+
+    @Before
+    public void before() throws Exception {
+        XmlUtil.setContextProvider(new MessageJAXBContextProvider());
+    }
+
+    @Test
+    public void defaultConstructor() throws Exception {
+        KapuaMetricValue kapuaMetricValue = new KapuaMetricValue();
+
+        assertNull(kapuaMetricValue.getValue());
+        assertNull(kapuaMetricValue.getTimestamp());
+        assertNull(kapuaMetricValue.getUUID());
+    }
+
+    @Test
+    public void initConstructor() throws Exception {
+        KapuaMetricValue kapuaMetricValue = new KapuaMetricValue(TIMESTAMP, "value", UUID);
+
+        assertEquals(TIMESTAMP, kapuaMetricValue.getTimestamp());
+        assertEquals("value", kapuaMetricValue.getValue());
+        assertEquals(UUID, kapuaMetricValue.getUUID());
+    }
+
+    @Test
+    public void initNullValueConstructor() throws Exception {
+        KapuaMetricValue kapuaMetricValue = new KapuaMetricValue(TIMESTAMP, null, UUID);
+
+        assertEquals(TIMESTAMP, kapuaMetricValue.getTimestamp());
+        assertNull(kapuaMetricValue.getValue());
+        assertEquals(UUID, kapuaMetricValue.getUUID());
+    }
+
+    @Test
+    public void initByteValueConstructor() throws Exception {
+        KapuaMetricValue kapuaMetricValue = new KapuaMetricValue(TIMESTAMP, BYTES, UUID);
+
+        assertEquals(TIMESTAMP, kapuaMetricValue.getTimestamp());
+        assertEquals(BASE64_BYTES, kapuaMetricValue.getValue());
+        assertEquals(UUID, kapuaMetricValue.getUUID());
+    }
+
+    @Test
+    public void getNullStringValue() throws Exception {
+
+        assertNull(KapuaMetricValue.getStringValue(null));
+    }
+
+    @Test
+    public void getByteArrayStringValue() throws Exception {
+
+        assertEquals(BASE64_BYTES, KapuaMetricValue.getStringValue(BYTES));
+    }
+
+    @Test
+    public void getIntegerStringValue() throws Exception {
+
+        assertEquals("42", KapuaMetricValue.getStringValue(new Integer(42)));
+    }
+
+    @Test
+    public void getStringStringValue() throws Exception {
+
+        assertEquals("Big brown fox", KapuaMetricValue.getStringValue("Big brown fox"));
+    }
+
+    @Test
+    public void getDoubleStringValue() throws Exception {
+
+        assertEquals("42.42", KapuaMetricValue.getStringValue(new Double(42.42d)));
+    }
+
+    @Test
+    public void getBooleanStringValue() throws Exception {
+
+        assertEquals("true", KapuaMetricValue.getStringValue(true));
+    }
+
+    @Test
+    public void marshallMetricValue() throws Exception {
+        KapuaMetricValue kapuaMetricValue = new KapuaMetricValue(TIMESTAMP, "value", UUID);
+
+        StringWriter strWriter = new StringWriter();
+        XmlUtil.marshal(kapuaMetricValue, strWriter);
+        assertEquals(METRIC_VALUE_XML_STR, strWriter.toString());
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMap.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMap.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMap.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.xml;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Map;
+
+@XmlRootElement(name = "metricsmap")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class KapuaMetricsMap {
+
+    @XmlElement(name = "metrics")
+    @XmlJavaTypeAdapter(KapuaMetricsMapAdapter.class)
+    private Map<String, Object> metrics;
+
+    public Map<String, Object> getMetrics()
+    {
+        return metrics;
+    }
+
+    public void setMetrics(Map<String, Object> metrics)
+    {
+        this.metrics = metrics;
+    }
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.xml;
+
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.message.internal.MessageJAXBContextProvider;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+public class KapuaMetricsMapAdapterTest extends Assert {
+
+    private static final String newline = System.lineSeparator();
+
+    private static final String METRICS_XML_STR = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + newline +
+            "<metricsmap>" + newline +
+            "   <metrics>" + newline +
+            "      <metric>" + newline +
+            "         <name>key1</name>" + newline +
+            "         <type>string</type>" + newline +
+            "         <value>value1</value>" + newline +
+            "      </metric>" + newline +
+            "   </metrics>" + newline +
+            "</metricsmap>" + newline;
+
+
+    @Before
+    public void before() throws Exception {
+        XmlUtil.setContextProvider(new MessageJAXBContextProvider());
+    }
+
+    @Test
+    public void marshalWithAdapter() throws Exception {
+        KapuaMetricsMap metricsMap = new KapuaMetricsMap();
+        Map<String, Object> metrics = new HashMap<>();
+        metrics.put(new String("key1"), new String("value1"));
+        metricsMap.setMetrics(metrics);
+
+        StringWriter strWriter = new StringWriter();
+        XmlUtil.marshal(metricsMap, strWriter);
+        assertEquals(METRICS_XML_STR, strWriter.toString());
+    }
+
+    @Test
+    public void unmarshalWithAdapter() throws Exception {
+        KapuaMetricsMap metricsMap = new KapuaMetricsMap();
+        Map<String, Object> metrics = new HashMap<>();
+        metrics.put(new String("key1"), new String("value1"));
+        metricsMap.setMetrics(metrics);
+
+        KapuaMetricsMap metricsMapResp = XmlUtil.unmarshal(METRICS_XML_STR, KapuaMetricsMap.class);
+        assertEquals(metricsMap.getMetrics().get("key1"), metricsMapResp.getMetrics().get("key1"));
+    }
+
+}

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.xml;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        KapuaMetricTest.class,
+        KapuaMetricValueTest.class,
+        KapuaMetricsMapAdapterTest.class
+})
+public class MetricTestSuite {
+}

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2017 Eurotech and/or its affiliates
    
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -1,0 +1,60 @@
+<!--
+    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+   
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<locator-config>
+	<provided>
+		<api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
+        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
+        
+		<api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
+		
+        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
+		<api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
+		<api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
+		<api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
+		<api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
+		<api>org.eclipse.kapua.service.authorization.role.RoleService</api>
+		<api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
+		<api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
+		<api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
+		<api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
+		<api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
+		<api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
+        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
+        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
+		<api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
+		<api>org.eclipse.kapua.service.authorization.domain.DomainService</api>
+		<api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
+		<api>org.eclipse.kapua.service.authorization.role.RoleService</api>
+		
+        <api>org.eclipse.kapua.service.account.AccountFactory</api>
+		<api>org.eclipse.kapua.service.account.AccountService</api>
+		
+        <api>org.eclipse.kapua.service.user.UserFactory</api>
+		<api>org.eclipse.kapua.service.user.UserService</api>
+	</provided>
+	<packages>
+		<package>org.eclipse.kapua.service.authentication.credential.shiro</package>
+
+        <package>org.eclipse.kapua.service.authorization.domain.shiro</package>
+		<package>org.eclipse.kapua.service.authorization.permission.shiro</package>
+		<package>org.eclipse.kapua.service.authorization.role.shiro</package>
+        <package>org.eclipse.kapua.service.authorization.group.shiro</package>
+		<package>org.eclipse.kapua.service.authorization.access.shiro</package>
+		<package>org.eclipse.kapua.service.authorization.role.shiro</package>
+		<package>org.eclipse.kapua.service.authorization.shiro</package>
+
+		<package>org.eclipse.kapua.test.user</package>
+		<package>org.eclipse.kapua.test.account</package>
+		<package>org.eclipse.kapua.test.authentication</package>
+	</packages>
+</locator-config>

--- a/message/internal/src/test/resources/message-error-messages.properties
+++ b/message/internal/src/test/resources/message-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/resources/message-error-messages.properties
+++ b/message/internal/src/test/resources/message-error-messages.properties
@@ -1,0 +1,16 @@
+###############################################################################
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+INVALID_DESTINATION=Invalid destination
+INVALID_MESSAGE=Invalid message
+INVALID_METRIC_TYPE=Invalid metric type {0}
+INVALID_METRIC_VALUE=Invalid metric value {0}


### PR DESCRIPTION
Code coverage of methods that provide data access to KapuaMessage and connected types.

This tests provide safe-net for possible refactoring and changes.

Corner cases are not covered as implementation does not check for those.

Also added marshalling for KapuaPosition.

Finished tests in xml package. KapuaMetrics test suite. It has 100% coverage.

Added tests for device data part of messages.

Added tests for Lifecycle messages.

All tests are also gruped into test suites.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>