### PR TITLE
Re-implement gzip compression with existing methods

### DIFF
--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/utils/GZIPUtils.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/utils/GZIPUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.message.kura.utils;
@@ -15,8 +16,12 @@ package org.eclipse.kapua.service.device.call.message.kura.utils;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+
+import com.google.common.io.ByteSource;
+import com.google.common.io.ByteStreams;
 
 /**
  * Gzip utilities.
@@ -25,6 +30,9 @@ import java.util.zip.GZIPOutputStream;
  *
  */
 public class GZIPUtils {
+
+    private GZIPUtils() {
+    }
 
     /**
      * Check if the byte array represents compressed data
@@ -41,72 +49,41 @@ public class GZIPUtils {
     }
 
     /**
-     * Returns the compressed provided data
+     * Compress provided data with GZIP
      *
      * @param source
+     *            the input data to compress
      * @return
+     *         the compressed output data, returns {@code null} if the input was {@code null}
      * @throws IOException
+     *             in case of an I/O error
      */
     public static byte[] compress(byte[] source) throws IOException {
-
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        GZIPOutputStream gzipos = null;
-        try {
-            gzipos = new GZIPOutputStream(baos);
-            gzipos.write(source);
-        } catch (IOException e) {
-            throw e;
-        } finally {
-            if (gzipos != null) {
-                try {
-                    gzipos.close();
-                } catch (IOException e) {
-                    // Ignore
-                }
-            }
+        if (source == null) {
+            return null;
         }
-        return baos.toByteArray();
+
+        final ByteArrayOutputStream result = new ByteArrayOutputStream();
+        try (final OutputStream out = new GZIPOutputStream(result)) {
+            ByteSource.wrap(source).copyTo(out);
+        }
+        return result.toByteArray();
     }
 
     /**
-     * Returns the decompressed provided data
+     * Uncompress GZIP compressed data
      *
      * @param source
-     * @return
+     *            the data to uncompress
+     * @return the uncompressed data, returns {@code null} if the input was {@code null}
      * @throws IOException
+     *             in case of an I/O error
      */
     public static byte[] decompress(byte[] source) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ByteArrayInputStream bais = new ByteArrayInputStream(source);
-        GZIPInputStream gzipis = null;
-
-        try {
-            gzipis = new GZIPInputStream(bais);
-
-            int n;
-            final int MAX_BUF = 1024;
-            byte[] buf = new byte[MAX_BUF];
-            while ((n = gzipis.read(buf, 0, MAX_BUF)) != -1) {
-                baos.write(buf, 0, n);
-            }
-        } catch (IOException e) {
-            throw e;
-        } finally {
-            if (gzipis != null) {
-                try {
-                    gzipis.close();
-                } catch (IOException e) {
-                    // Ignore
-                }
-            }
-
-            try {
-                baos.close();
-            } catch (IOException e) {
-                // Ignore
-            }
+        if (source == null) {
+            return null;
         }
 
-        return baos.toByteArray();
+        return ByteStreams.toByteArray(new GZIPInputStream(new ByteArrayInputStream(source)));
     }
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/utils/GZIPUtils.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/utils/GZIPUtils.java
@@ -20,55 +20,47 @@ import java.util.zip.GZIPOutputStream;
 
 /**
  * Gzip utilities.
- * 
+ *
  * @since 1.0
  *
  */
-public class GZIPUtils
-{
+public class GZIPUtils {
 
     /**
      * Check if the byte array represents compressed data
-     * 
+     *
      * @param bytes
      * @return
      */
-    public static boolean isCompressed(byte[] bytes)
-    {
-        if ((bytes == null) || (bytes.length < 2)) {
+    public static boolean isCompressed(byte[] bytes) {
+        if (bytes == null || bytes.length < 2) {
             return false;
-        }
-        else {
-            return ((bytes[0] == (byte) (GZIPInputStream.GZIP_MAGIC)) && (bytes[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8)));
+        } else {
+            return bytes[0] == (byte) GZIPInputStream.GZIP_MAGIC && bytes[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8);
         }
     }
 
     /**
      * Returns the compressed provided data
-     * 
+     *
      * @param source
      * @return
      * @throws IOException
      */
-    public static byte[] compress(byte[] source)
-        throws IOException
-    {
+    public static byte[] compress(byte[] source) throws IOException {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         GZIPOutputStream gzipos = null;
         try {
             gzipos = new GZIPOutputStream(baos);
             gzipos.write(source);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw e;
-        }
-        finally {
+        } finally {
             if (gzipos != null) {
                 try {
                     gzipos.close();
-                }
-                catch (IOException e) {
+                } catch (IOException e) {
                     // Ignore
                 }
             }
@@ -78,14 +70,12 @@ public class GZIPUtils
 
     /**
      * Returns the decompressed provided data
-     * 
+     *
      * @param source
      * @return
      * @throws IOException
      */
-    public static byte[] decompress(byte[] source)
-        throws IOException
-    {
+    public static byte[] decompress(byte[] source) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ByteArrayInputStream bais = new ByteArrayInputStream(source);
         GZIPInputStream gzipis = null;
@@ -99,24 +89,20 @@ public class GZIPUtils
             while ((n = gzipis.read(buf, 0, MAX_BUF)) != -1) {
                 baos.write(buf, 0, n);
             }
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw e;
-        }
-        finally {
+        } finally {
             if (gzipis != null) {
                 try {
                     gzipis.close();
-                }
-                catch (IOException e) {
+                } catch (IOException e) {
                     // Ignore
                 }
             }
 
             try {
                 baos.close();
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 // Ignore
             }
         }


### PR DESCRIPTION
This change leverages guava to perform the IO functionality in order to
keep the code readable and re-use existing functionality.

---

This PR is again split up in two commits, one for the code formatter and the second containing the actual change.