### PR TITLE
Provide Jetty images for Docker and OpenShift

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -774,6 +774,20 @@
 								</runCmds>
 							</build>
 						</image>
+						<image>
+							<name>${docker.account}/kapua-api-jetty</name>
+							<build>
+								<from>${docker.account}/jetty-base</from>
+								<assembly>
+									<descriptor>/src/main/descriptors/kapua-api-jetty.xml</descriptor>
+									<basedir>/var/lib/jetty</basedir>
+								</assembly>
+								<env>
+									<JAVA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</JAVA_OPTS>
+								</env>
+								<user>kapua</user>
+							</build>
+						</image>
 					</images>
 				</configuration>
 			</plugin>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,7 +20,7 @@
 	</parent>
 
 	<artifactId>kapua-assembly</artifactId>
-	<name>${project.artifactId}</name>
+	<packaging>pom</packaging>
 
 	<properties>
 		<tomcat.version>8.0.38</tomcat.version>
@@ -38,7 +38,19 @@
 			<version>${tomcat.version}</version>
 			<type>tar.gz</type>
 		</dependency>
-
+		
+		<dependency>
+			<groupId>org.apache.tomcat.extras</groupId>
+			<artifactId>tomcat-extras-juli</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.tomcat.extras</groupId>
+			<artifactId>tomcat-extras-juli-adapters</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.eclipse.kapua</groupId>
 			<artifactId>kapua-rest-api</artifactId>
@@ -247,6 +259,18 @@
 			<artifactId>jolokia-jvm</artifactId>
 			<version>1.3.4</version>
 			<classifier>agent</classifier>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
 		</dependency>
 	</dependencies>
 
@@ -557,11 +581,46 @@
 								<from>${java.base.image}</from>
 								<runCmds>
 									<runCmd><![CDATA[
-									apk update && apk add curl && \
+									apk update && apk add curl tar && \
 									adduser -D -g "Eclipse Kapua" kapua && \
 									curl -s https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.3.4/jolokia-jvm-1.3.4-agent.jar -o /jolokia-jvm-agent.jar
 									]]></runCmd>
 								</runCmds>
+							</build>
+						</image>
+						<image>
+							<name>${docker.account}/jetty-base</name>
+							<build>
+								<from>${docker.account}/java-base</from>
+								<runCmds>
+									<runCmd><![CDATA[
+									apk update && apk add bash && \
+									cd /home/kapua && \
+									curl -s https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.2.v20170220/jetty-distribution-9.4.2.v20170220.tar.gz -o jetty-distribution.tar.gz && \
+									mkdir -p jetty && cd jetty && \
+									tar --strip=1 -xzf ../jetty-distribution.tar.gz && \
+									rm ../jetty-distribution.tar.gz && \
+									chown -R kapua:kapua /home/kapua && \
+									mkdir -p /var/lib/jetty/lib/ext /var/lib/jetty/start.d && \
+									chown kapua:kapua /var/lib/jetty && \
+									cd /var/lib/jetty && \
+									java -jar /home/kapua/jetty/start.jar --approve-all-licenses --create-startd --add-to-start=http,jsp,jstl,websocket,deploy,logging-logback
+									]]></runCmd>
+								</runCmds>
+								<assembly>
+									<descriptor>/src/main/descriptors/jetty-base.xml</descriptor>
+									<basedir>/</basedir>
+								</assembly>
+								<workdir>/var/lib/jetty</workdir>
+								<entryPoint>
+									<exec>
+										<arg>/home/kapua/run-jetty</arg>
+									</exec>
+								</entryPoint>
+								<ports>
+									<port>8080</port>
+									<port>8778</port>
+								</ports>
 							</build>
 						</image>
 						<image>
@@ -618,7 +677,7 @@
 									</exec>
 								</entryPoint>
 								<env>
-									<JAVA_OPTS>-javaagent:/maven/jolokia-jvm-agent.jar</JAVA_OPTS>
+									<JAVA_OPTS>-javaagent:/jolokia-jvm-agent.jar</JAVA_OPTS>
 									<ACTIVEMQ_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</ACTIVEMQ_OPTS>
 								</env>
 								<ports>
@@ -653,7 +712,7 @@
 									</exec>
 								</entryPoint>
 								<env>
-									<JAVA_OPTS>-javaagent:/maven/jolokia-jvm-agent.jar</JAVA_OPTS>
+									<JAVA_OPTS>-javaagent:/jolokia-jvm-agent.jar</JAVA_OPTS>
 									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
 								</env>
 								<ports>
@@ -671,6 +730,20 @@
 							</build>
 						</image>
 						<image>
+							<name>${docker.account}/kapua-console-jetty</name>
+							<build>
+								<from>${docker.account}/jetty-base</from>
+								<assembly>
+									<descriptor>/src/main/descriptors/kapua-console-jetty.xml</descriptor>
+									<basedir>/var/lib/jetty</basedir>
+								</assembly>
+								<env>
+									<JAVA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</JAVA_OPTS>
+								</env>
+								<user>kapua</user>
+							</build>
+						</image>
+						<image>
 							<name>${docker.account}/kapua-api</name>
 							<build>
 								<from>${docker.account}/java-base</from>
@@ -684,7 +757,7 @@
 									</exec>
 								</entryPoint>
 								<env>
-									<JAVA_OPTS>-javaagent:/maven/jolokia-jvm-agent.jar</JAVA_OPTS>
+									<JAVA_OPTS>-javaagent:/jolokia-jvm-agent.jar</JAVA_OPTS>
 									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
 								</env>
 								<ports>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -678,7 +678,7 @@
 								</entryPoint>
 								<env>
 									<JAVA_OPTS>-javaagent:/jolokia-jvm-agent.jar</JAVA_OPTS>
-									<ACTIVEMQ_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</ACTIVEMQ_OPTS>
+									<ACTIVEMQ_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT}</ACTIVEMQ_OPTS>
 								</env>
 								<ports>
 									<port>1883</port>
@@ -713,7 +713,7 @@
 								</entryPoint>
 								<env>
 									<JAVA_OPTS>-javaagent:/jolokia-jvm-agent.jar</JAVA_OPTS>
-									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
+									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT}</CATALINA_OPTS>
 								</env>
 								<ports>
 									<port>8080</port>
@@ -738,7 +738,7 @@
 									<basedir>/var/lib/jetty</basedir>
 								</assembly>
 								<env>
-									<JAVA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</JAVA_OPTS>
+									<JAVA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT}</JAVA_OPTS>
 								</env>
 								<user>kapua</user>
 							</build>
@@ -758,7 +758,7 @@
 								</entryPoint>
 								<env>
 									<JAVA_OPTS>-javaagent:/jolokia-jvm-agent.jar</JAVA_OPTS>
-									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</CATALINA_OPTS>
+									<CATALINA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT}</CATALINA_OPTS>
 								</env>
 								<ports>
 									<port>8080</port>
@@ -783,7 +783,7 @@
 									<basedir>/var/lib/jetty</basedir>
 								</assembly>
 								<env>
-									<JAVA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT} -Dcommons.db.schema=</JAVA_OPTS>
+									<JAVA_OPTS>-Dcommons.db.connection.host=\${DB_PORT_3306_TCP_ADDR} -Dcommons.db.connection.port=\${DB_PORT_3306_TCP_PORT}</JAVA_OPTS>
 								</env>
 								<user>kapua</user>
 							</build>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -627,12 +627,17 @@
 							<name>${docker.account}/kapua-sql</name>
 							<build>
 								<from>${docker.account}/java-base</from>
+								<assembly>
+									<descriptor>/src/main/descriptors/kapua-sql.xml</descriptor>
+									<basedir>/</basedir>
+								</assembly>
 								<runCmds>
 									<runCmd><![CDATA[
 									mkdir -p /var/h2/data && \
 									chown kapua:kapua /var/h2/data && \
 									chmod a+rw /var/h2/data && \
 									cd /home/kapua && \
+									mkdir tmp && chmod a+rwx tmp && \
 									curl -s http://repo2.maven.org/maven2/com/h2database/h2/1.4.193/h2-1.4.193.jar -o h2.jar
 									]]></runCmd>
 								</runCmds>
@@ -647,18 +652,7 @@
 								<user>kapua</user>
 								<entryPoint>
 									<exec>
-										<arg>/usr/bin/java</arg>
-										<arg>-javaagent:/jolokia-jvm-agent.jar</arg>
-										<arg>-cp</arg><arg>/home/kapua/h2.jar</arg>
-										<arg>org.h2.tools.Server</arg>
-										<arg>-web</arg>
-										<arg>-webAllowOthers</arg>
-										<arg>-webPort</arg><arg>8181</arg>
-										<arg>-tcp</arg>
-										<arg>-tcpAllowOthers</arg>
-										<arg>-tcpPort</arg><arg>3306</arg>
-										<arg>-baseDir</arg>
-										<arg>/var/h2/data</arg>
+										<arg>/home/kapua/run-h2</arg>
 									</exec>
 								</entryPoint>
 							</build>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -796,7 +796,7 @@
 			</activation>
 			<build>
 				<plugins>
-	   				<plugin>
+					<plugin>
 		                <groupId>org.codehaus.mojo</groupId>
 		                <artifactId>exec-maven-plugin</artifactId>
 		                <version>1.1</version>

--- a/assembly/src/main/descriptors/jetty-base.xml
+++ b/assembly/src/main/descriptors/jetty-base.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Red Hat Inc and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+    
+    Contributors:
+        Red Hat Inc - initial API and implementation
+  -->
+<assembly
+    xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+
+    <id>jetty-base</id>
+
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+
+    <fileSets>
+        <fileSet>
+            <outputDirectory>home/kapua/</outputDirectory>
+            <directory>src/main/resources/jetty-base</directory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/assembly/src/main/descriptors/kapua-api-jetty.xml
+++ b/assembly/src/main/descriptors/kapua-api-jetty.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Red Hat Inc and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+    
+    Contributors:
+        Red Hat Inc - initial API and implementation
+  -->
+<assembly
+    xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+
+    <id>kapua-api-jetty</id>
+
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>webapps/root</outputDirectory>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <useProjectArtifact>false</useProjectArtifact>
+
+            <includes>
+                <include>${pom.groupId}:kapua-rest-api:war</include>
+            </includes>
+
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/assembly/src/main/descriptors/kapua-broker.xml
+++ b/assembly/src/main/descriptors/kapua-broker.xml
@@ -134,6 +134,7 @@
             <outputDirectory>lib/extra</outputDirectory>
             <unpack>false</unpack>
             <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <fileMode>0644</fileMode>
             <includes>
@@ -198,14 +199,6 @@
                 <include>${pom.groupId}:kapua-transport-api</include>
                 <include>${pom.groupId}:kapua-transport-jms</include>
                 <include>${pom.groupId}:kapua-transport-mqtt</include>
-            </includes>
-        </dependencySet>
-        
-        <dependencySet>
-            <outputDirectory>.</outputDirectory>
-            <outputFileNameMapping>jolokia-jvm-agent.jar</outputFileNameMapping>
-            <includes>
-                <include>org.jolokia:jolokia-jvm</include>
             </includes>
         </dependencySet>
 

--- a/assembly/src/main/descriptors/kapua-console-jetty.xml
+++ b/assembly/src/main/descriptors/kapua-console-jetty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -8,39 +8,32 @@
     http://www.eclipse.org/legal/epl-v10.html
     
     Contributors:
-        Eurotech - initial API and implementation
-        Red Hat Inc
+        Red Hat Inc - initial API and implementation
   -->
 <assembly
     xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
 
-    <id>kapua-api</id>
+    <id>kapua-console-jetty</id>
 
     <formats>
         <format>tar.gz</format>
     </formats>
 
-    <fileSets>
-        <fileSet>
-            <outputDirectory>.</outputDirectory>
-            <directory>${project.build.directory}/dependencies/tomcat/apache-tomcat-${tomcat.version}</directory>
-        </fileSet>
-    </fileSets>
-
     <dependencySets>
         <dependencySet>
-            <outputDirectory>webapps</outputDirectory>
-            <outputFileNameMapping>api.war</outputFileNameMapping>
-            <unpack>false</unpack>
+            <outputDirectory>webapps/root</outputDirectory>
+            <unpack>true</unpack>
             <scope>runtime</scope>
-            <useProjectArtifact>false</useProjectArtifact>
-            <useTransitiveDependencies>true</useTransitiveDependencies>
-            <includes>
-                <include>${pom.groupId}:kapua-rest-api:war</include>
-            </includes>
-        </dependencySet>
 
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <useProjectArtifact>false</useProjectArtifact>
+
+            <includes>
+                <include>${pom.groupId}:kapua-console:war</include>
+            </includes>
+
+        </dependencySet>
     </dependencySets>
 </assembly>

--- a/assembly/src/main/descriptors/kapua-console.xml
+++ b/assembly/src/main/descriptors/kapua-console.xml
@@ -22,10 +22,23 @@
         <format>tar.gz</format>
     </formats>
 
+    <files>
+        <file>
+            <outputDirectory>lib/</outputDirectory>
+            <source>src/main/resources/conf/console-tomcat/logback.xml</source>
+            <fileMode>0666</fileMode>
+        </file>
+    </files>
+
     <fileSets>
         <fileSet>
             <outputDirectory>.</outputDirectory>
             <directory>${project.build.directory}/dependencies/tomcat/apache-tomcat-${tomcat.version}</directory>
+            <excludes>
+                <exclude>**/conf/logging.properties</exclude>
+                <!-- don't use tomcat's juli, see below -->
+                <exclude>**/bin/tomcat-juli.jar</exclude>
+            </excludes>
         </fileSet>
     </fileSets>
 
@@ -35,16 +48,37 @@
             <outputFileNameMapping>console.war</outputFileNameMapping>
             <unpack>false</unpack>
             <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <includes>
                 <include>${pom.groupId}:kapua-console:war</include>
             </includes>
         </dependencySet>
+        
+        <!-- replace tomcat juli with full version -->
         <dependencySet>
-            <outputDirectory>.</outputDirectory>
-            <outputFileNameMapping>jolokia-jvm-agent.jar</outputFileNameMapping>
+            <outputDirectory>bin/</outputDirectory>
+            <outputFileNameMapping>tomcat-juli.jar</outputFileNameMapping>
+            <useProjectArtifact>false</useProjectArtifact>
             <includes>
-                <include>org.jolokia:jolokia-jvm</include>
+                <include>org.apache.tomcat.extras:tomcat-extras-juli</include>
+            </includes>
+        </dependencySet>
+        
+        <!--
+          - The full juli logs to JCL
+          - and JCL is actually from SLF4J
+          - which is provided by logback.  
+          -->
+        <dependencySet>
+            <outputDirectory>lib/</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <includes>
+                <include>org.slf4j:slf4j-api</include>
+                <include>org.slf4j:log4j-over-slf4j</include>
+                <include>org.apache.tomcat.extras:tomcat-extras-juli-adapters</include>
+                <include>ch.qos.logback:logback-core</include>
+                <include>ch.qos.logback:logback-classic</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/assembly/src/main/descriptors/kapua-sql.xml
+++ b/assembly/src/main/descriptors/kapua-sql.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Red Hat Inc and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+    
+    Contributors:
+        Red Hat Inc - initial API and implementation
+  -->
+<assembly
+    xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+
+    <id>kapua-sql</id>
+
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+
+    <files>
+        <file>
+            <outputDirectory>home/kapua</outputDirectory>
+            <source>src/main/resources/kapua-sql/run-h2</source>
+            <fileMode>0755</fileMode>
+        </file>
+    </files>
+
+</assembly>

--- a/assembly/src/main/resources/conf/console-tomcat/logback.xml
+++ b/assembly/src/main/resources/conf/console-tomcat/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+	<appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="console" />
+	</root>
+</configuration>

--- a/assembly/src/main/resources/jetty-base/run-jetty
+++ b/assembly/src/main/resources/jetty-base/run-jetty
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+################################################################################
+#    Copyright (c) 2017 Red Hat Inc
+#   
+#    All rights reserved. This program and the accompanying materials
+#    are made available under the terms of the Eclipse Public License v1.0
+#    which accompanies this distribution, and is available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#   
+#    Contributors:
+#        Red Hat Inc - initial API and implementation
+################################################################################
+
+START_ARGS="$START_ARGS -Djetty.home=/home/kapua/jetty"
+START_ARGS="$START_ARGS -Djetty.base=/var/lib/jetty"
+
+JAVA_ARGS="-javaagent:/jolokia-jvm-agent.jar"
+
+if [ -n "$JAVA_OPTS" ]; then
+   JAVA_ARGS="$JAVA_ARGS $JAVA_OPTS"
+fi 
+
+eval echo "START_ARGS = $START_ARGS"
+eval echo "JAVA_ARGS = $JAVA_ARGS"
+eval exec /usr/bin/java $START_ARGS -jar /home/kapua/jetty/start.jar $JAVA_ARGS "$@"

--- a/assembly/src/main/resources/kapua-sql/run-h2
+++ b/assembly/src/main/resources/kapua-sql/run-h2
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+################################################################################
+#    Copyright (c) 2017 Red Hat Inc
+#   
+#    All rights reserved. This program and the accompanying materials
+#    are made available under the terms of the Eclipse Public License v1.0
+#    which accompanies this distribution, and is available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#   
+#    Contributors:
+#        Red Hat Inc - initial API and implementation
+################################################################################
+
+set -e
+
+JAVA_ARGS="-javaagent:/jolokia-jvm-agent.jar"
+
+if [ -n "$JAVA_OPTS" ]; then
+   JAVA_ARGS="$JAVA_ARGS $JAVA_OPTS"
+fi
+
+# create schema right before startup
+echo "CREATE SCHEMA KAPUADB;" > /home/kapua/tmp/backup.sql
+java -cp /home/kapua/h2.jar org.h2.tools.RunScript -url jdbc:h2:/var/h2/data/kapuadb  -user kapua -password kapua -script /home/kapua/tmp/backup.sql
+rm /home/kapua/tmp/backup.sql
+
+# expand
+echo "JAVA_ARGS = $JAVA_ARGS"
+eval JAVA_ARGS="$JAVA_ARGS"
+echo "JAVA_ARGS = $JAVA_ARGS"
+
+# exec server
+exec /usr/bin/java $JAVA_ARGS -cp /home/kapua/h2.jar org.h2.tools.Server -web -webAllowOthers -webPort 8181 -tcp -tcpAllowOthers -tcpPort 3306 -baseDir /var/h2/data

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
  
 	<profiles>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -209,6 +209,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -206,10 +206,19 @@
             <artifactId>jetty-util</artifactId>
             <version>6.1.26</version>
         </dependency>
+        
+        <!-- use log4j only for testing -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- re-declare as provided as our web container will provide this -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -346,7 +355,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
 
         <pluginManagement>

--- a/dev-tools/src/main/openshift/kapua-template.yml
+++ b/dev-tools/src/main/openshift/kapua-template.yml
@@ -13,57 +13,6 @@ parameters:
   value:            eclipse
 objects:
 
-# Image streams
-
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: kapua-sql
-    labels:
-      app: kapua-sql
-  spec:
-    tags:
-    - name: latest
-      from:
-        kind: DockerImage
-        name: ${DOCKER_ACCOUNT}/kapua-sql:${IMAGE_VERSION}
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: kapua-broker
-    labels:
-      app: kapua-broker
-  spec:
-    tags:
-    - name: latest
-      from:
-        kind: DockerImage
-        name: ${DOCKER_ACCOUNT}/kapua-broker:${IMAGE_VERSION}
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: kapua-consoler
-    labels:
-      app: kapua-console
-  spec:
-    tags:
-    - name: latest
-      from:
-        kind: DockerImage
-        name: ${DOCKER_ACCOUNT}/kapua-console-jetty:${IMAGE_VERSION}
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    name: kapua-api
-    labels:
-      app: kapua-api
-  spec:
-    tags:
-    - name: latest
-      from:
-        kind: DockerImage
-        name: ${DOCKER_ACCOUNT}/kapua-api-jetty:${IMAGE_VERSION}
-
 # Deployment configs
 
 - apiVersion: v1
@@ -183,9 +132,9 @@ objects:
       spec:
         containers:
         - env:
-          - name: CATALINA_OPTS
+          - name: JAVA_OPTS
             value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
-          image: ${DOCKER_ACCOUNT}/kapua-console:${IMAGE_VERSION}
+          image: ${DOCKER_ACCOUNT}/kapua-console-jetty:${IMAGE_VERSION}
           imagePullPolicy: Always
           name: kapua-console
           ports:
@@ -193,7 +142,7 @@ objects:
             protocol: TCP
           readinessProbe:
             httpGet:
-              path: /console
+              path: /
               port: 8080
             initialDelaySeconds: 15
             timeoutSeconds: 5
@@ -222,9 +171,9 @@ objects:
       spec:
         containers:
         - env:
-          - name: CATALINA_OPTS
+          - name: JAVA_OPTS
             value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
-          image: ${DOCKER_ACCOUNT}/kapua-api:${IMAGE_VERSION}
+          image: ${DOCKER_ACCOUNT}/kapua-api-jetty:${IMAGE_VERSION}
           imagePullPolicy: Always
           name: kapua-console
           ports:
@@ -232,7 +181,7 @@ objects:
             protocol: TCP
           readinessProbe:
             httpGet:
-              path: /api
+              path: /
               port: 8080
             initialDelaySeconds: 15
             timeoutSeconds: 5

--- a/dev-tools/src/main/openshift/kapua-template.yml
+++ b/dev-tools/src/main/openshift/kapua-template.yml
@@ -50,7 +50,7 @@ objects:
     - name: latest
       from:
         kind: DockerImage
-        name: ${DOCKER_ACCOUNT}/kapua-console:${IMAGE_VERSION}
+        name: ${DOCKER_ACCOUNT}/kapua-console-jetty:${IMAGE_VERSION}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -62,7 +62,7 @@ objects:
     - name: latest
       from:
         kind: DockerImage
-        name: ${DOCKER_ACCOUNT}/kapua-api:${IMAGE_VERSION}
+        name: ${DOCKER_ACCOUNT}/kapua-api-jetty:${IMAGE_VERSION}
 
 # Deployment configs
 
@@ -137,7 +137,7 @@ objects:
         containers:
         - env:
           - name: ACTIVEMQ_OPTS
-            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dcommons.db.schema=
+            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT
           image: ${DOCKER_ACCOUNT}/kapua-broker:${IMAGE_VERSION}
           imagePullPolicy: Always
           name: kapua-broker
@@ -184,7 +184,7 @@ objects:
         containers:
         - env:
           - name: CATALINA_OPTS
-            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dcommons.db.schema= -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
+            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
           image: ${DOCKER_ACCOUNT}/kapua-console:${IMAGE_VERSION}
           imagePullPolicy: Always
           name: kapua-console
@@ -223,7 +223,7 @@ objects:
         containers:
         - env:
           - name: CATALINA_OPTS
-            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dcommons.db.schema= -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
+            value: -Dcommons.db.connection.host=$SQL_SERVICE_HOST -Dcommons.db.connection.port=$SQL_PORT_3306_TCP_PORT -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
           image: ${DOCKER_ACCOUNT}/kapua-api:${IMAGE_VERSION}
           imagePullPolicy: Always
           name: kapua-console

--- a/dev-tools/src/main/vagrant/baseBox/baseBox-Vagrantfile
+++ b/dev-tools/src/main/vagrant/baseBox/baseBox-Vagrantfile
@@ -8,7 +8,7 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
+#     Red Hat Inc
 #*******************************************************************************
 
 Vagrant.configure(2) do |config|
@@ -126,6 +126,12 @@ Vagrant.configure(2) do |config|
      sudo curl -O https://archive.apache.org/dist/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
      sudo tar zxvf apache-tomcat-${TOMCAT_VERSION}.tar.gz
      sudo rm apache-tomcat-${TOMCAT_VERSION}.tar.gz
+
+     ### fix tomcat8 to provide slf4j and logback
+     cd /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/lib
+     sudo curl -O https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.21/slf4j-api-1.7.21.jar
+     sudo curl -O https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.1.8/logback-core-1.1.8.jar
+     sudo curl -O https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.1.8/logback-classic-1.1.8.jar
 
 	cat /dev/null > ~/.bash_history && history -c
 

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -34,12 +34,6 @@
 		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -28,12 +28,23 @@
 			<artifactId>guice</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>com.google.guava</groupId>
-		    <artifactId>guava</artifactId>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
 		</dependency>
 
 		<!-- Testing dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -577,6 +577,11 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <reflections.version>0.9.10</reflections.version>
         <shiro.version>1.2.3</shiro.version>
         <slf4j.version>1.7.21</slf4j.version>
+        <logback.version>1.1.8</logback.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <cucumber.version>1.2.4</cucumber.version>
@@ -588,8 +589,13 @@
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.1.8</version>
+                <version>${logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <protobuf.version>2.6.1</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
         <shiro.version>1.2.3</shiro.version>
-        <slf4j.version>1.7.2</slf4j.version>
+        <slf4j.version>1.7.21</slf4j.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <cucumber.version>1.2.4</cucumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -589,6 +589,11 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,12 @@
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
                 <version>${commons-configuration.version}</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>commons-logging</groupId>
+                            <artifactId>commons-logging</artifactId>
+                        </exclusion>
+                    </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
-<!-- 
-
-	Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others All rights reserved. 
-
-	This program and the accompanying materials are made available under the 
-	terms of the Eclipse Public License v1.0 which accompanies this distribution, 
-	and is available at http://www.eclipse.org/legal/epl-v10.html 
-
-	Contributors: 
-		Eurotech - initial API and implementation 
-
+<!--
+	Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+   
+	All rights reserved. This program and the accompanying materials
+	are made available under the terms of the Eclipse Public License v1.0
+	which accompanies this distribution, and is available at
+	http://www.eclipse.org/legal/epl-v10.html
+   
+	Contributors:
+		Eurotech - initial API and implementation
+		Red Hat Inc
  -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,19 +30,19 @@
 		<swagger-ui.version>2.1.4</swagger-ui.version>
 	</properties>
 
-    <repositories>
-        <repository>
+	<repositories>
+		<repository>
 			<!-- This repository is needed for GXT.
 			We will remove it as soon as we migrate from GXT to some other UI framework. -->
-            <id>kapua_addons</id>
-            <name>Kapua Addons Maven Repository</name>
-            <url>https://raw.github.com/eurotech/kapua_addons/mvn-repo/</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
+			<id>kapua_addons</id>
+			<name>Kapua Addons Maven Repository</name>
+			<url>https://raw.github.com/eurotech/kapua_addons/mvn-repo/</url>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+		</repository>
+	</repositories>
 
 	<dependencies>
 		<!-- -->
@@ -160,10 +160,21 @@
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 		</dependency>
+		
+		<!-- use log4j only for testing -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
+			<scope>test</scope>
 		</dependency>
+
+		<!-- re-declare as provided as our web container will provide this -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
 	</dependencies>
 	<build>
 		<finalName>api</finalName>
@@ -190,24 +201,24 @@
 							</artifactItems>
 						</configuration>
 					</execution>
-                    <execution>
-                        <id>Create swagger ui libs</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>io.swagger</groupId>
-                                    <artifactId>swagger-ui-lib</artifactId>
-                                    <version>${swagger-ui.version}</version>
-                                    <!-- <overWrite>true</overWrite> -->
-                                    <outputDirectory>${project.build.directory}/tmp/</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
+					<execution>
+						<id>Create swagger ui libs</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>io.swagger</groupId>
+									<artifactId>swagger-ui-lib</artifactId>
+									<version>${swagger-ui.version}</version>
+									<!-- <overWrite>true</overWrite> -->
+									<outputDirectory>${project.build.directory}/tmp/</outputDirectory>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>
@@ -228,10 +239,10 @@
 									<fileset dir="${project.build.directory}/tmp/swagger-ui/" />
 								</copy>
 								
-                                <echo>Swagger-ui-lib: create lib dir for swagger-ui</echo>
-                                <copy todir="${project.build.directory}/${project.build.finalName}/doc/lib">
-                                    <fileset dir="${project.build.directory}/tmp/swagger-ui-lib/" />
-                                </copy>
+								<echo>Swagger-ui-lib: create lib dir for swagger-ui</echo>
+								<copy todir="${project.build.directory}/${project.build.finalName}/doc/lib">
+									<fileset dir="${project.build.directory}/tmp/swagger-ui-lib/" />
+								</copy>
 							</target>
 						</configuration>
 					</execution>
@@ -244,11 +255,11 @@
 						<configuration>
 							<target>
 								<echo>Swagger-ui: replace url in index.html</echo>
-								<replaceregexp byline="true" 
-                                               file="${project.build.directory}/${project.build.finalName}/doc/index.html" 
-                                               match="/api/docs/swagger.json" 
-                                               replace="/api/v1/swagger.json" />
-                                
+								<replaceregexp
+									byline="true" 
+									file="${project.build.directory}/${project.build.finalName}/doc/index.html" 
+									match="/api/docs/swagger.json" 
+									replace="/api/v1/swagger.json" />
 							</target>
 						</configuration>
 					</execution>


### PR DESCRIPTION
This change does provide Jetty based docker images for the web console and the API server. It also enables the use of those images for OpenShift, fixing the issue of the web contexts `/console` and `/api`, fixing the issue of providing the manager web applications from tomcat.

This change also implements a few additional fixes for #340 by correctly packaging the WAR files, and enabling the web containers to handle SLF4j and logback properly.