### PR TITLE
Fix configuration of ElasticSearch transports

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractBaseKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractBaseKapuaSetting.java
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.setting;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.DataConfiguration;
+import org.apache.commons.configuration.MapConfiguration;
+
+/**
+ * An abstract base class which does not make any assumptions on where the
+ * configuration comes from
+ * 
+ * @param <K>
+ *            The settings key type
+ */
+public class AbstractBaseKapuaSetting<K extends SettingKey> {
+
+    /**
+     * Create an abstract configuration from a provided map
+     * <p>
+     * This is useful for testing when the configuration has to be provided
+     * </p>
+     * @param map the map of values
+     * @return the configuration, may be {@code null} if the "map" parameter was null
+     */
+    public static <K extends SettingKey> AbstractBaseKapuaSetting<K> fromMap(Map<String, Object> map) {
+        if (map == null)
+            return null;
+        return new AbstractBaseKapuaSetting<>(new DataConfiguration(new MapConfiguration(map)));
+    }
+
+    protected final DataConfiguration config;
+
+    public AbstractBaseKapuaSetting(final DataConfiguration dataConfiguration) {
+        this.config = dataConfiguration;
+    }
+
+    /**
+     * Get the property for the key
+     *
+     * @param cls
+     * @param key
+     * @return
+     */
+    public <T> T get(Class<T> cls, K key) {
+        return config.get(cls, key.key());
+    }
+
+    /**
+     * Get the property for the key 'key'. Returns a default value if no property for that key is found.
+     *
+     * @param cls
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public <T> T get(Class<T> cls, K key, T defaultValue) {
+        return config.get(cls, key.key(), defaultValue);
+    }
+
+    /**
+     * Get the property list values for the key 'key'
+     *
+     * @param cls
+     * @param key
+     * @return
+     */
+    public <T> List<T> getList(Class<T> cls, K key) {
+        return config.getList(cls, key.key());
+    }
+
+    /**
+     * Get properties map with key matching the provided prefix and regex
+     *
+     * @param valueType
+     * @param prefixKey
+     * @param regex
+     * @return
+     */
+    public <V> Map<String, V> getMap(Class<V> valueType, K prefixKey, String regex) {
+        Map<String, V> map = new HashMap<>();
+        Configuration subsetConfig = config.subset(prefixKey.key());
+        DataConfiguration subsetDataConfig = new DataConfiguration(subsetConfig);
+        for (Iterator<String> it = subsetConfig.getKeys(); it.hasNext();) {
+            String key = it.next();
+            if (Pattern.matches(regex, key)) {
+                map.put(key, subsetDataConfig.get(valueType, key));
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Get properties map with key matching the provided prefix
+     *
+     * @param valueType
+     * @param prefixKey
+     * @return
+     */
+    public <V> Map<String, V> getMap(Class<V> valueType, K prefixKey) {
+        Map<String, V> map = new HashMap<>();
+        Configuration subsetConfig = config.subset(prefixKey.key());
+        DataConfiguration subsetDataConfig = new DataConfiguration(subsetConfig);
+        for (Iterator<String> it = subsetConfig.getKeys(); it.hasNext();) {
+            String key = it.next();
+            map.put(key, subsetDataConfig.get(valueType, key));
+        }
+        return map;
+    }
+
+    /**
+     * Get an integer property
+     *
+     * @param key
+     * @return
+     */
+    public int getInt(K key) {
+        return config.getInt(key.key());
+    }
+
+    /**
+     * Get an integer property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public int getInt(K key, int defaultValue) {
+        return config.getInt(key.key(), defaultValue);
+    }
+
+    /**
+     * Get an integer property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public int getInt(K key, Integer defaultValue) {
+        return config.getInt(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a boolean property
+     *
+     * @param key
+     * @return
+     */
+    public boolean getBoolean(K key) {
+        return config.getBoolean(key.key());
+    }
+
+    /**
+     * Get a boolean property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public boolean getBoolean(K key, boolean defaultValue) {
+        return config.getBoolean(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a boolean property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public boolean getBoolean(K key, Boolean defaultValue) {
+        return config.getBoolean(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a String property
+     *
+     * @param key
+     * @return
+     */
+    public String getString(K key) {
+        return config.getString(key.key());
+    }
+
+    /**
+     * Get a String property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public String getString(K key, String defaultValue) {
+        return config.getString(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a long property
+     *
+     * @param key
+     * @return
+     */
+    public long getLong(K key) {
+        return config.getLong(key.key());
+    }
+
+    /**
+     * Get a long property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public long getLong(K key, long defaultValue) {
+        return config.getLong(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a long property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public long getLong(K key, Long defaultValue) {
+        return config.getLong(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a float property
+     *
+     * @param key
+     * @return
+     */
+    public float getFloat(K key) {
+        return config.getFloat(key.key());
+    }
+
+    /**
+     * Get a float property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public float getFloat(K key, float defaultValue) {
+        return config.getFloat(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a float property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public float getFloat(K key, Float defaultValue) {
+        return config.getFloat(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a double property
+     *
+     * @param key
+     * @return
+     */
+    public double getDouble(K key) {
+        return config.getDouble(key.key());
+    }
+
+    /**
+     * Get a double property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public double getDouble(K key, double defaultValue) {
+        return config.getDouble(key.key(), defaultValue);
+    }
+
+    /**
+     * Get a double property with a default value (if property is not found)
+     *
+     * @param key
+     * @param defaultValue
+     * @return
+     */
+    public double getDouble(K key, Double defaultValue) {
+        return config.getDouble(key.key(), defaultValue);
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
@@ -13,14 +13,8 @@
 package org.eclipse.kapua.commons.setting;
 
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 
 import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.DataConfiguration;
 import org.apache.commons.configuration.EnvironmentConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -38,18 +32,11 @@ import org.slf4j.LoggerFactory;
  * @since 1.0
  *
  */
-public abstract class AbstractKapuaSetting<K extends SettingKey> {
+public abstract class AbstractKapuaSetting<K extends SettingKey> extends AbstractBaseKapuaSetting<K> {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractKapuaSetting.class);
 
-    protected DataConfiguration config;
-
-    /**
-     * Constructor
-     *
-     * @param configResourceName
-     */
-    protected AbstractKapuaSetting(String configResourceName) {
+    private static DataConfiguration createCompositeSource(String configResourceName) throws ExceptionInInitializerError {
         CompositeConfiguration compositeConfig = new EnvFriendlyConfiguration();
         compositeConfig.addConfiguration(new SystemConfiguration());
         compositeConfig.addConfiguration(new EnvironmentConfiguration());
@@ -65,260 +52,15 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> {
             throw new ExceptionInInitializerError(e);
         }
 
-        this.config = new DataConfiguration(compositeConfig);
+        return new DataConfiguration(compositeConfig);
     }
 
     /**
-     * Get the property for the key
+     * Constructor
      *
-     * @param cls
-     * @param key
-     * @return
+     * @param configResourceName
      */
-    public <T> T get(Class<T> cls, K key) {
-        return config.get(cls, key.key());
-    }
-
-    /**
-     * Get the property for the key 'key'. Returns a default value if no property for that key is found.
-     *
-     * @param cls
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public <T> T get(Class<T> cls, K key, T defaultValue) {
-        return config.get(cls, key.key(), defaultValue);
-    }
-
-    /**
-     * Get the property list values for the key 'key'
-     *
-     * @param cls
-     * @param key
-     * @return
-     */
-    public <T> List<T> getList(Class<T> cls, K key) {
-        return config.getList(cls, key.key());
-    }
-
-    /**
-     * Get properties map with key matching the provided prefix and regex
-     *
-     * @param valueType
-     * @param prefixKey
-     * @param regex
-     * @return
-     */
-    public <V> Map<String, V> getMap(Class<V> valueType, K prefixKey, String regex) {
-        Map<String, V> map = new HashMap<>();
-        Configuration subsetConfig = config.subset(prefixKey.key());
-        DataConfiguration subsetDataConfig = new DataConfiguration(subsetConfig);
-        for (Iterator<String> it = subsetConfig.getKeys(); it.hasNext();) {
-            String key = it.next();
-            if (Pattern.matches(regex, key)) {
-                map.put(key, subsetDataConfig.get(valueType, key));
-            }
-        }
-        return map;
-    }
-
-    /**
-     * Get properties map with key matching the provided prefix
-     *
-     * @param valueType
-     * @param prefixKey
-     * @return
-     */
-    public <V> Map<String, V> getMap(Class<V> valueType, K prefixKey) {
-        Map<String, V> map = new HashMap<>();
-        Configuration subsetConfig = config.subset(prefixKey.key());
-        DataConfiguration subsetDataConfig = new DataConfiguration(subsetConfig);
-        for (Iterator<String> it = subsetConfig.getKeys(); it.hasNext();) {
-            String key = it.next();
-            map.put(key, subsetDataConfig.get(valueType, key));
-        }
-        return map;
-    }
-
-    /**
-     * Get an integer property
-     *
-     * @param key
-     * @return
-     */
-    public int getInt(K key) {
-        return config.getInt(key.key());
-    }
-
-    /**
-     * Get an integer property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public int getInt(K key, int defaultValue) {
-        return config.getInt(key.key(), defaultValue);
-    }
-
-    /**
-     * Get an integer property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public int getInt(K key, Integer defaultValue) {
-        return config.getInt(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a boolean property
-     *
-     * @param key
-     * @return
-     */
-    public boolean getBoolean(K key) {
-        return config.getBoolean(key.key());
-    }
-
-    /**
-     * Get a boolean property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public boolean getBoolean(K key, boolean defaultValue) {
-        return config.getBoolean(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a boolean property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public boolean getBoolean(K key, Boolean defaultValue) {
-        return config.getBoolean(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a String property
-     *
-     * @param key
-     * @return
-     */
-    public String getString(K key) {
-        return config.getString(key.key());
-    }
-
-    /**
-     * Get a String property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public String getString(K key, String defaultValue) {
-        return config.getString(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a long property
-     *
-     * @param key
-     * @return
-     */
-    public long getLong(K key) {
-        return config.getLong(key.key());
-    }
-
-    /**
-     * Get a long property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public long getLong(K key, long defaultValue) {
-        return config.getLong(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a long property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public long getLong(K key, Long defaultValue) {
-        return config.getLong(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a float property
-     *
-     * @param key
-     * @return
-     */
-    public float getFloat(K key) {
-        return config.getFloat(key.key());
-    }
-
-    /**
-     * Get a float property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public float getFloat(K key, float defaultValue) {
-        return config.getFloat(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a float property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public float getFloat(K key, Float defaultValue) {
-        return config.getFloat(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a double property
-     *
-     * @param key
-     * @return
-     */
-    public double getDouble(K key) {
-        return config.getDouble(key.key());
-    }
-
-    /**
-     * Get a double property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public double getDouble(K key, double defaultValue) {
-        return config.getDouble(key.key(), defaultValue);
-    }
-
-    /**
-     * Get a double property with a default value (if property is not found)
-     *
-     * @param key
-     * @param defaultValue
-     * @return
-     */
-    public double getDouble(K key, Double defaultValue) {
-        return config.getDouble(key.key(), defaultValue);
+    protected AbstractKapuaSetting(String configResourceName) {
+        super(createCompositeSource(configResourceName));
     }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
@@ -32,9 +32,13 @@ public enum DatastoreSettingKey implements SettingKey
      */
     ELASTICSEARCH_CLIENT_PROVIDER("datastore.elasticsearch.client.provider"),
     /**
-     * Elasticsearch nodes count
+     * Comma separated list of elasticsearch nodes in the form "hostname[:port],hostname[:port]"
      */
-    ELASTICSEARCH_NODES("datastore.elasticsearch.node"),
+    ELASTICSEARCH_NODES("datastore.elasticsearch.nodes"),
+    /**
+     * Elasticsearch node map
+     */
+    ELASTICSEARCH_NODE("datastore.elasticsearch.node"),
     /**
      * Elasticsearch port
      */

--- a/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
@@ -16,7 +16,13 @@
 
 #datastore.elasticsearch.client.provider=org.eclipse.kapua.service.datastore.internal.elasticsearch.EsEmbeddedClientProvider
 datastore.elasticsearch.client.provider=org.eclipse.kapua.service.datastore.internal.elasticsearch.EsTransportClientProvider
-datastore.elasticsearch.node.01=127.0.0.1
+
+datastore.elasticsearch.node=127.0.0.1
+
+# A comma separated list of nodes in the form: "host1,host2" or "host1:port,host2:port"
+# **Note:** Using the "nodes" version overrides the "node" property.
+#datastore.elasticsearch.nodes=host1:port1,host2:port2
+
 datastore.elasticsearch.port=9300
 datastore.elasticsearch.cluster=kapua-datastore
 datastore.elasticsearch.topic.max.depth=5

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/elasticsearch/EsTransportClientProviderTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/elasticsearch/EsTransportClientProviderTest.java
@@ -1,0 +1,229 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal.elasticsearch;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.kapua.commons.setting.AbstractBaseKapuaSetting.fromMap;
+import static org.eclipse.kapua.service.datastore.internal.elasticsearch.EsTransportClientProvider.parseAddress;
+import static org.eclipse.kapua.service.datastore.internal.elasticsearch.EsTransportClientProvider.parseAddresses;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
+import org.eclipse.kapua.commons.setting.AbstractBaseKapuaSetting;
+import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettingKey;
+import org.elasticsearch.client.Client;
+import org.junit.Test;
+
+public class EsTransportClientProviderTest {
+
+    private static Condition<InetSocketAddress> unresolved = new Condition<>(InetSocketAddress::isUnresolved, "Host unresolved");
+
+    private void assertThatResolvedAs(InetSocketAddress result, Class<? extends InetAddress> addressClazz, String hostAddress, int port) {
+        assertThat(result).isNotNull();
+        assertThat(result.getAddress()).isNotNull();
+
+        assertThat(result).doesNotHave(unresolved);
+        assertThat(result.getHostString()).isEqualTo(hostAddress);
+        assertThat(result.getPort()).isEqualTo(port);
+        assertThat(result.getAddress()).isInstanceOf(addressClazz);
+    }
+
+    @Test
+    public void test1() {
+        InetSocketAddress result = parseAddress("127.0.0.1");
+        assertThatResolvedAs(result, Inet4Address.class, "127.0.0.1", 9300);
+    }
+
+    @Test
+    public void test2() {
+        InetSocketAddress result = parseAddress("127.0.0.1:");
+        assertThatResolvedAs(result, Inet4Address.class, "127.0.0.1", 9300);
+    }
+
+    @Test
+    public void test3() {
+        InetSocketAddress result = parseAddress("[::1]:");
+        assertThatResolvedAs(result, Inet6Address.class, "0:0:0:0:0:0:0:1", 9300);
+    }
+
+    @Test
+    public void test4() {
+        InetSocketAddress result = parseAddress("[::1]:1234");
+        assertThatResolvedAs(result, Inet6Address.class, "0:0:0:0:0:0:0:1", 1234);
+    }
+
+    @Test
+    public void testEmpty1() {
+        InetSocketAddress result = parseAddress("");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void testEmpty2() {
+        InetSocketAddress result = parseAddress(null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void testHostNotFound1() {
+        InetSocketAddress result = parseAddress("foo");
+        assertThat(result).isNotNull();
+        assertThat(result).has(unresolved);
+    }
+
+    @Test
+    public void testHostNotFound2() {
+        InetSocketAddress result = parseAddress("foo:123");
+        assertThat(result).isNotNull();
+        assertThat(result).has(unresolved);
+    }
+
+    @Test
+    public void testHostsEmpty1() throws EsClientUnavailableException {
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(emptyMap());
+        List<InetSocketAddress> result = parseAddresses(settings);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testHostsEmpty2() throws EsClientUnavailableException {
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(singletonMap(DatastoreSettingKey.ELASTICSEARCH_NODES.key(), ""));
+        List<InetSocketAddress> result = parseAddresses(settings);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testHostsEmpty3() throws EsClientUnavailableException {
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(singletonMap(DatastoreSettingKey.ELASTICSEARCH_NODE.key() + ".01", ""));
+        List<InetSocketAddress> result = parseAddresses(settings);
+        assertThat(result).isEmpty();
+    }
+    
+    @Test
+    public void testHostsEmpty4() throws EsClientUnavailableException {
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(singletonMap(DatastoreSettingKey.ELASTICSEARCH_NODE.key(), ""));
+        List<InetSocketAddress> result = parseAddresses(settings);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testHosts1() throws EsClientUnavailableException {
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(singletonMap(DatastoreSettingKey.ELASTICSEARCH_NODES.key(), "127.0.0.1,127.0.0.2:1234,[::1]:5678"));
+        List<InetSocketAddress> result = parseAddresses(settings);
+        assertThat(result).hasSize(3);
+
+        assertThatResolvedAs(result.get(0), Inet4Address.class, "127.0.0.1", 9300);
+        assertThatResolvedAs(result.get(1), Inet4Address.class, "127.0.0.2", 1234);
+        assertThatResolvedAs(result.get(2), Inet6Address.class, "0:0:0:0:0:0:0:1", 5678);
+    }
+    
+    @Test
+    public void testHosts2() throws EsClientUnavailableException {
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(singletonMap(DatastoreSettingKey.ELASTICSEARCH_NODE.key() + ".01", "127.0.0.1:1234"));
+        List<InetSocketAddress> result = parseAddresses(settings);
+        
+        assertThat(result).hasSize(1);
+        assertThatResolvedAs(result.get(0), Inet4Address.class, "127.0.0.1", 1234);
+    }
+    
+    @Test
+    public void testHosts3() throws EsClientUnavailableException {
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(singletonMap(DatastoreSettingKey.ELASTICSEARCH_NODE.key(), "127.0.0.1:1234"));
+        List<InetSocketAddress> result = parseAddresses(settings);
+        
+        assertThat(result).hasSize(1);
+        assertThatResolvedAs(result.get(0), Inet4Address.class, "127.0.0.1", 1234);
+    }
+    
+    @Test
+    public void testOverride1() throws EsClientUnavailableException {
+        Map<String, Object> map = new HashMap<>();
+        map.put(DatastoreSettingKey.ELASTICSEARCH_NODE.key(), "127.0.0.1:1234");
+        map.put(DatastoreSettingKey.ELASTICSEARCH_NODES.key(), "127.0.0.2:5678");
+        map.put(DatastoreSettingKey.ELASTICSEARCH_CLUSTER.key(), "foo");
+        
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(map);
+        List<InetSocketAddress> result = parseAddresses(settings);
+        
+        assertThat(result).hasSize(1);
+        
+        /*
+         * There must be only one entry, as the "nodes" entry overrides the "node" entry
+         */
+        assertThatResolvedAs(result.get(0), Inet4Address.class, "127.0.0.2", 5678);
+    }
+    
+    @Test
+    public void testOverride2() throws EsClientUnavailableException {
+        Map<String, Object> map = new HashMap<>();
+        map.put(DatastoreSettingKey.ELASTICSEARCH_NODE.key(), "127.0.0.1:1234");
+        map.put(DatastoreSettingKey.ELASTICSEARCH_NODES.key(), "127.0.0.2:5678");
+        map.put(DatastoreSettingKey.ELASTICSEARCH_NODE.key()+".01", "127.0.0.3:1234");
+        map.put(DatastoreSettingKey.ELASTICSEARCH_CLUSTER.key(), "foo");
+        
+        AbstractBaseKapuaSetting<DatastoreSettingKey> settings = fromMap(map);
+        List<InetSocketAddress> result = parseAddresses(settings);
+        
+        assertThat(result).hasSize(1);
+        
+        /*
+         * There must be only one entry, as the "nodes" entry overrides the "node" entry
+         */
+        assertThatResolvedAs(result.get(0), Inet4Address.class, "127.0.0.3", 1234);
+    }
+
+    @Test
+    public void testClient1() throws EsClientUnavailableException {
+        Map<String, Object> map = new HashMap<>();
+        map.put(DatastoreSettingKey.ELASTICSEARCH_NODES.key(), "127.0.0.1,127.0.0.2:1234,[::1]:5678");
+        map.put(DatastoreSettingKey.ELASTICSEARCH_CLUSTER.key(), "foo");
+
+        try (Client result = EsTransportClientProvider.createClient(fromMap(map))) {
+            assertThat(result).isNotNull();
+        }
+    }
+
+    @Test
+    public void testEmpty3()  {
+        Assertions.assertThatExceptionOfType(EsClientUnavailableException.class) //
+                .isThrownBy(() -> EsTransportClientProvider.getEsClient(null, null));
+    }
+    
+    @Test
+    public void testEmpty4()  {
+        Assertions.assertThatExceptionOfType(EsClientUnavailableException.class) //
+                .isThrownBy(() -> EsTransportClientProvider.getEsClient(Collections.emptyList(), null));
+    }
+    
+    @Test
+    public void testUnknownHost()  {
+        Assertions.assertThatExceptionOfType(EsClientUnavailableException.class) //
+                .isThrownBy(() -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put(DatastoreSettingKey.ELASTICSEARCH_NODES.key(), "foo-bar-does-not-exist");
+                    map.put(DatastoreSettingKey.ELASTICSEARCH_CLUSTER.key(), "foo");
+
+                    try (Client result = EsTransportClientProvider.createClient(fromMap(map))) {
+                    }
+                });
+    }
+}


### PR DESCRIPTION
This change fixes a few bugs in the ElasticSearch transport
configuration. It allows IPv6 addresses to be used, allows the
commons-configuration lists to be used, actually implements the
use of multiple nodes.

This change also provides a unit test with test coverage over 90%.

Signed-off-by: Jens Reimann <jreimann@redhat.com>