### PR TITLE
Provide a common base class for most kapua to kura translators

### DIFF
--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/AbstractTranslatorKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/AbstractTranslatorKapuaKura.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kapua.kura;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.message.KapuaChannel;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestChannel;
+import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestMessage;
+import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestPayload;
+import org.eclipse.kapua.service.device.management.bundle.message.internal.BundleRequestMessage;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.translator.Translator;
+
+/**
+ * Messages translator implementation from {@link BundleRequestMessage} to {@link KuraRequestMessage}
+ * 
+ * @since 1.0
+ *
+ */
+public abstract class AbstractTranslatorKapuaKura<FROM_C extends KapuaChannel, FROM_P extends KapuaPayload, FROM_M extends KapuaMessage<FROM_C,FROM_P>> extends Translator<FROM_M, KuraRequestMessage> {
+
+    @Override
+    public KuraRequestMessage translate(FROM_M kapuaMessage) throws KapuaException {
+        //
+        // Kura channel
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AccountService accountService = locator.getService(AccountService.class);
+        Account account = accountService.find(kapuaMessage.getScopeId());
+
+        DeviceRegistryService deviceService = locator.getService(DeviceRegistryService.class);
+        Device device = deviceService.find(kapuaMessage.getScopeId(),
+                kapuaMessage.getDeviceId());
+
+        KuraRequestChannel kuraRequestChannel = translateChannel(kapuaMessage.getChannel());
+        kuraRequestChannel.setScope(account.getName());
+        kuraRequestChannel.setClientId(device.getClientId());
+
+        //
+        // Kura payload
+        KuraRequestPayload kuraPayload = translatePayload(kapuaMessage.getPayload());
+
+        //
+        // Return Kura Message
+        return new KuraRequestMessage(kuraRequestChannel,
+                kapuaMessage.getReceivedOn(),
+                kuraPayload);
+
+    }
+
+    protected abstract KuraRequestChannel translateChannel(FROM_C kapuaChannel) throws KapuaException;
+
+    protected abstract KuraRequestPayload translatePayload(FROM_P kapuaPayload) throws KapuaException;
+
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppBundleKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppBundleKapuaKura.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *
  *******************************************************************************/
 package org.eclipse.kapua.translator.kapua.kura;
@@ -18,9 +19,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.service.account.Account;
-import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.device.call.kura.app.BundleMetrics;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestChannel;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestMessage;
@@ -31,9 +29,6 @@ import org.eclipse.kapua.service.device.management.bundle.internal.DeviceBundleA
 import org.eclipse.kapua.service.device.management.bundle.message.internal.BundleRequestChannel;
 import org.eclipse.kapua.service.device.management.bundle.message.internal.BundleRequestMessage;
 import org.eclipse.kapua.service.device.management.bundle.message.internal.BundleRequestPayload;
-import org.eclipse.kapua.service.device.registry.Device;
-import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
-import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link BundleRequestMessage} to {@link KuraRequestMessage}
@@ -41,50 +36,18 @@ import org.eclipse.kapua.translator.Translator;
  * @since 1.0
  *
  */
-public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessage, KuraRequestMessage> {
+public class TranslatorAppBundleKapuaKura extends AbstractTranslatorKapuaKura<BundleRequestChannel, BundleRequestPayload, BundleRequestMessage> {
 
     private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
-    private static Map<DeviceBundleAppProperties, BundleMetrics> propertiesDictionary;
-
-    /**
-     * Constructor
-     */
-    public TranslatorAppBundleKapuaKura() {
-        propertiesDictionary = new HashMap<>();
-
+    private static final Map<DeviceBundleAppProperties, BundleMetrics> propertiesDictionary= new HashMap<>();
+    
+    static {
         propertiesDictionary.put(DeviceBundleAppProperties.APP_NAME, BundleMetrics.APP_ID);
         propertiesDictionary.put(DeviceBundleAppProperties.APP_VERSION, BundleMetrics.APP_VERSION);
     }
 
-    @Override
-    public KuraRequestMessage translate(BundleRequestMessage kapuaMessage) throws KapuaException {
-        //
-        // Kura channel
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AccountService accountService = locator.getService(AccountService.class);
-        Account account = accountService.find(kapuaMessage.getScopeId());
 
-        DeviceRegistryService deviceService = locator.getService(DeviceRegistryService.class);
-        Device device = deviceService.find(kapuaMessage.getScopeId(),
-                kapuaMessage.getDeviceId());
-
-        KuraRequestChannel kuraRequestChannel = translate(kapuaMessage.getChannel());
-        kuraRequestChannel.setScope(account.getName());
-        kuraRequestChannel.setClientId(device.getClientId());
-
-        //
-        // Kura payload
-        KuraRequestPayload kuraPayload = translate(kapuaMessage.getPayload());
-
-        //
-        // Return Kura Message
-        return new KuraRequestMessage(kuraRequestChannel,
-                kapuaMessage.getReceivedOn(),
-                kuraPayload);
-
-    }
-
-    private KuraRequestChannel translate(BundleRequestChannel kapuaChannel) throws KapuaException {
+    protected KuraRequestChannel translateChannel(BundleRequestChannel kapuaChannel) throws KapuaException {
         KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 
@@ -131,8 +94,7 @@ public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessag
         return kuraRequestChannel;
     }
 
-    private KuraRequestPayload translate(BundleRequestPayload kapuaPayload)
-            throws KapuaException {
+    protected KuraRequestPayload translatePayload(BundleRequestPayload kapuaPayload) throws KapuaException {
         KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
 
         if (kapuaPayload.getBody() != null) {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppBundleKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppBundleKapuaKura.java
@@ -41,16 +41,15 @@ import org.eclipse.kapua.translator.Translator;
  * @since 1.0
  *
  */
-public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessage, KuraRequestMessage>
-{
-    private static final String                            CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
+public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessage, KuraRequestMessage> {
+
+    private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
     private static Map<DeviceBundleAppProperties, BundleMetrics> propertiesDictionary;
 
     /**
      * Constructor
      */
-    public TranslatorAppBundleKapuaKura()
-    {
+    public TranslatorAppBundleKapuaKura() {
         propertiesDictionary = new HashMap<>();
 
         propertiesDictionary.put(DeviceBundleAppProperties.APP_NAME, BundleMetrics.APP_ID);
@@ -58,9 +57,7 @@ public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessag
     }
 
     @Override
-    public KuraRequestMessage translate(BundleRequestMessage kapuaMessage)
-        throws KapuaException
-    {
+    public KuraRequestMessage translate(BundleRequestMessage kapuaMessage) throws KapuaException {
         //
         // Kura channel
         KapuaLocator locator = KapuaLocator.getInstance();
@@ -69,7 +66,7 @@ public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessag
 
         DeviceRegistryService deviceService = locator.getService(DeviceRegistryService.class);
         Device device = deviceService.find(kapuaMessage.getScopeId(),
-                                           kapuaMessage.getDeviceId());
+                kapuaMessage.getDeviceId());
 
         KuraRequestChannel kuraRequestChannel = translate(kapuaMessage.getChannel());
         kuraRequestChannel.setScope(account.getName());
@@ -82,22 +79,20 @@ public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessag
         //
         // Return Kura Message
         return new KuraRequestMessage(kuraRequestChannel,
-                                      kapuaMessage.getReceivedOn(),
-                                      kuraPayload);
+                kapuaMessage.getReceivedOn(),
+                kuraPayload);
 
     }
 
-    private KuraRequestChannel translate(BundleRequestChannel kapuaChannel)
-        throws KapuaException
-    {
+    private KuraRequestChannel translate(BundleRequestChannel kapuaChannel) throws KapuaException {
         KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 
         // Build appId
         StringBuilder appIdSb = new StringBuilder();
         appIdSb.append(propertiesDictionary.get(DeviceBundleAppProperties.APP_NAME).getValue())
-               .append("-")
-               .append(propertiesDictionary.get(DeviceBundleAppProperties.APP_VERSION).getValue());
+                .append("-")
+                .append(propertiesDictionary.get(DeviceBundleAppProperties.APP_VERSION).getValue());
 
         kuraRequestChannel.setAppId(appIdSb.toString());
         kuraRequestChannel.setMethod(MethodDictionaryKapuaKura.get(kapuaChannel.getMethod()));
@@ -105,30 +100,28 @@ public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessag
         // Build resources
         List<String> resources = new ArrayList<>();
         switch (kapuaChannel.getMethod()) {
-            case READ:
-                resources.add("bundles");
-                break;
-            case EXECUTE:
-            {
-                if (kapuaChannel.isStart()) {
-                    resources.add("start");
-                }
-                else {
-                    resources.add("stop");
-                }
-
-                String bundleId = kapuaChannel.getBundleId();
-                if (bundleId != null) {
-                    resources.add(bundleId);
-                }
+        case READ:
+            resources.add("bundles");
+            break;
+        case EXECUTE: {
+            if (kapuaChannel.isStart()) {
+                resources.add("start");
+            } else {
+                resources.add("stop");
             }
-                break;
-            case CREATE:
-            case DELETE:
-            case OPTIONS:
-            case WRITE:
-            default:
-                break;
+
+            String bundleId = kapuaChannel.getBundleId();
+            if (bundleId != null) {
+                resources.add(bundleId);
+            }
+        }
+            break;
+        case CREATE:
+        case DELETE:
+        case OPTIONS:
+        case WRITE:
+        default:
+            break;
 
         }
         kuraRequestChannel.setResources(resources.toArray(new String[resources.size()]));
@@ -139,8 +132,7 @@ public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessag
     }
 
     private KuraRequestPayload translate(BundleRequestPayload kapuaPayload)
-        throws KapuaException
-    {
+            throws KapuaException {
         KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
 
         if (kapuaPayload.getBody() != null) {
@@ -151,14 +143,12 @@ public class TranslatorAppBundleKapuaKura extends Translator<BundleRequestMessag
     }
 
     @Override
-    public Class<BundleRequestMessage> getClassFrom()
-    {
+    public Class<BundleRequestMessage> getClassFrom() {
         return BundleRequestMessage.class;
     }
 
     @Override
-    public Class<KuraRequestMessage> getClassTo()
-    {
+    public Class<KuraRequestMessage> getClassTo() {
         return KuraRequestMessage.class;
     }
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppCommandKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppCommandKapuaKura.java
@@ -39,16 +39,15 @@ import org.eclipse.kapua.translator.Translator;
  * @since 1.0
  *
  */
-public class TranslatorAppCommandKapuaKura extends Translator<CommandRequestMessage, KuraRequestMessage>
-{
-    private static final String                              CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
+public class TranslatorAppCommandKapuaKura extends Translator<CommandRequestMessage, KuraRequestMessage> {
+
+    private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
     private static Map<CommandAppProperties, CommandMetrics> propertiesDictionary;
 
     /**
      * Constructor
      */
-    public TranslatorAppCommandKapuaKura()
-    {
+    public TranslatorAppCommandKapuaKura() {
         propertiesDictionary = new HashMap<>();
 
         propertiesDictionary.put(CommandAppProperties.APP_NAME, CommandMetrics.APP_ID);
@@ -66,9 +65,7 @@ public class TranslatorAppCommandKapuaKura extends Translator<CommandRequestMess
     }
 
     @Override
-    public KuraRequestMessage translate(CommandRequestMessage kapuaMessage)
-        throws KapuaException
-    {
+    public KuraRequestMessage translate(CommandRequestMessage kapuaMessage) throws KapuaException {
         //
         // Kura channel
         KapuaLocator locator = KapuaLocator.getInstance();
@@ -77,7 +74,7 @@ public class TranslatorAppCommandKapuaKura extends Translator<CommandRequestMess
 
         DeviceRegistryService deviceService = locator.getService(DeviceRegistryService.class);
         Device device = deviceService.find(kapuaMessage.getScopeId(),
-                                           kapuaMessage.getDeviceId());
+                kapuaMessage.getDeviceId());
 
         KuraRequestChannel kuraRequestChannel = translate(kapuaMessage.getChannel());
         kuraRequestChannel.setScope(account.getName());
@@ -90,21 +87,19 @@ public class TranslatorAppCommandKapuaKura extends Translator<CommandRequestMess
         //
         // return Kura Message
         return new KuraRequestMessage(kuraRequestChannel,
-                                      kapuaMessage.getReceivedOn(),
-                                      kuraPayload);
+                kapuaMessage.getReceivedOn(),
+                kuraPayload);
     }
 
-    private KuraRequestChannel translate(CommandRequestChannel kapuaChannel)
-        throws KapuaException
-    {
+    private KuraRequestChannel translate(CommandRequestChannel kapuaChannel) throws KapuaException {
         KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 
         // Build appId
         StringBuilder appIdSb = new StringBuilder();
         appIdSb.append(propertiesDictionary.get(CommandAppProperties.APP_NAME).getValue())
-               .append("-")
-               .append(propertiesDictionary.get(CommandAppProperties.APP_VERSION).getValue());
+                .append("-")
+                .append(propertiesDictionary.get(CommandAppProperties.APP_VERSION).getValue());
 
         kuraRequestChannel.setAppId(appIdSb.toString());
         kuraRequestChannel.setMethod(MethodDictionaryKapuaKura.get(kapuaChannel.getMethod()));
@@ -116,8 +111,7 @@ public class TranslatorAppCommandKapuaKura extends Translator<CommandRequestMess
     }
 
     private KuraRequestPayload translate(CommandRequestPayload kapuaPayload)
-        throws KapuaException
-    {
+            throws KapuaException {
         KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
 
         //
@@ -150,14 +144,12 @@ public class TranslatorAppCommandKapuaKura extends Translator<CommandRequestMess
     }
 
     @Override
-    public Class<CommandRequestMessage> getClassFrom()
-    {
+    public Class<CommandRequestMessage> getClassFrom() {
         return CommandRequestMessage.class;
     }
 
     @Override
-    public Class<KuraRequestMessage> getClassTo()
-    {
+    public Class<KuraRequestMessage> getClassTo() {
         return KuraRequestMessage.class;
     }
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppConfigurationKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppConfigurationKapuaKura.java
@@ -62,16 +62,15 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
  * @since 1.0
  *
  */
-public class TranslatorAppConfigurationKapuaKura extends Translator<ConfigurationRequestMessage, KuraRequestMessage>
-{
-    private static final String                                          CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
+public class TranslatorAppConfigurationKapuaKura extends Translator<ConfigurationRequestMessage, KuraRequestMessage> {
+
+    private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
     private static Map<DeviceConfigurationAppProperties, ConfigurationMetrics> propertiesDictionary;
 
     /**
      * Constructor
      */
-    public TranslatorAppConfigurationKapuaKura()
-    {
+    public TranslatorAppConfigurationKapuaKura() {
         propertiesDictionary = new HashMap<>();
 
         propertiesDictionary.put(DeviceConfigurationAppProperties.APP_NAME, ConfigurationMetrics.APP_ID);
@@ -79,9 +78,7 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
     }
 
     @Override
-    public KuraRequestMessage translate(ConfigurationRequestMessage kapuaMessage)
-        throws KapuaException
-    {
+    public KuraRequestMessage translate(ConfigurationRequestMessage kapuaMessage) throws KapuaException {
         //
         // Kura channel
         KapuaLocator locator = KapuaLocator.getInstance();
@@ -90,7 +87,7 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
 
         DeviceRegistryService deviceService = locator.getService(DeviceRegistryService.class);
         Device device = deviceService.find(kapuaMessage.getScopeId(),
-                                           kapuaMessage.getDeviceId());
+                kapuaMessage.getDeviceId());
 
         KuraRequestChannel kuraRequestChannel = translate(kapuaMessage.getChannel());
         kuraRequestChannel.setScope(account.getName());
@@ -103,21 +100,19 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
         //
         // Return Kura Message
         return new KuraRequestMessage(kuraRequestChannel,
-                                      kapuaMessage.getReceivedOn(),
-                                      kuraPayload);
+                kapuaMessage.getReceivedOn(),
+                kuraPayload);
     }
 
-    private KuraRequestChannel translate(ConfigurationRequestChannel kapuaChannel)
-        throws KapuaException
-    {
+    private KuraRequestChannel translate(ConfigurationRequestChannel kapuaChannel) throws KapuaException {
         KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 
         // Build appId
         StringBuilder appIdSb = new StringBuilder();
         appIdSb.append(propertiesDictionary.get(DeviceConfigurationAppProperties.APP_NAME).getValue())
-               .append("-")
-               .append(propertiesDictionary.get(DeviceConfigurationAppProperties.APP_VERSION).getValue());
+                .append("-")
+                .append(propertiesDictionary.get(DeviceConfigurationAppProperties.APP_VERSION).getValue());
 
         kuraRequestChannel.setAppId(appIdSb.toString());
         kuraRequestChannel.setMethod(MethodDictionaryKapuaKura.get(kapuaChannel.getMethod()));
@@ -130,8 +125,7 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
             if (componentId != null) {
                 resources.add(componentId);
             }
-        }
-        else if (kapuaChannel.getConfigurationId() != null) {
+        } else if (kapuaChannel.getConfigurationId() != null) {
             resources.add("snapshots");
 
             String configurationId = kapuaChannel.getConfigurationId();
@@ -147,20 +141,18 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
     }
 
     private KuraRequestPayload translate(ConfigurationRequestPayload kapuaPayload)
-        throws KapuaException
-    {
+            throws KapuaException {
         KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
 
         if (kapuaPayload.getBody() != null) {
             DeviceConfiguration kapuaDeviceConfiguration;
             try {
                 kapuaDeviceConfiguration = XmlUtil.unmarshal(new String(kapuaPayload.getBody()),
-                                                             DeviceConfigurationImpl.class);
-            }
-            catch (Exception e) {
+                        DeviceConfigurationImpl.class);
+            } catch (Exception e) {
                 throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD,
-                                              e,
-                                              kapuaPayload.getBody());
+                        e,
+                        kapuaPayload.getBody());
             }
 
             KuraDeviceConfiguration kuraDeviceConfiguration = translate(kapuaDeviceConfiguration);
@@ -168,11 +160,10 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
             byte[] body;
             try {
                 body = XmlUtil.marshal(kuraDeviceConfiguration).getBytes();
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD,
-                                              e,
-                                              kapuaPayload.getBody());
+                        e,
+                        kapuaPayload.getBody());
             }
 
             kuraRequestPayload.setBody(body);
@@ -184,8 +175,7 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
     }
 
     private KuraDeviceConfiguration translate(DeviceConfiguration kapuaDeviceConfiguration)
-        throws KapuaException
-    {
+            throws KapuaException {
         KuraDeviceConfiguration kuraDeviceConfiguration = new KuraDeviceConfiguration();
 
         for (DeviceComponentConfiguration kapuaDeviceCompConf : kapuaDeviceConfiguration.getComponentConfigurations()) {
@@ -206,8 +196,7 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
         return kuraDeviceConfiguration;
     }
 
-    private KapuaTocd translate(KapuaTocd kapuaDefinition)
-    {
+    private KapuaTocd translate(KapuaTocd kapuaDefinition) {
         TocdImpl definition = new TocdImpl();
 
         definition.setId(kapuaDefinition.getId());
@@ -237,7 +226,7 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
 
             for (Entry<QName, String> entry : kapuaAd.getOtherAttributes().entrySet()) {
                 ad.putOtherAttribute(entry.getKey(),
-                                     entry.getValue());
+                        entry.getValue());
             }
 
             definition.addAD(ad);
@@ -257,14 +246,13 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
 
         for (Entry<QName, String> entry : kapuaDefinition.getOtherAttributes().entrySet()) {
             definition.putOtherAttribute(entry.getKey(),
-                                         entry.getValue());
+                    entry.getValue());
         }
 
         return definition;
     }
 
-    private Map<String, Object> translate(Map<String, Object> kapuaProperties)
-    {
+    private Map<String, Object> translate(Map<String, Object> kapuaProperties) {
         Map<String, Object> properties = new HashMap<>();
         for (Entry<String, Object> entry : kapuaProperties.entrySet()) {
             Object value = entry.getValue();
@@ -273,8 +261,7 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
             // Special management of Password type field
             if (value instanceof Password) {
                 value = new KuraPassword(((Password) value).getPassword());
-            }
-            else if (value instanceof Password[]) {
+            } else if (value instanceof Password[]) {
                 Password[] passwords = (Password[]) value;
                 KuraPassword[] kuraPasswords = new KuraPassword[passwords.length];
 
@@ -289,20 +276,18 @@ public class TranslatorAppConfigurationKapuaKura extends Translator<Configuratio
             //
             // Set property
             properties.put(entry.getKey(),
-                           value);
+                    value);
         }
         return properties;
     }
 
     @Override
-    public Class<ConfigurationRequestMessage> getClassFrom()
-    {
+    public Class<ConfigurationRequestMessage> getClassFrom() {
         return ConfigurationRequestMessage.class;
     }
 
     @Override
-    public Class<KuraRequestMessage> getClassTo()
-    {
+    public Class<KuraRequestMessage> getClassTo() {
         return KuraRequestMessage.class;
     }
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppPackageKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppPackageKapuaKura.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *
  *******************************************************************************/
 package org.eclipse.kapua.translator.kapua.kura;
@@ -18,10 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.account.Account;
-import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.device.call.kura.app.PackageMetrics;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestChannel;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestMessage;
@@ -32,9 +30,6 @@ import org.eclipse.kapua.service.device.management.packages.message.internal.Pac
 import org.eclipse.kapua.service.device.management.packages.message.internal.PackageRequestChannel;
 import org.eclipse.kapua.service.device.management.packages.message.internal.PackageRequestMessage;
 import org.eclipse.kapua.service.device.management.packages.message.internal.PackageRequestPayload;
-import org.eclipse.kapua.service.device.registry.Device;
-import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
-import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link PackageRequestMessage} to {@link KuraRequestMessage}
@@ -42,17 +37,12 @@ import org.eclipse.kapua.translator.Translator;
  * @since 1.0
  *
  */
-public class TranslatorAppPackageKapuaKura extends Translator<PackageRequestMessage, KuraRequestMessage> {
+public class TranslatorAppPackageKapuaKura extends AbstractTranslatorKapuaKura<PackageRequestChannel, PackageRequestPayload, PackageRequestMessage> {
 
     private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
-    private static Map<PackageAppProperties, PackageMetrics> propertiesDictionary;
+    private static final Map<PackageAppProperties, PackageMetrics> propertiesDictionary = new HashMap<>();
 
-    /**
-     * Constructor
-     */
-    public TranslatorAppPackageKapuaKura() {
-        propertiesDictionary = new HashMap<>();
-
+    static {
         propertiesDictionary.put(PackageAppProperties.APP_NAME, PackageMetrics.APP_ID);
         propertiesDictionary.put(PackageAppProperties.APP_VERSION, PackageMetrics.APP_VERSION);
 
@@ -77,34 +67,8 @@ public class TranslatorAppPackageKapuaKura extends Translator<PackageRequestMess
 
     }
 
-    @Override
-    public KuraRequestMessage translate(PackageRequestMessage kapuaMessage) throws KapuaException {
-        //
-        // Kura channel
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AccountService accountService = locator.getService(AccountService.class);
-        Account account = accountService.find(kapuaMessage.getScopeId());
 
-        DeviceRegistryService deviceService = locator.getService(DeviceRegistryService.class);
-        Device device = deviceService.find(kapuaMessage.getScopeId(),
-                kapuaMessage.getDeviceId());
-
-        KuraRequestChannel kuraRequestChannel = translate(kapuaMessage.getChannel());
-        kuraRequestChannel.setScope(account.getName());
-        kuraRequestChannel.setClientId(device.getClientId());
-
-        //
-        // Kura payload
-        KuraRequestPayload kuraPayload = translate(kapuaMessage.getPayload());
-
-        //
-        // Return Kura Message
-        return new KuraRequestMessage(kuraRequestChannel,
-                kapuaMessage.getReceivedOn(),
-                kuraPayload);
-    }
-
-    private KuraRequestChannel translate(PackageRequestChannel kapuaChannel) throws KapuaException {
+    protected KuraRequestChannel translateChannel(PackageRequestChannel kapuaChannel) throws KapuaException {
         KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 
@@ -141,8 +105,7 @@ public class TranslatorAppPackageKapuaKura extends Translator<PackageRequestMess
         return kuraRequestChannel;
     }
 
-    private KuraRequestPayload translate(PackageRequestPayload kapuaPayload)
-            throws KapuaException {
+    protected KuraRequestPayload translatePayload(PackageRequestPayload kapuaPayload) throws KapuaException {
         KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
 
         Map<String, Object> metrics = kuraRequestPayload.getMetrics();

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppPackageKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppPackageKapuaKura.java
@@ -78,8 +78,7 @@ public class TranslatorAppPackageKapuaKura extends Translator<PackageRequestMess
     }
 
     @Override
-    public KuraRequestMessage translate(PackageRequestMessage kapuaMessage)
-            throws KapuaException {
+    public KuraRequestMessage translate(PackageRequestMessage kapuaMessage) throws KapuaException {
         //
         // Kura channel
         KapuaLocator locator = KapuaLocator.getInstance();
@@ -105,8 +104,7 @@ public class TranslatorAppPackageKapuaKura extends Translator<PackageRequestMess
                 kuraPayload);
     }
 
-    private KuraRequestChannel translate(PackageRequestChannel kapuaChannel)
-            throws KapuaException {
+    private KuraRequestChannel translate(PackageRequestChannel kapuaChannel) throws KapuaException {
         KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppSnapshotKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppSnapshotKapuaKura.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *
  *******************************************************************************/
 package org.eclipse.kapua.translator.kapua.kura;
@@ -18,9 +19,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.service.account.Account;
-import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.device.call.kura.app.SnapshotMetrics;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestChannel;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestMessage;
@@ -31,9 +29,6 @@ import org.eclipse.kapua.service.device.management.configuration.snapshot.intern
 import org.eclipse.kapua.service.device.management.configuration.snapshot.internal.SnapshotRequestMessage;
 import org.eclipse.kapua.service.device.management.configuration.snapshot.internal.SnapshotRequestPayload;
 import org.eclipse.kapua.service.device.management.snapshot.internal.DeviceSnapshotAppProperties;
-import org.eclipse.kapua.service.device.registry.Device;
-import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
-import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link SnapshotRequestMessage} to {@link KuraRequestMessage}
@@ -41,47 +36,16 @@ import org.eclipse.kapua.translator.Translator;
  * @since 1.0
  *
  */
-public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMessage, KuraRequestMessage> {
-
+public class TranslatorAppSnapshotKapuaKura extends AbstractTranslatorKapuaKura<SnapshotRequestChannel, SnapshotRequestPayload, SnapshotRequestMessage> {
     private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
-    private static Map<DeviceSnapshotAppProperties, SnapshotMetrics> propertiesDictionary;
+    private static final Map<DeviceSnapshotAppProperties, SnapshotMetrics> propertiesDictionary = new HashMap<>();
 
-    /**
-     * Constructor
-     */
-    public TranslatorAppSnapshotKapuaKura() {
-        propertiesDictionary = new HashMap<>();
-
+    static {
         propertiesDictionary.put(DeviceSnapshotAppProperties.APP_NAME, SnapshotMetrics.APP_ID);
         propertiesDictionary.put(DeviceSnapshotAppProperties.APP_VERSION, SnapshotMetrics.APP_VERSION);
     }
 
-    @Override
-    public KuraRequestMessage translate(SnapshotRequestMessage kapuaMessage) throws KapuaException {
-        //
-        // Kura channel
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AccountService accountService = locator.getService(AccountService.class);
-        Account account = accountService.find(kapuaMessage.getScopeId());
-
-        DeviceRegistryService deviceService = locator.getService(DeviceRegistryService.class);
-        Device device = deviceService.find(kapuaMessage.getScopeId(), kapuaMessage.getDeviceId());
-
-        KuraRequestChannel kuraRequestChannel = translate(kapuaMessage.getChannel());
-        kuraRequestChannel.setScope(account.getName());
-        kuraRequestChannel.setClientId(device.getClientId());
-
-        //
-        // Kura payload
-        KuraRequestPayload kuraPayload = translate(kapuaMessage.getPayload());
-
-        //
-        // Return Kura Message
-        return new KuraRequestMessage(kuraRequestChannel, kapuaMessage.getReceivedOn(), kuraPayload);
-
-    }
-
-    private KuraRequestChannel translate(SnapshotRequestChannel kapuaChannel) throws KapuaException {
+    protected KuraRequestChannel translateChannel(SnapshotRequestChannel kapuaChannel) throws KapuaException {
         KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 
@@ -124,8 +88,7 @@ public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMe
         return kuraRequestChannel;
     }
 
-    private KuraRequestPayload translate(SnapshotRequestPayload kapuaPayload)
-            throws KapuaException {
+    protected KuraRequestPayload translatePayload(SnapshotRequestPayload kapuaPayload) throws KapuaException {
         KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
 
         if (kapuaPayload.getBody() != null) {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppSnapshotKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppSnapshotKapuaKura.java
@@ -41,16 +41,15 @@ import org.eclipse.kapua.translator.Translator;
  * @since 1.0
  *
  */
-public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMessage, KuraRequestMessage>
-{
-    private static final String                                CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
+public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMessage, KuraRequestMessage> {
+
+    private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
     private static Map<DeviceSnapshotAppProperties, SnapshotMetrics> propertiesDictionary;
 
     /**
      * Constructor
      */
-    public TranslatorAppSnapshotKapuaKura()
-    {
+    public TranslatorAppSnapshotKapuaKura() {
         propertiesDictionary = new HashMap<>();
 
         propertiesDictionary.put(DeviceSnapshotAppProperties.APP_NAME, SnapshotMetrics.APP_ID);
@@ -58,9 +57,7 @@ public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMe
     }
 
     @Override
-    public KuraRequestMessage translate(SnapshotRequestMessage kapuaMessage)
-        throws KapuaException
-    {
+    public KuraRequestMessage translate(SnapshotRequestMessage kapuaMessage) throws KapuaException {
         //
         // Kura channel
         KapuaLocator locator = KapuaLocator.getInstance();
@@ -84,17 +81,15 @@ public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMe
 
     }
 
-    private KuraRequestChannel translate(SnapshotRequestChannel kapuaChannel)
-        throws KapuaException
-    {
+    private KuraRequestChannel translate(SnapshotRequestChannel kapuaChannel) throws KapuaException {
         KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 
         // Build appId
         StringBuilder appIdSb = new StringBuilder();
         appIdSb.append(propertiesDictionary.get(DeviceSnapshotAppProperties.APP_NAME).getValue())
-               .append("-")
-               .append(propertiesDictionary.get(DeviceSnapshotAppProperties.APP_VERSION).getValue());
+                .append("-")
+                .append(propertiesDictionary.get(DeviceSnapshotAppProperties.APP_VERSION).getValue());
 
         kuraRequestChannel.setAppId(appIdSb.toString());
 
@@ -103,18 +98,18 @@ public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMe
         // Build resources
         List<String> resources = new ArrayList<>();
         switch (kapuaChannel.getMethod()) {
-            case EXECUTE:
-                resources.add("rollback");
-                break;
-            case READ:
-                resources.add("snapshots");
-                break;
-            case CREATE:
-            case DELETE:
-            case OPTIONS:
-            case WRITE:
-            default:
-                break;
+        case EXECUTE:
+            resources.add("rollback");
+            break;
+        case READ:
+            resources.add("snapshots");
+            break;
+        case CREATE:
+        case DELETE:
+        case OPTIONS:
+        case WRITE:
+        default:
+            break;
 
         }
 
@@ -130,8 +125,7 @@ public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMe
     }
 
     private KuraRequestPayload translate(SnapshotRequestPayload kapuaPayload)
-        throws KapuaException
-    {
+            throws KapuaException {
         KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
 
         if (kapuaPayload.getBody() != null) {
@@ -144,14 +138,12 @@ public class TranslatorAppSnapshotKapuaKura extends Translator<SnapshotRequestMe
     }
 
     @Override
-    public Class<SnapshotRequestMessage> getClassFrom()
-    {
+    public Class<SnapshotRequestMessage> getClassFrom() {
         return SnapshotRequestMessage.class;
     }
 
     @Override
-    public Class<KuraRequestMessage> getClassTo()
-    {
+    public Class<KuraRequestMessage> getClassTo() {
         return KuraRequestMessage.class;
     }
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorDataKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorDataKapuaKura.java
@@ -38,13 +38,11 @@ import org.eclipse.kapua.translator.Translator;
  *
  */
 @SuppressWarnings("rawtypes")
-public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessage>
-{
+public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessage> {
 
     @Override
     public KuraMessage translate(KapuaMessage kapuaMessage)
-        throws KapuaException
-    {
+            throws KapuaException {
         //
         // Kura channel
         KuraChannel kuraChannel = translate(kapuaMessage.getChannel());
@@ -55,7 +53,7 @@ public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessag
 
         Account account = accountService.find(kapuaMessage.getScopeId());
         Device device = deviceRegistryService.find(account.getId(),
-                                                   kapuaMessage.getDeviceId());
+                kapuaMessage.getDeviceId());
 
         kuraChannel.setScope(account.getName());
         kuraChannel.setClientId(device.getClientId());
@@ -68,13 +66,11 @@ public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessag
         //
         // Kura Message
         return new KuraMessage<KuraChannel, KuraPayload>(kuraChannel,
-                                                         new Date(),
-                                                         kuraPayload);
+                new Date(),
+                kuraPayload);
     }
 
-    private KuraDataChannel translate(KapuaChannel kapuaChannel)
-        throws KapuaException
-    {
+    private KuraDataChannel translate(KapuaChannel kapuaChannel) throws KapuaException {
         KuraDataChannel kuraChannel = new KuraDataChannel();
         kuraChannel.setSemanticChannelParts(kapuaChannel.getSemanticParts());
 
@@ -83,9 +79,7 @@ public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessag
         return kuraChannel;
     }
 
-    private KuraPayload translate(KapuaPayload kapuaPayload)
-        throws KapuaException
-    {
+    private KuraPayload translate(KapuaPayload kapuaPayload) throws KapuaException {
         KuraPayload kuraPayload = new KuraPayload();
         kuraPayload.getMetrics().putAll(kapuaPayload.getProperties());
         kuraPayload.setBody(kapuaPayload.getBody());
@@ -95,8 +89,7 @@ public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessag
         return kuraPayload;
     }
 
-    private KuraPosition translate(KapuaPosition position)
-    {
+    private KuraPosition translate(KapuaPosition position) {
         KuraPosition kuraPosition = new KuraPosition();
 
         kuraPosition.setAltitude(position.getAltitude());
@@ -115,14 +108,12 @@ public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessag
     }
 
     @Override
-    public Class<KapuaMessage> getClassFrom()
-    {
+    public Class<KapuaMessage> getClassFrom() {
         return KapuaMessage.class;
     }
 
     @Override
-    public Class<KuraMessage> getClassTo()
-    {
+    public Class<KuraMessage> getClassTo() {
         return KuraMessage.class;
     }
 


### PR DESCRIPTION
This change does provide a common translator implementation which
reduces the amount of duplicate code. All but one translators could
be covered by this approach.

Signed-off-by: Jens Reimann <jreimann@redhat.com>
