### PR TITLE
Shrink docker images and use non-root users

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -575,6 +575,13 @@
 									<port>61614</port>
 								</ports>
 								<user>kapua</user>
+								<runCmds>
+									<run><![CDATA[
+									chown -R kapua:kapua /maven && \
+									chmod -R a+rw /maven && \
+									find /maven -type d -exec chmod a+x {} +
+									]]></run>
+								</runCmds>
 								<volumes>
 									<volume>/maven/data</volume>
 								</volumes>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -28,7 +28,7 @@
         <commons.pool.version>2.3</commons.pool.version>
 
 		<docker.account>kapua</docker.account>
-		<java.base.image>java:8u111</java.base.image>
+		<java.base.image>openjdk:8u111-jre-alpine</java.base.image>
     </properties>
 
 	<dependencies>
@@ -546,14 +546,26 @@
 				<configuration>
 					<images>
 						<image>
-							<name>${docker.account}/kapua-broker</name>
+							<name>${docker.account}/java-base</name>
 							<build>
 								<from>${java.base.image}</from>
+								<runCmds>
+									<runCmd>adduser -D -g "Eclipse Kapua" kapua</runCmd>
+								</runCmds>
+							</build>
+						</image>
+						<image>
+							<name>${docker.account}/kapua-broker</name>
+							<build>
+								<from>${docker.account}/java-base</from>
 								<assembly>
 									<descriptor>/src/main/descriptors/kapua-broker.xml</descriptor>
 								</assembly>
 								<entryPoint>
-									<shell>/maven/bin/activemq console</shell>
+									<exec>
+										<arg>/maven/bin/activemq</arg>
+										<arg>console</arg>
+									</exec>
 								</entryPoint>
 								<env>
 									<ACTIVEMQ_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</ACTIVEMQ_OPTS>
@@ -562,6 +574,7 @@
 									<port>1883</port>
 									<port>61614</port>
 								</ports>
+								<user>kapua</user>
 								<volumes>
 									<volume>/maven/data</volume>
 								</volumes>
@@ -570,12 +583,15 @@
 						<image>
 							<name>${docker.account}/kapua-console</name>
 							<build>
-								<from>${java.base.image}</from>
+								<from>${docker.account}/java-base</from>
 								<assembly>
 									<descriptor>/src/main/descriptors/kapua-console.xml</descriptor>
 								</assembly>
 								<entryPoint>
-									<shell>/maven/bin/catalina.sh run</shell>
+									<exec>
+										<arg>/maven/bin/catalina.sh</arg>
+										<arg>run</arg>
+									</exec>
 								</entryPoint>
 								<env>
 									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
@@ -583,22 +599,28 @@
 								<ports>
 									<port>8080</port>
 								</ports>
+								<user>kapua</user>
 								<runCmds>
-									<run>chgrp -R 0 /maven</run>
-									<run>chmod -R g+rw /maven</run>
-									<run>find /maven -type d -exec chmod g+x {} +</run>
+									<run><![CDATA[
+									chown -R kapua:kapua /maven && \
+									chmod -R a+rw /maven && \
+									find /maven -type d -exec chmod a+x {} +
+									]]></run>
 								</runCmds>
 							</build>
 						</image>
 						<image>
 							<name>${docker.account}/kapua-api</name>
 							<build>
-								<from>${java.base.image}</from>
+								<from>${docker.account}/java-base</from>
 								<assembly>
 									<descriptor>/src/main/descriptors/kapua-api.xml</descriptor>
 								</assembly>
 								<entryPoint>
-									<shell>/maven/bin/catalina.sh run</shell>
+									<exec>
+										<arg>/maven/bin/catalina.sh</arg>
+										<arg>run</arg>
+									</exec>
 								</entryPoint>
 								<env>
 									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
@@ -606,10 +628,13 @@
 								<ports>
 									<port>8080</port>
 								</ports>
+								<user>kapua</user>
 								<runCmds>
-									<run>chgrp -R 0 /maven</run>
-									<run>chmod -R g+rw /maven</run>
-									<run>find /maven -type d -exec chmod g+x {} +</run>
+									<run><![CDATA[
+									chown -R kapua:kapua /maven && \
+									chmod -R a+rw /maven && \
+									find /maven -type d -exec chmod a+x {} +
+									]]></run>
 								</runCmds>
 							</build>
 						</image>

--- a/assembly/src/main/docker/sql/Dockerfile
+++ b/assembly/src/main/docker/sql/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Red Hat and/or its affiliates and others
+# Copyright (c) 2016, 2017 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -8,21 +8,28 @@
 #
 ###############################################################################
 
-FROM java:8
+FROM openjdk:8u111-jre-alpine
 
 MAINTAINER Henryk Konsek <hekonsek@gmail.com>
 
 ENV DATA_DIR /opt/h2-data
 
-RUN curl http://www.h2database.com/h2-2016-10-31.zip -o h2-2016-10-31.zip
-RUN unzip h2-2016-10-31.zip -d /opt/
-RUN rm h2-2016-10-31.zip
-RUN mkdir -p ${DATA_DIR}
+RUN adduser -D -g "Eclipse Kapua" kapua && \
+    apk update && apk add curl && \
+    mkdir -p "${DATA_DIR}" && \
+    chown kapua:kapua "${DATA_DIR}" && chmod a+rw "${DATA_DIR}"
+
+USER kapua
+
+WORKDIR /home/kapua
+RUN curl http://www.h2database.com/h2-2016-10-31.zip -o h2-2016-10-31.zip && \
+  unzip h2-2016-10-31.zip && \
+  rm h2-2016-10-31.zip
 
 VOLUME ${DATA_DIR}
 
 EXPOSE 8181 3306
 
-CMD java -cp /opt/h2/bin/h2*.jar org.h2.tools.Server \
+CMD java -cp /home/kapua/h2/bin/h2*.jar org.h2.tools.Server \
   -web -webAllowOthers -webPort 8181 -tcp -tcpAllowOthers -tcpPort 3306 \
-  -baseDir ${DATA_DIR}
+  -baseDir "${DATA_DIR}"


### PR DESCRIPTION
This change fixes issue #277 by using a dedicated "kapua" user. Permissions are also set to world as suggested by the [OpenShift Guidelines](https://docs.openshift.com/enterprise/3.0/creating_images/guidelines.html#use-uid).

Images are now based on the `openjdk:8-alpine` image series (locked to `8u111`) and file system operations are collapsed into a single run command so that e.g. the image size the `kapua-console` image was reduced to 192 MB from 476 MB.

Additionally a few Maven warnings were fixed.