### PR TITLE
Speed up GWT build when compiling locally

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -412,4 +412,33 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <!-- profile to speed up local development builds  -->
+        <profile>
+            <id>dev</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>gwt-maven-plugin</artifactId>
+                        <configuration>
+                            <!-- we can always enable draft compile -->
+                            <draftCompile>true</draftCompile>
+                            <!-- use "dev" profile, limiting permutations -->
+                            <module>org.eclipse.kapua.app.console.ConsoleDev</module>
+                            <!-- don't optimize -->
+                            <optimizationLevel>0</optimizationLevel>
+                            <!-- enable details -->
+                            <style>DETAILED</style>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/console/src/main/resources/org/eclipse/kapua/app/console/ConsoleDev.gwt.xml
+++ b/console/src/main/resources/org/eclipse/kapua/app/console/ConsoleDev.gwt.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2017 Red Hat Inc
+   
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        Red Hat Inc - initial API and implementation
+   
+ -->
+
+<module rename-to="console">
+  <inherits name="org.eclipse.kapua.app.console.console" />
+  
+  <!-- The 'user.agent' propery can be changed to the developer's
+       favorite browser engine for local testing. Just don't check
+       it in every time -->
+  <set-property name="user.agent" value="gecko1_8" />
+</module>


### PR DESCRIPTION
This change adds a "dev" profile to the "kapua-console" project which
allows for a speed up version of the GWT build, disabling optimizations
and enabling detailed informations.

Signed-off-by: Jens Reimann <jreimann@redhat.com>