### PR TITLE
Fix code style of MessageType enum

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.converter;
 
@@ -28,7 +28,7 @@ import org.eclipse.kapua.broker.core.message.CamelUtil;
 import org.eclipse.kapua.broker.core.message.JmsUtil;
 import org.eclipse.kapua.broker.core.message.MessageConstants;
 import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MESSAGE_TYPE;
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.metric.MetricsService;
@@ -74,7 +74,7 @@ public abstract class AbstractKapuaConverter {
      * @throws KapuaException
      *             if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
      */
-    protected CamelKapuaMessage<?> convertTo(Exchange exchange, Object value, MESSAGE_TYPE messageType) throws KapuaException {
+    protected CamelKapuaMessage<?> convertTo(Exchange exchange, Object value, MessageType messageType) throws KapuaException {
         // assume that the message is a Camel Jms message
         JmsMessage message = exchange.getIn(JmsMessage.class);
         if (message.getJmsMessage() instanceof BytesMessage) {

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaDataConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaDataConverter.java
@@ -16,7 +16,7 @@ import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.message.CamelKapuaMessage;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MESSAGE_TYPE;
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +52,7 @@ public class KapuaDataConverter extends AbstractKapuaConverter
     public CamelKapuaMessage<?> convertToData(Exchange exchange, Object value) throws KapuaException
     {
         metricConverterDataMessage.inc();
-        return convertTo(exchange, value, MESSAGE_TYPE.data);
+        return convertTo(exchange, value, MessageType.DATA);
     }
 
 }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaLifeCycleConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaLifeCycleConverter.java
@@ -16,7 +16,7 @@ import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.message.CamelKapuaMessage;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MESSAGE_TYPE;
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +60,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter
     public CamelKapuaMessage<?> convertToApps(Exchange exchange, Object value) throws KapuaException
     {
         metricConverterAppMessage.inc();
-        return convertTo(exchange, value, MESSAGE_TYPE.app);
+        return convertTo(exchange, value, MessageType.APP);
     }
 
     /**
@@ -75,7 +75,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter
     public CamelKapuaMessage<?> convertToBirth(Exchange exchange, Object value) throws KapuaException
     {
         metricConverterBirthMessage.inc();
-        return convertTo(exchange, value, MESSAGE_TYPE.birth);
+        return convertTo(exchange, value, MessageType.BIRTH);
     }
 
     /**
@@ -90,7 +90,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter
     public CamelKapuaMessage<?> convertToDisconnect(Exchange exchange, Object value) throws KapuaException
     {
         metricConverterDcMessage.inc();
-        return convertTo(exchange, value, MESSAGE_TYPE.disconnect);
+        return convertTo(exchange, value, MessageType.DISCONNECT);
     }
 
     /**
@@ -105,7 +105,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter
     public CamelKapuaMessage<?> convertToMissing(Exchange exchange, Object value) throws KapuaException
     {
         metricConverterMissingMessage.inc();
-        return convertTo(exchange, value, MESSAGE_TYPE.missing);
+        return convertTo(exchange, value, MessageType.MISSING);
     }
 
     /**
@@ -120,7 +120,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter
     public CamelKapuaMessage<?> convertToNotify(Exchange exchange, Object value) throws KapuaException
     {
         metricConverterNotifyMessage.inc();
-        return convertTo(exchange, value, MESSAGE_TYPE.notify);
+        return convertTo(exchange, value, MessageType.NOTIFY);
     }
 
     /**
@@ -135,7 +135,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter
     public CamelKapuaMessage<?> convertToUnmatched(Exchange exchange, Object value) throws KapuaException
     {
         metricConverterNotifyMessage.inc();
-        return convertTo(exchange, value, MESSAGE_TYPE.unmatched);
+        return convertTo(exchange, value, MessageType.UNMATCHED);
     }
 
 }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/JmsUtil.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/JmsUtil.java
@@ -25,7 +25,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.converter.AbstractKapuaConverter;
 import org.eclipse.kapua.broker.core.plugin.AclConstants;
 import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MESSAGE_TYPE;
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
@@ -86,7 +86,7 @@ public class JmsUtil
      * @throws JMSException
      * @throws KapuaException
      */
-    public static CamelKapuaMessage<?> convertToKapuaMessage(ConnectorDescriptor connectorDescriptor, MESSAGE_TYPE messageType, BytesMessage jmsMessage, KapuaId connectionId)
+    public static CamelKapuaMessage<?> convertToKapuaMessage(ConnectorDescriptor connectorDescriptor, MessageType messageType, BytesMessage jmsMessage, KapuaId connectionId)
         throws JMSException, KapuaException
     {
         String jmsTopic = jmsMessage.getStringProperty(MessageConstants.PROPERTY_ORIGINAL_TOPIC);
@@ -151,7 +151,7 @@ public class JmsUtil
      * @return
      * @throws KapuaException
      */
-    public static CamelKapuaMessage<?> convertToCamelKapuaMessage(ConnectorDescriptor connectorDescriptor, MESSAGE_TYPE messageType, byte[] messageBody, String jmsTopic, Date queuedOn, KapuaId connectionId)
+    public static CamelKapuaMessage<?> convertToCamelKapuaMessage(ConnectorDescriptor connectorDescriptor, MessageType messageType, byte[] messageBody, String jmsTopic, Date queuedOn, KapuaId connectionId)
         throws KapuaException
     {
         KapuaMessage<?,?> kapuaMessage = convertToKapuaMessage(connectorDescriptor.getDeviceClass(messageType), connectorDescriptor.getKapuaClass(messageType), messageBody, jmsTopic, queuedOn, connectionId);
@@ -201,7 +201,7 @@ public class JmsUtil
      * @throws KapuaException
      * @throws ClassNotFoundException
      */
-    public static JmsMessage convertToJmsMessage(ConnectorDescriptor connectorDescriptor, MESSAGE_TYPE messageType, KapuaMessage<?,?> kapuaMessage) throws KapuaException, ClassNotFoundException
+    public static JmsMessage convertToJmsMessage(ConnectorDescriptor connectorDescriptor, MessageType messageType, KapuaMessage<?,?> kapuaMessage) throws KapuaException, ClassNotFoundException
     {
         // first step... from Kapua to device level
         Translator<KapuaMessage<?, ?>, DeviceMessage<?, ?>> translatorFromKapua = null; // translatorFromKapuaMap.get(protocol);

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
@@ -26,16 +26,14 @@ import org.eclipse.kapua.service.device.call.message.DeviceMessage;
  *
  * @since 1.0
  */
-public class ConnectorDescriptor implements Serializable
-{
+public class ConnectorDescriptor implements Serializable {
 
     private static final long serialVersionUID = -7220383679289083726L;
 
     /**
      * Allowed message types
      */
-    public enum MESSAGE_TYPE
-    {
+    public enum MESSAGE_TYPE {
         /**
          * Application message type
          */
@@ -66,45 +64,44 @@ public class ConnectorDescriptor implements Serializable
         data
     }
 
-    private String connectorName;
-    private String deviceProtocolName;
+    private final String connectorName;
+    private final String deviceProtocolName;
 
     private final Map<MESSAGE_TYPE, Class<DeviceMessage<?, ?>>> deviceClass;
-    private final Map<MESSAGE_TYPE, Class<KapuaMessage<?, ?>>>  kapuaClass;
+    private final Map<MESSAGE_TYPE, Class<KapuaMessage<?, ?>>> kapuaClass;
 
     /**
      * Constructs a new connector descriptor
-     * 
-     * @param connectorName connector name (as defined in the activemq.xml)
-     * @param deviceProtocolName device level protocol name (ie Kura)
-     * @param deviceClass device level messages implementation classes
-     * @param kapuaClass Kapua level messages implementation classes
+     *
+     * @param connectorName
+     *            connector name (as defined in the activemq.xml)
+     * @param deviceProtocolName
+     *            device level protocol name (ie Kura)
+     * @param deviceClass
+     *            device level messages implementation classes
+     * @param kapuaClass
+     *            Kapua level messages implementation classes
      */
-    public ConnectorDescriptor(String connectorName, String deviceProtocolName, Map<MESSAGE_TYPE, Class<DeviceMessage<?, ?>>> deviceClass, Map<MESSAGE_TYPE, Class<KapuaMessage<?, ?>>> kapuaClass)
-    {
+    public ConnectorDescriptor(String connectorName, String deviceProtocolName, Map<MESSAGE_TYPE, Class<DeviceMessage<?, ?>>> deviceClass, Map<MESSAGE_TYPE, Class<KapuaMessage<?, ?>>> kapuaClass) {
         this.connectorName = connectorName;
         this.deviceProtocolName = deviceProtocolName;
         this.deviceClass = deviceClass;
         this.kapuaClass = kapuaClass;
     }
 
-    public String getConnectorName()
-    {
+    public String getConnectorName() {
         return connectorName;
     }
 
-    public String getDeviceProtocolName()
-    {
+    public String getDeviceProtocolName() {
         return deviceProtocolName;
     }
 
-    public Class<DeviceMessage<?, ?>> getDeviceClass(MESSAGE_TYPE messageType) throws KapuaException
-    {
+    public Class<DeviceMessage<?, ?>> getDeviceClass(MESSAGE_TYPE messageType) throws KapuaException {
         return deviceClass.get(messageType);
     }
 
-    public Class<KapuaMessage<?, ?>> getKapuaClass(MESSAGE_TYPE messageType) throws KapuaException
-    {
+    public Class<KapuaMessage<?, ?>> getKapuaClass(MESSAGE_TYPE messageType) throws KapuaException {
         return kapuaClass.get(messageType);
     }
 

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin;
 
@@ -33,42 +33,42 @@ public class ConnectorDescriptor implements Serializable {
     /**
      * Allowed message types
      */
-    public enum MESSAGE_TYPE {
+    public static enum MessageType {
         /**
          * Application message type
          */
-        app,
+        APP,
         /**
          * Birth message type
          */
-        birth,
+        BIRTH,
         /**
          * Disconnect message type
          */
-        disconnect,
+        DISCONNECT,
         /**
          * Missing message type
          */
-        missing,
+        MISSING,
         /**
          * Notify message type
          */
-        notify,
+        NOTIFY,
         /**
          * Unmatched filtering message type
          */
-        unmatched,
+        UNMATCHED,
         /**
          * Data message type
          */
-        data
+        DATA
     }
 
     private final String connectorName;
     private final String deviceProtocolName;
 
-    private final Map<MESSAGE_TYPE, Class<DeviceMessage<?, ?>>> deviceClass;
-    private final Map<MESSAGE_TYPE, Class<KapuaMessage<?, ?>>> kapuaClass;
+    private final Map<MessageType, Class<DeviceMessage<?, ?>>> deviceClass;
+    private final Map<MessageType, Class<KapuaMessage<?, ?>>> kapuaClass;
 
     /**
      * Constructs a new connector descriptor
@@ -82,7 +82,7 @@ public class ConnectorDescriptor implements Serializable {
      * @param kapuaClass
      *            Kapua level messages implementation classes
      */
-    public ConnectorDescriptor(String connectorName, String deviceProtocolName, Map<MESSAGE_TYPE, Class<DeviceMessage<?, ?>>> deviceClass, Map<MESSAGE_TYPE, Class<KapuaMessage<?, ?>>> kapuaClass) {
+    public ConnectorDescriptor(String connectorName, String deviceProtocolName, Map<MessageType, Class<DeviceMessage<?, ?>>> deviceClass, Map<MessageType, Class<KapuaMessage<?, ?>>> kapuaClass) {
         this.connectorName = connectorName;
         this.deviceProtocolName = deviceProtocolName;
         this.deviceClass = deviceClass;
@@ -97,11 +97,11 @@ public class ConnectorDescriptor implements Serializable {
         return deviceProtocolName;
     }
 
-    public Class<DeviceMessage<?, ?>> getDeviceClass(MESSAGE_TYPE messageType) throws KapuaException {
+    public Class<DeviceMessage<?, ?>> getDeviceClass(MessageType messageType) throws KapuaException {
         return deviceClass.get(messageType);
     }
 
-    public Class<KapuaMessage<?, ?>> getKapuaClass(MESSAGE_TYPE messageType) throws KapuaException {
+    public Class<KapuaMessage<?, ?>> getKapuaClass(MessageType messageType) throws KapuaException {
         return kapuaClass.get(messageType);
     }
 

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorLoader.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorLoader.java
@@ -16,7 +16,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MESSAGE_TYPE;
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 import org.slf4j.Logger;
@@ -46,23 +46,23 @@ public class ConnectorDescriptorLoader
         URL configurationUrl = ConnectorDescriptorLoader.class.getClassLoader().getResource(CONNECTOR_DESCRIPTOR_RESOURCE);
         // TODO load parameters from the file
 
-        Map<MESSAGE_TYPE, Class<DeviceMessage<?, ?>>> deviceClass = new HashMap<MESSAGE_TYPE, Class<DeviceMessage<?, ?>>>();
-        deviceClass.put(MESSAGE_TYPE.app, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage"));
-        deviceClass.put(MESSAGE_TYPE.birth, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraBirthMessage"));
-        deviceClass.put(MESSAGE_TYPE.disconnect, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraDisconnectMessage"));
-        deviceClass.put(MESSAGE_TYPE.missing, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraMissingMessage"));
-        deviceClass.put(MESSAGE_TYPE.notify, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraNotifyMessage"));
-        deviceClass.put(MESSAGE_TYPE.unmatched, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraUnmatchedMessage"));
-        deviceClass.put(MESSAGE_TYPE.data, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage"));
+        Map<MessageType, Class<DeviceMessage<?, ?>>> deviceClass = new HashMap<>();
+        deviceClass.put(MessageType.APP, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage"));
+        deviceClass.put(MessageType.BIRTH, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraBirthMessage"));
+        deviceClass.put(MessageType.DISCONNECT, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraDisconnectMessage"));
+        deviceClass.put(MessageType.MISSING, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraMissingMessage"));
+        deviceClass.put(MessageType.NOTIFY, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraNotifyMessage"));
+        deviceClass.put(MessageType.UNMATCHED, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraUnmatchedMessage"));
+        deviceClass.put(MessageType.DATA, getDeviceClazz("org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage"));
 
-        Map<MESSAGE_TYPE, Class<KapuaMessage<?, ?>>> kapuaClass = new HashMap<MESSAGE_TYPE, Class<KapuaMessage<?, ?>>>();
-        kapuaClass.put(MESSAGE_TYPE.app, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage"));
-        kapuaClass.put(MESSAGE_TYPE.birth, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage"));
-        kapuaClass.put(MESSAGE_TYPE.disconnect, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectMessage"));
-        kapuaClass.put(MESSAGE_TYPE.missing, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage"));
-        kapuaClass.put(MESSAGE_TYPE.notify, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaNotifyMessage"));
-        kapuaClass.put(MESSAGE_TYPE.unmatched, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedMessage"));
-        kapuaClass.put(MESSAGE_TYPE.data, getKapuaClazz("org.eclipse.kapua.message.device.data.KapuaDataMessage"));
+        Map<MessageType, Class<KapuaMessage<?, ?>>> kapuaClass = new HashMap<>();
+        kapuaClass.put(MessageType.APP, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage"));
+        kapuaClass.put(MessageType.BIRTH, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage"));
+        kapuaClass.put(MessageType.DISCONNECT, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectMessage"));
+        kapuaClass.put(MessageType.MISSING, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage"));
+        kapuaClass.put(MessageType.NOTIFY, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaNotifyMessage"));
+        kapuaClass.put(MessageType.UNMATCHED, getKapuaClazz("org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedMessage"));
+        kapuaClass.put(MessageType.DATA, getKapuaClazz("org.eclipse.kapua.message.device.data.KapuaDataMessage"));
 
         connectorsDescriptorMap.put("mqtt", new ConnectorDescriptor("mqtt", "kura", deviceClass, kapuaClass));
         connectorsDescriptorMap.put("mqtts", new ConnectorDescriptor("mqtts", "kura", deviceClass, kapuaClass));


### PR DESCRIPTION
All uppercase is used either for constants or enum values. Enum types should follow the schema of all types (classes, interfaces).

Kupua does this, except for the `MESSAGE_TYPE` enum, so when you look through the code `Map<MESSAGE_TYPE,?>` lets you think that `MESSAGE_TYPE` is a generic type argument, where in fact it is an enum type.