### PR TITLE
Fix the way the Kura/ESF version is being transmitted

### DIFF
--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/model/GwtDevice.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/model/GwtDevice.java
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.app.console.shared.model;
 
@@ -270,11 +270,11 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getIotFrameworkVersion() {
-        return (String) get("esfKuraVersion");
+        return (String) get("iotFrameworkVersion");
     }
 
-    public void setIotFrameworkVersion(String esfKuraVersion) {
-        set("esfKuraVersion", esfKuraVersion);
+    public void setIotFrameworkVersion(String iotFrameworkVersion) {
+        set("iotFrameworkVersion", iotFrameworkVersion);
     }
 
     public String getOsgiFramework() {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraAppsPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraAppsPayload.java
@@ -41,8 +41,8 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload {
     private final static String JVM_PROFILE = "jvm_profile";
     private final static String ESF_VERSION = "esf_version";
     private final static String KURA_VERSION = "kura_version";
-    private final static String ESF_PREFIX = "ESF_";
-    private final static String ESFKURA_VERSION = "esf_version";
+    private final static String APPLICATION_FRAMEWORK = "application_framework";
+    private final static String APPLICATION_FRAMEWORK_VERSION = "application_framework_version";
     private final static String OSGI_FRAMEWORK = "osgi_framework";
     private final static String OSGI_FRAMEWORK_VERSION = "osgi_framework_version";
     private final static String CONNECTION_INTERFACE = "connection_interface";
@@ -52,6 +52,8 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload {
     private final static String MODEM_IMEI = "modem_imei";
     private final static String MODEM_IMSI = "modem_imsi";
     private final static String MODEM_ICCID = "modem_iccid";
+
+    private final static String DEFAULT_APPLICATION_FRAMEWORK = "Kura";
 
     /**
      * Constructor
@@ -103,7 +105,8 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload {
             String jvmName,
             String jvmVersion,
             String jvmProfile,
-            String esfkuraVersion,
+            String applicationFramework,
+            String applicationFrameworkVersion,
             String connectionInterface,
             String connectionIp,
             String acceptEncoding,
@@ -157,8 +160,11 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload {
         if (jvmProfile != null) {
             getMetrics().put(JVM_PROFILE, jvmProfile);
         }
-        if (esfkuraVersion != null) {
-            getMetrics().put(ESFKURA_VERSION, esfkuraVersion);
+        if (applicationFramework != null) {
+            getMetrics().put(APPLICATION_FRAMEWORK, applicationFramework);
+        }
+        if (applicationFrameworkVersion != null) {
+            getMetrics().put(APPLICATION_FRAMEWORK_VERSION, applicationFrameworkVersion);
         }
         if (connectionInterface != null) {
             getMetrics().put(CONNECTION_INTERFACE, connectionInterface);
@@ -357,7 +363,11 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload {
      * @return
      */
     public String getApplicationFramework() {
-        return (String) getMetrics().get(ESFKURA_VERSION);
+        String value = (String) getMetrics().get(APPLICATION_FRAMEWORK);
+        if (value != null) {
+            return value;
+        }
+        return (String) getMetrics().get(DEFAULT_APPLICATION_FRAMEWORK);
     }
 
     /**
@@ -366,7 +376,15 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload {
      * @return
      */
     public String getApplicationFrameworkVersion() {
-        return (String) getMetrics().get(ESFKURA_VERSION);
+        String value = (String) getMetrics().get(APPLICATION_FRAMEWORK_VERSION);
+        if (value != null) {
+            return value;
+        }
+        value = (String) getMetrics().get(KURA_VERSION);
+        if (value != null) {
+            return value;
+        }
+        return (String) getMetrics().get(ESF_VERSION);
     }
 
     /**
@@ -480,7 +498,8 @@ public class KuraAppsPayload extends KuraPayload implements DevicePayload {
                 .append(", getJvmProfile()=").append(getJvmProfile())
                 .append(", getOsgiFramework()=").append(getContainerFramework())
                 .append(", getOsgiFrameworkVersion()=").append(getContainerFrameworkVersion())
-                .append(", getEsfKuraVersion()=").append(getApplicationFrameworkVersion())
+                .append(", getApplicationFramework()=").append(getApplicationFramework())
+                .append(", getApplicationFrameworkVersion()=").append(getApplicationFrameworkVersion())
                 .append(", getConnectionInterface()=").append(getConnectionInterface())
                 .append(", getConnectionIp()=").append(getConnectionIp())
                 .append(", getAcceptEncoding()=").append(getAcceptEncoding())

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraBirthPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraBirthPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.message.kura.lifecycle;
 
@@ -39,10 +39,10 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload {
     private final static String JVM_NAME = "jvm_name";
     private final static String JVM_VERSION = "jvm_version";
     private final static String JVM_PROFILE = "jvm_profile";
+    private final static String APPLICATION_FRAMEWORK = "application_framework";
+    private final static String APPLICATION_FRAMEWORK_VERSION = "application_framework_version";
     private final static String ESF_VERSION = "esf_version";
     private final static String KURA_VERSION = "kura_version";
-    private final static String ESF_PREFIX = "ESF_";
-    private final static String ESFKURA_VERSION = "esf_version";
     private final static String OSGI_FRAMEWORK = "osgi_framework";
     private final static String OSGI_FRAMEWORK_VERSION = "osgi_framework_version";
     private final static String CONNECTION_INTERFACE = "connection_interface";
@@ -53,11 +53,12 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload {
     private final static String MODEM_IMSI = "modem_imsi";
     private final static String MODEM_ICCID = "modem_iccid";
 
+    private final static String DEFAULT_APPLICATION_FRAMEWORK = "Kura";
+
     /**
      * Constructor
      */
     public KuraBirthPayload() {
-        super();
     }
 
     /**
@@ -103,7 +104,8 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload {
             String jvmName,
             String jvmVersion,
             String jvmProfile,
-            String esfkuraVersion,
+            String applicationFramework,
+            String applicationFrameworkVersion,
             String connectionInterface,
             String connectionIp,
             String acceptEncoding,
@@ -116,8 +118,6 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload {
             String modemImei,
             String modemImsi,
             String modemIccid) {
-        super();
-
         if (uptime != null) {
             getMetrics().put(UPTIME, uptime);
         }
@@ -157,8 +157,11 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload {
         if (jvmProfile != null) {
             getMetrics().put(JVM_PROFILE, jvmProfile);
         }
-        if (esfkuraVersion != null) {
-            getMetrics().put(ESFKURA_VERSION, esfkuraVersion);
+        if (applicationFramework != null) {
+            getMetrics().put(APPLICATION_FRAMEWORK, applicationFramework);
+        }
+        if (applicationFrameworkVersion != null) {
+            getMetrics().put(APPLICATION_FRAMEWORK_VERSION, applicationFrameworkVersion);
         }
         if (connectionInterface != null) {
             getMetrics().put(CONNECTION_INTERFACE, connectionInterface);
@@ -357,7 +360,11 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload {
      * @return
      */
     public String getApplicationFramework() {
-        return (String) getMetrics().get(ESFKURA_VERSION);
+        String value = (String) getMetrics().get(APPLICATION_FRAMEWORK);
+        if (value != null) {
+            return value;
+        }
+        return (String) getMetrics().get(DEFAULT_APPLICATION_FRAMEWORK);
     }
 
     /**
@@ -366,7 +373,15 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload {
      * @return
      */
     public String getApplicationFrameworkVersion() {
-        return (String) getMetrics().get(ESFKURA_VERSION);
+        String value = (String) getMetrics().get(APPLICATION_FRAMEWORK_VERSION);
+        if (value != null) {
+            return value;
+        }
+        value = (String) getMetrics().get(KURA_VERSION);
+        if (value != null) {
+            return value;
+        }
+        return (String) getMetrics().get(ESF_VERSION);
     }
 
     /**
@@ -480,7 +495,8 @@ public class KuraBirthPayload extends KuraPayload implements DevicePayload {
                 .append(", getJvmProfile()=").append(getJvmProfile())
                 .append(", getOsgiFramework()=").append(getContainerFramework())
                 .append(", getOsgiFrameworkVersion()=").append(getContainerFrameworkVersion())
-                .append(", getEsfKuraVersion()=").append(getApplicationFrameworkVersion())
+                .append(", getApplicationFramework()=").append(getApplicationFramework())
+                .append(", getApplicationFrameworkVersion()=").append(getApplicationFrameworkVersion())
                 .append(", getConnectionInterface()=").append(getConnectionInterface())
                 .append(", getConnectionIp()=").append(getConnectionIp())
                 .append(", getAcceptEncoding()=").append(getAcceptEncoding())

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
@@ -74,6 +74,7 @@ public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
             deviceCreator.setOsVersion(payload.getOsVersion());
             deviceCreator.setJvmVersion(payload.getJvmVersion());
             deviceCreator.setOsgiFrameworkVersion(payload.getContainerFrameworkVersion());
+            deviceCreator.setApplicationFrameworkVersion(payload.getApplicationFrameworkVersion());
             deviceCreator.setApplicationIdentifiers(payload.getApplicationIdentifiers());
             deviceCreator.setAcceptEncoding(payload.getAcceptEncoding());
             deviceCreator.setCredentialsMode(DeviceCredentialsMode.LOOSE);
@@ -95,6 +96,7 @@ public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
             device.setOsVersion(payload.getOsVersion());
             device.setJvmVersion(payload.getJvmVersion());
             device.setOsgiFrameworkVersion(payload.getContainerFrameworkVersion());
+            device.setApplicationFrameworkVersion(payload.getApplicationFrameworkVersion());
             device.setApplicationIdentifiers(payload.getApplicationIdentifiers());
             device.setAcceptEncoding(payload.getAcceptEncoding());
 


### PR DESCRIPTION
This change does implement a common way to transmit the Kura/ESF version information. Falling back to defaults for ESF and Kura.

The change also fixes the storage layer and the UI to store and show the information.