### PR TITLE
Device Event service CRUD tests

### DIFF
--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceRegistryConnectionTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceRegistryConnectionTestSteps.java
@@ -180,15 +180,6 @@ public class DeviceRegistryConnectionTestSteps extends KapuaTest {
 
     // The Cucumber test steps
 
-    @Given("^UngaBunga$")
-    public void testUngaBunga()
-            throws KapuaException {
-        KapuaId tmpId1 = new KapuaEid(BigInteger.valueOf(-1));
-        KapuaId tmpId2 = new KapuaEid(BigInteger.valueOf(-2));
-        DeviceConnectionCreator tmpCreator = prepareRegularConnectionCreator(tmpId1, tmpId2);
-        connection = deviceConnectionService.create(tmpCreator);
-    }
-
     @Given("^A regular connection creator$")
     public void createRegularCreator() {
         connectionCreator = prepareRegularConnectionCreator(rootScopeId,

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceTestSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceTestSteps.java
@@ -1,0 +1,461 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry.event.internal;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsEqualTo;
+import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsNotEqualTo;
+
+import java.math.BigInteger;
+import java.security.acl.Permission;
+import java.util.Date;
+import java.util.HashSet;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtils;
+import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.internal.KapuaPositionImpl;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.device.management.KapuaMethod;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionDomain;
+import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventQuery;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
+import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFactory;
+import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.MockedLocator;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+
+/**
+ * Implementation of Gherkin steps used in DeviceRegistry.feature scenarios.
+ *
+ * MockedLocator is used for Location Service. Mockito is used to mock other
+ * services that the Device Registry services dependent on. Dependent services are: -
+ * Authorization Service -
+ *
+ *
+ */
+public class DeviceEventServiceTestSteps extends KapuaTest {
+
+    public static String DEFAULT_PATH = "src/main/sql/H2";
+    public static String DEFAULT_COMMONS_PATH = "../../../commons";
+    public static String CREATE_DEVICE_TABLES = "dvc_*_create.sql";
+    public static String DROP_DEVICE_TABLES = "dvc_*_drop.sql";
+
+    KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
+    KapuaId sysUserId = new KapuaEid(BigInteger.ONE);
+
+    @SuppressWarnings("unused")
+    private static final Logger s_logger = LoggerFactory.getLogger(DeviceEventServiceTestSteps.class);
+
+    // Currently executing scenario.
+    Scenario scenario;
+
+    // Various device registry related service references
+    DeviceEventService eventService = null;
+    DeviceEventFactory eventFactory = null;
+
+    // Device registry related objects
+    DeviceEvent event = null;
+    DeviceEventCreator eventCreator = null;
+
+    // The entity ID of the last event
+    KapuaId eventId = null;
+
+    KapuaId scopeId = null;
+    KapuaId userId = null;
+
+    // Check if exception was fired in step.
+    boolean exceptionCaught = false;
+
+    // A list result for device query operations
+    DeviceEventListResult eventList = null;
+
+    // Item count
+    long count = 0;
+
+    // String scratchpad
+    String stringValue;
+
+    // *************************************
+    // Definition of Cucumber scenario steps
+    // *************************************
+
+    // Setup and tear-down steps
+
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+        this.scenario = scenario;
+        exceptionCaught = false;
+
+        // Create User Service tables
+        enableH2Connection();
+
+        // Drop the Device Registry Service tables
+        scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
+        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
+        
+        // Create the Device Registry Service tables
+        KapuaConfigurableServiceSchemaUtils.createSchemaObjects(DEFAULT_COMMONS_PATH);
+        scriptSession(DeviceEntityManagerFactory.instance(), CREATE_DEVICE_TABLES);
+
+        MockedLocator mockLocator = (MockedLocator) locator;
+
+        // Inject mocked Authorization Service method checkPermission
+        AuthorizationService mockedAuthorization = mock(AuthorizationService.class);
+        // TODO: Check why does this line needs an explicit cast!
+        Mockito.doNothing().when(mockedAuthorization).checkPermission(
+                (org.eclipse.kapua.service.authorization.permission.Permission) any(Permission.class));
+        mockLocator.setMockedService(org.eclipse.kapua.service.authorization.AuthorizationService.class,
+                mockedAuthorization);
+
+        // Inject mocked Permission Factory
+        PermissionFactory mockedPermissionFactory = mock(PermissionFactory.class);
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.authorization.permission.PermissionFactory.class,
+                mockedPermissionFactory);
+
+        // Inject actual device registry related services
+        eventService = new DeviceEventServiceImpl();
+        mockLocator.setMockedService(org.eclipse.kapua.service.device.registry.event.DeviceEventService.class, eventService);
+        eventFactory = new DeviceEventFactoryImpl();
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.device.registry.event.DeviceEventFactory.class, eventFactory);
+
+        // Set KapuaMetatypeFactory for Metatype configuration
+        mockLocator.setMockedFactory(org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory.class, new KapuaMetatypeFactoryImpl());
+
+        // All operations on database are performed using system user.
+        KapuaSession kapuaSession = new KapuaSession(null, new KapuaEid(BigInteger.ONE), new KapuaEid(BigInteger.ONE));
+        KapuaSecurityUtils.setSession(kapuaSession);
+
+        scopeId = rootScopeId;
+        userId = sysUserId;
+    }
+
+    @After
+    public void afterScenario()
+            throws Exception {
+        // Drop the Device Registry Service tables
+        scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
+        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
+        KapuaSecurityUtils.clearSession();
+    }
+
+    // The Cucumber test steps
+
+    @Given("^Scope (\\d+)$")
+    public void setScopeId(int scope)
+            throws Exception {
+        scopeId = new KapuaEid(BigInteger.valueOf(scope));
+
+        assertNotNull(scopeId);
+    }
+
+    @Given("^User (\\d+)$")
+    public void setUserId(int user)
+            throws Exception {
+        userId = new KapuaEid(BigInteger.valueOf(user));
+
+        assertNotNull(userId);
+    }    
+    
+    @Given("^Null scope ID$")
+    public void setNullScopeId()
+    {
+        scopeId = null;
+    }
+    
+    @Given("^Null user ID$")
+    public void setNullUserId()
+    {
+        userId = null;
+    }
+    
+    @Given("^An event creator with null action$")
+    public void prepareCreatorWithNullAction()
+    {
+        eventCreator = prepareRegularDeviceEventCreator(scopeId, createRandomId());
+        assertNotNull(eventCreator);
+        eventCreator.setAction(null);
+    }
+    
+    @Given("^A \"(.+)\" event from device (\\d+)$")
+    public void createRegularEvent(String eventType, int device)
+            throws KapuaException {
+        KapuaId tmpDevId = new KapuaEid(BigInteger.valueOf(device));
+        KapuaMethod tmpMeth = getMethodFromString(eventType);
+
+        eventCreator = prepareRegularDeviceEventCreator(scopeId, tmpDevId);
+        assertNotNull(eventCreator);
+        eventCreator.setAction(tmpMeth);
+
+        try {
+            exceptionCaught = false;
+            event = eventService.create(eventCreator);
+            assertNotNull(event);
+            eventId = event.getId();
+            assertNotNull(eventId);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+
+    @Given("^I have (\\d+) \"(.+)\" events? from device (\\d+)$")
+    public void createANumberOfEvents(int num, String eventType, int devId)
+            throws KapuaException {
+        KapuaId tmpDevId = new KapuaEid(BigInteger.valueOf(devId));
+        KapuaMethod tmpMeth = getMethodFromString(eventType);
+        DeviceEventCreator tmpCreator = null;
+        DeviceEvent tmpEvent = null; 
+        
+        for(int i = 0; i < num; i++) {
+            tmpCreator = prepareRegularDeviceEventCreator(scopeId, tmpDevId);
+            assertNotNull(tmpCreator);
+            tmpCreator.setAction(tmpMeth);
+            tmpEvent = eventService.create(tmpCreator);
+            assertNotNull(tmpEvent);
+        }
+    }
+    
+    @When("^I create an event from the existing creator$")
+    public void createEventFromCreator()
+    {
+        try {
+            exceptionCaught = false;
+            event = eventService.create(eventCreator);
+            assertNotNull(event);
+        } catch (KapuaException ex) {
+            exceptionCaught = true;
+        }
+    }
+    
+    @When("^I search for an event with the remembered ID$")
+    public void findEventById()
+            throws KapuaException
+    {
+        event = null;
+        event = eventService.find(scopeId, eventId);
+    }
+
+    @When("^I search for an event with a random ID$")
+    public void findEventByRandomId()
+            throws KapuaException
+    {
+        KapuaId  tmpId = new KapuaEid(BigInteger.valueOf(random.nextLong()));
+        event = eventService.find(scopeId, tmpId);
+    }
+    
+    @When("^I delete the event with the remembered ID$")
+    public void deleteEvent()
+            throws KapuaException
+    {
+        eventService.delete(scopeId,  eventId);
+    }
+
+    @When("^I delete an event with a random ID$")
+    public void deleteEventWithRandomId()
+    {
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(random.nextLong()));
+        try {
+            exceptionCaught = false;
+            eventService.delete(scopeId,  tmpId);
+        } catch (KapuaException ex){
+            exceptionCaught = true;
+        }
+    }
+    
+    @When("^I count events for scope (\\d+)$")
+    public void countEventsInScope(int scpId)
+            throws KapuaException
+    {
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(scpId));
+        DeviceEventQuery tmpQuery = eventFactory.newQuery(tmpId);
+        count = 0;
+        
+        count = eventService.count(tmpQuery);
+    }
+    
+    @When("^I query for \"(.+)\" events$")
+    public void queryForSpecificEvents(String eventType)
+            throws KapuaException
+    {
+        KapuaMethod tmpMeth = getMethodFromString(eventType);
+        DeviceEventQuery tmpQuery = eventFactory.newQuery(scopeId);
+        assertNotNull(tmpQuery);
+        assertNotNull(tmpMeth);
+        
+        tmpQuery.setPredicate(attributeIsEqualTo("action", tmpMeth));
+        eventList = (DeviceEventListResult) eventService.query(tmpQuery);
+    }
+    
+    @Then("^The event matches the creator parameters$")
+    public void checkCreatedEventAgainstCreatorParameters()
+            throws KapuaException {
+        assertNotNull(event.getId());
+        assertEquals(eventCreator.getScopeId(), event.getScopeId());
+        assertEquals(eventCreator.getDeviceId(), event.getDeviceId());
+        assertEquals(eventCreator.getSentOn(), event.getSentOn());
+        assertEquals(eventCreator.getReceivedOn(), event.getReceivedOn());
+        assertEquals(eventCreator.getResource(), event.getResource());
+        assertEquals(eventCreator.getResponseCode(), event.getResponseCode());
+        assertEquals(eventCreator.getEventMessage(), event.getEventMessage());
+        assertEquals(eventCreator.getAction(), event.getAction());
+        assertEquals(eventCreator.getPosition().toDisplayString(), 
+                event.getPosition().toDisplayString());
+    }
+
+    @Then("^I find (\\d+) events?$")
+    public void checkListForNumberOfItems(int number) {
+        assertEquals(number, eventList.getSize());
+    }
+
+    @Then("^There (?:are|is) (\\d+) events?$")
+    public void checkNumberOfEvents(int number) {
+        assertEquals(number, count);
+    }
+
+    @Then("^There is no such event$")
+    public void eventIsNull() {
+        assertNull(event);
+    }
+
+    @Then("^An event exception is caught$")
+    public void checkThatAnExceptionWasCaught() {
+        assertTrue(exceptionCaught);
+    }
+
+    @Then("^All device event factory functions must return non null objects$")
+    public void exerciseAllEventFactoryFunctions() {
+        DeviceEvent tmpEvent = null;
+        DeviceEventCreator tmpCreator = null;
+        DeviceEventQuery tmpQuery = null;
+        DeviceEventListResult tmpList = null;
+
+        tmpEvent = eventFactory.newDeviceEvent();
+        tmpCreator = eventFactory.newCreator(rootScopeId, new KapuaEid(BigInteger.valueOf(random.nextLong())), new Date(), "");
+        tmpQuery = eventFactory.newQuery(rootScopeId);
+        tmpList = eventFactory.newDeviceListResult();
+
+        assertNotNull(tmpEvent);
+        assertNotNull(tmpCreator);
+        assertNotNull(tmpQuery);
+        assertNotNull(tmpList);
+    }
+
+    @Then("^The device event domain data can be updated$")
+    public void checkDeviceEventDomainUpdate() {
+        DeviceEventDomain tmpDomain = new DeviceEventDomain();
+
+        tmpDomain.setName("test_name");
+        tmpDomain.setServiceName("test_service_name");
+        tmpDomain.setActions(new HashSet<>(Lists.newArrayList(Actions.connect, Actions.execute)));
+
+        assertEquals("test_name", tmpDomain.getName());
+        assertEquals("test_service_name", tmpDomain.getServiceName());
+        assertEquals(2, tmpDomain.getActions().size());
+        assertTrue(tmpDomain.getActions().contains(Actions.connect));
+        assertTrue(tmpDomain.getActions().contains(Actions.execute));
+    }
+    
+    // *******************
+    // * Private Helpers *
+    // *******************
+
+    // Create a event creator object. The creator is pre-filled with default data.
+    private DeviceEventCreator prepareRegularDeviceEventCreator(KapuaId accountId, KapuaId deviceId) {
+        DeviceEventCreatorImpl tmpCreator = new DeviceEventCreatorImpl(accountId);
+        KapuaPosition tmpPosition = new KapuaPositionImpl();
+        Date timeReceived = new Date();
+        Date timeSent = new Date(System.currentTimeMillis() - 5 * 60 * 1000);
+
+        tmpCreator.setDeviceId(deviceId);
+        tmpCreator.setSentOn(timeSent);
+        tmpCreator.setReceivedOn(timeReceived);
+        tmpCreator.setAction(KapuaMethod.CREATE);
+        tmpCreator.setResource("resource");
+        tmpCreator.setResponseCode(KapuaResponseCode.ACCEPTED);
+        tmpCreator.setEventMessage("test_message_hello_world");
+
+        tmpPosition.setLatitude(46.4);
+        tmpPosition.setLongitude(13.02);
+        tmpPosition.setAltitude(323.0);
+        tmpPosition.setSpeed(50.0);
+        tmpPosition.setHeading(0.0);
+        tmpPosition.setPrecision(0.15);
+        tmpPosition.setSatellites(16);
+        tmpPosition.setStatus(7);
+        tmpPosition.setTimestamp(timeSent);
+
+        tmpCreator.setPosition(tmpPosition);
+
+        return tmpCreator;
+    }
+    
+    private KapuaMethod getMethodFromString(String name)
+    {
+        KapuaMethod tmpMeth = null;
+
+        switch (name.trim().toUpperCase()) {
+        case "READ":
+            tmpMeth = KapuaMethod.READ;
+            break;
+        case "CREATE":
+            tmpMeth = KapuaMethod.CREATE;
+            break;
+        case "WRITE":
+            tmpMeth = KapuaMethod.WRITE;
+            break;
+        case "DELETE":
+            tmpMeth = KapuaMethod.DELETE;
+            break;
+        case "OPTIONS":
+            tmpMeth = KapuaMethod.OPTIONS;
+            break;
+        case "EXECUTE":
+            tmpMeth = KapuaMethod.EXECUTE;
+            break;
+        }
+        assertNotNull(tmpMeth);
+        
+        return tmpMeth;
+    }
+    
+    private KapuaId createRandomId()
+    {
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(random.nextLong()));
+        return tmpId;
+    }
+}

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceTestSteps.java
@@ -130,7 +130,11 @@ public class DeviceRegistryServiceTestSteps extends KapuaTest {
         // Create User Service tables
         enableH2Connection();
 
-        // Create the account service tables
+        // Drop the Device Registry Service tables
+        scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
+        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
+        
+        // Create the Device Registry Service tables
         KapuaConfigurableServiceSchemaUtils.createSchemaObjects(DEFAULT_COMMONS_PATH);
         scriptSession(DeviceEntityManagerFactory.instance(), CREATE_DEVICE_TABLES);
         // XmlUtil.setContextProvider(new AccountsJAXBContextProvider());
@@ -167,7 +171,7 @@ public class DeviceRegistryServiceTestSteps extends KapuaTest {
     @After
     public void afterScenario()
             throws Exception {
-        // Drop the Account Service tables
+        // Drop the Device Registry Service tables
         scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
         KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
         KapuaSecurityUtils.clearSession();

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
@@ -18,10 +18,11 @@ import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = "classpath:features",
-                 glue = { "org.eclipse.kapua.service.device.registry.internal",
-                          "org.eclipse.kapua.service.device.registry.common",
-                          "org.eclipse.kapua.service.device.registry.connection.internal" },
+@CucumberOptions(features = "classpath:features", 
+                 glue = { "org.eclipse.kapua.service.device.registry.common",
+                          "org.eclipse.kapua.service.device.registry.internal",
+                          "org.eclipse.kapua.service.device.registry.connection.internal",
+                          "org.eclipse.kapua.service.device.registry.event.internal"},
                  plugin = { "pretty", 
                             "html:target/cucumber",
                             "json:target/cucumber.json" }, 

--- a/service/device/registry/internal/src/test/resources/features/DeviceEvent.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceEvent.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/test/resources/features/DeviceEvent.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceEvent.feature
@@ -1,0 +1,128 @@
+###############################################################################
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+Feature: Device Event CRUD tests
+    The Device Event service is responsible for handling the incoming device 
+    events.
+
+Scenario: Create a regular event
+	Create a regular event. The event should not be null and should 
+	have a regular entity ID. Also the event entity shoould match the event 
+	creator parameters.
+	
+	Given Scope 12
+	And User 5
+	And A "CREATE" event from device 16
+	Then No exception is thrown
+	And The event matches the creator parameters
+
+Scenario: Create an event with a null scope ID
+	It should be impossible to create an event with a null scope ID. Such attempt
+	must raise an exception.
+	
+	Given Null scope ID
+	And User 5
+	When A "CREATE" event from device 16
+	Then An event exception is caught
+
+Scenario: Create an event with a null action
+	The database should reject any ebvent entity that has a null action parameter.
+	In such cases an exception must be thrown.
+	
+	Given Scope 12
+	And User 5
+	And An event creator with null action
+	When I create an event from the existing creator
+	Then An event exception is caught
+
+Scenario: Find an event by its ID
+	It must be possible to find an event entity based on the event ID.
+	
+	Given Scope 12
+	And User 5
+	And A "CREATE" event from device 16
+	When I search for an event with the remembered ID
+	Then The event matches the creator parameters
+
+Scenario: Find a non existing event
+	Searching for an event with a non existing entity ID should return null. No
+	exception must be thrown.
+	
+	Given Scope 12
+	And User 5
+	And A "CREATE" event from device 16
+	When I search for an event with a random ID
+	Then There is no such event
+
+Scenario: Delete an existing event
+	It must be possible to delete an existing event entity from the database.
+	
+	Given Scope 12
+	And User 5
+	And A "CREATE" event from device 16
+	When I search for an event with the remembered ID
+	Then The event matches the creator parameters
+	When I delete the event with the remembered ID
+	And I search for an event with the remembered ID
+	Then There is no such event
+
+Scenario: Delete a non existent event
+	Trying to delete a non existent event (no matching entity ID) must cause an 
+	exception to be thrown.
+	
+	Given Scope 12
+	And User 5
+	And A "CREATE" event from device 16
+	When  I delete an event with a random ID
+	Then An event exception is caught
+
+Scenario: Count events in scope
+	It must be possible to count all events in a given scope. Only the events for this 
+	scope should counted, all other events must be ignored.
+	
+	Given Scope 12
+	And User 5
+	And I have 15 "CREATE" events from device 16
+	Given Scope 42
+	And I have 25 "READ" events from device 32
+	When I count events for scope 12
+	Then There are 15 events
+
+Scenario: Count events in empty scope
+	Counting events in an empty (non existing) scope must return a count of 0. No
+	exception must be thrown.
+	
+	Given Scope 12
+	And User 5
+	And I have 15 "CREATE" events from device 16
+	When I count events for scope 42
+	Then There are 0 events
+
+Scenario: Basic Device Event queries
+	It must be possible to perform basic event entity queries.
+	
+	Given Scope 12
+	And User 5
+	And I have 10 "WRITE" events from device 16
+	And I have 15 "CREATE" events from device 16
+	And I have 20 "EXECUTE" events from device 16
+	When I query for "CREATE" events
+	Then I find 15 events
+	When I query for "WRITE" events
+	Then I find 10 events
+
+Scenario: Event factory sanity checks
+	Then All device event factory functions must return non null objects
+
+Scenario: Event service domain check
+	Then The device event domain data can be updated


### PR DESCRIPTION
## CRUD tests for the Device Event service
This CRUD part of the Device Events tests exercise the majority of the Device Event service code (package org.eclipse.kapua.service.device.registry.event.internal).

### Changes to Maven pom files
There is no change in the pom files.

### Implementation changes
The implementation of the Device Event service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented to test CRUD operations on the Device Event service.

### Misc changes
Some additional cleanup was added to the Device Registry test suite to prevent database collisions (creating already existing tables) between the various device  registry service tests (Device Registry, Device Connection, Device Event).
A test step that was mistakenly committed for the Device Connection service was also removed.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>