### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.message.internal;
 
@@ -23,11 +23,10 @@ import org.eclipse.kapua.message.KapuaPosition;
 public class KapuaMessageFactoryImpl implements KapuaMessageFactory
 {
 
-    @SuppressWarnings("rawtypes")
     @Override
-    public KapuaMessage newMessage()
+    public KapuaMessage<?,?> newMessage()
     {
-        return new KapuaMessageImpl();
+        return new KapuaMessageImpl<KapuaChannel,KapuaPayload>();
     }
 
     @Override

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.message.internal;
 
@@ -39,11 +39,10 @@ import org.eclipse.kapua.model.id.KapuaId;
  * @since 1.0
  *
  */
-@SuppressWarnings("rawtypes")
 @XmlRootElement(name = "message")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "destination", "timestamp", "payload" })
-public class KapuaMessageImpl<C extends KapuaChannel, P extends KapuaPayload> implements Comparable<KapuaMessageImpl>, KapuaMessage<C, P>
+public class KapuaMessageImpl<C extends KapuaChannel, P extends KapuaPayload> implements Comparable<KapuaMessageImpl<C,P>>, KapuaMessage<C, P>
 {
     private UUID          id;
 
@@ -190,7 +189,7 @@ public class KapuaMessageImpl<C extends KapuaChannel, P extends KapuaPayload> im
     }
 
     @Override
-    public int compareTo(KapuaMessageImpl msg)
+    public int compareTo(KapuaMessageImpl<C,P> msg)
     {
         return (receivedOn.compareTo(msg.getReceivedOn()) * (-1));
     }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.message.internal;
 
@@ -29,7 +29,7 @@ public class KapuaMessageFactoryTest extends Assert {
 
     @Test
     public void newMessage() throws Exception {
-        KapuaMessage message = kapuaMessageFactory.newMessage();
+        KapuaMessage<?,?> message = kapuaMessageFactory.newMessage();
 
         assertNotNull(message);
     }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.message.internal;
 
@@ -56,7 +56,7 @@ public class KapuaMessageTest extends Assert {
 
         populateChannel(kapuaChannel);
         populatePayload(kapuaMetrics);
-        KapuaMessage kapuaMessage = new KapuaMessageImpl(kapuaChannel, kapuaMetrics);
+        KapuaMessage<?,?> kapuaMessage = new KapuaMessageImpl<>(kapuaChannel, kapuaMetrics);
         populateKapuaMessage(kapuaMessage, referenceDate);
 
         assertEquals(UUID.fromString("11111111-2222-3333-4444-555555555555"), kapuaMessage.getId());
@@ -79,7 +79,7 @@ public class KapuaMessageTest extends Assert {
 
         populateChannel(kapuaChannel);
         populatePayload(kapuaPayload);
-        KapuaMessage kapuaMessage = new KapuaMessageImpl();
+        KapuaMessage<KapuaChannel,KapuaPayload> kapuaMessage = new KapuaMessageImpl<>();
         kapuaMessage.setChannel(kapuaChannel);
         kapuaMessage.setPayload(kapuaPayload);
 
@@ -89,13 +89,13 @@ public class KapuaMessageTest extends Assert {
 
     @Test
     public void messageEquals() throws Exception {
-        KapuaMessage kapuaMessageFirst = new KapuaMessageImpl();
+        KapuaMessage<KapuaChannel,KapuaPayload> kapuaMessageFirst = new KapuaMessageImpl<>();
         populateKapuaMessage(kapuaMessageFirst, referenceDate);
-        KapuaMessage kapuaMessageSecond = new KapuaMessageImpl();
+        KapuaMessage<KapuaChannel,KapuaPayload> kapuaMessageSecond = new KapuaMessageImpl<>();
         populateKapuaMessage(kapuaMessageSecond, referenceDate);
 
-        assertEquals(0, ((KapuaMessageImpl) kapuaMessageFirst).
-                compareTo((KapuaMessageImpl) kapuaMessageSecond));
+        assertEquals(0, ((KapuaMessageImpl<KapuaChannel,KapuaPayload>) kapuaMessageFirst).
+                compareTo((KapuaMessageImpl<KapuaChannel,KapuaPayload>) kapuaMessageSecond));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class KapuaMessageTest extends Assert {
 
         populateChannel(kapuaChannel);
         populatePayload(kapuaMetrics);
-        KapuaMessage kapuaMessage = new KapuaMessageImpl(kapuaChannel, kapuaMetrics);
+        KapuaMessage<KapuaChannel,KapuaPayload> kapuaMessage = new KapuaMessageImpl<>(kapuaChannel, kapuaMetrics);
         populateKapuaMessage(kapuaMessage, referenceDate);
 
         StringWriter strWriter = new StringWriter();

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.message.internal;
 
@@ -21,18 +21,14 @@ import org.eclipse.kapua.message.KapuaPosition;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 
 /**
- * Test Utility for repeating parts of code in Message moudule.
- * Mostly for populating sturctures with random / semi random test data.
+ * Test Utility for repeating parts of code in Message module.
+ * Mostly for populating structures with random / semi random test data.
  */
 public class KapuaMessageUtil {
-
-    private static ZoneId defaultZoneId = ZoneId.systemDefault();
 
     /**
      * Prepare payload data that contains two metrics and simple byte payload.
@@ -86,7 +82,7 @@ public class KapuaMessageUtil {
      * @param kapuaMessage  KapuaMessage reference to fill with test data
      * @param referenceDate reference date on which all date fields are based
      */
-    public static void populateKapuaMessage(KapuaMessage kapuaMessage, ZonedDateTime referenceDate) {
+    public static void populateKapuaMessage(KapuaMessage<?,?> kapuaMessage, ZonedDateTime referenceDate) {
         kapuaMessage.setId(UUID.fromString("11111111-2222-3333-4444-555555555555"));
         kapuaMessage.setScopeId(new KapuaEid(BigInteger.ONE));
         kapuaMessage.setDeviceId(new KapuaEid(BigInteger.ONE));

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
@@ -19,7 +19,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.StringWriter;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.message.internal.device.lifecycle;
 
-import org.eclipse.kapua.message.internal.xml.KapuaMetricTest;
-import org.eclipse.kapua.message.internal.xml.KapuaMetricValueTest;
-import org.eclipse.kapua.message.internal.xml.KapuaMetricsMapAdapterTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricValueTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricValueTest.java
@@ -26,8 +26,6 @@ public class KapuaMetricValueTest extends Assert {
 
     private static final String newline = System.lineSeparator();
 
-    private static final ZoneId defaultZoneId = ZoneId.systemDefault();
-
     private static final Long TIMESTAMP = ZonedDateTime.of(2017, 1, 18, 13, 10, 46, 0, ZoneId.systemDefault()).
             toEpochSecond();
 


### PR DESCRIPTION
This change fixes a bunch of warnings by using correct generics types
and by organizing imports, removing unused code.

Signed-off-by: Jens Reimann <jreimann@redhat.com>