### PR TITLE
Fix docker generation a bit

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -71,7 +71,6 @@
 		<dependency>
 			<groupId>org.eclipse.kapua</groupId>
 			<artifactId>kapua-message-internal</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.kapua</groupId>
@@ -80,7 +79,6 @@
 		<dependency>
 			<groupId>org.eclipse.kapua</groupId>
 			<artifactId>kapua-datastore-internal</artifactId>
-			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.kapua</groupId>
@@ -137,7 +135,6 @@
 		<dependency>
 			<groupId>org.eclipse.kapua</groupId>
 			<artifactId>kapua-device-packages-internal</artifactId>
-			<version>${project.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -148,7 +145,6 @@
 		<dependency>
 			<groupId>org.eclipse.kapua</groupId>
 			<artifactId>kapua-translator-kura-jms</artifactId>
-			<version>${project.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -287,7 +283,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>${maven-dependency-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>unpack-activemq</id>
@@ -463,7 +458,7 @@
 						<image>
 							<name>${docker.account}/kapua-broker</name>
 							<build>
-								<from>java:8u40</from>
+								<from>java:8</from>
 								<assembly>
 									<descriptor>/src/main/descriptors/kapua-broker.xml</descriptor>
 								</assembly>
@@ -481,13 +476,16 @@
 						<image>
 							<name>${docker.account}/kapua-console</name>
 							<build>
-								<from>java:8u40</from>
+								<from>java:8</from>
 								<assembly>
 									<descriptor>/src/main/descriptors/kapua-console.xml</descriptor>
 								</assembly>
 								<entryPoint>
 								   <shell>/maven/bin/catalina.sh run</shell>
 								</entryPoint>
+								<env>
+									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
+								</env>
 								<ports>
 									<port>8080</port>
 								</ports>
@@ -501,13 +499,16 @@
 						<image>
 							<name>${docker.account}/kapua-api</name>
 							<build>
-								<from>java:8u40</from>
+								<from>java:8</from>
 								<assembly>
 									<descriptor>/src/main/descriptors/kapua-api.xml</descriptor>
 								</assembly>
 								<entryPoint>
 								   <shell>/maven/bin/catalina.sh run</shell>
 								</entryPoint>
+								<env>
+									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
+								</env>
 								<ports>
 									<port>8080</port>
 								</ports>

--- a/assembly/readme.md
+++ b/assembly/readme.md
@@ -2,12 +2,18 @@
 
 ### Build
 
-mvn -Pdocker 
+    mvn -Pdocker
+    mvn -f../dev-tools/ -Pdocker
 
 ### Run
 
-docker run -td --name kapua-broker -p 1883:1883 kapua-broker
+    docker run -td --name kapua-sql -p 8181:8181 -p 3306:3306 kapua/kapua-sql
+    docker run -ti -e SQL_SERVICE_HOST=localhost --net=host kapua/kapua-liquibase
+    docker run -td --name kapua-broker -p 1883:1883 kapua/kapua-broker
+    docker run -td --name kapua-console --link kapua-sql:db -p 8080:8080 kapua/kapua-console
+    docker run -td --name kapua-api --link kapua-sql:db -p 8081:8080 kapua/kapua-api
 
-docker run -td --name kapua-console -p 8080:8080 kapua-console
+### Access
 
-docker run -td --name kapua-api -p 8081:8080 kapua-api
+Navigate your browser to http://localhost:8080/console and log in using the following credentials:
+`kapua-sys` : `kapua-password`


### PR DESCRIPTION
This change implements the following changes:

 * Fix name of docker images
 * Add missing docker containers in start list
 * Link docker containers to H2 container
 * Switch from java:8u40 to java:8 container image
 * Fix maven warnings

----

I stumbled over those issues while trying to get Kapua up and running locally. Those changes fix the startup of Kapua. But there is still the issue of a few columns and table missing (e.g. USR_USER.EXTERNAL_ID)