### PR TITLE
A set of OpenShift tweaks

### DIFF
--- a/dev-tools/src/main/openshift/liquibase_job.yml
+++ b/dev-tools/src/main/openshift/liquibase_job.yml
@@ -10,10 +10,7 @@ spec:
       name: liquibase
     spec:
       containers:
-      - env:
-        - name: SQL_SERVICE_HOST
-          value: sql # The name of the SVC instance
-        name: liquibase
+      - name: liquibase
         image: kapua/kapua-liquibase:latest
       restartPolicy: Never
 

--- a/dev-tools/src/main/openshift/openshift-deploy.sh
+++ b/dev-tools/src/main/openshift/openshift-deploy.sh
@@ -55,7 +55,7 @@ echo SQL database created
 echo Creating broker
 
 oc new-app ${DOCKER_ACCOUNT}/kapua-broker:latest -name=kapua-broker -n "$OPENSHIFT_PROJECT_NAME" '-eACTIVEMQ_OPTS=-Dcommons.db.connection.host=localhost -Dcommons.db.connection.port=3306 -Dcommons.db.schema='
-oc set probe dc/kapua-broker --readiness --open-tcp=1883
+oc set probe dc/kapua-broker --readiness --initial-delay-seconds=15 --open-tcp=1883
 
 echo Broker created
 
@@ -65,7 +65,7 @@ echo Broker created
 echo Creating web console
 
 oc new-app ${DOCKER_ACCOUNT}/kapua-console:latest -n "$OPENSHIFT_PROJECT_NAME" '-eCATALINA_OPTS=-Dcommons.db.connection.host=localhost -Dcommons.db.connection.port=3306 -Dcommons.db.schema='
-oc set probe dc/kapua-console --readiness --liveness --initial-delay-seconds=30 --get-url=http://:8080/console
+oc set probe dc/kapua-console --readiness --liveness --initial-delay-seconds=30 --timeout-seconds=10 --get-url=http://:8080/console
 
 echo Web console created
 
@@ -74,7 +74,7 @@ echo Web console created
 echo 'Creating Rest API'
 
 oc new-app ${DOCKER_ACCOUNT}/kapua-api:latest -n "$OPENSHIFT_PROJECT_NAME" '-eCATALINA_OPTS=-Dcommons.db.connection.host=localhost -Dcommons.db.connection.port=3306 -Dcommons.db.schema='
-oc set probe dc/kapua-api --readiness --liveness --initial-delay-seconds=30 --get-url=http://:8080/api
+oc set probe dc/kapua-api --readiness --liveness --initial-delay-seconds=30 --timeout-seconds=10 --get-url=http://:8080/api
 
 echo 'Rest API created'
 

--- a/dev-tools/src/main/openshift/openshift-deploy.sh
+++ b/dev-tools/src/main/openshift/openshift-deploy.sh
@@ -54,7 +54,8 @@ echo SQL database created
 
 echo Creating broker
 
-oc new-app ${DOCKER_ACCOUNT}/kapua-broker:latest -name=kapua-broker -n "$OPENSHIFT_PROJECT_NAME" '-eACTIVEMQ_OPTS=-Dcommons.db.connection.host=localhost -Dcommons.db.connection.port=3306 -Dcommons.db.schema='
+oc new-app ${DOCKER_ACCOUNT}/kapua-broker:latest -name=kapua-broker -n "$OPENSHIFT_PROJECT_NAME" \
+   '-eACTIVEMQ_OPTS=-Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_SERVICE_PORT_3306_TCP -Dcommons.db.schema='
 oc set probe dc/kapua-broker --readiness --initial-delay-seconds=15 --open-tcp=1883
 
 echo Broker created
@@ -64,7 +65,8 @@ echo Broker created
 
 echo Creating web console
 
-oc new-app ${DOCKER_ACCOUNT}/kapua-console:latest -n "$OPENSHIFT_PROJECT_NAME" '-eCATALINA_OPTS=-Dcommons.db.connection.host=localhost -Dcommons.db.connection.port=3306 -Dcommons.db.schema='
+oc new-app ${DOCKER_ACCOUNT}/kapua-console:latest -n "$OPENSHIFT_PROJECT_NAME" \
+   '-eCATALINA_OPTS=-Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_SERVICE_PORT_3306_TCP -Dcommons.db.schema= -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST'
 oc set probe dc/kapua-console --readiness --liveness --initial-delay-seconds=30 --timeout-seconds=10 --get-url=http://:8080/console
 
 echo Web console created
@@ -73,7 +75,8 @@ echo Web console created
 
 echo 'Creating Rest API'
 
-oc new-app ${DOCKER_ACCOUNT}/kapua-api:latest -n "$OPENSHIFT_PROJECT_NAME" '-eCATALINA_OPTS=-Dcommons.db.connection.host=localhost -Dcommons.db.connection.port=3306 -Dcommons.db.schema='
+oc new-app ${DOCKER_ACCOUNT}/kapua-api:latest -n "$OPENSHIFT_PROJECT_NAME" \
+   '-eCATALINA_OPTS=-Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_SERVICE_PORT_3306_TCP -Dcommons.db.schema= -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST'
 oc set probe dc/kapua-api --readiness --liveness --initial-delay-seconds=30 --timeout-seconds=10 --get-url=http://:8080/api
 
 echo 'Rest API created'

--- a/dev-tools/src/main/openshift/readme.md
+++ b/dev-tools/src/main/openshift/readme.md
@@ -50,10 +50,19 @@ which provides entropy to the kernel.
 
 On CentOS 7 it can be installed with the following commands (all as `root`):
 
+    yum install epel-release # only if you 
     yum install haveged
     systemctl enable --now haveged
-    
+
+As the package comes from the [EPEL repositories](https://fedoraproject.org/wiki/EPEL "Information about EPEL").
+If you haven't yet enabled those repositories, then you need to do this before trying to
+install `haveged`:
+
+    yum install epel-release
+
 For more information about `haveged` see http://www.issihosts.com/haveged/
+
+For more information about the "EPEL repositories" see https://fedoraproject.org/wiki/EPEL
 
 ## Starting Kapua on OpenShift
 

--- a/dev-tools/src/main/openshift/readme.md
+++ b/dev-tools/src/main/openshift/readme.md
@@ -30,6 +30,31 @@ Don't forget to start OpenShift server, log into it and creating new project bef
     oc login --insecure-skip-tls-verify=true https://localhost:8443 -u admin -p admin
     oc new-project eclipse-kapua
 
+## Ensuring enough entropy
+
+It may happen that firing up docker containers and starting up application which use
+Java's `SecureRandom` (which happens in the next step a few times) run dry the Linux
+Kernel's entropy pool. The result is that some application will block during startup
+(even longer than 30 seconds) which will trigger OpenShift to kill the pods since they
+are considered unresponsive (which they actually are).
+
+You can check the amount of entropy the kernel has available with the following command:
+
+    cat /proc/sys/kernel/random/entropy_avail
+
+If this number drops to zero, then the kernel has run out of entropy and application will
+block.
+
+One solution (there are a few others) is to install `haveged` a user-space daemon
+which provides entropy to the kernel.
+
+On CentOS 7 it can be installed with the following commands (all as `root`):
+
+    yum install haveged
+    systemctl enable --now haveged
+    
+For more information about `haveged` see http://www.issihosts.com/haveged/
+
 ## Starting Kapua on OpenShift
 
 Execute the following command:


### PR DESCRIPTION
This PR provides a few tweaks for OpenShift:
* Added request timeouts and increased the initial timeout for the broker instance
* Use cluster IPs instead of `localhost`
* Add some documentation about entropy