### PR TITLE
Convert OpenShift installation to an OpenShift template

### DIFF
--- a/dev-tools/src/main/openshift/kapua-template.yml
+++ b/dev-tools/src/main/openshift/kapua-template.yml
@@ -1,0 +1,359 @@
+apiVersion: v1
+id: kapua-broker
+kind: Template
+name: kapua-broker
+metadata:
+  name: kapua-broker
+parameters:
+- name:           IMAGE_VERSION 
+  description:      The version of the image to use
+  value:            latest
+- name:           DOCKER_ACCOUNT
+  description:      The docker hub account name to pull from
+  value:            eclipse
+objects:
+
+# Image streams
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: kapua-sql
+    labels:
+      app: kapua-sql
+  spec:
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: ${DOCKER_ACCOUNT}/kapua-sql:${IMAGE_VERSION}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: kapua-broker
+    labels:
+      app: kapua-broker
+  spec:
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: ${DOCKER_ACCOUNT}/kapua-broker:${IMAGE_VERSION}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: kapua-consoler
+    labels:
+      app: kapua-console
+  spec:
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: ${DOCKER_ACCOUNT}/kapua-console:${IMAGE_VERSION}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: kapua-api
+    labels:
+      app: kapua-api
+  spec:
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: ${DOCKER_ACCOUNT}/kapua-api:${IMAGE_VERSION}
+
+# Deployment configs
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    generation: 1
+    labels:
+      app: sql
+    name: sql
+  spec:
+    replicas: 1
+    selector:
+      app: sql
+      deploymentconfig: sql
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: sql
+          deploymentconfig: sql
+      spec:
+        containers:
+        - image: ${DOCKER_ACCOUNT}/kapua-sql:${IMAGE_VERSION}
+          imagePullPolicy: Always
+          name: sql
+          ports:
+          - containerPort: 3306
+            protocol: TCP
+          - containerPort: 8181
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3306
+            timeoutSeconds: 1
+          volumeMounts:
+          - mountPath: /opt/h2-data
+            name: sql-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - emptyDir: {}
+          name: sql-data
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    generation: 1
+    labels:
+      app: kapua-broker
+    name: kapua-broker
+  spec:
+    replicas: 1
+    selector:
+      app: kapua-broker
+      deploymentconfig: kapua-broker
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        annotations:
+          openshift.io/container.kapua-broker.image.entrypoint: '["/maven/bin/activemq","console"]'
+        labels:
+          app: kapua-broker
+          deploymentconfig: kapua-broker
+      spec:
+        containers:
+        - env:
+          - name: ACTIVEMQ_OPTS
+            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dcommons.db.schema=
+          image: ${DOCKER_ACCOUNT}/kapua-broker:${IMAGE_VERSION}
+          imagePullPolicy: Always
+          name: kapua-broker
+          ports:
+          - containerPort: 1883
+            protocol: TCP
+          - containerPort: 61614
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 1883
+            timeoutSeconds: 1
+          volumeMounts:
+          - mountPath: /maven/data
+            name: kapua-broker-volume-1
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - emptyDir: {}
+          name: kapua-broker-volume-1
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    generation: 1
+    labels:
+      app: kapua-console
+    name: kapua-console
+  spec:
+    replicas: 1
+    selector:
+      app: kapua-console
+      deploymentconfig: kapua-console
+    template:
+      metadata:
+        labels:
+          app: kapua-console
+          deploymentconfig: kapua-console
+      spec:
+        containers:
+        - env:
+          - name: CATALINA_OPTS
+            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dcommons.db.schema= -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
+          image: ${DOCKER_ACCOUNT}/kapua-console:${IMAGE_VERSION}
+          imagePullPolicy: Always
+          name: kapua-console
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /console
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+            periodSeconds: 10
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 30
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    generation: 1
+    labels:
+      app: kapua-api
+    name: kapua-api
+  spec:
+    replicas: 1
+    selector:
+      app: kapua-api
+      deploymentconfig: kapua-api
+    template:
+      metadata:
+        labels:
+          app: kapua-api
+          deploymentconfig: kapua-api
+      spec:
+        containers:
+        - env:
+          - name: CATALINA_OPTS
+            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dcommons.db.schema= -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
+          image: ${DOCKER_ACCOUNT}/kapua-api:${IMAGE_VERSION}
+          imagePullPolicy: Always
+          name: kapua-console
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /api
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+            periodSeconds: 10
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 30
+        
+# Services
+        
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: sql
+    labels:
+      app: sql
+  spec:
+    ports:
+    - name: h2-sql
+      protocol: TCP
+      port: 3306
+      targetPort: 3306
+    - name: h2-web
+      protocol: TCP
+      port: 8181
+      targetPort: 8181
+    selector:
+      app: sql
+      deploymentconfig: sql
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: kapua-broker
+    labels:
+      app: kapua-broker
+    annotations:
+      service.alpha.openshift.io/dependencies: '[{"name": "sql", "kind": "Service"}]'
+  spec:
+    ports:
+    - name: mqtt-tcp
+      protocol: TCP
+      port: 1883
+      targetPort: 1883
+    - name: mqtt-websocket-tcp
+      protocol: TCP
+      port: 61614
+      targetPort: 61614
+    selector:
+      app: kapua-broker
+      deploymentconfig: kapua-broker
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: kapua-console
+    labels:
+      app: kapua-console
+    annotations:
+      service.alpha.openshift.io/dependencies: '[{"name": "sql", "kind": "Service"}]'
+  spec:
+    ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+    selector:
+      app: kapua-console
+      deploymentconfig: kapua-console
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: kapua-api
+    labels:
+      app: kapua-api
+    annotations:
+      service.alpha.openshift.io/dependencies: '[{"name": "sql", "kind": "Service"}]'
+  spec:
+    ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+    selector:
+      app: kapua-api
+      deploymentconfig: kapua-api
+
+# Routes
+
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: broker
+    labels:
+      app: kapua-broker
+  spec:
+    to:
+      kind: Service
+      name: kapua-broker
+    port:
+      targetPort: mqtt-websocket-tcp
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: console
+    labels:
+      app: kapua-console
+  spec:
+    to:
+      kind: Service
+      name: kapua-console
+    port:
+      targetPort: http
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: api
+    labels:
+      app: kapua-api
+  spec:
+    to:
+      kind: Service
+      name: kapua-api
+    port:
+      targetPort: http

--- a/dev-tools/src/main/openshift/readme.md
+++ b/dev-tools/src/main/openshift/readme.md
@@ -19,15 +19,21 @@ Before you install OpenShift, make sure you have Docker server properly installe
 
 Now download OpenShift Origin binary distribution and install it into your file system:
 
-    wget -nc https://github.com/openshift/origin/releases/download/v1.4.1/openshift-origin-server-v1.4.1-3f9807a-linux-64bit.tar.gz
-    tar xpf openshift-origin-server-v1.4.1-3f9807a-linux-64bit.tar.gz
-    mv openshift-origin-server-v1.4.1+3f9807a-linux-64bit openshift
-    ln -s ~/openshift/oc /usr/local/bin/oc
+    wget -nc https://github.com/openshift/origin/releases/download/v1.4.1/openshift-origin-client-tools-v1.4.1-3f9807a-linux-64bit.tar.gz
+    tar xzf openshift-origin-client-tools-v1.4.1-3f9807a-linux-64bit.tar.gz
+    ln -s openshift-origin-client-tools-v1.4.1+3f9807a-linux-64bit openshift
+    ln -s openshift/oc /usr/local/bin/oc
 
-Don't forget to start OpenShift server, log into it and creating new project before you proceed:
+In order to start a local OpenShift installation simply run:
 
-    nohup openshift/openshift start &
-    oc login --insecure-skip-tls-verify=true https://localhost:8443 -u admin -p admin
+    oc cluster up
+    
+Or the following command if you want to enable metrics support:
+
+    oc cluster up --metrics
+
+An create a new project using:
+
     oc new-project eclipse-kapua
 
 ## Ensuring enough entropy
@@ -68,10 +74,12 @@ For more information about the "EPEL repositories" see https://fedoraproject.org
 
 Execute the following command:
 
-    DOCKER_ACCOUNT=hekonsek bash <(curl -sL https://raw.githubusercontent.com/eclipse/kapua/develop/dev-tools/src/main/openshift/openshift-deploy.sh)
+    oc new-app -f https://raw.githubusercontent.com/eclipse/kapua/develop/dev-tools/src/main/openshift/kapua-template.yml -p DOCKER_ACCOUNT=hekonsek
 
 Now open the following URL in your web browser - `http://localhost:8080/console`. And log-in into Kapua UI using default
 credentials:
 
-    username: kapua-sys
-    password: kapua-password
+<dl>
+	<dt>username</dt><dd>kapua-sys</dd>
+	<dt>password</dt><dd>kapua-password</dd>
+</dl>


### PR DESCRIPTION
This converts the current shell script OpenShift installation into an OpenShift template.

This allows for easier management of the parameters (DOCKER_ACCOUNT, …) and also allows us to create a simple creation UI for Kapua in OpenShift.

Further on this provides the basis for enabling metrics extraction further down the road.