### PR TITLE
Update of user service tests with new configuration option.

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/TestConfig.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/TestConfig.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.steps;
+
+import java.util.Map;
+
+/**
+ * Data object used in Gherkin to transfer configuration data.
+ */
+public class TestConfig {
+
+    /** Name of type that config value has. */
+    private String type;
+
+    /** Name of config parameter. */
+    private String  name;
+
+    /** String representation of parameter value. */
+    private String value;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Adds this config parameter to specified map.
+     *
+     * @param valueMap map to add parameter to
+     */
+    public void addConfigToMap(Map<String, Object> valueMap) {
+
+        switch (type) {
+            case "integer":
+                valueMap.put(name, Integer.valueOf(value));
+                break;
+            case "string":
+                valueMap.put(name, value);
+                break;
+            case "boolean":
+                valueMap.put(name, Boolean.valueOf(value));
+                break;
+        }
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -218,6 +218,22 @@ public class UserServiceSteps extends KapuaTest {
         }
     }
 
+    @When("^I configure$")
+    public void setConfigurationValue(List<TestConfig> testConfigs)
+            throws KapuaException {
+        Map<String, Object> valueMap = new HashMap<>();
+
+        for (TestConfig config: testConfigs) {
+            config.addConfigToMap(valueMap);
+        }
+        try {
+            isException = false;
+            accountService.setConfigValues(lastAccount.getId(), valueMap);
+        } catch (KapuaException ex) {
+            isException = true;
+        }
+    }
+
     @Then("^I get KapuaException$")
     public void thenGetKapuaException() throws KapuaException {
         if (!isException) {

--- a/qa/src/test/resources/features/UserServiceI9n.feature
+++ b/qa/src/test/resources/features/UserServiceI9n.feature
@@ -22,6 +22,10 @@ Feature: User Service Integration
     Given Account
       | name      | scopeId |
       | account-a | 1       |
+    And I configure
+      | type    | name                   | value |
+      | boolean | infiniteChildAccounts  | true  |
+      | integer | maxNumberChildAccounts |  5    |
     And User A
       | name    | displayName  | email             | phoneNumber     | status  | userType |
       | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
@@ -36,6 +40,10 @@ Feature: User Service Integration
     And Account
       | name      |
       | account-b |
+    And I configure
+      | type    | name                   | value |
+      | boolean | infiniteChildAccounts  | true  |
+      | integer | maxNumberChildAccounts |  5    |
     And User B
       | name    | displayName  | email             | phoneNumber     | status  | userType |
       | kapua-b | Kapua User B | kapua_b@kapua.com | +386 31 323 555 | ENABLED | INTERNAL |
@@ -61,6 +69,10 @@ Feature: User Service Integration
     Given Account
       | name      | scopeId |
       | account-a | 1       |
+    And I configure
+      | type    | name                   | value |
+      | boolean | infiniteChildAccounts  | true  |
+      | integer | maxNumberChildAccounts |  5    |
     And User A
       | name    | displayName  | email             | phoneNumber     | status  | userType |
       | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
@@ -75,6 +87,10 @@ Feature: User Service Integration
     And Account
       | name      |
       | account-b |
+    And I configure
+      | type    | name                   | value |
+      | boolean | infiniteChildAccounts  | true  |
+      | integer | maxNumberChildAccounts |  5    |
     And User B
       | name    | displayName  | email             | phoneNumber     | status  | userType |
       | kapua-b | Kapua User B | kapua_b@kapua.com | +386 31 323 555 | ENABLED | INTERNAL |


### PR DESCRIPTION
Account service has new configuration option that has to be set. This is
infiniteChildAccounts.

This option has to be set of maxNumberChildAccounts, othervise tests
fail when accounts for permission tests are created in gherkin
scenarios.

This solves failing tests. More tests for account service will be added.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>