### PR TITLE
Re-implement translator lookup using straight forward iterable

### DIFF
--- a/translator/api/src/main/java/org/eclipse/kapua/translator/Translator.java
+++ b/translator/api/src/main/java/org/eclipse/kapua/translator/Translator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,11 +8,12 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *
  *******************************************************************************/
 package org.eclipse.kapua.translator;
 
-import java.util.Iterator;
+import java.util.Objects;
 import java.util.ServiceLoader;
 
 import org.eclipse.kapua.KapuaException;
@@ -32,69 +33,68 @@ import org.slf4j.LoggerFactory;
  * <li>Transport level (ie jms, mqtt, ...)</li>
  * </ul>
  * 
- * @param <FROM_M> message from type
- * @param <TO_M> message to type
+ * @param <FROM_M>
+ *            message from type
+ * @param <TO_M>
+ *            message to type
  * 
  * @since 1.0
  * 
  */
 @SuppressWarnings("rawtypes")
-public abstract class Translator<FROM_M extends Message, TO_M extends Message>
-{
-	
-	public static final Logger logger = LoggerFactory.getLogger(Translator.class);
-	
-    static ServiceLoader<?> translators = ServiceLoader.load(Translator.class);
+public abstract class Translator<FROM_M extends Message, TO_M extends Message> {
+
+    public static final Logger logger = LoggerFactory.getLogger(Translator.class);
+
+    private static final ServiceLoader<Translator> translators = ServiceLoader.load(Translator.class);
 
     /**
-     * Return a translator for the given messages classes. This method lookup for the Translator through {@link java.util.ServiceLoader}
+     * Return a translator for the given messages classes.
+     * <br>
+     * This method will lookup instances of Translator through {@link java.util.ServiceLoader}
      * 
-     * @param fromMessageClass message from type
-     * @param toMessageClass message to type
+     * @param fromMessageClass
+     *            message from type
+     * @param toMessageClass
+     *            message to type
      * @return
      * @throws KapuaException
      */
     @SuppressWarnings("unchecked")
     public static synchronized <FROM_M extends Message, TO_M extends Message, T extends Translator<FROM_M, TO_M>> T getTranslatorFor(Class<FROM_M> fromMessageClass,
-                                                                                                                        Class<TO_M> toMessageClass)
-        throws KapuaException
-    {
-        T translator = null;
+            Class<TO_M> toMessageClass)
+            throws KapuaException {
 
-        Iterator<T> translatorIterator = (Iterator<T>) translators.iterator();
-        while (translatorIterator.hasNext()) {
-            T t = translatorIterator.next();
+        Objects.requireNonNull(fromMessageClass);
+        Objects.requireNonNull(toMessageClass);
 
-            if ((fromMessageClass.isAssignableFrom(t.getClassFrom())) &&
-                toMessageClass.isAssignableFrom(t.getClassTo())) {
-                translator = t;
-                break;
+        for (Translator translator : translators) {
+            if ((fromMessageClass.isAssignableFrom(translator.getClassFrom())) &&
+                    toMessageClass.isAssignableFrom(translator.getClassTo())) {
+                return (T) translator;
             }
         }
 
-        if (translator == null) {
-        	logger.error("Cannot find translator from - to: {} - {}", new Object[]{fromMessageClass.getName(), toMessageClass.getName()});
-            throw new KapuaRuntimeException(KapuaRuntimeErrorCodes.TRANSLATOR_NOT_FOUND,
-                                            null,
-                                            new Object[] {
-                                                           translators,
-                                                           fromMessageClass.getName(),
-                                                           toMessageClass.getName(),
-                                            });
-        }
-
-        return translator;
+        logger.error("Cannot find translator from: {}- to: {}", fromMessageClass.getName(), toMessageClass.getName());
+        throw new KapuaRuntimeException(KapuaRuntimeErrorCodes.TRANSLATOR_NOT_FOUND,
+                null,
+                new Object[] {
+                        translators,
+                        fromMessageClass.getName(),
+                        toMessageClass.getName(),
+                });
     }
 
     /**
      * Translate message from the domain FROM_M to the domain TO_M
      * 
-     * @param message the message to translate
+     * @param message
+     *            the message to translate
      * @return the translated message
      * @throws KapuaException
      */
     public abstract TO_M translate(FROM_M message)
-        throws KapuaException;
+            throws KapuaException;
 
     /**
      * Return the FROM_M message type


### PR DESCRIPTION
This change re-implements the lookup logic by simply relying on the
Iterable interface of the ServiceLocator.

Signed-off-by: Jens Reimann <jreimann@redhat.com>