### PR TITLE
Remove code which can never be called

### DIFF
--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraPayload.java
@@ -144,12 +144,7 @@ public class KuraPayload implements DevicePayload
                 protoMsg.addMetric(metricB);
             }
             catch (MessageException eihte) {
-                try {
-                    s_logger.error("During serialization, ignoring metric named: {}. Unrecognized value type: {}.", name, value.getClass().getName());
-                }
-                catch (NullPointerException npe) {
-                    s_logger.error("During serialization, ignoring metric named: {}. The value is null.", name);
-                }
+                s_logger.error("During serialization, ignoring metric named: {}. Unrecognized value type: {}.", name, value.getClass().getName());
                 throw new RuntimeException(eihte);
             }
         }


### PR DESCRIPTION
The value is tested before for null and so it can never become null
afterwards as there is no assignment to it.

Signed-off-by: Jens Reimann <jreimann@redhat.com>