### PR TITLE
Unit tests for group and role service fixed

### DIFF
--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
+import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 /**
  * {@link Group} service definition.
@@ -24,7 +25,9 @@ import org.eclipse.kapua.service.KapuaUpdatableEntityService;
  * @since 1.0.0
  *
  */
-public interface GroupService extends KapuaEntityService<Group, GroupCreator>, KapuaUpdatableEntityService<Group> {
+public interface GroupService extends KapuaEntityService<Group, GroupCreator>,
+        KapuaUpdatableEntityService<Group>,
+        KapuaConfigurableService {
 
     /**
      * Creates a new {@link Group} based on the parameters provided in the {@link GroupCreator}.<br>

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
+import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 /**
  * {@link Role} service definition.
@@ -24,7 +25,9 @@ import org.eclipse.kapua.service.KapuaUpdatableEntityService;
  * @since 1.0.0
  *
  */
-public interface RoleService extends KapuaEntityService<Role, RoleCreator>, KapuaUpdatableEntityService<Role> {
+public interface RoleService extends KapuaEntityService<Role, RoleCreator>,
+        KapuaUpdatableEntityService<Role>,
+        KapuaConfigurableService {
 
     /**
      * Creates a new {@link Role} based on the parameters provided in the {@link RoleCreator}.<br>

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
@@ -41,6 +42,8 @@ import org.eclipse.kapua.service.user.UserCreator;
 import org.eclipse.kapua.service.user.UserFactory;
 import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.ResourceLimitsConfig;
+import org.junit.Before;
 import org.junit.Test;
 
 public class AccessInfoServiceTest extends KapuaTest {
@@ -48,6 +51,12 @@ public class AccessInfoServiceTest extends KapuaTest {
     private static final Domain testDomain = new TestDomain();
 
     KapuaEid scope = new KapuaEid(BigInteger.valueOf(random.nextLong()));
+
+    @Before
+    public void before() {
+        // Setup JAXB context
+        XmlUtil.setContextProvider(new ShiroJAXBContextProvider());
+    }
 
     // Tests
 
@@ -145,6 +154,10 @@ public class AccessInfoServiceTest extends KapuaTest {
             RoleCreator roleCreator = roleFactory.newCreator(scope);
             roleCreator.setName("testRole-" + random.nextLong());
             roleCreator.setPermissions(permissions);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(roleService);
             Role role = roleService.create(roleCreator);
 
             Set<KapuaId> roleIds = new HashSet<>();
@@ -203,6 +216,10 @@ public class AccessInfoServiceTest extends KapuaTest {
             RoleCreator roleCreator = roleFactory.newCreator(scope);
             roleCreator.setName("testRole-" + random.nextLong());
             roleCreator.setPermissions(permissionsRole);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(roleService);
             Role role = roleService.create(roleCreator);
 
             Set<KapuaId> roleIds = new HashSet<>();
@@ -268,6 +285,10 @@ public class AccessInfoServiceTest extends KapuaTest {
             RoleCreator roleCreator = roleFactory.newCreator(scope);
             roleCreator.setName("testRole-" + random.nextLong());
             roleCreator.setPermissions(permissions);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(roleService);
             Role role = roleService.create(roleCreator);
 
             Set<KapuaId> roleIds = new HashSet<>();

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTest.java
@@ -12,25 +12,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
-import java.math.BigInteger;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.service.authorization.group.Group;
-import org.eclipse.kapua.service.authorization.group.GroupCreator;
-import org.eclipse.kapua.service.authorization.group.GroupListResult;
-import org.eclipse.kapua.service.authorization.group.GroupQuery;
-import org.eclipse.kapua.service.authorization.group.GroupService;
+import org.eclipse.kapua.service.authorization.group.*;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupCreatorImpl;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupPredicates;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupQueryImpl;
 import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.ResourceLimitsConfig;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.math.BigInteger;
 
 public class GroupServiceTest extends KapuaTest {
 
@@ -50,6 +49,12 @@ public class GroupServiceTest extends KapuaTest {
         //        scriptSession(AuthorizationEntityManagerFactory.getInstance(), DROP_FILTER);
     }
 
+    @Before
+    public void before() {
+        // Setup JAXB context
+        XmlUtil.setContextProvider(new ShiroJAXBContextProvider());
+    }
+
     // Tests
 
     @Test
@@ -65,6 +70,10 @@ public class GroupServiceTest extends KapuaTest {
             //
             // Create
             GroupService groupService = locator.getService(GroupService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(groupService);
             Group group = groupService.create(groupCreator);
 
             //
@@ -92,6 +101,10 @@ public class GroupServiceTest extends KapuaTest {
             GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             GroupService groupService = locator.getService(GroupService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(groupService);
             Group group = groupService.create(groupCreator);
 
             assertNotNull(group);
@@ -130,6 +143,10 @@ public class GroupServiceTest extends KapuaTest {
             GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             GroupService groupService = locator.getService(GroupService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(groupService);
             Group group = groupService.create(groupCreator);
 
             assertNotNull(group);
@@ -165,6 +182,10 @@ public class GroupServiceTest extends KapuaTest {
             GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             GroupService groupService = locator.getService(GroupService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(groupService);
             Group group = groupService.create(groupCreator);
 
             assertNotNull(group);
@@ -209,6 +230,10 @@ public class GroupServiceTest extends KapuaTest {
             GroupCreator groupCreator = new GroupCreatorImpl(scope, "test-" + random.nextLong());
 
             GroupService groupService = locator.getService(GroupService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(groupService);
             Group group = groupService.create(groupCreator);
 
             assertNotNull(group);

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTest.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
@@ -37,7 +38,9 @@ import org.eclipse.kapua.service.authorization.role.shiro.RoleCreatorImpl;
 import org.eclipse.kapua.service.authorization.role.shiro.RolePredicates;
 import org.eclipse.kapua.service.authorization.role.shiro.RoleQueryImpl;
 import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.ResourceLimitsConfig;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -59,6 +62,12 @@ public class RoleServiceTest extends KapuaTest {
     @AfterClass
     public static void afterClass() throws KapuaException {
         // scriptSession(AuthorizationEntityManagerFactory.getInstance(), DROP_FILTER);
+    }
+
+    @Before
+    public void before() {
+        // Setup JAXB context
+        XmlUtil.setContextProvider(new ShiroJAXBContextProvider());
     }
 
     // Tests
@@ -84,6 +93,10 @@ public class RoleServiceTest extends KapuaTest {
             //
             // Create
             RoleService roleService = locator.getService(RoleService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(roleService);
             Role role = roleService.create(roleCreator);
 
             //
@@ -138,6 +151,10 @@ public class RoleServiceTest extends KapuaTest {
             roleCreator.setPermissions(permissions);
 
             RoleService roleService = locator.getService(RoleService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(roleService);
             Role role = roleService.create(roleCreator);
 
             RolePermissionService rolePermissionService = locator.getService(RolePermissionService.class);
@@ -188,6 +205,10 @@ public class RoleServiceTest extends KapuaTest {
             roleCreator.setPermissions(permissions);
 
             RoleService roleService = locator.getService(RoleService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(roleService);
             Role role = roleService.create(roleCreator);
 
             assertNotNull(role);
@@ -232,6 +253,10 @@ public class RoleServiceTest extends KapuaTest {
             roleCreator.setPermissions(permissions);
 
             RoleService roleService = locator.getService(RoleService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(roleService);
             Role role = roleService.create(roleCreator);
 
             assertNotNull(role);
@@ -290,6 +315,10 @@ public class RoleServiceTest extends KapuaTest {
             roleCreator.setPermissions(permissions);
 
             RoleService roleService = locator.getService(RoleService.class);
+            ResourceLimitsConfig resourceLimits = new ResourceLimitsConfig(scope.getId(), BigInteger.ONE);
+            resourceLimits.addConfig("infiniteChildEntities", Boolean.TRUE);
+            resourceLimits.addConfig("maxNumberChildEntities", new Integer(5));
+            resourceLimits.setServiceConfig(roleService);
             Role role = roleService.create(roleCreator);
 
             assertNotNull(role);

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/ShiroJAXBContextProvider.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/ShiroJAXBContextProvider.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.metatype.TscalarImpl;
+import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
+import org.eclipse.kapua.model.config.metatype.*;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserListResult;
+import org.eclipse.kapua.service.user.UserXmlRegistry;
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+/**
+ * JAXB context provider for unit tests. Otherwise it is provided by application
+ * that is using service.
+ */
+public class ShiroJAXBContextProvider implements JAXBContextProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(ShiroJAXBContextProvider.class);
+
+    private JAXBContext context;
+
+    @Override
+    public JAXBContext getJAXBContext() throws KapuaException {
+        if (context == null) {
+            Class<?>[] classes = new Class<?>[]{
+                    User.class,
+                    UserListResult.class,
+                    UserXmlRegistry.class,
+                    KapuaTmetadata.class,
+                    KapuaTocd.class,
+                    KapuaTad.class,
+                    KapuaTicon.class,
+                    TscalarImpl.class,
+                    KapuaToption.class,
+                    KapuaTdesignate.class,
+                    KapuaTobject.class
+            };
+            try {
+                context = JAXBContextFactory.createContext(classes, null);
+            } catch (JAXBException jaxbException) {
+                logger.warn("Error creating JAXBContext, tests will fail!");
+            }
+        }
+        return context;
+    }
+}

--- a/service/security/shiro/src/test/resources/locator.xml
+++ b/service/security/shiro/src/test/resources/locator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xml>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2017 Eurotech and/or its affiliates
    
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -45,6 +45,8 @@
 		<api>org.eclipse.kapua.service.user.UserService</api>
         
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
+
+        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 	</provided>
 	<packages>
 		<package>org.eclipse.kapua.service.authentication.credential.shiro</package>
@@ -63,5 +65,6 @@
 		<package>org.eclipse.kapua.test.authentication</package>
         
         <package>org.eclipse.kapua.commons.model.id</package>
+		<package>org.eclipse.kapua.commons.configuration</package>
 	</packages>
 </locator-config>

--- a/test/src/main/java/org/eclipse/kapua/test/ResourceLimitsConfig.java
+++ b/test/src/main/java/org/eclipse/kapua/test/ResourceLimitsConfig.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.test;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.service.config.KapuaConfigurableService;
+
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Usage of this class instances is mainly in test cases that have to configure
+ * services with specific values. Otherwise this is set in kapua user specific
+ * configuration.
+ */
+public class ResourceLimitsConfig {
+
+    /**
+     * Scope id for which service limits are set.
+     */
+    private final KapuaEid scopeId;
+
+    /**
+     * Parent scope id for which service limits are set.
+     */
+    private final KapuaEid parentScopeId;
+
+    /**
+     * Map of limits set for service.
+     */
+    private Map<String, Object> valueMap = new HashMap<>();
+
+
+    /**
+     * Only allowed constructor with id of user for which limits are set.
+     *
+     * @param scopeId       users scope Id
+     * @param parentScopeId parent id of specified scopeId
+     */
+    public ResourceLimitsConfig(BigInteger scopeId, BigInteger parentScopeId) {
+
+        this.scopeId = new KapuaEid(scopeId);
+        this.parentScopeId = new KapuaEid(parentScopeId);
+    }
+
+    /**
+     * Add new resource limit value.
+     *
+     * @param key   resource limit key
+     * @param value resource limit value, can be String, Boolean, Integer
+     */
+    public void addConfig(String key, Object value) {
+
+        valueMap.put(key, value);
+    }
+
+    /**
+     * Apply configuration of resource limits to specific service.
+     *
+     * @param service that supports resource limits
+     * @throws KapuaException
+     */
+    public void setServiceConfig(KapuaConfigurableService service) throws KapuaException {
+
+        service.setConfigValues(scopeId, parentScopeId, valueMap);
+    }
+}


### PR DESCRIPTION
Unit tests were failing because resource limits were introduced to role
and group service.

Changes were made to GroupService and RoleService so that they are now
implementing KapuaConfigurableService.

Unit tests ware changed by configuring limits on resources.
JAXB provider has been added to support unmarshaling of configuration
xml in tests.
locator.xml for tests was also modified to support configuration of
resource limits.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>