### PR TITLE
Add a customizable footer snippet on the login page

### DIFF
--- a/console/src/main/java/org/eclipse/kapua/app/console/server/GwtSettingsServiceImpl.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/server/GwtSettingsServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.app.console.server;
 
@@ -16,6 +16,7 @@ import java.util.UUID;
 
 import org.eclipse.kapua.app.console.setting.ConsoleSetting;
 import org.eclipse.kapua.app.console.setting.ConsoleSettingKeys;
+import org.eclipse.kapua.app.console.shared.model.GwtLoginInformation;
 import org.eclipse.kapua.app.console.shared.service.GwtSettingsService;
 
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
@@ -28,15 +29,19 @@ public class GwtSettingsServiceImpl extends RemoteServiceServlet implements
 
     private static final long serialVersionUID = -6876999298300071273L;
     private static final ConsoleSetting settings = ConsoleSetting.getInstance();
-    
+
     @Override
-    public String getLoginBackgroundCredits() {
-        return settings.getString(ConsoleSettingKeys.LOGIN_BACKGROUND_CREDITS);
+    public GwtLoginInformation getLoginInformation() {
+        final GwtLoginInformation result = new GwtLoginInformation();
+        result.setBackgroundCredits(settings.getString(ConsoleSettingKeys.LOGIN_BACKGROUND_CREDITS));
+        result.setInformationSnippet(settings.getString(ConsoleSettingKeys.LOGIN_GENERIC_SNIPPET));
+        return result;
     }
 
     @Override
     public String getSsoLoginUri() {
-        return settings.getString(ConsoleSettingKeys.SSO_OPENID_SERVER_ENDPOINT_AUTH) + "?scope=openid&response_type=code&client_id=" + settings.getString(ConsoleSettingKeys.SSO_OPENID_CLIENT_ID)+ "&state=" + UUID.randomUUID() + "&redirect_uri=" + settings.getString(ConsoleSettingKeys.SSO_OPENID_REDIRECT_URI);
+        return settings.getString(ConsoleSettingKeys.SSO_OPENID_SERVER_ENDPOINT_AUTH) + "?scope=openid&response_type=code&client_id=" + settings.getString(ConsoleSettingKeys.SSO_OPENID_CLIENT_ID)
+                + "&state=" + UUID.randomUUID() + "&redirect_uri=" + settings.getString(ConsoleSettingKeys.SSO_OPENID_REDIRECT_URI);
     }
 
     @Override

--- a/console/src/main/java/org/eclipse/kapua/app/console/setting/ConsoleSettingKeys.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/setting/ConsoleSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.app.console.setting;
 
@@ -17,6 +17,7 @@ import org.eclipse.kapua.commons.setting.SettingKey;
 public enum ConsoleSettingKeys implements SettingKey {
     SKIN_RESOURCE_DIR("skin.resource.dir"), //
     LOGIN_BACKGROUND_CREDITS("login.background.credits"), //
+    LOGIN_GENERIC_SNIPPET("login.generic.snippet"), //
 
     DEVICE_CONFIGURATION_ICON_FOLDER("device.configuration.icon.folder"), //
     DEVICE_CONFIGURATION_ICON_CACHE_TIME("device.configuration.icon.cache.time"), //

--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/model/GwtLoginInformation.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/model/GwtLoginInformation.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.shared.model;
+
+import java.io.Serializable;
+
+public class GwtLoginInformation implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String backgroundCredits;
+
+    private String informationSnippet;
+
+    public String getBackgroundCredits() {
+        return backgroundCredits;
+    }
+
+    public void setBackgroundCredits(String backgroundCredits) {
+        this.backgroundCredits = backgroundCredits;
+    }
+
+    public String getInformationSnippet() {
+        return informationSnippet;
+    }
+
+    public void setInformationSnippet(String informationSnippet) {
+        this.informationSnippet = informationSnippet;
+    }
+}

--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/service/GwtSettingsService.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/service/GwtSettingsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,9 +8,11 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.app.console.shared.service;
+
+import org.eclipse.kapua.app.console.shared.model.GwtLoginInformation;
 
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
@@ -21,9 +23,9 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 @RemoteServiceRelativePath("settings")
 public interface GwtSettingsService extends RemoteService {
 
-    public String getLoginBackgroundCredits();
+    public GwtLoginInformation getLoginInformation();
 
     public String getSsoLoginUri();
-    
+
     public boolean getSsoEnabled();
 }

--- a/console/src/main/resources/console-setting.properties
+++ b/console/src/main/resources/console-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -8,10 +8,11 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
+#     Red Hat Inc
 ###############################################################################
 
 login.background.credits=Photo by <a href='https://unsplash.com/@danist07' target='_blank'>\u8D1D\u8389\u513F NG</a>
+login.generic.snippet=
 
 device.configuration.icon.folder=iconResources
 device.configuration.icon.cache.time=600000


### PR DESCRIPTION
This change does add a customizable HTML snippet section in the login
page footer. It's content can be set using the Kapua settings for the
web console.

It is currently required for the Eclipse Foundation sandbox server,
showing some mandatory links like "Terms of service", …

But I guess it might come in handy for other use cases as well.