### PR TITLE
Resloving issue with translateChannel NPE (#279)

### DIFF
--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppConfigurationKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppConfigurationKapuaKura.java
@@ -63,6 +63,7 @@ public class TranslatorAppConfigurationKapuaKura extends AbstractTranslatorKapua
     private static final Map<DeviceConfigurationAppProperties, ConfigurationMetrics> propertiesDictionary = new HashMap<>();
 
     static {
+        propertiesDictionary.put(DeviceConfigurationAppProperties.APP_NAME, ConfigurationMetrics.APP_ID);
         propertiesDictionary.put(DeviceConfigurationAppProperties.APP_VERSION, ConfigurationMetrics.APP_VERSION);
     }
 


### PR DESCRIPTION
APP_NAME was removed from static initialiser and was causing NPE in translateChannel method.

@ctron Please check if fix is appropriate

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>