### PR TITLE
Possible fix to failing datastore tests

### DIFF
--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
@@ -99,6 +99,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
     private static final Logger s_logger = LoggerFactory.getLogger(MessageStoreServiceTest.class);
     private static final long QUERY_TIME_WINDOW = 2000l;
     private static final long PUBLISH_DATE_TEST_CHECK_TIME_WINDOW = 1000l;
+    private static final long INDEX_TIME_ESTIMATE_SECONDS = 2; // Trail and error value depends on system where tests are run
 
     private static final DeviceRegistryService deviceRegistryService = KapuaLocator.getInstance().getService(DeviceRegistryService.class);
     private static final DeviceFactory deviceFactory = KapuaLocator.getInstance().getFactory(DeviceFactory.class);
@@ -108,7 +109,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
     private static final MetricInfoRegistryService metricInfoRegistryService = KapuaLocator.getInstance().getService(MetricInfoRegistryService.class);
     private static final ClientInfoRegistryService clientInfoRegistryService = KapuaLocator.getInstance().getService(ClientInfoRegistryService.class);
 
-    private long elasticsearchRefreshTime = DatastoreSettings.getInstance().getLong(DatastoreSettingKey.ELASTICSEARCH_IDX_REFRESH_INTERVAL) * KapuaDateUtils.SEC_MILLIS;
+    private long elasticsearchRefreshTime = (DatastoreSettings.getInstance().getLong(DatastoreSettingKey.ELASTICSEARCH_IDX_REFRESH_INTERVAL) + INDEX_TIME_ESTIMATE_SECONDS) * KapuaDateUtils.SEC_MILLIS;
 
     @Test
     /**


### PR DESCRIPTION
When inserting data tests were waiting for time that was set to the same
value as ES index interval. As indexing takes some time, time between
insert and query should be index interval plus some fixed time.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>