### PR TITLE
Fix NPE in Data View for metrics containing . in name

### DIFF
--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/model/GwtMessage.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/model/GwtMessage.java
@@ -18,6 +18,7 @@ public class GwtMessage extends KapuaBaseModel implements Serializable {
     private static final long serialVersionUID = 5344433827767946887L;
 
     public GwtMessage() {
+        setAllowNestedValues(false);
     }
 }
 


### PR DESCRIPTION
Hi all,

This PR fixes a NPE in GWT Console Data View when querying a metric that contains a . in its name