### PR TITLE
Shiro Authorization Group service cucumber based CRUD tests

### DIFF
--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -62,11 +62,11 @@
             <artifactId>shiro-core</artifactId>
             <version>${shiro.version}</version>
         </dependency>
-	    <dependency>
-	        <groupId>org.springframework.security</groupId>
-	        <artifactId>spring-security-core</artifactId>
-	        <version>4.1.3.RELEASE</version>
-	    </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>4.1.3.RELEASE</version>
+        </dependency>
        <!--  <dependency>
             Json Web Token implementation
             https://github.com/auth0/java-jwt
@@ -95,7 +95,6 @@
         </dependency> -->
         
     
-	
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
@@ -122,6 +121,12 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-guice</artifactId>
             <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AbstractAuthorizationServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AbstractAuthorizationServiceTest.java
@@ -12,11 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
+import java.math.BigInteger;
 import java.util.Random;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.commons.jpa.SimpleSqlScriptExecutor;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.shiro.AuthenticationEntityManagerFactory;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
 import org.junit.Assert;
@@ -26,13 +29,17 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractAuthorizationServiceTest extends Assert {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractAuthorizationServiceTest.class);
-    protected static Random random = new Random();
+    private static String DEFAULT_PATH = "../../../dev-tools/src/main/database";
+    private static String DROP_ALL_TABLES = "all_drop.sql";
 
-    public static String DEFAULT_PATH = "../../../dev-tools/src/main/database";
-    public static String DROP_ALL_TABLES = "all_drop.sql";
+    protected static Random random = new Random();
+    protected static KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
 
     // Drop the whole database. All tables are deleted.
     public static void dropDatabase() {
+        // TODO: Check if it is (will be) possible to scrub the database using the Liquibase client.
+        // Using two separate mechanisms to drop and create the database tables is inconvenient
+        // and introduces maintainability issues.
         scriptSession(DEFAULT_PATH, DROP_ALL_TABLES);
     }
 
@@ -75,6 +82,14 @@ public abstract class AbstractAuthorizationServiceTest extends Assert {
                 em.close();
             }
         }
+    }
 
+    // *******************
+    // * Private Helpers *
+    // *******************
+
+    // Generate a random KapuaId
+    protected KapuaId generateId() {
+        return new KapuaEid(BigInteger.valueOf(random.nextLong()));
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestData.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestData.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class CommonTestData {
+
+    /**
+     * A flag to mark that an exception was thrown in the preceding steps.
+     */
+    public boolean exceptionCaught;
+    public long count;
+    public int intValue;
+    public String stringValue;
+
+    public void clearData() {
+        exceptionCaught = false;
+        count = 0;
+        intValue = 0;
+        stringValue = "";
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import javax.inject.Inject;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.test.KapuaTest;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+
+// Implementation of Gherkin steps used in various integration test scenarios.
+@ScenarioScoped
+public class CommonTestSteps extends KapuaTest {
+
+    // Scenario scoped common test data
+    CommonTestData commonData = null;
+
+    @Inject
+    public CommonTestSteps(CommonTestData commonData) {
+        this.commonData = commonData;
+    }
+
+    // Database setup and tear-down steps
+    @Before
+    public void beforeScenario(Scenario scenario) throws KapuaException {
+        commonData.clearData();
+    }
+
+    @After
+    public void afterScenario() throws KapuaException {
+    }
+
+    // Cucumber test steps
+
+    @Then("^An exception was thrown$")
+    public void exceptionCaught() {
+        assertTrue(commonData.exceptionCaught);
+    }
+
+    @Then("^No exception was thrown$")
+    public void noExceptionCaught() {
+        assertFalse(commonData.exceptionCaught);
+    }
+
+    @Then("^I get (\\d+) as result$")
+    public void checkCountResult(int num) {
+        assertEquals(num, commonData.count);
+    }
+
+    @Then("^I get the string \"(.+)\" as result$")
+    public void checkStringResult(String text) {
+        assertEquals(text, commonData.stringValue);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucGroup.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucGroup.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import java.math.BigInteger;
+
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+
+public class CucGroup {
+
+    private String name = null;
+    private Integer scope = null;
+    private KapuaId scopeId = null;
+
+    public void doParse() {
+        if (this.scope != null) {
+            this.scopeId = new KapuaEid(BigInteger.valueOf(scope.longValue()));
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public KapuaId getScopeId() {
+        return scopeId;
+    }
+
+    public void setScopeId(KapuaId scopeId) {
+        this.scopeId = scopeId;
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTestData.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTestData.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import javax.inject.Singleton;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.domain.DomainCreator;
+import org.eclipse.kapua.service.authorization.domain.DomainListResult;
+
+@Singleton
+public class DomainServiceTestData {
+
+    Domain domain;
+    DomainCreator domainCreator;
+    DomainListResult domainList;
+    KapuaId domainId;
+    long initial_count;
+
+    public void clearData() {
+        domain = null;
+        domainCreator = null;
+        domainList = null;
+        domainId = null;
+        initial_count = 0;
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTestSteps.java
@@ -166,7 +166,7 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
     public void countDomainEntries()
             throws KapuaException {
         KapuaSecurityUtils.doPrivileged(() -> {
-            commonData.count = domainService.count(domainFactory.newQuery());
+            commonData.count = domainService.count(domainFactory.newQuery(null));
             return null;
         });
     }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTestSteps.java
@@ -12,19 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
-import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
-import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.domain.DomainCreator;
 import org.eclipse.kapua.service.authorization.domain.DomainFactory;
-import org.eclipse.kapua.service.authorization.domain.DomainListResult;
 import org.eclipse.kapua.service.authorization.domain.DomainQuery;
 import org.eclipse.kapua.service.authorization.domain.DomainService;
 import org.eclipse.kapua.service.authorization.domain.shiro.DomainFactoryImpl;
@@ -43,6 +41,7 @@ import cucumber.api.java.Before;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
 
 /**
  * Implementation of Gherkin steps used in DomainService.feature scenarios.
@@ -52,12 +51,11 @@ import cucumber.api.java.en.When;
  *
  */
 
+@ScenarioScoped
 public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @SuppressWarnings("unused")
     private static final Logger s_logger = LoggerFactory.getLogger(DomainServiceTestSteps.class);
-
-    KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
 
     // Various domain related service references
     DomainService domainService = null;
@@ -68,28 +66,21 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
     // Currently executing scenario.
     Scenario scenario;
 
-    // Domain service related objects
-    Domain domain = null;
-    DomainCreator domainCreator = null;
-    DomainListResult domainList = null;
-    KapuaId domainId = null;
+    // Test data scratchpads
+    CommonTestData commonData = null;
+    DomainServiceTestData domainData = null;
 
-    // Check if exception was fired in step.
-    boolean exceptionCaught = false;
-
-    // Interstep data scratchpads
-    int intVal;
-    String strVal;
-    long count;
-    long initial_count;
-    KapuaId lastId;
+    @Inject
+    public DomainServiceTestSteps(DomainServiceTestData domainData, CommonTestData commonData) {
+        this.domainData = domainData;
+        this.commonData = commonData;
+    }
 
     // Setup and tear-down steps
     @Before
     public void beforeScenario(Scenario scenario)
             throws Exception {
         this.scenario = scenario;
-        exceptionCaught = false;
 
         // Instantiate all the services and factories that are required by the tests
         domainService = new DomainServiceImpl();
@@ -101,6 +92,10 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
         // test case executions!
         dropDatabase();
         setupDatabase();
+
+        // Clean up the test data scratchpads
+        commonData.clearData();
+        domainData.clearData();
     }
 
     // *************************************
@@ -111,25 +106,25 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
     public void createAListOfDomains(List<CucDomain> domains)
             throws KapuaException {
         for (CucDomain tmpDom : domains) {
-            exceptionCaught = false;
+            commonData.exceptionCaught = false;
             tmpDom.doParse();
-            domainCreator = domainFactory.newCreator(tmpDom.getName(), tmpDom.getServiceName());
+            domainData.domainCreator = domainFactory.newCreator(tmpDom.getName(), tmpDom.getServiceName());
             if (tmpDom.getActionSet() != null) {
-                domainCreator.setActions(tmpDom.getActionSet());
+                domainData.domainCreator.setActions(tmpDom.getActionSet());
             }
             KapuaSecurityUtils.doPrivileged(() -> {
                 try {
-                    domain = domainService.create(domainCreator);
+                    domainData.domain = domainService.create(domainData.domainCreator);
                 } catch (KapuaException ex) {
-                    exceptionCaught = true;
+                    commonData.exceptionCaught = true;
                     return null;
                 }
-                assertNotNull(domain);
-                assertNotNull(domain.getId());
-                domainId = domain.getId();
+                assertNotNull(domainData.domain);
+                assertNotNull(domainData.domain.getId());
+                domainData.domainId = domainData.domain.getId();
                 return null;
             });
-            if (exceptionCaught) {
+            if (commonData.exceptionCaught) {
                 break;
             }
         }
@@ -139,7 +134,7 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
     public void findDomainByRememberedId()
             throws KapuaException {
         KapuaSecurityUtils.doPrivileged(() -> {
-            domain = domainService.find(null, domainId);
+            domainData.domain = domainService.find(null, domainData.domainId);
             return null;
         });
     }
@@ -148,7 +143,7 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
     public void deleteLastCreatedDomain()
             throws KapuaException {
         KapuaSecurityUtils.doPrivileged(() -> {
-            domainService.delete(null, domainId);
+            domainService.delete(null, domainData.domainId);
             return null;
         });
     }
@@ -158,10 +153,10 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
             throws KapuaException {
         KapuaSecurityUtils.doPrivileged(() -> {
             try {
-                exceptionCaught = false;
+                commonData.exceptionCaught = false;
                 domainService.delete(null, generateId());
             } catch (KapuaException ex) {
-                exceptionCaught = true;
+                commonData.exceptionCaught = true;
             }
             return null;
         });
@@ -171,7 +166,7 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
     public void countDomainEntries()
             throws KapuaException {
         KapuaSecurityUtils.doPrivileged(() -> {
-            count = domainService.count(domainFactory.newQuery(null));
+            commonData.count = domainService.count(domainFactory.newQuery());
             return null;
         });
     }
@@ -182,11 +177,11 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
         DomainQuery query = domainFactory.newQuery(null);
         query.setPredicate(new AttributePredicate<>(DomainPredicates.NAME, name));
         KapuaSecurityUtils.doPrivileged(() -> {
-            domainList = domainService.query(query);
+            domainData.domainList = domainService.query(query);
             return null;
         });
-        assertNotNull(domainList);
-        count = domainList.getSize();
+        assertNotNull(domainData.domainList);
+        commonData.count = domainData.domainList.getSize();
     }
 
     @When("^I query for domains with the service name \"(.+)\"$")
@@ -195,35 +190,35 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
         DomainQuery query = domainFactory.newQuery(null);
         query.setPredicate(new AttributePredicate<>(DomainPredicates.SERVICE_NAME, service_name));
         KapuaSecurityUtils.doPrivileged(() -> {
-            domainList = domainService.query(query);
+            domainData.domainList = domainService.query(query);
             return null;
         });
-        assertNotNull(domainList);
-        count = domainList.getSize();
+        assertNotNull(domainData.domainList);
+        commonData.count = domainData.domainList.getSize();
     }
 
     @When("^I search for the domains for the service \"(.+)\"$")
     public void findDomainsByServiceName(String serviceName)
             throws KapuaException {
         KapuaSecurityUtils.doPrivileged(() -> {
-            domain = domainService.findByServiceName(serviceName);
+            domainData.domain = domainService.findByServiceName(serviceName);
             return null;
         });
     }
 
     @Then("^This is the initial count$")
     public void setInitialCount() {
-        initial_count = count;
+        domainData.initial_count = commonData.count;
     }
 
     @Then("^A domain was created$")
     public void checkDomainNotNull() {
-        assertNotNull(domain);
+        assertNotNull(domainData.domain);
     }
 
     @Then("^There is no domain$")
     public void checkDomainIsNull() {
-        assertNull(domain);
+        assertNull(domainData.domain);
     }
 
     // The following test step is more of a filler. The only purpose is to achieve some coverage
@@ -276,16 +271,16 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @Then("^The domain matches the creator$")
     public void checkDomainAgainstCreator() {
-        assertNotNull(domain);
-        assertNotNull(domain.getId());
-        assertNotNull(domainCreator);
-        assertEquals(domainCreator.getName(), domain.getName());
-        assertEquals(domainCreator.getServiceName(), domain.getServiceName());
-        if (domainCreator.getActions() != null) {
-            assertNotNull(domain.getActions());
-            assertEquals(domainCreator.getActions().size(), domain.getActions().size());
-            for (Actions a : domainCreator.getActions()) {
-                assertTrue(domain.getActions().contains(a));
+        assertNotNull(domainData.domain);
+        assertNotNull(domainData.domain.getId());
+        assertNotNull(domainData.domainCreator);
+        assertEquals(domainData.domainCreator.getName(), domainData.domain.getName());
+        assertEquals(domainData.domainCreator.getServiceName(), domainData.domain.getServiceName());
+        if (domainData.domainCreator.getActions() != null) {
+            assertNotNull(domainData.domain.getActions());
+            assertEquals(domainData.domainCreator.getActions().size(), domainData.domain.getActions().size());
+            for (Actions a : domainData.domainCreator.getActions()) {
+                assertTrue(domainData.domain.getActions().contains(a));
             }
         }
     }
@@ -299,40 +294,21 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
 
         tmpDom.doParse();
         if (tmpDom.getName() != null) {
-            assertEquals(tmpDom.getName(), domain.getName());
+            assertEquals(tmpDom.getName(), domainData.domain.getName());
         }
         if (tmpDom.getServiceName() != null) {
-            assertEquals(tmpDom.getServiceName(), domain.getServiceName());
+            assertEquals(tmpDom.getServiceName(), domainData.domain.getServiceName());
         }
         if (tmpDom.getActionSet() != null) {
-            assertEquals(tmpDom.getActionSet().size(), domain.getActions().size());
+            assertEquals(tmpDom.getActionSet().size(), domainData.domain.getActions().size());
             for (Actions a : tmpDom.getActionSet()) {
-                assertTrue(domain.getActions().contains(a));
+                assertTrue(domainData.domain.getActions().contains(a));
             }
         }
     }
 
-    @Then("^There (?:is|are) (\\d+) domain(?:|s)$")
-    public void checkCountResult(int cnt) {
-        assertEquals(cnt, count);
-    }
-
     @Then("^(\\d+) more domains (?:was|were) created$")
     public void checkIncreasedCountResult(int cnt) {
-        assertEquals(cnt, count - initial_count);
-    }
-
-    @Then("^An exception was caught$")
-    public void exceptionWasCaught() {
-        assertTrue(exceptionCaught);
-    }
-
-    // *******************
-    // * Private Helpers *
-    // *******************
-
-    // Generate a random KapuaId
-    private KapuaId generateId() {
-        return new KapuaEid(BigInteger.valueOf(random.nextLong()));
+        assertEquals(cnt, commonData.count - domainData.initial_count);
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTestData.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTestData.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import javax.inject.Singleton;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.authorization.group.GroupCreator;
+import org.eclipse.kapua.service.authorization.group.GroupListResult;
+
+@Singleton
+public class GroupServiceTestData {
+
+    Group group;
+    Group groupSecond;
+    GroupCreator groupCreator;
+    GroupListResult groupList;
+    KapuaId groupId;
+
+    public void clearData() {
+        group = null;
+        groupSecond = null;
+        groupCreator = null;
+        groupList = null;
+        groupId = null;
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTestSteps.java
@@ -1,0 +1,278 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.group.GroupFactory;
+import org.eclipse.kapua.service.authorization.group.GroupQuery;
+import org.eclipse.kapua.service.authorization.group.GroupService;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupFactoryImpl;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupPredicates;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+
+/**
+ * Implementation of Gherkin steps used in GroupService.feature scenarios.
+ *
+ */
+@ScenarioScoped
+public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger s_logger = LoggerFactory.getLogger(GroupServiceTestSteps.class);
+
+    // Test data scratchpads
+    CommonTestData commonData = null;
+    GroupServiceTestData groupData = null;
+
+    // Various domain related service references
+    GroupService groupService = null;
+    GroupFactory groupFactory = null;
+
+    // Currently executing scenario.
+    Scenario scenario;
+
+    @Inject
+    public GroupServiceTestSteps(GroupServiceTestData groupData, CommonTestData commonData) {
+        this.groupData = groupData;
+        this.commonData = commonData;
+    }
+
+    // Setup and tear-down steps
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+        this.scenario = scenario;
+        commonData.exceptionCaught = false;
+
+        // Instantiate all the services and factories that are required by the tests
+        groupService = new GroupServiceImpl();
+        groupFactory = new GroupFactoryImpl();
+
+        // Clean up the database. A clean slate is needed for truly independent
+        // test case executions!
+        dropDatabase();
+        setupDatabase();
+
+        // Clean up the test data scratchpads
+        commonData.clearData();
+        groupData.clearData();
+    }
+
+    // *************************************
+    // Definition of Cucumber scenario steps
+    // *************************************
+    @When("^I count the group entries in the database$")
+    public void countDomainEntries()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            commonData.count = groupService.count(groupFactory.newQuery(rootScopeId));
+            return null;
+        });
+    }
+
+    @Given("^I create the group(?:|s)$")
+    public void createAListOfDomains(List<CucGroup> groups)
+            throws KapuaException {
+        for (CucGroup tmpGrp : groups) {
+            commonData.exceptionCaught = false;
+            tmpGrp.doParse();
+            groupData.groupCreator = groupFactory.newCreator(tmpGrp.getScopeId(), tmpGrp.getName());
+
+            KapuaSecurityUtils.doPrivileged(() -> {
+                try {
+                    groupData.group = groupService.create(groupData.groupCreator);
+                } catch (KapuaException ex) {
+                    commonData.exceptionCaught = true;
+                    return null;
+                }
+                assertNotNull(groupData.group);
+                assertNotNull(groupData.group.getId());
+                groupData.groupId = groupData.group.getId();
+                return null;
+            });
+            if (commonData.exceptionCaught) {
+                break;
+            }
+        }
+    }
+
+    @When("^I update the group name to \"(.+)\"$")
+    public void updateLastGroupName(String name)
+            throws KapuaException {
+
+        groupData.group.setName(name);
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            // Sleep for a bit to make sure the time stamps are really different!
+            Thread.sleep(50);
+            groupData.groupSecond = groupService.update(groupData.group);
+            assertNotNull(groupData.groupSecond);
+            return null;
+        });
+    }
+
+    @When("^I update the group with an incorrect ID$")
+    public void updateGroupWithFalseId()
+            throws KapuaException {
+
+        groupData.group.setId(generateId());
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            try {
+                commonData.exceptionCaught = false;
+                groupService.update(groupData.group);
+            } catch (KapuaException ex) {
+                commonData.exceptionCaught = true;
+            }
+            return null;
+        });
+    }
+
+    @When("^I delete the last created group$")
+    public void deleteLastCreatedGroup()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            groupService.delete(groupData.group.getScopeId(), groupData.group.getId());
+            return null;
+        });
+    }
+
+    @When("^I try to delete a random group id$")
+    public void deleteGroupWithRandomId()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            try {
+                groupService.delete(rootScopeId, generateId());
+                commonData.exceptionCaught = false;
+            } catch (KapuaException ex) {
+                commonData.exceptionCaught = true;
+            }
+            return null;
+        });
+    }
+
+    @When("^I search for the last created group$")
+    public void findDomainByRememberedId()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            groupData.groupSecond = groupService.find(groupData.group.getScopeId(), groupData.group.getId());
+            return null;
+        });
+    }
+
+    @When("^I count all the groups in scope (\\d+)$")
+    public void countGroupsInScope(int scope)
+            throws KapuaException {
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(scope));
+        GroupQuery tmpQuery = groupFactory.newQuery(tmpId);
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            commonData.count = groupService.count(tmpQuery);
+            return null;
+        });
+    }
+
+    @When("^I query for the group \"(.+)\" in scope (\\d+)$")
+    public void queryForGroup(String name, int scope)
+            throws KapuaException {
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(scope));
+        GroupQuery tmpQuery = groupFactory.newQuery(tmpId);
+        tmpQuery.setPredicate(new AttributePredicate<>(GroupPredicates.NAME, name));
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            groupData.groupList = groupService.query(tmpQuery);
+            return null;
+        });
+
+        assertNotNull(groupData.groupList);
+        commonData.count = groupData.groupList.getSize();
+        if (groupData.groupList.getSize() > 0) {
+            groupData.group = groupData.groupList.getItem(0);
+        }
+    }
+
+    @Then("^A group was created$")
+    public void checkGroupNotNull() {
+        assertNotNull(groupData.group);
+    }
+
+    @Then("^No group was created$")
+    public void checkGroupIsNull() {
+        assertNull(groupData.group);
+    }
+
+    @Then("^No group was found$")
+    public void checkNoGroupWasFound() {
+        assertNull(groupData.groupSecond);
+    }
+
+    @Then("^The group name is \"(.+)\"$")
+    public void checkGroupName(String name) {
+        assertEquals(groupData.group.getName(), name.trim());
+    }
+
+    @Then("^The group matches the creator$")
+    public void checkGroupAgainstCreator() {
+        assertNotNull(groupData.group);
+        assertNotNull(groupData.group.getId());
+        assertNotNull(groupData.groupCreator);
+        assertEquals(groupData.groupCreator.getScopeId(), groupData.group.getScopeId());
+        assertEquals(groupData.groupCreator.getName(), groupData.group.getName());
+        assertNotNull(groupData.group.getCreatedBy());
+        assertNotNull(groupData.group.getCreatedOn());
+        assertNotNull(groupData.group.getModifiedBy());
+        assertNotNull(groupData.group.getModifiedOn());
+    }
+
+    @Then("^The group was correctly updated$")
+    public void checkUpdatedGroup() {
+        assertNotNull(groupData.groupSecond);
+        assertNotNull(groupData.groupSecond.getId());
+        assertEquals(groupData.group.getScopeId(), groupData.groupSecond.getScopeId());
+        assertEquals(groupData.group.getName(), groupData.groupSecond.getName());
+        assertEquals(groupData.group.getCreatedBy(), groupData.groupSecond.getCreatedBy());
+        assertEquals(groupData.group.getCreatedOn(), groupData.groupSecond.getCreatedOn());
+        assertEquals(groupData.group.getModifiedBy(), groupData.groupSecond.getModifiedBy());
+        assertNotEquals(groupData.group.getModifiedOn(), groupData.groupSecond.getModifiedOn());
+    }
+
+    @Then("^The group was correctly found$")
+    public void checkFoundGroup() {
+        assertNotNull(groupData.groupSecond);
+        assertNotNull(groupData.groupSecond.getId());
+        assertEquals(groupData.group.getScopeId(), groupData.groupSecond.getScopeId());
+        assertEquals(groupData.group.getName(), groupData.groupSecond.getName());
+        assertEquals(groupData.group.getCreatedBy(), groupData.groupSecond.getCreatedBy());
+        assertEquals(groupData.group.getCreatedOn(), groupData.groupSecond.getCreatedOn());
+        assertEquals(groupData.group.getModifiedBy(), groupData.groupSecond.getModifiedBy());
+        assertEquals(groupData.group.getModifiedOn(), groupData.groupSecond.getModifiedOn());
+    }
+}

--- a/service/security/shiro/src/test/resources/features/DomainService.feature
+++ b/service/security/shiro/src/test/resources/features/DomainService.feature
@@ -17,7 +17,7 @@ Scenario: Count domains in a blank database
 	The default domain table must contain 15 preset entries.
 	
 	When I count the domain entries in the database
-	Then There are 15 domains
+	Then I get 15 as result
 
 Scenario: Regular domain
 	Create a regular domain entry. The newly created entry must match the 
@@ -36,7 +36,7 @@ Scenario: Domain with null name
 	Given I create the domain
 	|serviceName    |actions   |
 	|test_service_1 |read,write|
-	Then An exception was caught
+	Then An exception was thrown
 
 Scenario: Domain with null service name
 	It must not be possible to create a domain entry with a null service name. In 
@@ -45,7 +45,7 @@ Scenario: Domain with null service name
 	Given I create the domain
 	|name        |actions   |
 	|test_name_1 |read,write|
-	Then An exception was caught
+	Then An exception was thrown
 
 Scenario: Domain with null actions
 	It must not be possible to create a domain entry with a null set of supported actions. In 
@@ -54,7 +54,7 @@ Scenario: Domain with null actions
 	Given I create the domain
 	|name        |serviceName    |
 	|test_name_1 |test_service_1 |
-	Then An exception was caught
+	Then An exception was thrown
 
 Scenario: Domains with duplicate names
 	Domain names must be unique in the database. If an already existing name is used for a 
@@ -68,7 +68,7 @@ Scenario: Domains with duplicate names
 	When I create the domain
 	|name        |serviceName    |actions   |
 	|test_name_1 |test_service_1 |read,write|
-	Then An exception was caught
+	Then An exception was thrown
 
 Scenario: Find the last created domain entry
 	It must be possible to find a dmain entry based on its unique ID.
@@ -115,7 +115,7 @@ Scenario: Delete an inexistent domain
 	an exception.
 	
 	When I try to delete domain with a random ID
-	Then An exception was caught
+	Then An exception was thrown
 
 Scenario: Count domains in the database
 	It must be possible to count all the domain entries in the domain table.
@@ -139,7 +139,7 @@ Scenario: Domain entry query
 	|test_name_2 |test_service_2 |read,execute |
 	|test_name_3 |test_service_3 |write,delete |
 	When I query for domains with the name "test_name_2"
-	Then There is 1 domain
+	Then I get 1 as result
 
 Scenario: Domain entry query - service name
 	It must be possible to query domain entries based on the service name.
@@ -154,8 +154,8 @@ Scenario: Domain entry query - service name
 	|test_name_5 |test_service_3 |read,execute |
 	|test_name_6 |test_service_2 |write,delete |
 	When I query for domains with the service name "test_service_2"
-	Then There are 2 domains
+	Then I get 2 as result
 	When I query for domains with the service name "test_service_3"
-	Then There are 3 domains
+	Then I get 3 as result
 	When I query for domains with the service name "test_service_x"
-	Then There are 0 domains
+	Then I get 0 as result

--- a/service/security/shiro/src/test/resources/features/GroupService.feature
+++ b/service/security/shiro/src/test/resources/features/GroupService.feature
@@ -1,0 +1,162 @@
+###############################################################################
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+Feature: Group Service CRUD tests
+
+Scenario: Count groups in a blank database
+	The default group table must be empty.
+	
+	When I count the group entries in the database
+	Then I get 0 as result
+
+Scenario: Regular group in root scope
+	Create a regular group entry. The newly created entry must match the 
+	creator parameters.
+	 
+	Given I create the group
+	|scope |name        |
+	|0     |test_name_1 |
+	Then A group was created
+	And The group matches the creator
+
+Scenario: Regular group in random scope
+	Create a regular group entry. The newly created entry must match the 
+	creator parameters.
+	 
+	Given I create the group
+	|scope |name        |
+	|1234  |test_name_1 |
+	Then A group was created
+	And The group matches the creator
+
+Scenario: Duplicate group name in root scope
+	Create a regular group entry. The newly created entry must match the 
+	creator parameters. Try to create a second group entry with the same name.
+	An exception should be thrown.
+	 
+	Given I create the group
+	|scope |name        |
+	|0     |test_name_1 |
+	Then A group was created
+	And The group matches the creator
+	When I create the group
+	|scope |name        |
+	|0     |test_name_1 |
+	Then An exception was thrown
+	
+Scenario: Group with a null name
+	Try to create a second group entry with a null name.
+	An exception should be thrown.
+	 
+	Given I create the group
+	|scope |
+	|1234  |
+	Then An exception was thrown
+
+Scenario: Update a group entry in the database
+	Create a regular group entry. Change the entry name. The updated entry 
+	parameters should match the original group.
+	 
+	Given I create the group
+	|scope |name        |
+	|0     |test_name_1 |
+	Then A group was created
+	And The group matches the creator
+	When I update the group name to "test_name_new"
+	Then The group was correctly updated
+	
+Scenario: Update a group entry with a false ID
+	Create a regular group entry. Modify the group object ID to a random value.
+	Trying to update such an group object should raise an exception.
+	 
+	Given I create the group
+	|scope |name        |
+	|0     |test_name_1 |
+	Then A group was created
+	And The group matches the creator
+	When I update the group with an incorrect ID
+	Then An exception was thrown
+
+Scenario: Find a group entry in the database
+	It must be possible to find a specific group entry based on the group 
+	entry ID.
+	
+	Given I create the group	
+	|scope |name        |
+	|0     |test_name_1 |
+	Then A group was created
+	And The group matches the creator
+	When I search for the last created group
+	Then The group was correctly found
+
+Scenario: Delete a group from the database
+	It must be possible to delete a group entry from the database. In this test 
+	the last created entry is deleted.
+
+	Given I create the groups
+	|scope |name        |
+	|0     |test_name_1 |
+	|0     |test_name_2 |
+	When I delete the last created group
+	And I search for the last created group
+	Then No group was found
+
+Scenario: Delete a group from the database - Unknown group ID
+	Trying to delete a group record that does not exist (unknown group ID) should
+	raise an exception.
+	
+	When I try to delete a random group id
+	Then An exception was thrown
+
+Scenario: Count groups
+	It must be possible to count all the groups belonging to a certain scope.
+
+	Given I create the groups
+	|scope |name        |
+	|0     |test_name_1 |
+	|1     |test_name_2 |
+	|2     |test_name_3 |
+	|2     |test_name_4 |
+	|2     |test_name_5 |
+	|3     |test_name_6 |
+	|3     |test_name_7 |
+	|0     |test_name_8 |
+	When I count all the groups in scope 2
+	Then I get 3 as result
+	When I count all the groups in scope 3
+	Then I get 2 as result
+	When I count all the groups in scope 15
+	Then I get 0 as result
+
+Scenario: Query for a specific group by name
+	It must be possible to query the database for a specific group by name. Since the 
+	scope ID / name pairs must be unique, only a single entry can be returned by such a query.
+
+	Given I create the groups
+	|scope |name        |
+	|0     |test_name_1 |
+	|1     |test_name_2 |
+	|2     |test_name_1 |
+	|2     |test_name_4 |
+	|2     |test_name_5 |
+	|3     |test_name_6 |
+	|3     |test_name_7 |
+	|0     |test_name_8 |
+	When I query for the group "test_name_1" in scope 0
+	Then I get 1 as result
+	And The group name is "test_name_1"
+	When I query for the group "test_name_1" in scope 2
+	Then I get 1 as result
+	And The group name is "test_name_1"
+	When I query for the group "test_name_15" in scope 1
+	Then I get 0 as result


### PR DESCRIPTION
## CRUD tests for the Authorization Group service
This set of Authorization Group tests exercises the majority of the main Authorization Group service (package org.eclipse.kapua.service.authorization.group.shiro). The implementation of cucumber based tests for the other packages that make up the Authorization service is in progress.
**Note**: The existing jUnit tests are still enabled since they do not conflict with the cucumber based implementations. They will be gradually removed as more cucumber based tests are implemented.

### Changes to Maven pom files
The Shiro Authorization implementation pom file is modified with additional Cucumber dependencies.

### Implementation changes
The implementation of the Shiro Authorization service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented to test CRUD operations on the Shiro Authorization service.
The existing Authorization Domain service tests were refactored to use the inter-step data scratchpad singletons.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>