### PR TITLE
Possible fix to device broker QA test

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/BrokerSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/BrokerSteps.java
@@ -75,6 +75,12 @@ public class BrokerSteps extends Assert {
     private static final long BROKER_STARTUP_WAIT_MILIS = 10_000;
 
     /**
+     * Timeout for complete broker with channels and rules to start.
+     * Might vary depending on system.
+     */
+    private static final long BROKER_RULES_WAIT_MILIS = 60_000;
+
+    /**
      * Device birth topic.
      */
     private static final String MQTT_BIRTH = "$EDC/kapua-sys/rpione3/MQTT/BIRTH";
@@ -159,10 +165,14 @@ public class BrokerSteps extends Assert {
          * Initialize broker from MQ configuration file ad start it.
          * After issuing start wait a moment to start completely.
          */
+        logger.info("******* Broker will start ********");
         broker = new MQBrokerRunner(BROKER_STARTUP_WAIT_MILIS, ACTIVEMQ_XML);
         new Thread(broker).start();
         // FIXME Issue with broker startup, not listening on topics and missing client connect messages.
-        Thread.sleep(60_000);
+        // This could be moved to Gherkin as first step.
+        logger.info("******* Wait for Broker ********");
+        Thread.sleep(BROKER_RULES_WAIT_MILIS);
+        logger.info("******* Wait Broker Finished ********");
 
         kuraDevice = new KuraDevice();
         kuraDevice.mqttClientConnect();
@@ -284,7 +294,9 @@ public class BrokerSteps extends Assert {
 
     @When("^I wait (\\d+) second")
     public void iWait(int waitInSeconds) throws Exception {
+        logger.info("***** Start wait step ******");
         Thread.sleep(1000L * waitInSeconds);
+        logger.info("***** End wait step ******");
     }
 
 }

--- a/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -19,7 +19,7 @@ Feature: Device Broker Integration
   Scenario: Send BIRTH message and then DC message. Effectively this is connect and
     disconnect of Kura device.
     When Device birth message is sent
-    And I wait 1 second for system to receive and process that message
+    And I wait 5 second for system to receive and process that message
     And I login as user with name "kapua-sys" and password "kapua-password"
     And Packages are requested
     Then Packages are received


### PR DESCRIPTION
Integration tests with embedded broker are failing, but
just on Hudson CI. For that reson, additional logging was
added and timeout after birth message was set to 5 sec.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>