### PR TITLE
Fix a maven build warning about duplicate plugins

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -281,13 +281,7 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
                     <execution>
                         <id>Create openlayers resources</id>
                         <phase>prepare-package</phase>


### PR DESCRIPTION
This change will fix a build warning which complains about duplicate plugins in the same project.

Signed-off-by: Jens Reimann <jreimann@redhat.com>