### PR TITLE
Write a logging adapter for Liquibase to forward to SLF4J

### DIFF
--- a/commons/src/test/resources/logback.xml
+++ b/commons/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/message/internal/src/test/resources/logback.xml
+++ b/message/internal/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/service/account/internal/src/test/resources/logback.xml
+++ b/service/account/internal/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/service/datastore/internal/src/test/resources/logback.xml
+++ b/service/datastore/internal/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/service/device/registry/internal/src/test/resources/logback.xml
+++ b/service/device/registry/internal/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/service/liquibase/pom.xml
+++ b/service/liquibase/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -54,6 +58,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/service/liquibase/src/main/java/liquibase/ext/logging/slf4j/LoggerImpl.java
+++ b/service/liquibase/src/main/java/liquibase/ext/logging/slf4j/LoggerImpl.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc- initial API and implementation
+ *******************************************************************************/
+package liquibase.ext.logging.slf4j;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.logging.core.AbstractLogger;
+
+/**
+ * A logger implementation for liquibase
+ * <p>
+ * <strong>Note:</strong> This class must reside in a package starting with <code>liquibase.ext.logging</code>.
+ * </p>
+ */
+public class LoggerImpl extends AbstractLogger {
+
+    private Logger logger;
+
+    @Override
+    public void setName(String name) {
+        this.logger = LoggerFactory.getLogger(name);
+    }
+
+    @Override
+    public void setLogLevel(String logLevel, String logFile) {
+    }
+
+    @Override
+    public void severe(String message) {
+        logger.error(message);
+    }
+
+    @Override
+    public void severe(String message, Throwable e) {
+        logger.error(message, e);
+    }
+
+    @Override
+    public void warning(String message) {
+        logger.warn(message);
+    }
+
+    @Override
+    public void warning(String message, Throwable e) {
+        logger.warn(message, e);
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    public void info(String message, Throwable e) {
+        logger.info(message, e);
+    }
+
+    @Override
+    public void debug(String message) {
+        logger.debug(message);
+    }
+
+    @Override
+    public void debug(String message, Throwable e) {
+        logger.debug(message, e);
+    }
+
+    @Override
+    public void setChangeLog(DatabaseChangeLog databaseChangeLog) {
+    }
+
+    @Override
+    public void setChangeSet(ChangeSet changeSet) {
+    }
+
+    @Override
+    public int getPriority() {
+        return Integer.getInteger("org.eclipse.kapua.liquibase.logger.priority", 10);
+    }
+}

--- a/service/liquibase/src/test/java/org/eclipse/kapua/service/liquibase/KapuaLiquibaseClientTest.java
+++ b/service/liquibase/src/test/java/org/eclipse/kapua/service/liquibase/KapuaLiquibaseClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Red Hat and/or its affiliates and others
+ * Copyright (c) 2017 Red Hat and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/liquibase/src/test/resources/logback.xml
+++ b/service/liquibase/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/service/security/shiro/src/test/resources/logback.xml
+++ b/service/security/shiro/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/service/user/internal/src/test/resources/logback.xml
+++ b/service/user/internal/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+			</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>


### PR DESCRIPTION
This adds a logging adapter for Liquibase forwarding the output to SLF4J so that the final application can forward it to either logging framework supported by SLF4J.