### PR TITLE
Upgrade Tomcat to version 8.0.41

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -23,7 +23,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tomcat.version>8.0.38</tomcat.version>
+		<tomcat.version>8.0.41</tomcat.version>
 		<commons.pool.version>2.3</commons.pool.version>
 
 		<docker.account>kapua</docker.account>


### PR DESCRIPTION
This change updates Tomcat from version 8.0.38 to 8.0.41.

For a list of changes see:
https://tomcat.apache.org/tomcat-8.0-doc/changelog.html#Tomcat_8.0.41_(violetagg)

Signed-off-by: Jens Reimann <jreimann@redhat.com>