### PR TITLE
Fixed clientId as query param in REST API

### DIFF
--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Devices.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Devices.java
@@ -76,7 +76,7 @@ public class Devices extends AbstractKapuaResource {
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public DeviceListResult simpleQuery(
             @ApiParam(value = "The ScopeId in which to search results.", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
-            @ApiParam(value = "The client id to filter results.") String clientId,
+            @ApiParam(value = "The client id to filter results.") @QueryParam("clientId") String clientId,
             @ApiParam(value = "The connection status to filter results.")@QueryParam("status") DeviceConnectionStatus connectionStatus,
             @ApiParam(value = "The result set offset.", defaultValue = "0") @QueryParam("offset") @DefaultValue("0") int offset,
             @ApiParam(value = "The result set limit.", defaultValue = "50") @QueryParam("limit") @DefaultValue("50") int limit)


### PR DESCRIPTION
After merging #370, `clientId` was erroneously set as body instead of query param in `GET /devices`