### PR TITLE
Refactor translators to use a common base class

### DIFF
--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractSimpleTranslatorResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractSimpleTranslatorResponseKuraKapua.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kura.kapua;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseChannel;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseMessage;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponsePayload;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
+
+public abstract class AbstractSimpleTranslatorResponseKuraKapua<TO_C extends KapuaResponseChannel, TO_P extends KapuaResponsePayload, TO_M extends KapuaResponseMessage<TO_C, TO_P>>
+        extends AbstractTranslatorResponseKuraKapua<TO_C, TO_P, TO_M> {
+
+    private Class<TO_M> messageClazz;
+
+    public AbstractSimpleTranslatorResponseKuraKapua(Class<TO_M> messageClazz) {
+        this.messageClazz = messageClazz;
+    }
+
+    @Override
+    protected TO_M createMessage() throws KapuaException {
+        try {
+            return this.messageClazz.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw KapuaException.internalError(e);
+        }
+    }
+
+    @Override
+    public Class<KuraResponseMessage> getClassFrom() {
+        return KuraResponseMessage.class;
+    }
+
+    @Override
+    public Class<TO_M> getClassTo() {
+        return this.messageClazz;
+    }
+
+    @Override
+    protected abstract TO_C translateChannel(KuraResponseChannel kuraChannel) throws KapuaException;
+
+    @Override
+    protected abstract TO_P translatePayload(KuraResponsePayload kuraPayload) throws KapuaException;
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractTranslatorKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractTranslatorKuraKapua.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kura.kapua;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.message.KapuaChannel;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseChannel;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseMessage;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponsePayload;
+import org.eclipse.kapua.translator.Translator;
+
+public abstract class AbstractTranslatorKuraKapua<TO_C extends KapuaChannel, TO_P extends KapuaPayload, TO_M extends KapuaMessage<TO_C, TO_P>> extends Translator<KuraResponseMessage, TO_M> {
+
+    @Override
+    public TO_M translate(KuraResponseMessage kuraMessage) throws KapuaException {
+
+        final KapuaLocator locator = KapuaLocator.getInstance();
+        final AccountService accountService = locator.getService(AccountService.class);
+        final Account account = accountService.findByName(kuraMessage.getChannel().getScope());
+
+        if (account == null) {
+            throw new KapuaEntityNotFoundException(Account.TYPE, kuraMessage.getChannel().getScope());
+        }
+
+        return translateMessage(kuraMessage, account);
+    }
+    
+    protected abstract TO_M translateMessage(KuraResponseMessage kuraMessage, Account account) throws KapuaException;
+
+    protected abstract TO_C translateChannel(KuraResponseChannel kuraChannel) throws KapuaException;
+
+    protected abstract TO_P translatePayload(KuraResponsePayload kuraPayload) throws KapuaException;
+
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractTranslatorResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractTranslatorResponseKuraKapua.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kura.kapua;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.device.call.kura.app.ResponseMetrics;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseChannel;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseMessage;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponsePayload;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
+
+public abstract class AbstractTranslatorResponseKuraKapua<TO_C extends KapuaResponseChannel, TO_P extends KapuaResponsePayload, TO_M extends KapuaResponseMessage<TO_C, TO_P>> extends AbstractTranslatorKuraKapua<TO_C, TO_P, TO_M> {
+
+    @Override
+    protected TO_M translateMessage(KuraResponseMessage kuraMessage, Account account) throws KapuaException
+    {
+        // Translate channel
+        
+        TO_C bundleResponseChannel = translateChannel(kuraMessage.getChannel());
+
+        // Translate payload
+        
+        TO_P responsePayload = translatePayload(kuraMessage.getPayload());
+
+        // Process messsage
+        
+        TO_M kapuaMessage = createMessage();
+        kapuaMessage.setScopeId(account.getId());
+        kapuaMessage.setChannel(bundleResponseChannel);
+        kapuaMessage.setPayload(responsePayload);
+        kapuaMessage.setCapturedOn(kuraMessage.getPayload().getTimestamp());
+        kapuaMessage.setSentOn(kuraMessage.getPayload().getTimestamp());
+        kapuaMessage.setReceivedOn(kuraMessage.getTimestamp());
+        kapuaMessage.setResponseCode(TranslatorKuraKapuaUtils.translate((Integer) kuraMessage.getPayload().getMetrics().get(ResponseMetrics.RESP_METRIC_EXIT_CODE.getValue())));
+
+        //
+        // Return Kapua Message
+        return kapuaMessage;
+    }
+
+    protected abstract TO_M createMessage () throws KapuaException;
+    
+    protected abstract TO_C translateChannel(KuraResponseChannel kuraChannel) throws KapuaException;
+
+    protected abstract TO_P translatePayload(KuraResponsePayload kuraPayload) throws KapuaException;
+
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/MethodDictionaryKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/MethodDictionaryKuraKapua.java
@@ -21,12 +21,12 @@ import org.eclipse.kapua.service.device.management.KapuaMethod;
 /**
  * Dictionary class to define actions translations between Kura domain to Kapua domain.<br>
  * For detail about action please refer to {@link KapuaMethod} and {@link KuraMethod}
- * 
+ *
  * @since 1.0
  *
  */
-public class MethodDictionaryKuraKapua
-{
+public class MethodDictionaryKuraKapua {
+
     /**
      * Translations dictionary map
      */
@@ -44,12 +44,11 @@ public class MethodDictionaryKuraKapua
 
     /**
      * Returns the action translation from Kura domain to Kapua domain
-     * 
+     *
      * @param kuraMethod
      * @return
      */
-    public static KapuaMethod get(KuraMethod kuraMethod)
-    {
+    public static KapuaMethod get(KuraMethod kuraMethod) {
         return dictionary.get(kuraMethod);
     }
 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
@@ -47,7 +47,7 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
 
 /**
  * Messages translator implementation from {@link KuraResponseMessage} to {@link BundleResponseMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppCommandKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppCommandKuraKapua.java
@@ -37,7 +37,7 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
 
 /**
  * Messages translator implementation from {@link KuraResponseMessage} to {@link CommandResponseMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppCommandKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppCommandKuraKapua.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,18 +8,14 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.translator.kura.kapua;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.service.account.Account;
-import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.device.call.kura.app.CommandMetrics;
 import org.eclipse.kapua.service.device.call.kura.app.ResponseMetrics;
 import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseChannel;
@@ -31,7 +27,6 @@ import org.eclipse.kapua.service.device.management.command.internal.CommandAppPr
 import org.eclipse.kapua.service.device.management.command.message.internal.CommandResponseChannel;
 import org.eclipse.kapua.service.device.management.command.message.internal.CommandResponseMessage;
 import org.eclipse.kapua.service.device.management.command.message.internal.CommandResponsePayload;
-import org.eclipse.kapua.translator.Translator;
 import org.eclipse.kapua.translator.exception.TranslatorErrorCodes;
 import org.eclipse.kapua.translator.exception.TranslatorException;
 
@@ -41,15 +36,12 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
  * @since 1.0
  *
  */
-public class TranslatorAppCommandKuraKapua extends Translator<KuraResponseMessage, CommandResponseMessage> {
+public class TranslatorAppCommandKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<CommandResponseChannel,CommandResponsePayload, CommandResponseMessage> {
 
     private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
-    private static Map<CommandMetrics, CommandAppProperties> metricsDictionary;
+    private static final Map<CommandMetrics, CommandAppProperties> metricsDictionary;
 
-    /**
-     * Constructor
-     */
-    public TranslatorAppCommandKuraKapua() {
+    static {
         metricsDictionary = new HashMap<>();
 
         metricsDictionary.put(CommandMetrics.APP_ID, CommandAppProperties.APP_NAME);
@@ -59,46 +51,16 @@ public class TranslatorAppCommandKuraKapua extends Translator<KuraResponseMessag
         metricsDictionary.put(CommandMetrics.APP_METRIC_STDOUT, CommandAppProperties.APP_PROPERTY_STDOUT);
         metricsDictionary.put(CommandMetrics.APP_METRIC_EXIT_CODE, CommandAppProperties.APP_PROPERTY_EXIT_CODE);
         metricsDictionary.put(CommandMetrics.APP_METRIC_TIMED_OUT, CommandAppProperties.APP_PROPERTY_TIMED_OUT);
-
+    }
+    
+    /**
+     * Constructor
+     */
+    public TranslatorAppCommandKuraKapua() {
+            super(CommandResponseMessage.class);
     }
 
-    @Override
-    public CommandResponseMessage translate(KuraResponseMessage kuraMessage)
-            throws KapuaException {
-        //
-        // Kura channel
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AccountService accountService = locator.getService(AccountService.class);
-        Account account = accountService.findByName(kuraMessage.getChannel().getScope());
-
-        if (account == null) {
-            throw new KapuaEntityNotFoundException(Account.TYPE, kuraMessage.getChannel().getScope());
-        }
-
-        CommandResponseChannel commandResponseChannel = translate(kuraMessage.getChannel());
-
-        //
-        // Kura payload
-        CommandResponsePayload responsePayload = translate(kuraMessage.getPayload());
-
-        //
-        // Kura Message
-        CommandResponseMessage kapuaMessage = new CommandResponseMessage();
-        kapuaMessage.setScopeId(account.getId());
-        kapuaMessage.setChannel(commandResponseChannel);
-        kapuaMessage.setPayload(responsePayload);
-        kapuaMessage.setCapturedOn(kuraMessage.getPayload().getTimestamp());
-        kapuaMessage.setSentOn(kuraMessage.getPayload().getTimestamp());
-        kapuaMessage.setReceivedOn(kuraMessage.getTimestamp());
-        kapuaMessage.setResponseCode(TranslatorKuraKapuaUtils.translate((Integer) kuraMessage.getPayload().getMetrics().get(ResponseMetrics.RESP_METRIC_EXIT_CODE.getValue())));
-
-        //
-        // Return Kapua Message
-        return kapuaMessage;
-    }
-
-    private CommandResponseChannel translate(KuraResponseChannel kuraChannel)
-            throws KapuaException {
+    protected CommandResponseChannel translateChannel(KuraResponseChannel kuraChannel) throws KapuaException {
 
         if (!CONTROL_MESSAGE_CLASSIFIER.equals(kuraChannel.getMessageClassification())) {
             throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_CLASSIFIER,
@@ -130,8 +92,7 @@ public class TranslatorAppCommandKuraKapua extends Translator<KuraResponseMessag
         return kapuaChannel;
     }
 
-    private CommandResponsePayload translate(KuraResponsePayload kuraPayload)
-            throws KapuaException {
+    protected CommandResponsePayload translatePayload(KuraResponsePayload kuraPayload) throws KapuaException {
         CommandResponsePayload commandResponsePayload = new CommandResponsePayload();
 
         Map<String, Object> metrics = kuraPayload.getMetrics();
@@ -151,15 +112,4 @@ public class TranslatorAppCommandKuraKapua extends Translator<KuraResponseMessag
         // Return Kapua Payload
         return commandResponsePayload;
     }
-
-    @Override
-    public Class<KuraResponseMessage> getClassFrom() {
-        return KuraResponseMessage.class;
-    }
-
-    @Override
-    public Class<CommandResponseMessage> getClassTo() {
-        return CommandResponseMessage.class;
-    }
-
 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
@@ -58,7 +58,7 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
 
 /**
  * Messages translator implementation from {@link KuraResponseMessage} to {@link ConfigurationResponseMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.translator.kura.kapua;
 
@@ -17,13 +17,10 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.service.account.Account;
-import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.device.call.kura.app.PackageMetrics;
 import org.eclipse.kapua.service.device.call.kura.app.ResponseMetrics;
 import org.eclipse.kapua.service.device.call.kura.model.deploy.KuraBundleInfo;
@@ -46,7 +43,6 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackageB
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageBundleInfos;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackages;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadStatus;
-import org.eclipse.kapua.translator.Translator;
 import org.eclipse.kapua.translator.exception.TranslatorErrorCodes;
 import org.eclipse.kapua.translator.exception.TranslatorException;
 
@@ -56,59 +52,26 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
  * @since 1.0
  *
  */
-public class TranslatorAppPackageKuraKapua extends Translator<KuraResponseMessage, PackageResponseMessage> {
+public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<PackageResponseChannel,PackageResponsePayload, PackageResponseMessage> {
 
     private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
-    private static Map<PackageMetrics, PackageAppProperties> metricsDictionary;
+    private static final Map<PackageMetrics, PackageAppProperties> metricsDictionary;
 
-    /**
-     * Constructor
-     */
-    public TranslatorAppPackageKuraKapua() {
+    static {
         metricsDictionary = new HashMap<>();
 
         metricsDictionary.put(PackageMetrics.APP_ID, PackageAppProperties.APP_NAME);
         metricsDictionary.put(PackageMetrics.APP_VERSION, PackageAppProperties.APP_VERSION);
-
+    }
+    
+    /**
+     * Constructor
+     */
+    public TranslatorAppPackageKuraKapua() {
+        super(PackageResponseMessage.class);
     }
 
-    @Override
-    public PackageResponseMessage translate(KuraResponseMessage kuraMessage)
-            throws KapuaException {
-        //
-        // Kura channel
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AccountService accountService = locator.getService(AccountService.class);
-        Account account = accountService.findByName(kuraMessage.getChannel().getScope());
-
-        if (account == null) {
-            throw new KapuaEntityNotFoundException(Account.TYPE, kuraMessage.getChannel().getScope());
-        }
-
-        PackageResponseChannel responseChannel = translate(kuraMessage.getChannel());
-
-        //
-        // Kura payload
-        PackageResponsePayload responsePayload = translate(kuraMessage.getPayload());
-
-        //
-        // Kura Message
-        PackageResponseMessage kapuaMessage = new PackageResponseMessage();
-        kapuaMessage.setScopeId(account.getId());
-        kapuaMessage.setChannel(responseChannel);
-        kapuaMessage.setPayload(responsePayload);
-        kapuaMessage.setCapturedOn(kuraMessage.getPayload().getTimestamp());
-        kapuaMessage.setSentOn(kuraMessage.getPayload().getTimestamp());
-        kapuaMessage.setReceivedOn(kuraMessage.getTimestamp());
-        kapuaMessage.setResponseCode(TranslatorKuraKapuaUtils.translate((Integer) kuraMessage.getPayload().getMetrics().get(ResponseMetrics.RESP_METRIC_EXIT_CODE.getValue())));
-
-        //
-        // Return Kapua Message
-        return kapuaMessage;
-    }
-
-    private PackageResponseChannel translate(KuraResponseChannel kuraChannel)
-            throws KapuaException {
+    protected PackageResponseChannel translateChannel(KuraResponseChannel kuraChannel) throws KapuaException {
 
         if (!CONTROL_MESSAGE_CLASSIFIER.equals(kuraChannel.getMessageClassification())) {
             throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_CLASSIFIER,
@@ -140,8 +103,7 @@ public class TranslatorAppPackageKuraKapua extends Translator<KuraResponseMessag
         return responseChannel;
     }
 
-    private PackageResponsePayload translate(KuraResponsePayload kuraResponsePayload)
-            throws KapuaException {
+    protected PackageResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws KapuaException {
         PackageResponsePayload responsePayload = new PackageResponsePayload();
 
         Map<String, Object> metrics = kuraResponsePayload.getMetrics();
@@ -230,15 +192,5 @@ public class TranslatorAppPackageKuraKapua extends Translator<KuraResponseMessag
                     e,
                     kuraDeploymentPackages);
         }
-    }
-
-    @Override
-    public Class<KuraResponseMessage> getClassFrom() {
-        return KuraResponseMessage.class;
-    }
-
-    @Override
-    public Class<PackageResponseMessage> getClassTo() {
-        return PackageResponseMessage.class;
     }
 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
@@ -52,7 +52,7 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
 
 /**
  * Messages translator implementation from {@link KuraResponseMessage} to {@link PackageResponseMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
@@ -47,7 +47,7 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
 
 /**
  * Messages translator implementation from {@link KuraResponseMessage} to {@link SnapshotResponseMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.translator.kura.kapua;
 
@@ -17,12 +17,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.service.account.Account;
-import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.device.call.kura.app.ResponseMetrics;
 import org.eclipse.kapua.service.device.call.kura.app.SnapshotMetrics;
 import org.eclipse.kapua.service.device.call.kura.model.snapshot.KuraSnapshotIds;
@@ -41,7 +38,6 @@ import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshot;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshots;
 import org.eclipse.kapua.service.device.management.snapshot.internal.DeviceSnapshotAppProperties;
-import org.eclipse.kapua.translator.Translator;
 import org.eclipse.kapua.translator.exception.TranslatorErrorCodes;
 import org.eclipse.kapua.translator.exception.TranslatorException;
 
@@ -51,58 +47,27 @@ import org.eclipse.kapua.translator.exception.TranslatorException;
  * @since 1.0
  *
  */
-public class TranslatorAppSnapshotKuraKapua extends Translator<KuraResponseMessage, SnapshotResponseMessage> {
+public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<SnapshotResponseChannel, SnapshotResponsePayload, SnapshotResponseMessage> {
 
     private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
-    private static Map<SnapshotMetrics, DeviceSnapshotAppProperties> metricsDictionary;
+    private static final Map<SnapshotMetrics, DeviceSnapshotAppProperties> metricsDictionary;
 
-    /**
-     * Constructor
-     */
-    public TranslatorAppSnapshotKuraKapua() {
+    static {
         metricsDictionary = new HashMap<>();
 
         metricsDictionary.put(SnapshotMetrics.APP_ID, DeviceSnapshotAppProperties.APP_NAME);
         metricsDictionary.put(SnapshotMetrics.APP_VERSION, DeviceSnapshotAppProperties.APP_VERSION);
     }
-
-    @Override
-    public SnapshotResponseMessage translate(KuraResponseMessage kuraMessage)
-            throws KapuaException {
-        //
-        // Kura channel
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AccountService accountService = locator.getService(AccountService.class);
-        Account account = accountService.findByName(kuraMessage.getChannel().getScope());
-
-        if (account == null) {
-            throw new KapuaEntityNotFoundException(Account.TYPE, kuraMessage.getChannel().getScope());
-        }
-
-        SnapshotResponseChannel commandResponseChannel = translate(kuraMessage.getChannel());
-
-        //
-        // Kura payload
-        SnapshotResponsePayload responsePayload = translate(kuraMessage.getPayload());
-
-        //
-        // Kura Message
-        SnapshotResponseMessage kapuaMessage = new SnapshotResponseMessage();
-        kapuaMessage.setScopeId(account.getId());
-        kapuaMessage.setChannel(commandResponseChannel);
-        kapuaMessage.setPayload(responsePayload);
-        kapuaMessage.setCapturedOn(kuraMessage.getPayload().getTimestamp());
-        kapuaMessage.setSentOn(kuraMessage.getPayload().getTimestamp());
-        kapuaMessage.setReceivedOn(kuraMessage.getTimestamp());
-        kapuaMessage.setResponseCode(TranslatorKuraKapuaUtils.translate((Integer) kuraMessage.getPayload().getMetrics().get(ResponseMetrics.RESP_METRIC_EXIT_CODE.getValue())));
-
-        //
-        // Return Kapua Message
-        return kapuaMessage;
+    
+    
+    /**
+     * Constructor
+     */
+    public TranslatorAppSnapshotKuraKapua() {
+        super(SnapshotResponseMessage.class);
     }
 
-    private SnapshotResponseChannel translate(KuraResponseChannel kuraChannel)
-            throws KapuaException {
+    protected SnapshotResponseChannel translateChannel(KuraResponseChannel kuraChannel) throws KapuaException {
 
         if (!CONTROL_MESSAGE_CLASSIFIER.equals(kuraChannel.getMessageClassification())) {
             throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_CLASSIFIER,
@@ -134,8 +99,7 @@ public class TranslatorAppSnapshotKuraKapua extends Translator<KuraResponseMessa
         return snapshotResponseChannel;
     }
 
-    private SnapshotResponsePayload translate(KuraResponsePayload kuraPayload)
-            throws KapuaException {
+    protected SnapshotResponsePayload translatePayload(KuraResponsePayload kuraPayload) throws KapuaException {
         SnapshotResponsePayload snapshotResponsePayload = new SnapshotResponsePayload();
 
         snapshotResponsePayload.setExceptionMessage((String) kuraPayload.getMetrics().get(ResponseMetrics.RESP_METRIC_EXCEPTION_MESSAGE.getValue()));
@@ -197,15 +161,5 @@ public class TranslatorAppSnapshotKuraKapua extends Translator<KuraResponseMessa
                     e,
                     kuraSnapshotIdResult); // null for now
         }
-    }
-
-    @Override
-    public Class<KuraResponseMessage> getClassFrom() {
-        return KuraResponseMessage.class;
-    }
-
-    @Override
-    public Class<SnapshotResponseMessage> getClassTo() {
-        return SnapshotResponseMessage.class;
     }
 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorDataKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorDataKuraKapua.java
@@ -34,7 +34,7 @@ import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link KuraDataMessage} to {@link KapuaDataMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.translator.kura.kapua;
 
@@ -25,8 +25,12 @@ import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
  * @since 1.0
  *
  */
-public class TranslatorKuraKapuaUtils {
+public final class TranslatorKuraKapuaUtils {
 
+    
+    private TranslatorKuraKapuaUtils() {
+    }
+    
     /**
      * Translate {@link DevicePosition} to {@link KapuaPosition}
      *

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
@@ -21,21 +21,19 @@ import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
 /**
  * Messages translator utilities.<br>
  * It provides helpful methods for translate position and response code.
- * 
+ *
  * @since 1.0
  *
  */
-public class TranslatorKuraKapuaUtils
-{
+public class TranslatorKuraKapuaUtils {
 
     /**
      * Translate {@link DevicePosition} to {@link KapuaPosition}
-     * 
+     *
      * @param kuraPosition
      * @return
      */
-    public static KapuaPosition translate(DevicePosition kuraPosition)
-    {
+    public static KapuaPosition translate(DevicePosition kuraPosition) {
         KapuaPosition kapuaPosition = null;
 
         if (kuraPosition != null) {
@@ -59,32 +57,30 @@ public class TranslatorKuraKapuaUtils
 
     /**
      * Translate Kura response code to {@link KapuaResponseCode}
-     * 
+     *
      * @param kuraResponseCode
      * @return
      */
-    public static KapuaResponseCode translate(Integer kuraResponseCode)
-    {
+    public static KapuaResponseCode translate(Integer kuraResponseCode) {
         KapuaResponseCode responseCode;
         if (kuraResponseCode == null) {
             responseCode = null;
-        }
-        else {
+        } else {
             switch (kuraResponseCode) {
-                case 200:
-                    responseCode = KapuaResponseCode.ACCEPTED;
-                    break;
-                case 400:
-                    responseCode = KapuaResponseCode.BAD_REQUEST;
-                    break;
-                case 404:
-                    responseCode = KapuaResponseCode.NOT_FOUND;
-                    break;
-                case 500:
-                    responseCode = KapuaResponseCode.INTERNAL_ERROR;
-                    break;
-                default:
-                    responseCode = null;
+            case 200:
+                responseCode = KapuaResponseCode.ACCEPTED;
+                break;
+            case 400:
+                responseCode = KapuaResponseCode.BAD_REQUEST;
+                break;
+            case 404:
+                responseCode = KapuaResponseCode.NOT_FOUND;
+                break;
+            case 500:
+                responseCode = KapuaResponseCode.INTERNAL_ERROR;
+                break;
+            default:
+                responseCode = null;
             }
         }
         return responseCode;

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeAppsKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeAppsKuraKapua.java
@@ -32,7 +32,7 @@ import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link KuraAppsMessage} to {@link KapuaAppsMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeBirthKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeBirthKuraKapua.java
@@ -32,7 +32,7 @@ import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link KuraBirthMessage} to {@link KapuaBirthMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeDisconnectKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeDisconnectKuraKapua.java
@@ -32,7 +32,7 @@ import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link KuraDisconnectMessage} to {@link KapuaDisconnectMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeMissingKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeMissingKuraKapua.java
@@ -32,7 +32,7 @@ import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link KuraMissingMessage} to {@link KapuaMissingMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeNotifyKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeNotifyKuraKapua.java
@@ -32,7 +32,7 @@ import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link KuraNotifyMessage} to {@link KapuaNotifyMessage}
- * 
+ *
  * @since 1.0
  *
  */

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeUnmatchedKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeUnmatchedKuraKapua.java
@@ -30,7 +30,7 @@ import org.eclipse.kapua.translator.Translator;
 
 /**
  * Messages translator implementation from {@link KuraUnmatchedMessage} to {@link KapuaUnmatchedMessage}
- * 
+ *
  * @since 1.0
  *
  */


### PR DESCRIPTION
Refactor translators to use a common base class

This change refactors the kura -> kapua app translators to use a common base class.

---

The first commit applies to code formatter.