### PR TITLE
Fix Vagrant demo script

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -72,35 +72,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
- 
-	<profiles>
-		<profile>
-			<id>sql</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>sql-maven-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>create-schema</id>
-								<phase>process-test-resources</phase>
-								<goals>
-									<goal>execute</goal>
-								</goals>
-								<configuration>
-									<autocommit>true</autocommit>
-									<srcFiles>
-										<srcFile>src/main/sql/H2/sys_configuration_drop.sql</srcFile>
-                                        <srcFile>src/main/resources/liquibase/configuration.sql</srcFile>
-                                    </srcFiles>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
         
 </project>

--- a/dev-tools/src/main/bin/start-demo.sh
+++ b/dev-tools/src/main/bin/start-demo.sh
@@ -1,6 +1,6 @@
 export KAPUA_GIT_ROOT="$(pwd)"
 export ACTIVEMQ_VERSION=5.14.0
-export TOMCAT_VERSION=8.0.38
+export TOMCAT_VERSION=8.0.41
 
 cd ../vagrant
 
@@ -22,7 +22,7 @@ echo 'creating demo vagrant machine'
 
 cd $KAPUA_GIT_ROOT/../../../../
 
-mvn clean install -Psql -Pdeploy
+mvn clean install -P deploy -D skipTests
 
 cd dev-tools/src/main/vagrant
 

--- a/dev-tools/src/main/vagrant/baseBox/baseBox-Vagrantfile
+++ b/dev-tools/src/main/vagrant/baseBox/baseBox-Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure(2) do |config|
 	 export ELASTICSEARCH_VERSION="2.3.4"
 	 export H2DB_VERSION="1.4.192"
 	 export ACTIVE_MQ_VERSION="5.14.0"
-	 export TOMCAT_VERSION="8.0.38"
+	 export TOMCAT_VERSION="8.0.41"
 
      # update
      sudo apt-get update -y

--- a/dev-tools/src/main/vagrant/demo/demo-Vagrantfile
+++ b/dev-tools/src/main/vagrant/demo/demo-Vagrantfile
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |config|
 	 export ELASTICSEARCH_VERSION="2.3.4"
 	 export H2DB_VERSION="1.4.192"
 	 export ACTIVE_MQ_VERSION="5.14.0"
-	 export TOMCAT_VERSION="8.0.38"
+	 export TOMCAT_VERSION="8.0.41"
 
 	 ###########################
      ### H2 database startup ###

--- a/dev-tools/src/main/vagrant/demo/deployScript/deploy-broker.sh
+++ b/dev-tools/src/main/vagrant/demo/deployScript/deploy-broker.sh
@@ -18,8 +18,9 @@ vagrant ssh -c "echo 'deploying the Kapua broker'
 	echo 'deleting old Kapua runtime dependency'
 	find lib/extra ! -name 'mqtt-client*.jar' -type f -exec rm -f {} +
 	echo 'copying Kapua runtime dependency'
-	sudo cp /kapua/assembly/target/broker_dependency/* lib/extra
-	echo 'copying Kapua arctifact'
+    sudo cp /kapua/assembly/target/broker_dependency/* lib/extra
+	for name in \$(ls /kapua/broker-core/target/dependency/ | grep -Ev 'jaxb-|activemq-|kapua-'); do echo copying from /kapua/broker-core/target/dependency/\$name lib/extra/\$name; sudo cp /kapua/broker-core/target/dependency/\$name lib/extra/\$name; done;
+	echo 'copying Kapua artifact'
 	sudo cp /kapua/broker-core/target/kapua-*.jar lib/extra
 	sudo cp /kapua/commons/target/kapua-*.jar lib/extra
 	sudo cp /kapua/service/device/api/target/kapua-*.jar lib/extra
@@ -46,6 +47,7 @@ vagrant ssh -c "echo 'deploying the Kapua broker'
 	sudo cp /kapua/service/device/registry/internal/target/kapua-*.jar lib/extra
 	sudo cp /kapua/service/idgenerator/api/target/kapua-*.jar lib/extra
 	sudo cp /kapua/service/idgenerator/sequence/target/kapua-*.jar lib/extra
+	sudo cp /kapua/service/liquibase/target/kapua-*.jar lib/extra
 	sudo cp /kapua/service/security/authentication/api/target/kapua-*.jar lib/extra
 	sudo cp /kapua/service/security/authorization/api/target/kapua-*.jar lib/extra
 	sudo cp /kapua/service/security/shiro/target/kapua-*.jar lib/extra
@@ -59,6 +61,7 @@ vagrant ssh -c "echo 'deploying the Kapua broker'
 	sudo cp /kapua/transport/jms/target/kapua-*.jar lib/extra
 	sudo cp /kapua/transport/mqtt/target/kapua-*.jar lib/extra
 	echo 'copying Kapua configuration'
-	sudo cp /kapua/assembly/src/main/resources/conf/broker/activemq.xml conf/
+	sudo cp /kapua/assembly/src/main/resources/conf/broker/activemq.xml conf/ 
+	sudo cp /kapua/assembly/src/main/resources/conf/broker/camel.xml conf/
 	cd ..
 	sudo chown -R vagrant:vagrant apache-activemq-${ACTIVEMQ_VERSION}"

--- a/dev-tools/src/main/vagrant/develop/develop-Vagrantfile
+++ b/dev-tools/src/main/vagrant/develop/develop-Vagrantfile
@@ -53,7 +53,7 @@ Vagrant.configure("2") do |config|
 	 export ELASTICSEARCH_VERSION="2.3.4"
 	 export H2DB_VERSION="1.4.192"
 	 export ACTIVEMQ_VERSION="5.14.0"
-	 export TOMCAT_VERSION="8.0.38"
+	 export TOMCAT_VERSION="8.0.41"
 	 export KAPUA_VERSION="0.2.0-SNAPSHOT"
 
 	 #########################

--- a/dev-tools/src/main/vagrant/develop/script/broker/update-kapua-jars-cfg.sh
+++ b/dev-tools/src/main/vagrant/develop/script/broker/update-kapua-jars-cfg.sh
@@ -14,7 +14,7 @@ echo 'cleanup the symbolic links to Kapua jars'
 for name in $(find lib/extra -type l); do echo remove symbolic link from ./$name; rm ./$name; done;
 echo 'create the symbolic links to Kapua jars'
 echo '===> copy dependencies for broker core'
-for name in $(ls /kapua/broker-core/target/dependency/ | grep -Ev 'jaxb-|activemq-|kapua-'); do echo create symbolic link from ./lib/extra$name /kapua/broker-core/target/dependency/$name; ln -s /kapua/broker-core/target/dependency/$name ./lib/extra/$name; done;
+for name in $(ls /kapua/broker-core/target/dependency/ | grep -Ev 'jaxb-|activemq-|kapua-'); do echo create symbolic link from ./lib/extra/$name /kapua/broker-core/target/dependency/$name; ln -s /kapua/broker-core/target/dependency/$name ./lib/extra/$name; done;
 echo '===> copy dependencies for locator/guice'
 for name in $(ls /kapua/locator/guice/target/dependency/ | grep -Ev 'jaxb-|activemq-|kapua-'); do echo create symbolic link from ./lib/extra/$name /kapua/locator/guice/target/dependency/$name; ln -s /kapua/locator/guice/target/dependency/$name ./lib/extra/$name; done;
 echo '===> copy kapua modules'


### PR DESCRIPTION
Hi all,

This PR should address all the issues reported with the Vagrant demo script.

The script has the following changes:

1. Removed any remaining reference to `sql` Maven profile
1. Aligned Tomcat version to 8.0.41
1. Skip tests on build
1. Jars are copied from `/broker-core/target/dependency` since copying from `/assembly/target/broker_dependency` was not enough.

I'll open an issue to improve point 4, since it should be addressed when building the assembly and not by manually copying the jars.

Fixes #386, fixes #384