### PR TITLE
Cucumber based Authorization Role service CRUD tests.

### DIFF
--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestData.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestData.java
@@ -14,6 +14,8 @@ package org.eclipse.kapua.service.authorization.shiro;
 
 import javax.inject.Singleton;
 
+import org.eclipse.kapua.model.id.KapuaId;
+
 @Singleton
 public class CommonTestData {
 
@@ -24,11 +26,13 @@ public class CommonTestData {
     public long count;
     public int intValue;
     public String stringValue;
+    public KapuaId scopeId;
 
     public void clearData() {
         exceptionCaught = false;
         count = 0;
         intValue = 0;
         stringValue = "";
+        scopeId = null;
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
@@ -12,14 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
+import java.math.BigInteger;
+
 import javax.inject.Inject;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.test.KapuaTest;
 
 import cucumber.api.Scenario;
-import cucumber.api.java.After;
 import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.runtime.java.guice.ScenarioScoped;
 
@@ -41,11 +44,17 @@ public class CommonTestSteps extends KapuaTest {
         commonData.clearData();
     }
 
-    @After
-    public void afterScenario() throws KapuaException {
+    // Cucumber test steps
+    @Given("^A scope with ID (\\d+)$")
+    public void setScopeId(Integer scope) {
+        commonData.scopeId = new KapuaEid(BigInteger.valueOf(scope));
+        assertNotNull(commonData.scopeId);
     }
 
-    // Cucumber test steps
+    @Given("^A null scope$")
+    public void setNullScopId() {
+        commonData.scopeId = null;
+    }
 
     @Then("^An exception was thrown$")
     public void exceptionCaught() {
@@ -58,8 +67,9 @@ public class CommonTestSteps extends KapuaTest {
     }
 
     @Then("^I get (\\d+) as result$")
-    public void checkCountResult(int num) {
-        assertEquals(num, commonData.count);
+    public void checkCountResult(Integer num) {
+        assertNotNull(num);
+        assertEquals(num.longValue(), commonData.count);
     }
 
     @Then("^I get the string \"(.+)\" as result$")

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucRole.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucRole.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+
+public class CucRole {
+
+    private String name = null;
+    private Integer scopeId = null;
+    private String actions = null;
+    private KapuaId id = null;
+    private Set<Actions> actionSet = null;
+
+    public void doParse() {
+        if (this.scopeId != null) {
+            this.id = new KapuaEid(BigInteger.valueOf(scopeId));
+        }
+        if (this.actions != null) {
+            String tmpAct = this.actions.trim().toLowerCase();
+            if (tmpAct.length() != 0) {
+                this.actionSet = new HashSet<>();
+                String[] tmpList = this.actions.split(",");
+
+                for (String tmpS : tmpList) {
+                    switch (tmpS.trim().toLowerCase()) {
+                    case "read":
+                        this.actionSet.add(Actions.read);
+                        break;
+                    case "write":
+                        this.actionSet.add(Actions.write);
+                        break;
+                    case "delete":
+                        this.actionSet.add(Actions.delete);
+                        break;
+                    case "connect":
+                        this.actionSet.add(Actions.connect);
+                        break;
+                    case "execute":
+                        this.actionSet.add(Actions.execute);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setScopeId(KapuaId id) {
+        this.id = id;
+    }
+
+    public KapuaId getScopeId() {
+        return this.id;
+    }
+
+    public Set<Actions> getActions() {
+        return actionSet;
+    }
+
+    public void setActions(Set<Actions> actions) {
+        this.actionSet = actions;
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucRolePermission.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucRolePermission.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import java.math.BigInteger;
+
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+
+public class CucRolePermission {
+
+    private Integer scopeId = null;
+    private Integer roleId = null;
+    private String actionName = null;
+    private KapuaId scope = null;
+    private KapuaId role = null;
+    private Actions action = null;
+
+    public void doParse() {
+        if (this.scopeId != null) {
+            this.scope = new KapuaEid(BigInteger.valueOf(scopeId));
+        }
+        if (this.roleId != null) {
+            this.role = new KapuaEid(BigInteger.valueOf(roleId));
+        }
+        if (this.actionName != null) {
+            switch (actionName.trim().toLowerCase()) {
+            case "read":
+                this.action = Actions.read;
+                break;
+            case "write":
+                this.action = Actions.write;
+                break;
+            case "delete":
+                this.action = Actions.delete;
+                break;
+            case "connect":
+                this.action = Actions.connect;
+                break;
+            case "execute":
+                this.action = Actions.execute;
+                break;
+            }
+        }
+    }
+
+    public void setScopeId(KapuaId id) {
+        this.scope = id;
+    }
+
+    public KapuaId getScopeId() {
+        return this.scope;
+    }
+
+    public void setRoleId(KapuaId id) {
+        this.role = id;
+    }
+    
+    public KapuaId getRoleId() {
+        return this.role;
+    }
+
+    public Actions getAction() {
+        return action;
+    }
+
+    public void setAction(Actions action) {
+        this.action = action;
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTestData.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTestData.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import java.util.Set;
+import javax.inject.Singleton;
+
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.role.Role;
+import org.eclipse.kapua.service.authorization.role.RoleListResult;
+import org.eclipse.kapua.service.authorization.role.RolePermission;
+import org.eclipse.kapua.service.authorization.role.RolePermissionListResult;
+
+@Singleton
+public class RoleServiceTestData {
+
+    Role role;
+    Role roleFound;
+    RoleListResult roleList;
+    Set<Permission> permissions;
+    RolePermission rolePermission;
+    RolePermission rolePermissionFound;
+    RolePermissionListResult permissionList;
+
+    public void clearData() {
+        role = null;
+        roleFound = null;
+        roleList = null;
+        permissions = null;
+        rolePermission = null;
+        rolePermissionFound = null;
+        permissionList = null;
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTestSteps.java
@@ -1,0 +1,513 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionFactoryImpl;
+import org.eclipse.kapua.service.authorization.role.Role;
+import org.eclipse.kapua.service.authorization.role.RoleCreator;
+import org.eclipse.kapua.service.authorization.role.RoleFactory;
+import org.eclipse.kapua.service.authorization.role.RolePermission;
+import org.eclipse.kapua.service.authorization.role.RolePermissionCreator;
+import org.eclipse.kapua.service.authorization.role.RolePermissionFactory;
+import org.eclipse.kapua.service.authorization.role.RolePermissionQuery;
+import org.eclipse.kapua.service.authorization.role.RolePermissionService;
+import org.eclipse.kapua.service.authorization.role.RoleQuery;
+import org.eclipse.kapua.service.authorization.role.RoleService;
+import org.eclipse.kapua.service.authorization.role.shiro.RoleFactoryImpl;
+import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionFactoryImpl;
+import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionImpl;
+import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionServiceImpl;
+import org.eclipse.kapua.service.authorization.role.shiro.RolePredicates;
+import org.eclipse.kapua.service.authorization.role.shiro.RoleServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+
+/**
+ * Implementation of Gherkin steps used in DomainService.feature scenarios.
+ */
+@ScenarioScoped
+public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger s_logger = LoggerFactory.getLogger(RoleServiceTestSteps.class);
+
+    private static final Domain testDomain = new TestDomain();
+
+    // Various Role related service references
+    RoleCreator roleCreator = null;
+    RoleService roleService = null;
+    RoleFactory roleFactory = null;
+    RolePermissionCreator rolePermissionCreator = null;
+    RolePermissionService rolePermissionService = null;
+    RolePermissionFactory rolePermissionFactory = null;
+    PermissionFactory permissionFactory = null;
+
+    // Currently executing scenario.
+    Scenario scenario;
+
+    // Test data scratchpads
+    CommonTestData commonData = null;
+    RoleServiceTestData roleData = null;
+
+    @Inject
+    public RoleServiceTestSteps(RoleServiceTestData roleData, CommonTestData commonData) {
+        this.roleData = roleData;
+        this.commonData = commonData;
+    }
+    
+    // Setup and tear-down steps
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+        this.scenario = scenario;
+        commonData.exceptionCaught = false;
+
+        // Instantiate all the services and factories that are required by the tests
+        roleService = new RoleServiceImpl();
+        roleFactory = new RoleFactoryImpl();
+        rolePermissionService = new RolePermissionServiceImpl();
+        rolePermissionFactory = new RolePermissionFactoryImpl();
+        permissionFactory = new PermissionFactoryImpl();
+
+        // Clean up the database. A clean slate is needed for truly independent
+        // test case executions!
+        dropDatabase();
+        setupDatabase();
+        
+        // Clean up the test data scratchpads
+        commonData.clearData();
+        roleData.clearData();
+    }
+
+    // *************************************
+    // Definition of Cucumber scenario steps
+    // *************************************
+    @Given("^I create the following role(?:|s)$")
+    public void createAListOfRoles(List<CucRole> roles)
+            throws KapuaException {
+        for (CucRole tmpRole : roles) {
+            commonData.exceptionCaught = false;
+            tmpRole.doParse();
+            roleData.permissions = new HashSet<>();
+            if ((tmpRole.getActions() != null) && (tmpRole.getActions().size() > 0)) {
+                for (Actions tmpAct : tmpRole.getActions()) {
+                    roleData.permissions.add(permissionFactory.newPermission(testDomain, tmpAct, tmpRole.getScopeId()));
+                }
+            }
+            roleCreator = roleFactory.newCreator(tmpRole.getScopeId());
+            roleCreator.setName(tmpRole.getName());
+            roleCreator.setPermissions(roleData.permissions);
+            KapuaSecurityUtils.doPrivileged(() -> {
+                try {
+                    roleData.role = roleService.create(roleCreator);
+                } catch (KapuaException ex) {
+                    commonData.exceptionCaught = true;
+                }
+                return null;
+            });
+
+            if (commonData.exceptionCaught)
+                break;
+        }
+    }
+
+    @Given("^I create the following role permission(?:|s)$")
+    public void createAListOfRolePermissions(List<CucRolePermission> perms)
+            throws KapuaException {
+        
+        TestDomain tmpDom = new TestDomain();
+        assertNotNull(perms);
+        assertFalse(perms.isEmpty());
+        
+        for(CucRolePermission tmpCPerm : perms) {
+            tmpCPerm.doParse();
+            assertNotNull(tmpCPerm.getScopeId());
+            assertNotNull(tmpCPerm.getRoleId());
+            assertNotNull(tmpCPerm.getAction());
+
+            tmpDom.setScopeId(tmpCPerm.getScopeId());
+
+            rolePermissionCreator = rolePermissionFactory.newCreator(tmpCPerm.getScopeId());
+            rolePermissionCreator.setRoleId(tmpCPerm.getRoleId());
+            rolePermissionCreator.setPermission(permissionFactory.newPermission(tmpDom, tmpCPerm.getAction(), tmpCPerm.getScopeId()));
+            
+            KapuaSecurityUtils.doPrivileged(() -> {
+                try {
+                    commonData.exceptionCaught = false;
+                    roleData.rolePermission = rolePermissionService.create(rolePermissionCreator);
+                } catch (KapuaException ex) {
+                    commonData.exceptionCaught = true;
+                    return null;
+                }
+                return null;
+            });
+        }
+    }
+    
+    @When("^I update the last created role name to \"(.+)\"$")
+    public void updateRoleNameTo(String name)
+            throws Exception {
+        roleData.role.setName(name);
+        Thread.sleep(100);
+        KapuaSecurityUtils.doPrivileged(() -> {
+            try {
+                commonData.exceptionCaught = false;
+                roleService.update(roleData.role);
+            } catch (KapuaException ex) {
+                commonData.exceptionCaught = true;
+            }
+            return null;
+        });
+    }
+
+    @When("^I examine the permissions for the last role$")
+    public void findPermissionsForTheLastCreatedRole()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            roleData.permissionList = rolePermissionService.findByRoleId(
+                    roleData.role.getScopeId(), roleData.role.getId());
+            return null;
+        });
+    }
+
+    @When("^I search for the last created role$")
+    public void findLastCreatedRole()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            roleData.roleFound = roleService.find(
+                    roleData.role.getScopeId(), roleData.role.getId());
+            return null;
+        });
+    }
+
+    @When("^I search for the last created role permission$")
+    public void findLastCreatedRolePermission()
+            throws KapuaException {
+        roleData.rolePermissionFound = null;
+        KapuaSecurityUtils.doPrivileged(() -> {
+            roleData.rolePermissionFound = rolePermissionService.find(
+                    roleData.rolePermission.getScopeId(), roleData.rolePermission.getId());
+            return null;
+        });
+    }
+    
+    @When("^I search for a random role ID$")
+    public void searchForRandomId()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            roleData.roleFound = roleService.find(rootScopeId, generateId());
+            return null;
+        });
+    }
+
+    @When("^I delete the last created role$")
+    public void deleteLastCreatedRole()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            try {
+                commonData.exceptionCaught = false;
+                roleService.delete(roleData.role.getScopeId(), roleData.role.getId());
+            } catch (KapuaException ex) {
+                commonData.exceptionCaught = true;
+            }
+            return null;
+        });
+    }
+
+    @When("^I delete the last created role permission$")
+    public void deleteLastCreatedRolePermission()
+            throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            try {
+                commonData.exceptionCaught = false;
+                rolePermissionService.delete(
+                        roleData.rolePermission.getScopeId(), roleData.rolePermission.getId());
+            } catch (KapuaException ex) {
+                commonData.exceptionCaught = true;
+            }
+            return null;
+        });
+    }
+    
+    @When("^I count the roles in scope (\\d+)$")
+    public void countRolesInScope(Integer scope)
+            throws KapuaException {
+        assertNotNull(scope);
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(scope));
+        assertNotNull(tmpId);
+
+        final RoleQuery tmpQuery = roleFactory.newQuery(tmpId);
+        KapuaSecurityUtils.doPrivileged(() -> {
+            commonData.count = roleService.count(tmpQuery);
+            return null;
+        });
+    }
+
+    @When("^I count the permission in scope (\\d+)$")
+    public void countRolePermissionsInScope(Integer scope)
+            throws KapuaException {
+        assertNotNull(scope);
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(scope));
+        assertNotNull(tmpId);
+
+        final RolePermissionQuery tmpQuery = rolePermissionFactory.newQuery(tmpId);
+        KapuaSecurityUtils.doPrivileged(() -> {
+            commonData.count = rolePermissionService.count(tmpQuery);
+            return null;
+        });
+    }
+    
+    @When("^I query for the role \"(.+)\" in scope (\\d+)$")
+    public void queryForRoleInScope(String name, Integer scope)
+    throws KapuaException {
+        assertNotNull(scope);
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(scope));
+        assertNotNull(tmpId);
+        assertNotNull(name);
+        assertNotEquals(0, name.length());
+        
+        final RoleQuery tmpQuery = roleFactory.newQuery(tmpId);
+        tmpQuery.setPredicate(new AttributePredicate<String>(RolePredicates.NAME, name));
+        KapuaSecurityUtils.doPrivileged(() -> {
+            roleData.roleList = roleService.query(tmpQuery);
+            return null;
+        });
+        
+        assertNotNull(roleData.roleList);
+        if (roleData.roleList.getSize() > 1) {
+            fail("Query returned too many results!");
+        }
+        
+        if (!roleData.roleList.isEmpty()) {
+            roleData.roleFound = roleData.roleList.getFirstItem();
+        }
+        
+        commonData.count = roleData.roleList.getSize();
+    }
+    
+    @Then("^I find no roles$")
+    public void chackThatNothingWasFound() {
+        assertNull(roleData.roleFound);
+    }
+    
+    @Then("^I find no permissions$")
+    public void checkThatNoPermissionWasFound() {
+        assertNull(roleData.rolePermissionFound);
+    }
+
+    @Then("^The role matches the creator$")
+    public void checkLastRoleAgainstCreator()
+            throws KapuaException {
+
+        assertNotNull(roleData.role);
+        assertNotNull(roleCreator);
+        assertEquals(roleCreator.getScopeId(), roleData.role.getScopeId());
+        assertEquals(roleCreator.getName(), roleData.role.getName());
+        assertNotNull(roleData.role.getCreatedBy());
+        assertNotNull(roleData.role.getCreatedOn());
+        assertNotNull(roleData.role.getModifiedBy());
+        assertNotNull(roleData.role.getModifiedOn());
+    }
+
+    @Then("^The permissions match$")
+    public void checkPermissionsAgainstRole() {
+
+        boolean found = false;
+        assertNotNull(roleData.permissions);
+        assertNotNull(roleData.permissionList);
+        assertEquals(roleData.permissions.size(), roleData.permissionList.getSize());
+        if (roleData.permissions.size() > 0) {
+            for (RolePermission tmpRolePerm : roleData.permissionList.getItems()) {
+                found = false;
+                for (Permission tmpPerm : roleData.permissions) {
+                    if (tmpPerm.getAction() == tmpRolePerm.getPermission().getAction()) {
+                        found = true;
+                        break;
+                    }
+                }
+                assertTrue(found);
+            }
+        }
+    }
+
+    @Then("^I find the following actions$")
+    public void checkPermissionsAgainstList(List<CucRole> roles) {
+
+        assertNotNull(roles);
+        assertEquals(1, roles.size());
+        CucRole tmpRole = roles.get(0);
+        assertNotNull(tmpRole);
+        tmpRole.doParse();
+        Set<Actions> actLst = tmpRole.getActions();
+        assertNotNull(actLst);
+        assertNotNull(roleData.permissionList);
+        assertNotEquals(0, roleData.permissionList.getSize());
+        assertEquals(actLst.size(), roleData.permissionList.getSize());
+        for (RolePermission tmpPerm : roleData.permissionList.getItems()) {
+            assertTrue(actLst.contains(tmpPerm.getPermission().getAction()));
+        }
+    }
+
+    @Then("^The correct role entry was found$")
+    public void verifyThatRolesMatch() {
+        assertNotNull(roleData.role);
+        assertNotNull(roleData.roleFound);
+        assertEquals(roleData.role.getScopeId(), roleData.roleFound.getScopeId());
+        assertEquals(roleData.role.getScopeId(), roleData.roleFound.getScopeId());
+        assertEquals(roleData.role.getName(), roleData.roleFound.getName());
+        assertEquals(roleData.role.getCreatedBy(), roleData.roleFound.getCreatedBy());
+        assertEquals(roleData.role.getCreatedOn(), roleData.roleFound.getCreatedOn());
+        assertEquals(roleData.role.getModifiedBy(), roleData.roleFound.getModifiedBy());
+        assertEquals(roleData.role.getModifiedOn(), roleData.roleFound.getModifiedOn());
+    }
+
+    @Then("^The correct role permission entry was found$")
+    public void verifyThatRolePermissionsMatch() {
+        assertNotNull(roleData.rolePermission);
+        assertNotNull(roleData.rolePermissionFound);
+        assertEquals(roleData.rolePermission.getScopeId(), roleData.rolePermissionFound.getScopeId());
+        assertEquals(roleData.rolePermission.getScopeId(), roleData.rolePermissionFound.getScopeId());
+        assertEquals(roleData.rolePermission.getCreatedBy(), roleData.rolePermissionFound.getCreatedBy());
+        assertEquals(roleData.rolePermission.getCreatedOn(), roleData.rolePermissionFound.getCreatedOn());
+    }
+
+    @Then("^The role was successfully updated$")
+    public void checkRoleForUpdates() {
+        assertNotNull(roleData.role);
+        assertNotNull(roleData.roleFound);
+        assertEquals(roleData.role.getScopeId(), roleData.roleFound.getScopeId());
+        assertEquals(roleData.role.getScopeId(), roleData.roleFound.getScopeId());
+        assertEquals(roleData.role.getName(), roleData.roleFound.getName());
+        assertEquals(roleData.role.getCreatedBy(), roleData.roleFound.getCreatedBy());
+        assertEquals(roleData.role.getCreatedOn(), roleData.roleFound.getCreatedOn());
+        assertEquals(roleData.role.getModifiedBy(), roleData.roleFound.getModifiedBy());
+        assertNotEquals(roleData.role.getModifiedOn(), roleData.roleFound.getModifiedOn());
+    }
+
+    @Then("^The role factory returns sane results$")
+    public void performRoleFactorySanityChecks() {
+        assertNotNull(roleFactory.newEntity(rootScopeId));
+        assertNotNull(roleFactory.newCreator(rootScopeId));
+        assertNotNull(roleFactory.newQuery(rootScopeId));
+        assertNotNull(roleFactory.newListResult());
+        assertNotNull(roleFactory.newRolePermission());
+    }
+
+    @Then("^The role permission factory returns sane results$")
+    public void performRolePermissionFactorySanityChecks() {
+        assertNotNull(rolePermissionFactory.newEntity(rootScopeId));
+        assertNotNull(rolePermissionFactory.newCreator(rootScopeId));
+        assertNotNull(rolePermissionFactory.newQuery(rootScopeId));
+        assertNotNull(rolePermissionFactory.newListResult());
+    }
+
+    @Then("^The role comparator does its job$")
+    public void checkRoleEqualityMethod() {
+        Role role1 = roleFactory.newEntity(rootScopeId);
+        Role role2 = roleFactory.newEntity(rootScopeId);
+        Integer miscObj = 10;
+        
+        assertNotNull(role1);
+        assertNotNull(role2);
+        assertNotNull(miscObj);
+        
+        assertTrue(role1.equals(role1));
+        assertFalse(role1.equals(null));
+        assertFalse(role1.equals(miscObj));
+        assertTrue(role1.equals(role2));
+        role2.setName("test_name_2");
+        assertFalse(role1.equals(role2));
+        role1.setName("test_name_1");
+        assertFalse(role1.equals(role2));
+        role2.setName("test_name_1");
+        assertTrue(role1.equals(role2));
+    }
+
+    @Then("^The role permission comparator does its job$")
+    public void checkRolePermissionEqualityMethod() {
+        RolePermission perm1 = rolePermissionFactory.newEntity(rootScopeId);
+        RolePermission perm2 = rolePermissionFactory.newEntity(rootScopeId);
+        Integer miscObj = 1;
+        Permission tmpPermission1 = permissionFactory.newPermission(testDomain, Actions.read, rootScopeId);
+        Permission tmpPermission2 = permissionFactory.newPermission(testDomain, Actions.write, rootScopeId);
+        KapuaId tmpRoleId1 = generateId();
+        KapuaId tmpRoleId2 = generateId();
+        
+        assertNotNull(perm1);
+        assertNotNull(perm2);
+        assertTrue(perm1.equals(perm1));
+        assertFalse(perm1.equals(null));
+        assertFalse(perm1.equals(miscObj));
+        assertTrue(perm1.equals(perm2));
+        
+        perm2.setPermission(tmpPermission2);
+        assertFalse(perm1.equals(perm2));
+        
+        perm1.setPermission(tmpPermission1);
+        assertFalse(perm1.equals(perm2));
+
+        perm2.setPermission(tmpPermission1);
+        assertTrue(perm1.equals(perm2));
+        
+        perm2.setRoleId(tmpRoleId1);
+        assertFalse(perm1.equals(perm2));
+        perm1.setRoleId(tmpRoleId1);
+        assertTrue(perm1.equals(perm2));
+        perm2.setRoleId(tmpRoleId2);
+        assertFalse(perm1.equals(perm2));
+    }
+    
+    @Then("^The role permission object constructors are sane$")
+    public void checkRolePermissionConstructors() {
+        
+        Permission tmpPermission = permissionFactory.newPermission(testDomain, Actions.read, rootScopeId);
+        KapuaId tmpRoleId = generateId();
+
+        assertNotNull(tmpRoleId);
+        RolePermission perm1 = new RolePermissionImpl(rootScopeId);
+        assertNotNull(perm1);
+        RolePermission perm2 = new RolePermissionImpl(perm1);
+        assertNotNull(perm2);
+        assertTrue(perm1.equals(perm2));
+        RolePermission perm3 = new RolePermissionImpl(rootScopeId, tmpPermission);
+        assertNotNull(perm3);
+        assertEquals(perm3.getPermission(), tmpPermission);
+        perm1.setRoleId(tmpRoleId);
+        assertEquals(tmpRoleId, perm1.getRoleId());
+        perm1.setPermission(tmpPermission);
+        assertEquals(perm1.getPermission(), tmpPermission);
+    }
+}

--- a/service/security/shiro/src/test/resources/features/RoleService.feature
+++ b/service/security/shiro/src/test/resources/features/RoleService.feature
@@ -1,0 +1,242 @@
+###############################################################################
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+Feature: Role Service CRUD tests
+
+Scenario: Regular role creation
+	Create a regular role entry. The entry must match the creator details.
+	
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	Then The role matches the creator
+	When I examine the permissions for the last role
+	Then I find the following actions
+	|actions              |
+	|write, read, connect |
+	And The permissions match
+
+Scenario: Nameless role entry
+	It must not be possible to create a role entry without a name.
+	Such an attempt must throw an exception.
+	
+	Given I create the following role
+	|scopeId |actions              |
+	|1       |write, read, connect |
+	Then An exception was thrown
+
+Scenario: Duplicate role names
+	It must not be possible to create role entries with duplicate names.
+	Such an attempt must throw an exception.
+	
+	Given I create the following role
+	|scopeId |name      |actions                 |
+	|1       |test_role |write, read, connect    |
+	|1       |test_role |write, execute, connect |
+	Then An exception was thrown
+
+Scenario: Role entry with no actions
+	It should be possible to create a role entry without a single action.
+	
+	Given I create the following role
+	|scopeId |name      |
+	|1       |test_role |
+	Then No exception was thrown
+	And The role matches the creator
+
+Scenario: Find role by ID
+	It must be possible to find a specific role entry in the database based 
+	on the known role ID.
+
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	When I search for the last created role
+	Then The correct role entry was found
+
+Scenario: Search the role database for a random ID
+	Searching the database for an unknown ID should be silently ignored. No 
+	exception should be raised.
+
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	When I search for a random role ID
+	Then I find no roles
+
+Scenario: Delete an existing role
+	It must be possible to delete an existing role item from the database.
+	
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	When I delete the last created role
+	And I search for the last created role
+	Then I find no roles
+	
+Scenario: Delete a non existing role entry
+	Deleting a non existing role must throw an exception. This scenario explores what 
+	happens when it is attempted to delete the same role twice.
+
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	When I delete the last created role
+	And I search for the last created role
+	Then I find no roles
+	When I delete the last created role
+	Then An exception was thrown
+
+Scenario: Update existing role name
+	It must be possible to change the name of an already existing role.
+
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	When I update the last created role name to "test_role_changed"
+	And I search for the last created role
+	Then The role was successfully updated
+
+Scenario: Modify a role that was deleted
+	If an update operation is tried on a role that was previously deleted,
+	an exception must be thrown.
+	
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	And I delete the last created role
+	When I update the last created role name to "test_role_changed"
+	Then An exception was thrown
+
+Scenario: Count roles in specific scopes
+	It must be possible to count all the roles defined for specific scopes. If
+	there is no role for a specific domain a 0 should be returned. No error or 
+	exception is expected.
+	
+	Given I create the following roles
+	|scopeId |name        |actions              |
+	|4       |test_role_1 |write, read, connect |
+	|2       |test_role_2 |write, read, connect |
+	|3       |test_role_3 |write, read, connect |
+	|4       |test_role_4 |write, read, connect |
+	|2       |test_role_5 |write, read, connect |
+	|4       |test_role_6 |write, read, connect |
+	|4       |test_role_7 |write, read, connect |
+	|2       |test_role_8 |write, read, connect |
+	When I count the roles in scope 4
+	Then I get 4 as result
+	When I count the roles in scope 2
+	Then I get 3 as result
+	When I count the roles in scope 3
+	Then I get 1 as result
+	When I count the roles in scope 15
+	Then I get 0 as result
+
+Scenario: A fresh database must contain 1 default role in the root scope
+	When I count the roles in scope 1
+	Then I get 1 as result
+	
+Scenario: It must be possible to query for specific entries in the role database
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	When I query for the role "test_role" in scope 1
+	Then I get 1 as result
+	And The correct role entry was found
+
+Scenario: Empty query results are supported
+	If a query does not yield any result only an empty list must be returned. This is not
+	an error situation.
+	
+	Given I create the following role
+	|scopeId |name      |actions              |
+	|1       |test_role |write, read, connect |
+	When I query for the role "test_role_unknown" in scope 1
+	Then No exception was thrown
+	And I get 0 as result
+
+Scenario: Create some regular role permissions
+	Given I create the following role permissions
+	|scopeId |roleId |actionName |
+	|1       |15     |read       |
+	|1       |15     |write      |
+	|5       |8      |connect    |
+	Then No exception was thrown
+	When I search for the last created role permission
+	Then The correct role permission entry was found
+
+Scenario: Delete role permissions
+	It must be possible to delete an existing role permission record from the database.
+	
+	Given I create the following role permission
+	|scopeId |roleId |actionName |
+	|1       |15     |read       |
+	Then No exception was thrown
+	When I delete the last created role permission
+	And I search for the last created role permission
+	Then I find no permissions
+
+Scenario: Delete nonexisting role permission
+	An attempt to delete a non existing role permission from the database must result 
+	in an exception being thrown.
+	
+	Given I create the following role permission
+	|scopeId |roleId |actionName |
+	|1       |15     |read       |
+	Then No exception was thrown
+	When I delete the last created role permission
+	And I search for the last created role permission
+	Then I find no permissions
+	When I delete the last created role permission
+	Then An exception was thrown
+
+Scenario: Count role permissions in specific scopes
+	It must be possible to count all the role permissions defined for specific scopes. If
+	there is no role permission for a specific domain a 0 should be returned. No error or 
+	exception is expected.
+	
+	Given I create the following role permissions
+	|scopeId  |roleId |actionName |
+	|10       |15     |read       |
+	|10       |16     |read       |
+	|10       |17     |read       |
+	|11       |18     |read       |
+	|11       |19     |read       |
+	|12       |20     |read       |
+	When I count the permission in scope 10
+	Then I get 3 as result
+	When I count the permission in scope 11
+	Then I get 2 as result
+	When I count the permission in scope 12
+	Then I get 1 as result
+	When I count the permission in scope 42
+	Then I get 0 as result
+
+Scenario: Role creator sanity checks
+	Check that the role factory returns non null objects.
+	
+	Then The role factory returns sane results
+
+Scenario: Role object equality check
+	Check that the role object comparator method correctly compares two objects and returns the
+	expected results.
+	
+	Then The role comparator does its job
+
+Scenario: Role service related objects sanity checks
+	Check that the objects related to the shiro role service behave sanely.
+
+	Then The role permission factory returns sane results
+	Then The role permission object constructors are sane
+	Then The role permission comparator does its job
+


### PR DESCRIPTION
## CRUD tests for the Authorization Role service
This set of Authorization Role tests exercises the majority of the main Authorization Role service (package org.eclipse.kapua.service.authorization.group.shiro). The implementation of cucumber based tests for the other packages that make up the Authorization service is in progress.
**Note**: The existing jUnit tests are still enabled since they do not conflict with the cucumber based implementations. They will be gradually removed as more cucumber based tests are implemented.

### Changes to Maven pom files
There is no change to the package pom files.

### Implementation changes
The implementation of the Shiro Authorization service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented to test CRUD operations on the Shiro Authorization Role service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>