### PR TITLE
Help IntelliJ IDEA Maven auto import feature

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -6,7 +6,7 @@
     Eurotech - initial API and implementation -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM file generated with GWT webAppCreator -->
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -223,6 +223,7 @@
 
     <build>
         <finalName>console</finalName>
+
         <!-- 
         <outputDirectory>${webappDirectory}/WEB-INF/classes</outputDirectory>  -->
 
@@ -249,15 +250,15 @@
 
                     <extraJvmArgs>-Xmx2048m -XX:+UseParallelGC</extraJvmArgs>
                     <hostedWebapp>${webappDirectory}</hostedWebapp>
-                    
+
                     <i18nConstantsWithLookupBundle>org.eclipse.kapua.app.console.client.messages.ValidationMessages</i18nConstantsWithLookupBundle>
                     <i18nMessagesBundles>
                         <i18nMessagesBundle>org.eclipse.kapua.app.console.client.messages.ConsoleMessages</i18nMessagesBundle>
                         <i18nMessagesBundle>org.eclipse.kapua.app.console.client.messages.ConsoleRoleMessages</i18nMessagesBundle>
-						<i18nMessagesBundle>org.eclipse.kapua.app.console.client.messages.ConsoleUserMessages</i18nMessagesBundle>
+                        <i18nMessagesBundle>org.eclipse.kapua.app.console.client.messages.ConsoleUserMessages</i18nMessagesBundle>
                         <i18nMessagesBundle>org.eclipse.kapua.app.console.client.messages.ConsoleWelcomeMessages</i18nMessagesBundle>
                     </i18nMessagesBundles>
-                    
+
                     <optimizationLevel>9</optimizationLevel>
                     <runTarget>console.jsp</runTarget>
                     <webappDirectory>${project.build.directory}</webappDirectory>
@@ -323,10 +324,10 @@
                             <target>
                                 <echo>Openlayers: copy resources to webapp output folder</echo>
                                 <copy
-                                    todir="${project.build.directory}/${project.build.finalName}">
+                                        todir="${project.build.directory}/${project.build.finalName}">
                                     <fileset
-                                        dir="${project.build.directory}/tmp/openlayers-${openlayers.version}/META-INF/resources/webjars/">
-                                        <exclude name="**/OpenLayers.*.js" />
+                                            dir="${project.build.directory}/tmp/openlayers-${openlayers.version}/META-INF/resources/webjars/">
+                                        <exclude name="**/OpenLayers.*.js"/>
                                     </fileset>
                                 </copy>
                             </target>
@@ -342,14 +343,15 @@
                             <target>
                                 <echo>Openlayers: customize openlayers 'ImgPath' variable</echo>
                                 <replaceregexp byline="true"
-                                    file="${project.build.directory}/${project.build.finalName}/openlayers/${openlayers.version}/OpenLayers.js"
-                                    match="ImgPath:&quot;&quot;"
-                                    replace="ImgPath:&quot;openlayers/${openlayers.version}/img/&quot;" />
+                                               file="${project.build.directory}/${project.build.finalName}/openlayers/${openlayers.version}/OpenLayers.js"
+                                               match="ImgPath:&quot;&quot;"
+                                               replace="ImgPath:&quot;openlayers/${openlayers.version}/img/&quot;"/>
                             </target>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+
         </plugins>
 
         <pluginManagement>
@@ -374,7 +376,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore />
+                                        <ignore/>
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -387,7 +389,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore />
+                                        <ignore/>
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -401,11 +403,27 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore />
+                                        <ignore/>
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+
+                <!-- To help IntelliJ IDEA correctly recognize the source path when using Maven Auto Import -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <configuration>
+                        <webResources>
+                            <resource>
+                                <directory>
+                                    ${project.build.directory}/${project.build.finalName}
+                                </directory>
+                            </resource>
+                        </webResources>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
When importing web applications in IntelliJ IDEA, the IDE assumes that
the web root is on <project>/src/main/webapp. By adding the
configuration for the maven-war-plugin, and specifically the
<webResources> section, will improve its auto import feature and
always configure the correct web root. This is particularly useful when
Maven Auto Import feature of IntelliJ IDEA is enabled, who will
reconfigure the web root every time the pom.xml is reloaded, including
the execution of the clean goal.