### PR TITLE
Replace slf4j-log4j version 1.7.13 with 1.7.21 during the build

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -272,6 +272,10 @@
 			<artifactId>log4j-over-slf4j</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.ning</groupId>
 			<artifactId>compress-lzf</artifactId>
 			<version>1.0.3</version>

--- a/assembly/src/main/descriptors/kapua-broker.xml
+++ b/assembly/src/main/descriptors/kapua-broker.xml
@@ -84,6 +84,7 @@
                 <exclude>lib/optional/proton-j*</exclude>
                 <exclude>lib/optional/scala-library*</exclude>
                 <exclude>lib/optional/shiro*</exclude>
+                <exclude>lib/optional/slf4j*</exclude> <!-- pull in version 1.7.21 - CQ12852 -->
                 <exclude>lib/optional/snappy-*</exclude>
                 <exclude>lib/optional/spring-oxm-*</exclude>
                 <exclude>lib/optional/velocity*</exclude>
@@ -131,6 +132,18 @@
     </fileSets>
 
     <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib/optional</outputDirectory>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>false</useTransitiveDependencies>
+            <fileMode>0644</fileMode>
+            <includes>
+                <include>org.slf4j:slf4j-log4j12</include><!-- CQ12852 -->
+            </includes>
+        </dependencySet>
+        
         <dependencySet>
             <outputDirectory>lib/extra</outputDirectory>
             <unpack>false</unpack>


### PR DESCRIPTION
This is done since we are using 1.7.21 and do have a CQ for this
specific version.

Signed-off-by: Jens Reimann <jreimann@redhat.com>