### PR TITLE
Cleanup initialization of LocatorConfig

### DIFF
--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/LocatorConfig.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/LocatorConfig.java
@@ -23,60 +23,63 @@ import org.eclipse.kapua.locator.KapuaLocatorErrorCodes;
 import org.eclipse.kapua.locator.KapuaLocatorException;
 
 public class LocatorConfig {
-	
-	private static final String SERVICE_RESOURCE_INTERFACES = "provided.api";
-	private static final String SERVICE_RESOURCE_PACKAGES = "packages.package";
-	
-	private final URL url;
-	private List<String> packageNames;
-	private List<String> providedInterfaceNames;
-	
-	private LocatorConfig(URL url)
-	{
-		this.url = url;
-		this.packageNames = new ArrayList<String>();
-		this.providedInterfaceNames = new ArrayList<String>();
-	}
-	
-	public static LocatorConfig fromURL(URL url) throws KapuaLocatorException 
-	{
 
-		if (url == null)
-			throw new IllegalArgumentException();
-				
-		LocatorConfig config = new LocatorConfig(url);
-		
-		XMLConfiguration xmlConfig;
-		try {
-			xmlConfig = new XMLConfiguration(url);
-		} catch (ConfigurationException e) {
-			throw new KapuaLocatorException(KapuaLocatorErrorCodes.INVALID_CONFIGURATION, e);
-		}
-		
-		Object props = xmlConfig.getProperty(SERVICE_RESOURCE_PACKAGES);
-		if (props instanceof Collection)
-			config.packageNames.addAll((Collection<String>) props);
-		if (props instanceof String)
-			config.packageNames.add((String) props);
-		
-		props = xmlConfig.getProperty(SERVICE_RESOURCE_INTERFACES);
-		if (props instanceof Collection)
-			config.providedInterfaceNames.addAll((Collection<String>) props);
-		if (props instanceof String)
-			config.providedInterfaceNames.add((String)props);
-		
-		return config;
-	}
+    private static final String SERVICE_RESOURCE_INTERFACES = "provided.api";
+    private static final String SERVICE_RESOURCE_PACKAGES = "packages.package";
 
-	public URL getURL() {
-		return url;
-	}
+    private final URL url;
+    private final List<String> packageNames;
+    private final List<String> providedInterfaceNames;
 
-	public Collection<String> getPackageNames() {
-		return Collections.unmodifiableCollection(packageNames);
-	}
+    private LocatorConfig(URL url) {
+        this.url = url;
+        packageNames = new ArrayList<>();
+        providedInterfaceNames = new ArrayList<>();
+    }
 
-	public Collection<String> getProvidedInterfaceNames() {
-		return Collections.unmodifiableCollection(providedInterfaceNames);
-	}
+    public static LocatorConfig fromURL(URL url) throws KapuaLocatorException {
+
+        if (url == null) {
+            throw new IllegalArgumentException();
+        }
+
+        LocatorConfig config = new LocatorConfig(url);
+
+        XMLConfiguration xmlConfig;
+        try {
+            xmlConfig = new XMLConfiguration(url);
+        } catch (ConfigurationException e) {
+            throw new KapuaLocatorException(KapuaLocatorErrorCodes.INVALID_CONFIGURATION, e);
+        }
+
+        Object props = xmlConfig.getProperty(SERVICE_RESOURCE_PACKAGES);
+        if (props instanceof Collection) {
+            config.packageNames.addAll((Collection<String>) props);
+        }
+        if (props instanceof String) {
+            config.packageNames.add((String) props);
+        }
+
+        props = xmlConfig.getProperty(SERVICE_RESOURCE_INTERFACES);
+        if (props instanceof Collection) {
+            config.providedInterfaceNames.addAll((Collection<String>) props);
+        }
+        if (props instanceof String) {
+            config.providedInterfaceNames.add((String) props);
+        }
+
+        return config;
+    }
+
+    public URL getURL() {
+        return url;
+    }
+
+    public Collection<String> getPackageNames() {
+        return Collections.unmodifiableCollection(packageNames);
+    }
+
+    public Collection<String> getProvidedInterfaceNames() {
+        return Collections.unmodifiableCollection(providedInterfaceNames);
+    }
 }


### PR DESCRIPTION
This change cleans up the initialization of the LocatorConfig. Instead
of manipulating the internal state during the initialization, the full
state is created and handed over to the new instance, which is then
immutable.

Also is there a check for the correct type from the lists.

---

The first commit applies the code formatter
