### PR TITLE
Replace Mortbay Jetty 6.x with a more recent version

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others All rights reserved. 
-    This program and the accompanying materials are made available under the 
-    terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-    and is available at http://www.eclipse.org/legal/epl-v10.html Contributors: 
-    Eurotech - initial API and implementation -->
-
+<!--
+    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+   
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        Eurotech - initial API and implementation
+        Red Hat Inc
+   
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <!-- POM file generated with GWT webAppCreator -->
+
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.eclipse.kapua</groupId>
@@ -202,11 +209,11 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>jetty-util</artifactId>
-            <version>6.1.26</version>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>9.1.6.v20160112</version>
         </dependency>
-        
+
         <!-- use log4j only for testing -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/console/src/main/webapp/WEB-INF/web.xml
+++ b/console/src/main/webapp/WEB-INF/web.xml
@@ -9,6 +9,7 @@
    
     Contributors:
         Eurotech - initial API and implementation
+        Red Hat Inc
    
  -->
 
@@ -62,7 +63,7 @@
 	
     <filter>
 	    <filter-name>jetty-gzip</filter-name>
-	    <filter-class>org.mortbay.servlet.GzipFilter</filter-class>
+	    <filter-class>org.eclipse.jetty.servlets.GzipFilter</filter-class>
 	</filter>
 	<filter-mapping>
 	    <filter-name>jetty-gzip</filter-name>


### PR DESCRIPTION
This version replaces the GzipFilter from Mortbay Jetty 6.x with
a more recent version of Eclipse Jetty (9.1.x).

There is no CQ required for this change as this version of Jetty is an
Eclipse project.

Upgrading to any version after 9.1.x is not possible as this
functionality is actually deprecated starting with Jetty 9.2.0.

Signed-off-by: Jens Reimann <jreimann@redhat.com>