### PR TITLE
Improvements for OpenShift deployment

### DIFF
--- a/dev-tools/src/main/database/Dockerfile
+++ b/dev-tools/src/main/database/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Red Hat and/or its affiliates and others
+# Copyright (c) 2016, 2017 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -8,24 +8,21 @@
 #
 ###############################################################################
 
-FROM java:8
+FROM fedora:25
 
 MAINTAINER Henryk Konsek <hekonsek@gmail.com>
 
-RUN apt-get update -qq
-RUN apt-get install -qq maven
+RUN dnf -y install maven git-core
 
 # Download Maven project
-RUN apt-get install -qq git
-RUN echo 'Downloading project...'
-RUN git clone https://github.com/eclipse/kapua.git
-WORKDIR kapua/dev-tools
-RUN git checkout develop
+RUN git clone -b develop https://github.com/eclipse/kapua.git
 
 # Use Liquibase changelog from current build, not downloaded version
-ADD liquibase.sql /root/kapua/dev-tools/src/main/database/
+ADD liquibase.sql /kapua/dev-tools/src/main/database/
 
 # Cache Maven dependencies
-RUN mvn clean install liquibase:help
+RUN mvn -Dmaven.repo.local=/m2-repo -B -f/kapua/dev-tools/pom.xml clean install liquibase:help \
+  && chmod a+rw -R /m2-repo /kapua
+
 # Prepare final command
-ENTRYPOINT ["/usr/share/maven/bin/mvn", "-Pliquibase"]
+ENTRYPOINT mvn -B -Dmaven.repo.local=/m2-repo -Pliquibase -fkapua/dev-tools/pom.xml

--- a/dev-tools/src/main/database/liquibase.sql
+++ b/dev-tools/src/main/database/liquibase.sql
@@ -156,7 +156,8 @@ CREATE TABLE athz_role_permission (
   role_id             	    BIGINT(21) 	  UNSIGNED,
   domain					VARCHAR(64)   NOT NULL,
   action					VARCHAR(64),
-  target_scope_id		    BIGINT(21),
+  target_scope_id		    BIGINT(21)    UNSIGNED,
+  group_id             	    BIGINT(21) 	  UNSIGNED,
 
   PRIMARY KEY (id)
 
@@ -266,6 +267,7 @@ CREATE INDEX idx_connection_status_id ON dvc_device_connection (scope_id, id, co
 CREATE TABLE dvc_device (
   scope_id             	    BIGINT(21) 	    UNSIGNED NOT NULL,
   id                     	BIGINT(21) 	    UNSIGNED NOT NULL,
+  group_id             	    BIGINT(21) 	  UNSIGNED,
   client_id                 VARCHAR(255)    NOT NULL,
   connection_id             BIGINT(21) 	    UNSIGNED NULL,
   created_on             	TIMESTAMP(3)    NULL,
@@ -423,7 +425,8 @@ CREATE TABLE usr_user (
   optlock               	INT UNSIGNED,
   attributes             	TEXT,
   properties             	TEXT,
-
+  user_type               VARCHAR(64)   NOT NULL DEFAULT 'INTERNAL',
+  external_id             VARCHAR(255),
   PRIMARY KEY (id),
   CONSTRAINT usr_uc_name UNIQUE (name)
 ) DEFAULT CHARSET=utf8;
@@ -476,8 +479,9 @@ CREATE TABLE athz_access_permission (
   access_info_id			BIGINT(21) 	  UNSIGNED NOT NULL,
 
   domain					VARCHAR(64)	  NOT NULL,
-  action					VARCHAR(64)	  NOT NULL,
+  action					VARCHAR(64),
   target_scope_id			BIGINT(21)	  UNSIGNED,
+  group_id             	    BIGINT(21) 	  UNSIGNED,
 
   PRIMARY KEY (id),
 --  FOREIGN KEY (access_id) REFERENCES athz_access_info(id) ON DELETE CASCADE
@@ -490,7 +494,7 @@ CREATE INDEX idx_scopeId_accessId_domain_action_targetScopeId ON athz_access_per
 
 INSERT INTO athz_access_permission
 	VALUES
-		(1, 1, NOW(), 1, 2, 'broker', 'connect', 1); -- kapua-broker assigned of permission: broker:connect:1
+		(1, 1, NOW(), 1, 2, 'broker', 'connect', 1, null); -- kapua-broker assigned of permission: broker:connect:1
 
 --changeset hekonsek:22
 
@@ -527,17 +531,42 @@ INSERT INTO athz_role
 
 INSERT INTO athz_role_permission
 	VALUES
-		(1, 1, NOW(), 1, 1, 'account', null, null),
-		(1, 2, NOW(), 1, 1, 'user', null, null),
-		(1, 3, NOW(), 1, 1, 'device_event', null, null),
-		(1, 4, NOW(), 1, 1, 'device_connection', null, null),
-		(1, 5, NOW(), 1, 1, 'device', null, null),
-		(1, 6, NOW(), 1, 1, 'data', null, null),
-		(1, 7, NOW(), 1, 1, 'broker', null, null),
-		(1, 8, NOW(), 1, 1, 'credential', null, null),
-		(1, 9, NOW(), 1, 1, 'role', null, null),
-		(1, 10, NOW(), 1, 1, 'user_permission', null, null),
-		(1, 11, NOW(), 1, 1, 'device_lifecycle', null, null),
-		(1, 12, NOW(), 1, 1, 'device_management', null, null),
-		(1, 13, NOW(), 1, 1, 'account', null, null),
-		(1, 14, NOW(), 1, 1, 'account', null, null);
+		(1, 1, NOW(), 1, 1, 'account', null, null, null),
+		(1, 2, NOW(), 1, 1, 'user', null, null, null),
+		(1, 3, NOW(), 1, 1, 'device_event', null, null, null),
+		(1, 4, NOW(), 1, 1, 'device_connection', null, null, null),
+		(1, 5, NOW(), 1, 1, 'device', null, null, null),
+		(1, 6, NOW(), 1, 1, 'data', null, null, null),
+		(1, 7, NOW(), 1, 1, 'broker', null, null, null),
+		(1, 8, NOW(), 1, 1, 'credential', null, null, null),
+		(1, 9, NOW(), 1, 1, 'role', null, null, null),
+		(1, 10, NOW(), 1, 1, 'user_permission', null, null, null),
+		(1, 11, NOW(), 1, 1, 'device_lifecycle', null, null, null),
+		(1, 12, NOW(), 1, 1, 'device_management', null, null, null),
+		(1, 13, NOW(), 1, 1, 'account', null, null, null),
+		(1, 14, NOW(), 1, 1, 'account', null, null, null);
+
+--changeset jreimann:26
+
+CREATE TABLE atht_access_token (
+  scope_id             		BIGINT(21) 	  UNSIGNED NOT NULL,
+  id                     	BIGINT(21) 	  UNSIGNED NOT NULL,
+  created_on             	TIMESTAMP(3)  NOT NULL,
+  created_by             	BIGINT(21)    UNSIGNED NOT NULL,
+  modified_on            	TIMESTAMP(3),
+  modified_by            	BIGINT(21)    UNSIGNED,
+
+  user_id 					BIGINT(21) 	  UNSIGNED NOT NULL,
+  token_id					TEXT	      NOT NULL,
+  expires_on				TIMESTAMP(3)  NOT NULL,
+
+  optlock               	INT UNSIGNED,
+  attributes             	TEXT,
+  properties             	TEXT,
+
+  PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8;
+
+CREATE INDEX idx_atht_access_token_scope_id ON atht_access_token (scope_id);
+CREATE INDEX idx_atht_access_token_user_id ON atht_access_token (scope_id, user_id);
+

--- a/dev-tools/src/main/openshift/liquibase_job.yml
+++ b/dev-tools/src/main/openshift/liquibase_job.yml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: liquibase
+spec:
+  parallelism: 1
+  completions: 1
+  template:
+    metadata:
+      name: liquibase
+    spec:
+      containers:
+      - env:
+        - name: SQL_SERVICE_HOST
+          value: sql # The name of the SVC instance
+        name: liquibase
+        image: kapua/kapua-liquibase:latest
+      restartPolicy: Never
+
+

--- a/dev-tools/src/main/openshift/openshift-deploy.sh
+++ b/dev-tools/src/main/openshift/openshift-deploy.sh
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016 Red Hat and/or its affiliates and others
+# Copyright (c) 2016, 2017 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -10,69 +10,82 @@
 
 #!/usr/bin/env bash
 
+set -e
+
+OPENSHIFT_PROJECT_NAME="eclipse-kapua"
+
+# print error and exit when necessary
+die() { printf "$@" "\n" 1>&2 ; exit 1; }
+
 #minishift start
 #eval $(minishift docker-env)
 
+# test if the project is already created ... fail otherwise 
+
+oc describe "project/$OPENSHIFT_PROJECT_NAME" &>/dev/null || die "Project '$OPENSHIFT_PROJECT_NAME' not created or OpenShift is unreachable. Try with:\n\n\toc new-project eclipse-kapua\n\n"
+
 #oc login
-#oc new-project eclipse-kapua --description="Open source IoT Platform" --display-name="Eclipse Kapua"
+#oc new-project "$OPENSHIFT_PROJECT_NAME" --description="Open source IoT Platform" --display-name="Eclipse Kapua"
 
 if [ -z "${DOCKER_ACCOUNT}" ]; then
-  DOCKER_ACCOUNT='kapua'
+  DOCKER_ACCOUNT=kapua
 fi
 
-echo 'Starting ElasticSearch server...'
+echo Creating ElasticSearch server...
 
 if [ -z "${ELASTIC_SEARCH_MEMORY}" ]; then
-  ELASTIC_SEARCH_MEMORY='512M'
+  ELASTIC_SEARCH_MEMORY=512M
 fi
 
-oc new-app -e ES_JAVA_OPTS="-Xms${ELASTIC_SEARCH_MEMORY} -Xmx${ELASTIC_SEARCH_MEMORY}" elasticsearch:2.4 -n eclipse-kapua
+oc new-app -e ES_JAVA_OPTS="-Xms${ELASTIC_SEARCH_MEMORY} -Xmx${ELASTIC_SEARCH_MEMORY}" elasticsearch:2.4 -n "$OPENSHIFT_PROJECT_NAME"
 
-echo 'ElasticSearch server started.'
+echo ElasticSearch server created
 
 ### SQL database
 
-echo 'Staring SQL database'
+echo Creating SQL database
 
-oc new-app ${DOCKER_ACCOUNT}/kapua-sql --name=sql -n eclipse-kapua
+oc new-app ${DOCKER_ACCOUNT}/kapua-sql --name=sql -n "$OPENSHIFT_PROJECT_NAME"
+oc set probe dc/sql --readiness --open-tcp=3306
 
-echo 'SQL database started'
+echo SQL database created
 
 ### Broker
 
-echo 'Starting broker'
+echo Creating broker
 
-oc new-app ${DOCKER_ACCOUNT}/kapua-broker:latest -name=kapua-broker -n eclipse-kapua
+oc new-app ${DOCKER_ACCOUNT}/kapua-broker:latest -name=kapua-broker -n "$OPENSHIFT_PROJECT_NAME"
 
-echo 'Broker started'
+echo Broker created
 
 ## Build assembly module with
 ## mvn -Pdocker
 
-echo 'Starting web console'
+echo Creating web console
 
-oc new-app ${DOCKER_ACCOUNT}/kapua-console:latest -n eclipse-kapua -eCOMMONS_DB_SCHEMA=' '
+oc new-app ${DOCKER_ACCOUNT}/kapua-console:latest -n "$OPENSHIFT_PROJECT_NAME" -eCOMMONS_DB_SCHEMA=' '
 
-echo 'Web console started.'
+echo Web console created
 
-echo 'Starting rest api'
+### REST API
 
-oc new-app ${DOCKER_ACCOUNT}/kapua-api:latest -n eclipse-kapua
+echo 'Creating Rest API'
 
-echo 'Rest api started'
+oc new-app ${DOCKER_ACCOUNT}/kapua-api:latest -n "$OPENSHIFT_PROJECT_NAME"
+
+echo 'Rest API created'
 
 ## Applying DB schema
 
-SQL_HOST=`oc get service | grep sql | awk '{print $2}'`
-docker run -it -e SQL_SERVICE_HOST=${SQL_HOST} ${DOCKER_ACCOUNT}/kapua-liquibase
+# Create batch job for liquibase
+oc set image -f liquibase_job.yml "liquibase=$DOCKER_ACCOUNT/kapua-liquibase:latest" --local --source=docker -o yaml | oc create -f -
 
 ## Start router
 
 #oc adm policy add-scc-to-user hostnetwork -z router
-
 #oc adm router --create
 
 ## Expose web console
 
-#oc expose svc/kapua-console
+oc expose svc/kapua-console
 


### PR DESCRIPTION
##  Re-build docker file based on Fedora 25

The dockerfile was changed primarily to be able to run on OpenShift as a batch job.

The reason to change it to Fedora was due to the fact that java:8 images are rather unstable, dependencies where missing from upstream compared to the provided image and thus the dockerbuild actually re-installed java 7 during the installation of Maven.

##  Improve minor things deploying to OpenShift

* Test first if the project already exists
* Set a readyness probe for the database
* Start liquibase as an Openshift job in the same project in order to
  access the database
* Finally expose the kapua-console service