### PR TITLE
Shiro authorization tests: Replaced timestamps with random longs in test names

### DIFF
--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -80,7 +80,7 @@ public class AccessInfoServiceTest extends KapuaTest {
             // Create mock user
             UserService userService = locator.getService(UserService.class);
             UserFactory userFactory = locator.getFactory(UserFactory.class);
-            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + System.currentTimeMillis());
+            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + random.nextLong());
             User user = userService.create(userCreator);
 
             // Create access info
@@ -107,7 +107,7 @@ public class AccessInfoServiceTest extends KapuaTest {
             // Create mock user
             UserService userService = locator.getService(UserService.class);
             UserFactory userFactory = locator.getFactory(UserFactory.class);
-            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + System.currentTimeMillis());
+            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + random.nextLong());
             User user = userService.create(userCreator);
 
             // Create permission
@@ -149,7 +149,7 @@ public class AccessInfoServiceTest extends KapuaTest {
             // Create mock user
             UserService userService = locator.getService(UserService.class);
             UserFactory userFactory = locator.getFactory(UserFactory.class);
-            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + System.currentTimeMillis());
+            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + random.nextLong());
             User user = userService.create(userCreator);
 
             // Create permission
@@ -162,7 +162,7 @@ public class AccessInfoServiceTest extends KapuaTest {
             RoleService roleService = locator.getService(RoleService.class);
             RoleFactory roleFactory = locator.getFactory(RoleFactory.class);
             RoleCreator roleCreator = roleFactory.newCreator(scope);
-            roleCreator.setName("testRole-" + System.currentTimeMillis());
+            roleCreator.setName("testRole-" + random.nextLong());
             roleCreator.setPermissions(permissions);
             Role role = roleService.create(roleCreator);
 
@@ -203,7 +203,7 @@ public class AccessInfoServiceTest extends KapuaTest {
             // Create mock user
             UserService userService = locator.getService(UserService.class);
             UserFactory userFactory = locator.getFactory(UserFactory.class);
-            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + System.currentTimeMillis());
+            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + random.nextLong());
             User user = userService.create(userCreator);
 
             // Create permission
@@ -220,7 +220,7 @@ public class AccessInfoServiceTest extends KapuaTest {
             RoleService roleService = locator.getService(RoleService.class);
             RoleFactory roleFactory = locator.getFactory(RoleFactory.class);
             RoleCreator roleCreator = roleFactory.newCreator(scope);
-            roleCreator.setName("testRole-" + System.currentTimeMillis());
+            roleCreator.setName("testRole-" + random.nextLong());
             roleCreator.setPermissions(permissionsRole);
             Role role = roleService.create(roleCreator);
 
@@ -272,7 +272,7 @@ public class AccessInfoServiceTest extends KapuaTest {
             // Create mock user
             UserService userService = locator.getService(UserService.class);
             UserFactory userFactory = locator.getFactory(UserFactory.class);
-            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + System.currentTimeMillis());
+            UserCreator userCreator = userFactory.newCreator(scope, "test-user-" + random.nextLong());
             User user = userService.create(userCreator);
 
             // Create permission
@@ -285,7 +285,7 @@ public class AccessInfoServiceTest extends KapuaTest {
             RoleService roleService = locator.getService(RoleService.class);
             RoleFactory roleFactory = locator.getFactory(RoleFactory.class);
             RoleCreator roleCreator = roleFactory.newCreator(scope);
-            roleCreator.setName("testRole-" + System.currentTimeMillis());
+            roleCreator.setName("testRole-" + random.nextLong());
             roleCreator.setPermissions(permissions);
             Role role = roleService.create(roleCreator);
 

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
 import java.math.BigInteger;
@@ -56,7 +68,7 @@ public class DomainServiceTest extends KapuaTest {
             domainActions.add(Actions.read);
             domainActions.add(Actions.write);
 
-            DomainCreator domainCreator = domainFactory.newCreator("test-" + System.currentTimeMillis(), DomainServiceTest.class.getName() + System.currentTimeMillis());
+            DomainCreator domainCreator = domainFactory.newCreator("test-" + random.nextLong(), DomainServiceTest.class.getName() + random.nextLong());
             domainCreator.setActions(domainActions);
 
             DomainService domainService = locator.getService(DomainService.class);
@@ -92,7 +104,7 @@ public class DomainServiceTest extends KapuaTest {
             domainActions.add(Actions.read);
             domainActions.add(Actions.write);
 
-            DomainCreator domainCreator = domainFactory.newCreator("test-" + System.currentTimeMillis(), DomainServiceTest.class.getName() + System.currentTimeMillis());
+            DomainCreator domainCreator = domainFactory.newCreator("test-" + random.nextLong(), DomainServiceTest.class.getName() + random.nextLong());
             domainCreator.setActions(domainActions);
 
             DomainService domainService = locator.getService(DomainService.class);
@@ -137,7 +149,7 @@ public class DomainServiceTest extends KapuaTest {
             domainActions.add(Actions.read);
             domainActions.add(Actions.write);
 
-            DomainCreator domainCreator = domainFactory.newCreator("test-" + System.currentTimeMillis(), DomainServiceTest.class.getName() + System.currentTimeMillis());
+            DomainCreator domainCreator = domainFactory.newCreator("test-" + random.nextLong(), DomainServiceTest.class.getName() + random.nextLong());
             domainCreator.setActions(domainActions);
 
             Domain domain1 = domainService.create(domainCreator);
@@ -147,7 +159,7 @@ public class DomainServiceTest extends KapuaTest {
             domainActions.add(Actions.read);
             domainActions.add(Actions.write);
 
-            domainCreator = domainFactory.newCreator("test-" + System.currentTimeMillis(), DomainServiceTest.class.getName() + System.currentTimeMillis());
+            domainCreator = domainFactory.newCreator("test-" + random.nextLong(), DomainServiceTest.class.getName() + random.nextLong());
             domainCreator.setActions(domainActions);
 
             Domain domain2 = domainService.create(domainCreator);
@@ -204,7 +216,7 @@ public class DomainServiceTest extends KapuaTest {
             domainActions.add(Actions.read);
             domainActions.add(Actions.write);
 
-            DomainCreator domainCreator = domainFactory.newCreator("test-" + System.currentTimeMillis(), DomainServiceTest.class.getName() + System.currentTimeMillis());
+            DomainCreator domainCreator = domainFactory.newCreator("test-" + random.nextLong(), DomainServiceTest.class.getName() + random.nextLong());
             domainCreator.setActions(domainActions);
 
             DomainService domainService = locator.getService(DomainService.class);

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -63,7 +63,7 @@ public class GroupServiceTest extends KapuaTest {
             KapuaLocator locator = KapuaLocator.getInstance();
 
             // Create group
-            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + new Date().getTime());
+            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             //
             // Create
@@ -92,7 +92,7 @@ public class GroupServiceTest extends KapuaTest {
         KapuaSecurityUtils.doPriviledge(() -> {
             KapuaLocator locator = KapuaLocator.getInstance();
 
-            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + new Date().getTime());
+            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             GroupService groupService = locator.getService(GroupService.class);
             Group group = groupService.create(groupCreator);
@@ -103,8 +103,8 @@ public class GroupServiceTest extends KapuaTest {
 
             //
             // Update
-            group.setName("updated-" + new Date().getTime());
-
+            group.setName("updated-" + random.nextLong());
+            Thread.sleep(50); // Added some delay to make sure the modification time-stamps are really different
             Group groupUpdated1 = groupService.update(group);
 
             //
@@ -130,7 +130,7 @@ public class GroupServiceTest extends KapuaTest {
             KapuaLocator locator = KapuaLocator.getInstance();
 
             // Create Group
-            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + new Date().getTime());
+            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             GroupService groupService = locator.getService(GroupService.class);
             Group group = groupService.create(groupCreator);
@@ -165,7 +165,7 @@ public class GroupServiceTest extends KapuaTest {
             KapuaLocator locator = KapuaLocator.getInstance();
 
             // Create group
-            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + new Date().getTime());
+            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             GroupService groupService = locator.getService(GroupService.class);
             Group group = groupService.create(groupCreator);
@@ -209,7 +209,7 @@ public class GroupServiceTest extends KapuaTest {
             KapuaLocator locator = KapuaLocator.getInstance();
 
             // Create group
-            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + new Date().getTime());
+            GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             GroupService groupService = locator.getService(GroupService.class);
             Group group = groupService.create(groupCreator);

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -82,7 +82,7 @@ public class RoleServiceTest extends KapuaTest {
 
             // Create role
             RoleCreator roleCreator = new RoleCreatorImpl(scope);
-            roleCreator.setName("test-" + new Date().getTime());
+            roleCreator.setName("test-" + random.nextLong());
             roleCreator.setPermissions(permissions);
 
             //
@@ -138,7 +138,7 @@ public class RoleServiceTest extends KapuaTest {
             permissions.add(permission3);
 
             RoleCreator roleCreator = new RoleCreatorImpl(scope);
-            roleCreator.setName("test-" + new Date().getTime());
+            roleCreator.setName("test-" + random.nextLong());
             roleCreator.setPermissions(permissions);
 
             RoleService roleService = locator.getService(RoleService.class);
@@ -153,8 +153,8 @@ public class RoleServiceTest extends KapuaTest {
 
             //
             // Update
-            role.setName("updated-" + new Date().getTime());
-
+            role.setName("updated-" + random.nextLong());
+            Thread.sleep(50); // Added some delay to make sure the modification time-stamps are really different
             Role roleUpdated1 = roleService.update(role);
 
             //
@@ -188,7 +188,7 @@ public class RoleServiceTest extends KapuaTest {
 
             // Create Role
             RoleCreator roleCreator = new RoleCreatorImpl(scope);
-            roleCreator.setName("test-" + new Date().getTime());
+            roleCreator.setName("test-" + random.nextLong());
             roleCreator.setPermissions(permissions);
 
             RoleService roleService = locator.getService(RoleService.class);
@@ -232,7 +232,7 @@ public class RoleServiceTest extends KapuaTest {
 
             // Create role
             RoleCreator roleCreator = new RoleCreatorImpl(scope);
-            roleCreator.setName("test-" + new Date().getTime());
+            roleCreator.setName("test-" + random.nextLong());
             roleCreator.setPermissions(permissions);
 
             RoleService roleService = locator.getService(RoleService.class);
@@ -290,7 +290,7 @@ public class RoleServiceTest extends KapuaTest {
 
             // Create role
             RoleCreator roleCreator = new RoleCreatorImpl(scope);
-            roleCreator.setName("test-" + new Date().getTime());
+            roleCreator.setName("test-" + random.nextLong());
             roleCreator.setPermissions(permissions);
 
             RoleService roleService = locator.getService(RoleService.class);


### PR DESCRIPTION
## Slight tweaks to the shiro authorization tests
The shiro authorization tests were made somewhat more robust by replacing timestamps with random numbers for naming database entries.
In some cases it was possible that the timestamps for two successive testcases were reported as exactly equal, resulting in duplicate entity names, which then caused a database exception (**org.h2.jdbc.JdbcSQLException: Unique index or primary key violation**).

Also, the copyright headers of the affected files are updated to reflect the current year.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>