### PR TITLE
Allow to automatically configure database link with container links

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -465,8 +465,11 @@
 									<descriptor>/src/main/descriptors/kapua-broker.xml</descriptor>
 								</assembly>
 								<entryPoint>
-								   <shell>/maven/bin/activemq console</shell>
+									<shell>/maven/bin/activemq console</shell>
 								</entryPoint>
+								<env>
+									<ACTIVEMQ_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</ACTIVEMQ_OPTS>
+								</env>
 								<ports>
 									<port>1883</port>
 								</ports>
@@ -483,7 +486,7 @@
 									<descriptor>/src/main/descriptors/kapua-console.xml</descriptor>
 								</assembly>
 								<entryPoint>
-								   <shell>/maven/bin/catalina.sh run</shell>
+									<shell>/maven/bin/catalina.sh run</shell>
 								</entryPoint>
 								<env>
 									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
@@ -506,7 +509,7 @@
 									<descriptor>/src/main/descriptors/kapua-api.xml</descriptor>
 								</assembly>
 								<entryPoint>
-								   <shell>/maven/bin/catalina.sh run</shell>
+									<shell>/maven/bin/catalina.sh run</shell>
 								</entryPoint>
 								<env>
 									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -485,6 +485,9 @@
 								<entryPoint>
 								   <shell>/maven/bin/catalina.sh run</shell>
 								</entryPoint>
+								<env>
+									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
+								</env>
 								<ports>
 									<port>8080</port>
 								</ports>
@@ -505,6 +508,9 @@
 								<entryPoint>
 								   <shell>/maven/bin/catalina.sh run</shell>
 								</entryPoint>
+								<env>
+									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
+								</env>
 								<ports>
 									<port>8080</port>
 								</ports>

--- a/assembly/readme.md
+++ b/assembly/readme.md
@@ -9,7 +9,7 @@
 
     docker run -td --name kapua-sql -p 8181:8181 -p 3306:3306 kapua/kapua-sql
     docker run -ti -e SQL_SERVICE_HOST=localhost --net=host kapua/kapua-liquibase
-    docker run -td --name kapua-broker -p 1883:1883 kapua/kapua-broker
+    docker run -td --name kapua-broker --link kapua-sql:db -p 1883:1883 kapua/kapua-broker
     docker run -td --name kapua-console --link kapua-sql:db -p 8080:8080 kapua/kapua-console
     docker run -td --name kapua-api --link kapua-sql:db -p 8081:8080 kapua/kapua-api
 


### PR DESCRIPTION
This change uses the container link alias "db" for connecting to the
Kapua database.

Signed-off-by: Jens Reimann <jreimann@redhat.com>