### PR TITLE
Drop findbugs due to CQ issues

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -234,10 +234,6 @@
 			<artifactId>javassist</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>annotations</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
@@ -540,14 +536,6 @@
 									<groupId>org.javassist</groupId>
 									<artifactId>javassist</artifactId>
 									<version>${javassist.version}</version>
-									<type>jar</type>
-									<overWrite>true</overWrite>
-									<outputDirectory>target/broker_dependency</outputDirectory>
-								</artifactItem>
-								<artifactItem>
-									<groupId>com.google.code.findbugs</groupId>
-									<artifactId>annotations</artifactId>
-									<version>${findbugs.version}</version>
 									<type>jar</type>
 									<overWrite>true</overWrite>
 									<outputDirectory>target/broker_dependency</outputDirectory>


### PR DESCRIPTION
Drop findbugs as a deployed JAR as the probably won't get a proper CQ for it: [findbugs CQs](https://dev.eclipse.org/ipzilla/buglist.cgi?query_format=advanced&short_desc_type=allwordssubstr&short_desc=findbugs&long_desc_type=substring&long_desc=&bug_file_loc_type=allwordssubstr&bug_file_loc=&keywords_type=allwords&keywords=&emailassigned_to1=1&emailtype1=substring&email1=&emailassigned_to2=1&emailreporter2=1&emailcc2=1&emailtype2=substring&email2=&bugidtype=include&bug_id=&chfieldfrom=&chfieldto=Now&chfieldvalue=&cmdtype=doit&order=Reuse+same+sort+as+last+time&field0-0-0=noop&type0-0-0=noop&value0-0-0=)