### PR TITLE
Add a security scan for dependencies based on OWASP Dependency Check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,6 +617,31 @@
                 <module>dev-tools</module>
             </modules>
         </profile>
+        <profile>
+            <id>security-scan</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>1.4.5</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <suppressionFile>src/main/dependency-checker/suppress.xml</suppressionFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -637,6 +637,7 @@
                         </executions>
                         <configuration>
                             <suppressionFile>src/main/dependency-checker/suppress.xml</suppressionFile>
+                            <format>ALL</format>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/dependency-checker/suppress.xml
+++ b/src/main/dependency-checker/suppress.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions
+    xmlns="https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://www.owasp.org/index.php/OWASP_Dependency_Check_Suppression https://raw.githubusercontent.com/jeremylong/DependencyCheck/master/dependency-check-core/src/main/resources/schema/suppression.xsd"
+    >
+    <suppress>
+        <notes>Ignore 'com.allen-sauer.gwt.log:gwt-log:3.1.8'</notes>
+        <sha1>bf4765735ce58de89e8247eb22fee4e48a8da8ce</sha1>
+        <cpe>cpe:/a:google:web_toolkit:3.1.8</cpe>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
This change does add a security scan of used artifacts using the OWASP Dependency Check [1].

In order to activate this check a top level project has to be built, enabling the profile `security-scan` with `-Psecurity-scan` (which is disabled by default). The reason why this is disabled by default is because the scans are rather time consuming.

The final output is an HTML file located at `kapua.git/target/dependency-check-report.html`.

[1] https://www.owasp.org/index.php/OWASP_Dependency_Check
[2] https://jeremylong.github.io/DependencyCheck/index.html