### PR TITLE
#340: Backport EclipseLink 2.7.0 SLF4Logger

### DIFF
--- a/commons/src/main/java/org/eclipse/persistence/logging/slf4j/LogCategory.java
+++ b/commons/src/main/java/org/eclipse/persistence/logging/slf4j/LogCategory.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2016  Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *      Tomas Kraus - Initial implementation
+ ******************************************************************************/
+package org.eclipse.persistence.logging.slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.persistence.logging.SessionLog;
+
+/**
+ * EclipseLink categories used for logging name space.
+ * The EclipseLink categories for the logging name space are:<br>
+ * <table summary="">
+ * <tr><td>&nbsp;</td><td>ALL</td>            <td>&nbsp;</td><td>= "all"</td></tr>
+ * <tr><td>&nbsp;</td><td>CACHE</td>          <td>&nbsp;</td><td>= "cache"</td></tr>
+ * <tr><td>&nbsp;</td><td>CONNECTION</td>     <td>&nbsp;</td><td>= "connection"</td></tr>
+ * <tr><td>&nbsp;</td><td>DDL</td>            <td>&nbsp;</td><td>= "ddl"</td></tr>
+ * <tr><td>&nbsp;</td><td>DMS</td>            <td>&nbsp;</td><td>= "dms"</td></tr>
+ * <tr><td>&nbsp;</td><td>EJB</td>            <td>&nbsp;</td><td>= "ejb"</td></tr>
+ * <tr><td>&nbsp;</td><td>EJB_OR_METADATA</td><td>&nbsp;</td><td>= "ejb_or_metadata"</td></tr>
+ * <tr><td>&nbsp;</td><td>EVENT</td>          <td>&nbsp;</td><td>= "event"</td></tr>
+ * <tr><td>&nbsp;</td><td>JPA</td>            <td>&nbsp;</td><td>= "jpa"</td></tr>
+ * <tr><td>&nbsp;</td><td>JPARS</td>          <td>&nbsp;</td><td>= "jpars"</td></tr>
+ * <tr><td>&nbsp;</td><td>METADATA</td>       <td>&nbsp;</td><td>= "metadata"</td></tr>
+ * <tr><td>&nbsp;</td><td>METAMODEL</td>      <td>&nbsp;</td><td>= "metamodel"</td></tr>
+ * <tr><td>&nbsp;</td><td>MONITORING</td>     <td>&nbsp;</td><td>= "monitoring"</td></tr>
+ * <tr><td>&nbsp;</td><td>PROPAGATION</td>    <td>&nbsp;</td><td>= "propagation"</td></tr>
+ * <tr><td>&nbsp;</td><td>PROPERTIES</td>     <td>&nbsp;</td><td>= "properties"</td></tr>
+ * <tr><td>&nbsp;</td><td>QUERY</td>          <td>&nbsp;</td><td>= "query"</td></tr>
+ * <tr><td>&nbsp;</td><td>SEQUENCING</td>     <td>&nbsp;</td><td>= "sequencing"</td></tr>
+ * <tr><td>&nbsp;</td><td>SERVER</td>         <td>&nbsp;</td><td>= "server"</td></tr>
+ * <tr><td>&nbsp;</td><td>SQL</td>            <td>&nbsp;</td><td>= "sql"</td></tr>
+ * <tr><td>&nbsp;</td><td>TRANSACTION</td>    <td>&nbsp;</td><td>= "transaction"</td></tr>
+ * <tr><td>&nbsp;</td><td>WEAVER</td>         <td>&nbsp;</td><td>= "weaver"</td></tr>
+ * </table>
+ */
+public enum LogCategory {
+    ALL(        (byte)0x00, "all"),
+    CACHE(      (byte)0x01, SessionLog.CACHE),
+    CONNECTION( (byte)0x02, SessionLog.CONNECTION),
+    DDL(        (byte)0x03, SessionLog.DDL),
+    DMS(        (byte)0x04, SessionLog.DMS),
+    EJB(        (byte)0x05, SessionLog.EJB),
+    EVENT(      (byte)0x06, SessionLog.EVENT),
+    JPA(        (byte)0x07, SessionLog.JPA),
+    JPARS(      (byte)0x08, SessionLog.JPARS),
+    METADATA(   (byte)0x09, SessionLog.METADATA),
+    METAMODEL(  (byte)0x0A, SessionLog.METAMODEL),
+    MISC(       (byte)0x0B, SessionLog.MISC),
+    MONITORING( (byte)0x0C, SessionLog.MONITORING),
+    PROPAGATION((byte)0x0D, SessionLog.PROPAGATION),
+    PROPERTIES( (byte)0x0E, SessionLog.PROPERTIES),
+    QUERY(      (byte)0x0F, SessionLog.QUERY),
+    SEQUENCING( (byte)0x10, SessionLog.SEQUENCING),
+    SERVER(     (byte)0x11, SessionLog.SERVER),
+    SQL(        (byte)0x12, SessionLog.SQL),
+    TRANSACTION((byte)0x13, SessionLog.TRANSACTION),
+    WEAVER(     (byte)0x14, SessionLog.WEAVER);
+
+    /** Logging categories enumeration length. */
+    public static final int length = LogCategory.values().length;
+
+    /** Logger name spaces prefix. */
+    private static final String NAMESPACE_PREFIX = "eclipselink.logging.";
+
+    /** {@link Map} for {@link String} to {@link LogCategory} case insensitive conversion. */
+    private static final Map<String, LogCategory> stringValuesMap = new HashMap<String, LogCategory>(2 * length);
+
+    /** Logger name spaces lookup table. */
+    private static final String[] nameSpaces = new String[length];
+
+    static {
+        // Initialize String to LogCategory case insensitive lookup Map.
+        for (LogCategory category : LogCategory.values()) {
+            stringValuesMap.put(category.name.toLowerCase(), category);
+        }
+        // Initialize logger name spaces lookup table.
+        for (LogCategory category : LogCategory.values()) {
+            nameSpaces[category.id] = NAMESPACE_PREFIX + category.name;
+        }
+    }
+
+    /**
+     * Returns {@link LogCategory} object holding the value of the specified {@link String}.
+     * @param name The {@link String} to be parsed.
+     * @return {@link LogCategory} object holding the value represented by the string argument or {@code null} when
+     *         there exists no corresponding {@link LogCategory} object to provided argument value. {@code null} value
+     *         of the string argument is converted to {@code ALL}.
+     */
+    public static final LogCategory toValue(final String name) {
+        return name != null  && name.length() > 0 ? stringValuesMap.get(name.toLowerCase()) : ALL;
+    }
+
+    /** Logging category ID. Continuous integer sequence starting from 0. */
+    private final byte id;
+
+    /** Logging category name. */
+    private final String name;
+
+    /**
+     * Creates an instance of logging category.
+     * @param id   Logging category ID.
+     * @param name Logging category name.
+     */
+    private LogCategory(final byte id, final String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    /**
+     * Get logging category ID.
+     * @return Logging category ID.
+     */
+    public byte getId() {
+        return id;
+    }
+
+    /**
+     * Get logging category name.
+     * @return Logging category name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Get logger name space for this logging category.
+     * @return Logger name space for this logging category.
+     */
+    public String getNameSpace() {
+        return nameSpaces[id];
+    }
+
+}

--- a/commons/src/main/java/org/eclipse/persistence/logging/slf4j/LogCategory.java
+++ b/commons/src/main/java/org/eclipse/persistence/logging/slf4j/LogCategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016  Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2017  Oracle and/or its affiliates and others. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *      Tomas Kraus - Initial implementation
+ *      Jens Reimann - fix missing categories
  ******************************************************************************/
 package org.eclipse.persistence.logging.slf4j;
 
@@ -65,8 +66,10 @@ public enum LogCategory {
     SERVER(     (byte)0x11, SessionLog.SERVER),
     SQL(        (byte)0x12, SessionLog.SQL),
     TRANSACTION((byte)0x13, SessionLog.TRANSACTION),
-    WEAVER(     (byte)0x14, SessionLog.WEAVER);
-
+    WEAVER(     (byte)0x14, SessionLog.WEAVER),
+    DBWS(       (byte)0x15, SessionLog.DBWS),
+    MOXY(       (byte)0x16, SessionLog.MOXY);
+    
     /** Logging categories enumeration length. */
     public static final int length = LogCategory.values().length;
 

--- a/commons/src/main/java/org/eclipse/persistence/logging/slf4j/LogLevel.java
+++ b/commons/src/main/java/org/eclipse/persistence/logging/slf4j/LogLevel.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2016  Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *      Tomas Kraus - Initial API and implementation.
+ ******************************************************************************/
+package org.eclipse.persistence.logging.slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Log levels for EclipseLink logging.
+ * The EclipseLink logging levels available are:<br>
+ * <table summary="">
+ * <tr><td>ALL</td>    <td>&nbsp;</td><td>=&nbsp;0</td>
+ *     <td>This level currently logs at the same level as FINEST.</td></tr>
+ * <tr><td>FINEST</td> <td>&nbsp;</td><td>=&nbsp;1</td>
+ *     <td>This level enables logging of more debugging information than the FINER setting, such as a very detailed
+ *         information about certain features (for example, sequencing). You may want to use this log level during
+ *         debugging and testing, but not at production.</td></tr>
+ * <tr><td>FINER</td>  <td>&nbsp;</td><td>=&nbsp;2</td>
+ *     <td>This level enables logging of more debugging information than the FINE setting. For example, the transaction
+ *         information is logged at this level. You may want to use this log level during debugging and testing,
+ *         but not at production.</td></tr>
+ * <tr><td>FINE</td>   <td>&nbsp;</td><td>=&nbsp;3</td>
+ *     <td>This level enables logging of the first level of the debugging information and SQL. You may want to use
+ *         this log level during debugging and testing, but not at production.</td></tr>
+ * <tr><td>CONFIG</td> <td>&nbsp;</td><td>=&nbsp;4</td>
+ *     <td>This level enables logging of such configuration details as your database login information and some metadata
+ *         information. You may want to use the CONFIG log level at deployment time.</td></tr>
+ * <tr><td>INFO</td>   <td>&nbsp;</td><td>=&nbsp;5</td>
+ *     <td>This level enables the standard output. The contents of this output is very limited. It is the default
+ *         logging level if a logging level is not set.</td></tr>
+ * <tr><td>WARNING</td><td>&nbsp;</td><td>=&nbsp;6</td>
+ *     <td>This level enables logging of issues that have a potential to cause problems. For example, a setting that
+ *         is picked by the application and not by the user.</td></tr>
+ * <tr><td>SEVERE</td> <td>&nbsp;</td><td>=&nbsp;7</td>
+ *     <td>This level enables reporting of failure cases only. Usually, if the failure occurs, the application
+ *         stops.</td></tr>
+ * <tr><td>OFF</td>    <td>&nbsp;</td><td>=&nbsp;8</td>
+ *     <td>This setting disables the generation of the log output. You may want to set logging to OFF during production
+ *         to avoid the overhead of logging.</td></tr>
+ * </table>
+ */
+public enum LogLevel {
+
+    /** Log everything. */
+    ALL(    (byte)0x00, "ALL"),
+    /** Finest (the most detailed) logging level. */
+    FINEST( (byte)0x01, "FINEST"),
+    /** Finer logging level. */
+    FINER(  (byte)0x02, "FINER"),
+    /** Fine logging level. */
+    FINE(   (byte)0x03, "FINE"),
+    /** Configuration information logging level. */
+    CONFIG( (byte)0x04, "CONFIG"),
+    /** Informational messages. */
+    INFO(   (byte)0x05, "INFO"),
+    /** Exceptions that are not fatal. */
+    WARNING((byte)0x06, "WARNING"),
+    /** Fatal exceptions. */
+    SEVERE( (byte)0x07, "SEVERE"),
+    /** Logging is turned off. */
+    OFF(    (byte)0x08, "OFF");
+
+    /** Logging levels enumeration length. */
+    public static final int length = LogLevel.values().length;
+
+    /** {@link Map} for {@link String} to {@link LogLevel} case insensitive lookup. */
+    private static final Map<String, LogLevel> stringValuesMap = new HashMap<String, LogLevel>(2 * length);
+
+    // Initialize String to LogLevel case insensitive lookup Map.
+    static {
+        for (LogLevel logLevel : LogLevel.values()) {
+            stringValuesMap.put(logLevel.name.toUpperCase(), logLevel);
+        }
+    }
+
+    /** Array for id to {@link LogLevel} lookup. */
+    private static final LogLevel idValues[] = new LogLevel[length];
+
+    // Initialize id to LogLevel lookup array.
+    static {
+        for (LogLevel logLevel : LogLevel.values()) {
+            idValues[logLevel.id] = logLevel;
+        }
+    }
+
+    /**
+     * Returns {@link LogLevel} object holding the value of the specified {@link String}.
+     * @param name The {@link String} to be parsed.
+     * @return {@link LogLevel} object holding the value represented by the string argument or {@code null} when
+     *         there exists no corresponding {@link LogLevel} object to provided argument value.
+     */
+    public static final LogLevel toValue(final String name) {
+        return name != null ? stringValuesMap.get(name.toUpperCase()) : null;
+    }
+
+    /**
+     * Returns {@link LogLevel} object holding the value of the specified {@link LogLevel} ID.
+     * @param id {@link LogLevel} ID.
+     * @return {@link LogLevel} object holding the value represented by the {@code id} argument.
+     * @throws IllegalArgumentException when {@link LogLevel} ID is out of valid {@link LogLevel} IDs range.
+     */
+    public static final LogLevel toValue(final int id) {
+        if (id < 0 || id >= length) {
+            throw new IllegalArgumentException(
+                    "Log level ID " + id + "is out of range <0, " + Integer.toString(length) + ">.");
+        }
+        return idValues[id];
+    }
+
+    /**
+     * Returns {@link LogLevel} object holding the value of the specified {@link LogLevel} ID.
+     * @param id       {@link LogLevel} ID.
+     * @param fallBack {@link LogLevel} object to return on ID lookup failure.
+     * @return {@link LogLevel} object holding the value represented by the {@code id} argument or {@code fallBack}
+     *         when provided ID is not valid {@link LogLevel} ID.
+     * @throws IllegalArgumentException when {@link LogLevel} ID is out of valid {@link LogLevel} IDs range.
+     */
+    public static final LogLevel toValue(final int id, final LogLevel fallBack) {
+        if (id >= 0 && id < length) {
+            return idValues[id];
+        }
+        return fallBack;
+    }
+
+    // Holds value of SessionLog logging levels constants (e.g. ALL, FINES, FINER, ...).
+    /** Logging level ID. Continuous integer sequence starting from 0. */
+    private final byte id;
+
+    /** Logging level name. */
+    private final String name;
+
+    /**
+     * Creates an instance of logging level.
+     * @param id   Logging level ID.
+     * @param name Logging level name.
+     */
+    private LogLevel(final byte id, final String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    /**
+     * Get logging level ID.
+     * @return Logging level ID.
+     */
+    public byte getId() {
+        return id;
+    }
+
+    /**
+     * Get logging level name.
+     * @return Logging level name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Check if a message of the given level would actually be logged under this logging level.
+     * @param level Message logging level.
+     * @return Value of {@code true} if the given message logging level will be logged or {@code false} otherwise.
+     */
+    public boolean shouldLog(final LogLevel level) {
+        return this.id <= level.id;
+    }
+
+    /**
+     * Check if a message of the given level ID would actually be logged under this logging level.
+     * @param id Message logging level.
+     * @return Value of {@code true} if the given message logging level will be logged or {@code false} otherwise.
+     */
+    public boolean shouldLog(final byte id) {
+        return this.id <= id;
+    }
+
+}

--- a/commons/src/main/java/org/eclipse/persistence/logging/slf4j/SLF4JLogger.java
+++ b/commons/src/main/java/org/eclipse/persistence/logging/slf4j/SLF4JLogger.java
@@ -1,0 +1,278 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016  Oracle and/or its affiliates. All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
+ * which accompanies this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *      Jaro Kuruc  - Initial API and implementation.
+ *      Tomas Kraus - EclipseLink 2.7 integration.
+ ******************************************************************************/
+package org.eclipse.persistence.logging.slf4j;
+
+import java.security.AccessController;
+
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
+import org.eclipse.persistence.internal.security.PrivilegedGetSystemProperty;
+import org.eclipse.persistence.logging.AbstractSessionLog;
+import org.eclipse.persistence.logging.SessionLogEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * EclipseLink logger bridge over SLF4J.
+ */
+public class SLF4JLogger extends AbstractSessionLog {
+
+    /** Logger callback interface. */
+    private static interface LoggerCall {
+        void log(final Logger logger, final String msg, final Throwable t);
+        void log(final Logger logger, final String message);
+    }
+
+    /** {@code TRACE} level log. */
+    private static final class LogTrace implements LoggerCall {
+        @Override
+        public void log(final Logger logger, final String msg, final Throwable t) {
+            logger.trace(msg, t);
+        }
+        @Override
+        public void log(final Logger logger, final String message) {
+            logger.trace(message);
+        }
+    }
+
+    /** {@code DEBUG} level log. */
+    private static final class LogDebug implements LoggerCall {
+        @Override
+        public void log(final Logger logger, final String msg, final Throwable t) {
+            logger.debug(msg, t);
+        }
+        @Override
+        public void log(final Logger logger, final String message) {
+            logger.debug(message);
+        }
+    }
+
+    /** {@code INFO} level log. */
+    private static final class LogInfo implements LoggerCall {
+        @Override
+        public void log(final Logger logger, final String msg, final Throwable t) {
+            logger.info(msg, t);
+        }
+        @Override
+        public void log(final Logger logger, final String message) {
+            logger.info(message);
+        }
+    }
+
+    /** {@code WARN} level log. */
+    private static final class LogWarn implements LoggerCall {
+        @Override
+        public void log(final Logger logger, final String msg, final Throwable t) {
+            logger.warn(msg, t);
+        }
+        @Override
+        public void log(final Logger logger, final String message) {
+            logger.warn(message);
+        }
+    }
+
+    /** {@code ERROR} level log. */
+    private static final class LogError implements LoggerCall {
+        @Override
+        public void log(final Logger logger, final String msg, final Throwable t) {
+            logger.error(msg, t);
+        }
+        @Override
+        public void log(final Logger logger, final String message) {
+            logger.error(message);
+        }
+    }
+
+    /** Do not log anything. */
+    private static final class LogNop implements LoggerCall {
+        @Override
+        public void log(final Logger logger, final String msg, final Throwable t) {
+        }
+        @Override
+        public void log(final Logger logger, final String message) {
+        }
+    }
+
+    /** The default session name in case there is session name is missing. */
+    public static final String ECLIPSELINK_NAMESPACE = "org.eclipse.persistence";
+
+    /** SLF4J logger calls mapping for EclipseLink logging levels. */
+    private static final LoggerCall[] loggerCall = new LoggerCall[LogLevel.length];
+
+    /** Loggers lookup array. */
+    private static final Logger[] categoryLoggers = new Logger[LogCategory.length];
+
+    static {
+        // Initialize loggers lookup array.
+        for (int i = 0; i < LogCategory.length; i++) {
+            categoryLoggers[i] = null;
+        }
+        // Initialize SLF4J logger calls mapping for EclipseLink logging levels.
+        loggerCall[LogLevel.ALL.getId()]     = loggerCall[LogLevel.FINEST.getId()] = new LogTrace();
+        loggerCall[LogLevel.FINER.getId()]   = loggerCall[LogLevel.FINE.getId()]   = new LogDebug();
+        loggerCall[LogLevel.CONFIG.getId()]  = loggerCall[LogLevel.INFO.getId()]   = new LogInfo();
+        loggerCall[LogLevel.WARNING.getId()] = new LogWarn();
+        loggerCall[LogLevel.SEVERE.getId()]  = new LogError();
+        loggerCall[LogLevel.OFF.getId()]     = new LogNop();
+    }
+
+    /**
+     * Retrieve Logger for the given category.
+     * @param category EclipseLink logging category
+     * @return Logger for the given logging category.
+     */
+    private static Logger getLogger(final LogCategory category) {
+        final Logger logger = categoryLoggers[category.getId()];
+        if (logger != null) {
+            return logger;
+        }
+        return categoryLoggers[category.getId()] = LoggerFactory.getLogger(category.getNameSpace());
+    }
+
+    /** Logging levels for individual logging categories. */
+    private final LogLevel[] logLevels;
+
+    /**
+     * Creates an instance of EclipseLink logger bridge over SLF4J
+     */
+    public SLF4JLogger() {
+        super();
+        // Set default logging levels for all logging categories.
+        final byte defaultLevel = LogLevel.toValue(level).getId();
+        logLevels = new LogLevel[LogCategory.length];
+        for (LogCategory category : LogCategory.values()) {
+            final int i = category.getId();
+            switch(category) {
+            case ALL:
+                logLevels[i] = LogLevel.toValue(defaultLevel);
+                break;
+            default:
+                final String property = PersistenceUnitProperties.CATEGORY_LOGGING_LEVEL_ + category.getName();
+                final String logLevelStr = PrivilegedAccessHelper.shouldUsePrivilegedAccess()
+                        ? AccessController.doPrivileged(new PrivilegedGetSystemProperty(property))
+                        : System.getProperty(property);
+                logLevels[i] = LogLevel.toValue(
+                        logLevelStr != null ? translateStringToLoggingLevel(logLevelStr) : defaultLevel);
+            }
+        }
+    }
+
+    /**
+     * Get the logging level for the default logging category.
+     * @return level Current logging level for default the default logging category.
+     */
+    @Override
+    public int getLevel() {
+        return logLevels[LogCategory.ALL.getId()].getId();
+    }
+
+    /**
+     * Get the logging level for the specified logging category.
+     * @param categoryName The {@link String} representation of an EclipseLink logging category.
+     * @return level Current logging level for default the default logging category.
+     */
+    @Override
+    public int getLevel(final String categoryName) {
+        final LogCategory category = LogCategory.toValue(categoryName);
+        if (category == null) {
+            throw new IllegalArgumentException("Unknown logging category name.");
+        }
+        return logLevels[category.getId()].getId();
+    }
+
+    /**
+     * Set the logging level for the default logging category.
+     * @param level The logging level to be set.
+     */
+    @Override
+    public void setLevel(final int level) {
+        super.setLevel(level);
+        logLevels[LogCategory.ALL.getId()] = LogLevel.toValue(level);
+        // TODO: Handle logging levels on SLF4J side too.
+    }
+
+    /**
+     * Set the logging level for the specified logging category.
+     * @param level        The logging level to be set.
+     * @param categoryName The {@link String} representation of an EclipseLink logging category.
+     */
+    @Override
+    public void setLevel(final int level, final String categoryName) {
+        final LogCategory category = LogCategory.toValue(categoryName);
+        if (category == null) {
+            throw new IllegalArgumentException("Unknown logging category name.");
+        }
+        logLevels[category.getId()] = LogLevel.toValue(level);
+        // TODO: Handle logging levels on SLF4J side too.
+    }
+
+    /**
+     * Check if a message of the given level would actually be logged under logging level for the default logging
+     * category.
+     * @param level Message logging level.
+     * @return Value of {@code true} if the given message logging level will be logged or {@code false} otherwise.
+     */
+    @Override
+    public boolean shouldLog(final int level) {
+        return logLevels[LogCategory.ALL.getId()].shouldLog((byte)level);
+    }
+
+    /**
+     * Check if a message of the given level would actually be logged under logging level for the specified logging
+     * category.
+     * @param level Message logging level.
+     * @param categoryName The {@link String} representation of an EclipseLink logging category.
+     * @return Value of {@code true} if the given message logging level will be logged or {@code false} otherwise.
+     */
+    @Override
+    public boolean shouldLog(final int level, final String categoryName) {
+        final LogCategory category = LogCategory.toValue(categoryName);
+        if (category == null) {
+            throw new IllegalArgumentException("Unknown logging category name.");
+        }
+        return logLevels[category.getId()].shouldLog((byte)level);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void log(final SessionLogEntry logEntry) {
+        if (logEntry == null) {
+            return;
+        }
+        final LogCategory category = LogCategory.toValue(logEntry.getNameSpace());
+        if (category == null) {
+            throw new IllegalArgumentException("Unknown logging category name.");
+        }
+        final byte levelId = (byte)logEntry.getLevel();
+        if (logLevels[category.getId()].shouldLog(levelId)) {
+            final LogLevel level = LogLevel.toValue(levelId);
+            final Logger logger = getLogger(category);
+            if (logEntry.hasException()) {
+                if (shouldLogExceptionStackTrace()) {
+                    // Message is rendered on EclipseLink side. SLF4J gets final String. Exception is passed too.
+                    loggerCall[level.getId()].log(logger, formatMessage(logEntry), logEntry.getException());
+                } else {
+                    // Exception message is rendered on EclipseLink side. SLF4J gets final String.
+                    loggerCall[level.getId()].log(logger, logEntry.getException().toString());
+                }
+            } else {
+                // Message is rendered on EclipseLink side. SLF4J gets final String.
+                loggerCall[level.getId()].log(logger, formatMessage(logEntry));
+            }
+        }
+    }
+
+}

--- a/commons/src/main/java/org/eclipse/persistence/logging/slf4j/SLF4JLogger.java
+++ b/commons/src/main/java/org/eclipse/persistence/logging/slf4j/SLF4JLogger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2016  Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2017  Oracle and/or its affiliates and others. All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
  * which accompanies this distribution.
@@ -10,6 +10,7 @@
  * Contributors:
  *      Jaro Kuruc  - Initial API and implementation.
  *      Tomas Kraus - EclipseLink 2.7 integration.
+ *      Jens Reimann - Improve exception message
  ******************************************************************************/
 package org.eclipse.persistence.logging.slf4j;
 
@@ -254,7 +255,7 @@ public class SLF4JLogger extends AbstractSessionLog {
         }
         final LogCategory category = LogCategory.toValue(logEntry.getNameSpace());
         if (category == null) {
-            throw new IllegalArgumentException("Unknown logging category name.");
+            throw new IllegalArgumentException("Unknown logging category name: " + logEntry.getNameSpace());
         }
         final byte levelId = (byte)logEntry.getLevel();
         if (logLevels[category.getId()].shouldLog(levelId)) {

--- a/commons/src/main/java/org/eclipse/persistence/logging/slf4j/package-info.java
+++ b/commons/src/main/java/org/eclipse/persistence/logging/slf4j/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * SLF4J logging adapter for EclipseLink
+ * <p>
+ * <strong>Note:</strong> This is backported from EclipeLink 2.7.0.
+ * Remove this once we switched to a final release of EclipseLink 2.7.0.
+ * </p>
+ */
+package org.eclipse.persistence.logging.slf4j;

--- a/commons/src/main/resources/META-INF/persistence.xml
+++ b/commons/src/main/resources/META-INF/persistence.xml
@@ -25,6 +25,8 @@
 		<properties>
 			<!-- <property name="javax.persistence.jdbc.driver" value="org.mariadb.jdbc.Driver" /> -->
 			<property name="javax.persistence.lock.timeout" value="1000" />
+			
+			<property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger" />
 		</properties>
 	</persistence-unit>
 </persistence>

--- a/commons/src/test/resources/META-INF/persistence.xml
+++ b/commons/src/test/resources/META-INF/persistence.xml
@@ -16,5 +16,9 @@
 	<persistence-unit name="kapua-commons-unit-test" transaction-type="RESOURCE_LOCAL">
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>org.eclipse.kapua.commons.model.misc.CollisionEntity</class>
+        
+        <properties>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger" />
+        </properties>
 	</persistence-unit>
 </persistence>

--- a/service/account/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/account/internal/src/main/resources/META-INF/persistence.xml
@@ -33,6 +33,7 @@
 		<properties>
 			<!-- <property name="javax.persistence.jdbc.driver" value="org.mariadb.jdbc.Driver" /> -->
 			<property name="javax.persistence.lock.timeout" value="1000" />
+			<property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger" />
 		</properties>
 	</persistence-unit>
 </persistence>

--- a/service/datastore/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/persistence.xml
@@ -21,6 +21,10 @@
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 
 		<class>org.eclipse.kapua.commons.configuration.ServiceConfigImpl</class>
+		
+		<properties>
+			<property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger" />
+		</properties>
 
 	</persistence-unit>
 </persistence>

--- a/service/device/registry/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/device/registry/internal/src/main/resources/META-INF/persistence.xml
@@ -36,6 +36,8 @@
             <property name="javax.persistence.lock.timeout" value="1000" />
             <!-- <property name="eclipselink.logging.level.sql" value="FINE"/>
             <property name="eclipselink.logging.parameters" value="true"/> -->
+            
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.Slf4jSessionLogger" />
         </properties>
     </persistence-unit>
 </persistence>

--- a/service/device/registry/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/device/registry/internal/src/main/resources/META-INF/persistence.xml
@@ -37,7 +37,7 @@
             <!-- <property name="eclipselink.logging.level.sql" value="FINE"/>
             <property name="eclipselink.logging.parameters" value="true"/> -->
             
-            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.Slf4jSessionLogger" />
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger" />
         </properties>
     </persistence-unit>
 </persistence>

--- a/service/security/shiro/src/main/resources/META-INF/persistence.xml
+++ b/service/security/shiro/src/main/resources/META-INF/persistence.xml
@@ -33,6 +33,7 @@
 		<properties>
 			<!-- <property name="javax.persistence.jdbc.driver" value="org.mariadb.jdbc.Driver" /> -->
 			<property name="javax.persistence.lock.timeout" value="1000" />
+			<property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger" />
 		</properties>
 	</persistence-unit>
 
@@ -63,6 +64,7 @@
 
 		<properties>
 			<property name="javax.persistence.lock.timeout" value="1000" />
+			<property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger" />
 		</properties>
 	</persistence-unit>
 </persistence>

--- a/service/user/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/user/internal/src/main/resources/META-INF/persistence.xml
@@ -29,5 +29,9 @@
 		<class>org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity</class>
 		<class>org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity</class>
 
+		<properties>
+			<property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger" />
+		</properties>
+
 	</persistence-unit>
 </persistence>


### PR DESCRIPTION
This change backports the SLF4Logger from EclipseLink 2.7.0 and
enables its use throughout Kapua.

This allows for consolidated logging throughout the Kapua platform.

Signed-off-by: Jens Reimann <jreimann@redhat.com>