### PR TITLE
Shiro authorization - Access info service; First batch of CRUD tests

### DIFF
--- a/assembly/src/main/descriptors/kapua-cucumber-report.xml
+++ b/assembly/src/main/descriptors/kapua-cucumber-report.xml
@@ -47,6 +47,11 @@
         </fileSet>
 
         <fileSet>
+            <outputDirectory>/authorization-service</outputDirectory>
+            <directory>../service/security/shiro/target/cucumber</directory>
+        </fileSet>
+        
+        <fileSet>
             <outputDirectory>/user-service-i9n</outputDirectory>
             <directory>../qa/target/cucumber/UserServiceI9n</directory>
         </fileSet>

--- a/assembly/src/main/resources/html/cucumber/index.html
+++ b/assembly/src/main/resources/html/cucumber/index.html
@@ -53,6 +53,7 @@
                     <li><a href="user-service/index.html">User service</a></li>
                     <li><a href="account-service/index.html">Account service</a></li>
                     <li><a href="device-registry-service/index.html">Device registry service</a></li>
+                    <li><a href="authorization-service/index.html">Authorization service</a></li>
                     <!--li>Other service</li-->
                   </ul>
                 </div>

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -53,6 +53,10 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-user-internal</artifactId>
+        </dependency>
 
         <!-- -->
         <!-- External dependencies -->

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AbstractAuthorizationServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AbstractAuthorizationServiceTest.java
@@ -19,6 +19,7 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.commons.jpa.SimpleSqlScriptExecutor;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.shiro.AuthenticationEntityManagerFactory;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
@@ -32,8 +33,9 @@ public abstract class AbstractAuthorizationServiceTest extends Assert {
     private static String DEFAULT_PATH = "../../../dev-tools/src/main/database";
     private static String DROP_ALL_TABLES = "all_drop.sql";
 
+    protected static final KapuaLocator locator = KapuaLocator.getInstance();
+    protected static final KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
     protected static Random random = new Random();
-    protected static KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
 
     // Drop the whole database. All tables are deleted.
     public static void dropDatabase() {
@@ -91,5 +93,10 @@ public abstract class AbstractAuthorizationServiceTest extends Assert {
     // Generate a random KapuaId
     protected KapuaId generateId() {
         return new KapuaEid(BigInteger.valueOf(random.nextLong()));
+    }
+    
+    // Generate a KapuaId from an integer
+    protected KapuaId generateId(Integer id) {
+        return new KapuaEid(BigInteger.valueOf(id));
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestData.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestData.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Singleton;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
+import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
+import org.eclipse.kapua.service.authorization.access.AccessInfoListResult;
+import org.eclipse.kapua.service.authorization.access.AccessPermission;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionCreator;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionListResult;
+import org.eclipse.kapua.service.authorization.access.AccessRole;
+import org.eclipse.kapua.service.authorization.access.AccessRoleListResult;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.role.Role;
+import org.eclipse.kapua.service.authorization.role.RoleCreator;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserCreator;
+
+@Singleton
+public class AccessInfoServiceTestData {
+
+    public AccessInfoCreator accessInfoCreator;
+    public AccessInfo accessInfo;
+    public AccessInfo accessInfoFound;
+    public AccessInfoListResult accessList;
+    public UserCreator userCreator;
+    public User user;
+    public Permission permission;
+    public Set<Permission> permissions;
+    public AccessPermissionCreator accessPermissionCreator;
+    public AccessPermission accessPermission;
+    public AccessPermission accessPermissionFound;
+    public AccessPermissionListResult accessPermissions;
+    public RoleCreator roleCreator;
+    public Role role;
+    public Role roleFound;
+    public AccessRole accessRole;
+    public AccessRole accessRoleFound;
+    public AccessRoleListResult accessRoles;
+    public Set<KapuaId> roleIds;
+    
+    public void clearData() {
+        accessInfoCreator = null;
+        accessInfo = null;
+        accessInfoFound = null;
+        accessList = null;
+        userCreator = null;
+        user = null;
+        permission = null;
+        permissions = new HashSet<>();
+        accessPermissionCreator = null;
+        accessPermission = null;
+        accessPermissionFound = null;
+        accessPermissions = null;
+        roleCreator = null;
+        role = null;
+        roleFound = null;
+        accessRole = null;
+        accessRoleFound = null;
+        accessRoles = null;
+        roleIds = null;
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestSteps.java
@@ -1,0 +1,468 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import java.math.BigInteger;
+import java.util.HashSet;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
+import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
+import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
+import org.eclipse.kapua.service.authorization.access.AccessInfoPredicates;
+import org.eclipse.kapua.service.authorization.access.AccessInfoQuery;
+import org.eclipse.kapua.service.authorization.access.AccessInfoService;
+import org.eclipse.kapua.service.authorization.access.AccessPermission;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionCreator;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionFactory;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionQuery;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionService;
+import org.eclipse.kapua.service.authorization.access.AccessRole;
+import org.eclipse.kapua.service.authorization.access.AccessRoleCreator;
+import org.eclipse.kapua.service.authorization.access.AccessRoleFactory;
+import org.eclipse.kapua.service.authorization.access.AccessRoleQuery;
+import org.eclipse.kapua.service.authorization.access.AccessRoleService;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoCreatorImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoFactoryImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoServiceImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionCreatorImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionFactoryImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionServiceImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleCreatorImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleFactoryImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleServiceImpl;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionImpl;
+import org.eclipse.kapua.service.authorization.role.RoleFactory;
+import org.eclipse.kapua.service.authorization.role.RoleService;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserFactory;
+import org.eclipse.kapua.service.user.UserService;
+import org.eclipse.kapua.service.user.internal.UserImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+
+/**
+ * Implementation of Gherkin steps used in AccessInfoService.feature scenarios.
+ *
+ */
+@ScenarioScoped
+public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger s_logger = LoggerFactory.getLogger(AccessInfoServiceTestSteps.class);
+
+    private static final Domain testDomain = new TestDomain();
+
+    // Test data scratchpads
+    private CommonTestData commonData = null;
+    private AccessInfoServiceTestData accessData = null;
+
+    // Various Access service related service references
+    private AccessInfoService accessInfoService = null;
+    private AccessInfoFactory accessInfoFactory = null;
+    private AccessPermissionService accessPermissionService = null;
+    private AccessPermissionFactory accessPermissionFactory = null;
+    private AccessRoleService accessRoleService = null;
+    private AccessRoleFactory accessRoleFactory = null;
+
+    // References to dependent services
+    private UserService userService = null;
+    private UserFactory userFactory = null;
+    private PermissionFactory permissionFactory = null;
+    private RoleService roleService = null;
+    private RoleFactory roleFactory = null;
+
+    // Currently executing scenario.
+    private Scenario scenario;
+
+    @Inject
+    public AccessInfoServiceTestSteps(AccessInfoServiceTestData accessData, CommonTestData commonData) {
+        this.accessData = accessData;
+        this.commonData = commonData;
+    }
+
+    // Setup and tear-down steps
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+        this.scenario = scenario;
+
+        // Instantiate all the services and factories that are required by the tests
+        accessInfoService = new AccessInfoServiceImpl();
+        accessInfoFactory = new AccessInfoFactoryImpl();
+        accessPermissionService = new AccessPermissionServiceImpl();
+        accessPermissionFactory = new AccessPermissionFactoryImpl();
+        accessRoleService = new AccessRoleServiceImpl();
+        accessRoleFactory = new AccessRoleFactoryImpl();
+
+        userService = locator.getService(UserService.class);
+        userFactory = locator.getFactory(UserFactory.class);
+        permissionFactory = locator.getFactory(PermissionFactory.class);
+
+        roleService = locator.getService(RoleService.class);
+        roleFactory = locator.getFactory(RoleFactory.class);
+
+        // Clean up the database. A clean slate is needed for truly independent
+        // test case executions!
+        dropDatabase();
+        setupDatabase();
+
+        // Clean up the test data scratchpads
+        accessData.clearData();
+        commonData.clearData();
+    }
+
+    // *************************************
+    // Definition of Cucumber scenario steps
+    // *************************************
+
+    @Given("^A user such as$")
+    public void createUser(List<UserImpl> users)
+            throws KapuaException {
+
+        // The scope ID must be defined for this test step!
+        assertNotNull(commonData.scopeId);
+
+        // Sanity checks; There must be exactly one user defined by the test step
+        assertNotNull(users);
+        assertEquals(1, users.size());
+
+        // Additional sanity checks; At least the user name must be specified.
+        User tmpUsr = users.get(0);
+        assertNotNull(tmpUsr);
+        assertNotNull(tmpUsr.getName());
+
+        // Prepare test user data
+        accessData.userCreator = userFactory.newCreator(commonData.scopeId, tmpUsr.getName());
+        assertNotNull(accessData.userCreator);
+
+        if (tmpUsr.getDisplayName() != null && !tmpUsr.getDisplayName().isEmpty()) {
+            accessData.userCreator.setDisplayName(tmpUsr.getDisplayName());
+        } else {
+            accessData.userCreator.setDisplayName(tmpUsr.getName() + " display");
+        }
+
+        if (tmpUsr.getEmail() != null && !tmpUsr.getEmail().isEmpty()) {
+            accessData.userCreator.setEmail(tmpUsr.getEmail());
+        } else {
+            accessData.userCreator.setEmail(tmpUsr.getName() + "@test.company.org");
+        }
+
+        if (tmpUsr.getPhoneNumber() != null && !tmpUsr.getPhoneNumber().isEmpty()) {
+            accessData.userCreator.setPhoneNumber(tmpUsr.getPhoneNumber());
+        } else {
+            accessData.userCreator.setPhoneNumber(BigInteger.valueOf(random.nextLong()).toString());
+        }
+
+        // Create the actual user in the database
+        KapuaSecurityUtils.doPrivileged(() -> {
+            accessData.user = userService.create(accessData.userCreator);
+            return null;
+        });
+        assertNotNull(accessData.user);
+        assertNotNull(accessData.user.getId());
+    }
+
+    @Given("^An invalid user$")
+    public void provideInvalidUserObject() {
+        accessData.user = new UserImpl(generateId(), generateId().toString());
+        accessData.user.setId(generateId());
+        assertNotNull(accessData.user);
+    }
+
+    @Given("^The permission(?:|s) \"(.+)\"$")
+    public void createPermissionsForDomain(String permList) {
+        // Sanity checks
+        // The scope ID must be defined
+        assertNotNull(commonData.scopeId);
+
+        // Split the parameter string and make sure there is at least one
+        // item
+        String[] tmpList = permList.toLowerCase().split(",");
+        assertNotNull(tmpList);
+        assertNotEquals(0, tmpList.length);
+
+        // Parse the items and fill the list
+        accessData.permissions = new HashSet<>();
+        for (String perm : tmpList) {
+            switch (perm.trim()) {
+            case "read":
+                accessData.permissions.add(permissionFactory.newPermission(testDomain, Actions.read, commonData.scopeId));
+                break;
+            case "write":
+                accessData.permissions.add(permissionFactory.newPermission(testDomain, Actions.write, commonData.scopeId));
+                break;
+            case "delete":
+                accessData.permissions.add(permissionFactory.newPermission(testDomain, Actions.delete, commonData.scopeId));
+                break;
+            case "connect":
+                accessData.permissions.add(permissionFactory.newPermission(testDomain, Actions.connect, commonData.scopeId));
+                break;
+            case "execute":
+                accessData.permissions.add(permissionFactory.newPermission(testDomain, Actions.execute, commonData.scopeId));
+                break;
+            }
+        }
+        // Make sure that there is at least one valid item
+        assertFalse(accessData.permissions.isEmpty());
+    }
+
+    @Given("^The role \"(.*)\"$")
+    public void provideRoleForDomain(String name)
+            throws KapuaException {
+
+        assertNotNull(commonData.scopeId);
+        assertNotNull(accessData.permissions);
+        assertFalse(accessData.permissions.isEmpty());
+
+        assertNotNull(name);
+        assertFalse(name.isEmpty());
+
+        accessData.roleCreator = roleFactory.newCreator(commonData.scopeId);
+        assertNotNull(accessData.roleCreator);
+
+        accessData.roleCreator.setName(name);
+        accessData.roleCreator.setPermissions(accessData.permissions);
+
+        try {
+            commonData.exceptionCaught = false;
+            KapuaSecurityUtils.doPrivileged(() -> {
+                accessData.role = roleService.create(accessData.roleCreator);
+                return null;
+            });
+        } catch (KapuaException e) {
+            commonData.exceptionCaught = true;
+            return;
+        }
+        assertNotNull(accessData.role);
+        assertNotNull(accessData.role.getId());
+
+        accessData.roleIds = new HashSet<>();
+        accessData.roleIds.add(accessData.role.getId());
+        assertEquals(1, accessData.roleIds.size());
+    }
+
+    @Given("^An invalid role ID$")
+    public void provideInvalidRoleObjectID() {
+        accessData.roleIds = new HashSet<>();
+        accessData.roleIds.add(generateId());
+        assertEquals(1, accessData.roleIds.size());
+    }
+
+    @When("^I create the access info entity$")
+    public void createAccessInfoEntity() {
+
+        assertNotNull(commonData.scopeId);
+        assertNotNull(accessData.user);
+
+        accessData.accessInfoCreator = accessInfoFactory.newCreator(commonData.scopeId);
+        assertNotNull(accessData.accessInfoCreator);
+
+        accessData.accessInfoCreator.setUserId(accessData.user.getId());
+
+        if (accessData.permissions != null && !accessData.permissions.isEmpty()) {
+            accessData.accessInfoCreator.setPermissions(accessData.permissions);
+        } else {
+            accessData.accessInfoCreator.setPermissions(null);
+        }
+
+        if (accessData.roleIds != null && !accessData.roleIds.isEmpty()) {
+            accessData.accessInfoCreator.setRoleIds(accessData.roleIds);
+        } else {
+            accessData.accessInfoCreator.setRoleIds(null);
+        }
+
+        try {
+            KapuaSecurityUtils.doPrivileged(() -> {
+                commonData.exceptionCaught = false;
+                accessData.accessInfo = accessInfoService.create(accessData.accessInfoCreator);
+                return null;
+            });
+        } catch (KapuaException ex) {
+            commonData.exceptionCaught = true;
+        }
+    }
+
+    @When("^I search for the permissions of the last access info entity$")
+    public void findThePermissionsOfTheLastAccessInfoEntity()
+            throws KapuaException {
+        assertNotNull(accessData.accessInfo);
+        assertNotNull(accessData.accessInfo.getScopeId());
+        assertNotNull(accessData.accessInfo.getId());
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            accessData.accessPermissions = accessPermissionService.findByAccessInfoId(
+                    accessData.accessInfo.getScopeId(), accessData.accessInfo.getId());
+            return null;
+        });
+    }
+
+    @When("^I search for the roles of the last access info entity$")
+    public void findTheRolesOfTheLastAccessInfoEntity()
+            throws KapuaException {
+        assertNotNull(accessData.accessInfo);
+        assertNotNull(accessData.accessInfo.getScopeId());
+        assertNotNull(accessData.accessInfo.getId());
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            accessData.accessRoles = accessRoleService.findByAccessInfoId(
+                    accessData.accessInfo.getScopeId(), accessData.accessInfo.getId());
+            return null;
+        });
+    }
+
+    @When("^I search for the last created access info entity$")
+    public void findLastCreatedAccessInfoEntity()
+            throws KapuaException {
+        assertNotNull(accessData.accessInfo);
+        assertNotNull(accessData.accessInfo.getScopeId());
+        assertNotNull(accessData.accessInfo.getId());
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            accessData.accessInfoFound = null;
+            accessData.accessInfoFound = accessInfoService.find(
+                    accessData.accessInfo.getScopeId(), accessData.accessInfo.getId());
+            return null;
+        });
+    }
+    
+    @When("^I search for an access info entity by user ID$")
+    public void findTheAccessInfoEntityByUserId()
+            throws KapuaException {
+        assertNotNull(commonData.scopeId);
+        assertNotNull(accessData.user);
+        assertNotNull(accessData.user.getId());
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            accessData.accessInfoFound = accessInfoService.findByUserId(commonData.scopeId, accessData.user.getId());
+            return null;
+        });
+    }
+
+    @When("^I delete the existing access info entity$")
+    public void deleteLastCreatedAccessInfoEntity()
+            throws KapuaException {
+        assertNotNull(commonData.scopeId);
+        assertNotNull(accessData.accessInfo);
+        assertNotNull(accessData.accessInfo.getId());
+
+        try {
+            commonData.exceptionCaught = false;
+            KapuaSecurityUtils.doPrivileged(() -> {
+                accessInfoService.delete(commonData.scopeId, accessData.accessInfo.getId());
+                return null;
+            });
+        } catch (KapuaException ex) {
+            commonData.exceptionCaught = true;
+        }
+    }
+
+    @When("^I count the access info entities for scope (\\d+)$")
+    public void countAccessInfoEntitiesInScope(Integer scope)
+            throws KapuaException {
+        assertNotNull(scope);
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(scope));
+        AccessInfoQuery tmpQuery = accessInfoFactory.newQuery(tmpId);
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            commonData.count = accessInfoService.count(tmpQuery);
+            return null;
+        });
+    }
+
+    @When("^I query for the access info entities for the last user$")
+    public void queryForLastUserAccessInfoEntities()
+            throws KapuaException {
+        assertNotNull(accessData.user);
+        assertNotNull(accessData.user.getId());
+        assertNotNull(commonData.scopeId);
+
+        AccessInfoQuery tmpQuery = accessInfoFactory.newQuery(commonData.scopeId);
+        tmpQuery.setPredicate(new AttributePredicate<>(AccessInfoPredicates.USER_ID, accessData.user.getId()));
+        accessData.accessList = accessInfoFactory.newListResult();
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            accessData.accessList = accessInfoService.query(tmpQuery);
+            return null;
+        });
+
+        if (accessData.accessList != null) {
+            commonData.count = accessData.accessList.getSize();
+        }
+    }
+
+    @Then("^An access info entity was created$")
+    public void checkThatAccessInfoEntityExists() {
+        assertNotNull(accessData.accessInfo);
+    }
+
+    @Then("^I find an accessinfo entity$")
+    public void checkThatAnAccessInfoEntityWasFound() {
+        assertNotNull(accessData.accessInfoFound);
+    }
+    
+    @Then("^I find no access info entity$")
+    public void checkThatNoAccessInfoEntityWasFound() {
+        assertNull(accessData.accessInfoFound);
+    }
+    
+    @Then("^The entity matches the creator$")
+    public void checkEntityAgainstCreator() {
+        assertNotNull(accessData.accessInfoCreator);
+        assertNotNull(accessData.accessInfo);
+        assertEquals(accessData.accessInfoCreator.getUserId(), accessData.accessInfo.getUserId());
+        assertEquals(accessData.accessInfoCreator.getScopeId(), accessData.accessInfo.getScopeId());
+    }
+
+    @Then("^The permissions match the creator$")
+    public void checkAccessInfoEntityPermissions() {
+        assertNotNull(accessData.accessPermissions);
+        assertEquals(accessData.accessInfoCreator.getPermissions().size(), accessData.accessPermissions.getSize());
+
+        for (int i = 0; i < accessData.accessPermissions.getSize(); i++) {
+            assertTrue(accessData.accessInfoCreator.getPermissions().contains(accessData.accessPermissions.getItem(i).getPermission()));
+        }
+    }
+
+    @Then("^The access info roles match the creator$")
+    public void checkAccessInfoEntityRoles() {
+        assertNotNull(accessData.accessRoles);
+        assertNotEquals(0, accessData.accessRoles.getSize());
+        assertEquals(accessData.accessInfoCreator.getRoleIds().size(), accessData.accessRoles.getSize());
+
+        for (int i = 0; i < accessData.accessRoles.getSize(); i++) {
+            assertTrue(accessData.accessInfoCreator.getRoleIds().contains(accessData.accessRoles.getItem(i).getRoleId()));
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
@@ -55,7 +55,7 @@ public class CommonTestSteps extends KapuaTest {
     public void setNullScopId() {
         commonData.scopeId = null;
     }
-
+    
     @Then("^An exception was thrown$")
     public void exceptionCaught() {
         assertTrue(commonData.exceptionCaught);

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucRole.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucRole.java
@@ -29,31 +29,31 @@ public class CucRole {
     private Set<Actions> actionSet = null;
 
     public void doParse() {
-        if (this.scopeId != null) {
-            this.id = new KapuaEid(BigInteger.valueOf(scopeId));
+        if (scopeId != null) {
+            id = new KapuaEid(BigInteger.valueOf(scopeId));
         }
-        if (this.actions != null) {
-            String tmpAct = this.actions.trim().toLowerCase();
+        if (actions != null) {
+            String tmpAct = actions.trim().toLowerCase();
             if (tmpAct.length() != 0) {
-                this.actionSet = new HashSet<>();
-                String[] tmpList = this.actions.split(",");
+                actionSet = new HashSet<>();
+                String[] tmpList = actions.split(",");
 
                 for (String tmpS : tmpList) {
                     switch (tmpS.trim().toLowerCase()) {
                     case "read":
-                        this.actionSet.add(Actions.read);
+                        actionSet.add(Actions.read);
                         break;
                     case "write":
-                        this.actionSet.add(Actions.write);
+                        actionSet.add(Actions.write);
                         break;
                     case "delete":
-                        this.actionSet.add(Actions.delete);
+                        actionSet.add(Actions.delete);
                         break;
                     case "connect":
-                        this.actionSet.add(Actions.connect);
+                        actionSet.add(Actions.connect);
                         break;
                     case "execute":
-                        this.actionSet.add(Actions.execute);
+                        actionSet.add(Actions.execute);
                         break;
                     }
                 }
@@ -74,7 +74,7 @@ public class CucRole {
     }
 
     public KapuaId getScopeId() {
-        return this.id;
+        return id;
     }
 
     public Set<Actions> getActions() {
@@ -82,6 +82,6 @@ public class CucRole {
     }
 
     public void setActions(Set<Actions> actions) {
-        this.actionSet = actions;
+        actionSet = actions;
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucRolePermission.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CucRolePermission.java
@@ -66,7 +66,7 @@ public class CucRolePermission {
     public void setRoleId(KapuaId id) {
         this.role = id;
     }
-    
+
     public KapuaId getRoleId() {
         return this.role;
     }

--- a/service/security/shiro/src/test/resources/features/AccessInfoService.feature
+++ b/service/security/shiro/src/test/resources/features/AccessInfoService.feature
@@ -17,7 +17,7 @@ Scenario: Simple create
     Create a simple access info entry. Only a user is supplied. The entry must 
     match the creator parameters.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -30,7 +30,7 @@ Scenario: Create with permissions
     Create an access info entry. In addition to a user a list of permissions is 
     supplied too. The entry must match the creator parameters.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -46,7 +46,7 @@ Scenario: Create with permissions and a role
     Create a full access info entry. A user,  a list of permissions and
     an access role are supplied. The entry must match the creator parameters.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -65,7 +65,7 @@ Scenario: Try to create an access into entity with an invalid role id
     It must not be possible to create an access info entity if the given role is invalid.
     Such an attempt must result in an exception.
     
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -78,7 +78,7 @@ Scenario: Find an access info entity
     It must be possible to find an existing access info entity in the database 
     based on its ID.
     
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -92,7 +92,7 @@ Scenario: Find an access info entity by user ID
     It must be possible to find an existing access info entity in the database 
     based on the entity user ID. 
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -105,7 +105,7 @@ Scenario: Search for an access info entity by an incorrect user ID
     If the user ID supplied for a search is invalid, only a null result 
     must be returned. No exception must be thrown.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -120,7 +120,7 @@ Scenario: Search for an access info entity by an incorrect user ID
 Scenario: Delete an existing access info entity
     It must be possible to delete an existing entity from the database.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -134,7 +134,7 @@ Scenario: Delete an existing access info entity
 Scenario: Delete a access info entity with permissions and roles
     It must be possible to delete an existing entity from the database.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -149,7 +149,7 @@ Scenario: Delete an access info entity twice
     An attempt to delete the same entity multiple times should result 
     in an exception.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -162,7 +162,7 @@ Scenario: Delete an access info entity using the wrong scope ID
     An attempt to delete an entity using the wrong scope ID must result 
     in an exception.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -200,7 +200,7 @@ Scenario: Query for all the access info entities of a specific user
     It must be possible to find all the access info entities that belong 
     to a specific user.
 
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
@@ -223,7 +223,7 @@ Scenario: Query for all the access info entities of an invalid user
     If an invalid user is supplied for an entity count, the result list must be empty.
     No exceptions should be thrown.
  
-    Given A scope with ID 10
+    Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |

--- a/service/security/shiro/src/test/resources/features/AccessInfoService.feature
+++ b/service/security/shiro/src/test/resources/features/AccessInfoService.feature
@@ -1,0 +1,234 @@
+###############################################################################
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+Feature: Access Info Service CRUD tests
+
+Scenario: Simple create
+    Create a simple access info entry. Only a user is supplied. The entry must 
+    match the creator parameters.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    When I create the access info entity
+    Then No exception was thrown
+    And An access info entity was created
+    And The entity matches the creator
+
+Scenario: Create with permissions
+    Create an access info entry. In addition to a user a list of permissions is 
+    supplied too. The entry must match the creator parameters.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And The permissions "read, write, execute"
+    When I create the access info entity
+    Then No exception was thrown
+    And An access info entity was created
+    And The entity matches the creator
+    When I search for the permissions of the last access info entity
+    Then The permissions match the creator
+
+Scenario: Create with permissions and a role
+    Create a full access info entry. A user,  a list of permissions and
+    an access role are supplied. The entry must match the creator parameters.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And The permissions "read, write, execute"
+    And The role "test_role_1"
+    When I create the access info entity
+    Then No exception was thrown
+    And An access info entity was created
+    And The entity matches the creator
+    When I search for the permissions of the last access info entity
+    Then The permissions match the creator
+    When I search for the roles of the last access info entity
+    Then The access info roles match the creator
+
+Scenario: Try to create an access into entity with an invalid role id
+    It must not be possible to create an access info entity if the given role is invalid.
+    Such an attempt must result in an exception.
+    
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And The permissions "read, write, execute"
+    And An invalid role ID
+    When I create the access info entity
+    Then An exception was thrown
+
+Scenario: Find an access info entity
+    It must be possible to find an existing access info entity in the database 
+    based on its ID.
+    
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    When I create the access info entity
+    Then No exception was thrown
+    And An access info entity was created
+    When I search for the last created access info entity
+    Then I find an accessinfo entity
+
+Scenario: Find an access info entity by user ID
+    It must be possible to find an existing access info entity in the database 
+    based on the entity user ID. 
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    When I create the access info entity
+    Then No exception was thrown
+    When I search for an access info entity by user ID
+    Then I find an accessinfo entity
+
+Scenario: Search for an access info entity by an incorrect user ID
+    If the user ID supplied for a search is invalid, only a null result 
+    must be returned. No exception must be thrown.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    When I create the access info entity
+    Then No exception was thrown
+    Given A user such as
+          | name     | displayName     | email              | phoneNumber     |
+          | kapua-u2 | Kapua User 2    | kapua_u2@kapua.com | +386 31 323 555 |
+    When I search for an access info entity by user ID
+    Then I find no access info entity
+
+Scenario: Delete an existing access info entity
+    It must be possible to delete an existing entity from the database.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    When I create the access info entity
+    Then No exception was thrown
+    When I delete the existing access info entity
+    And I search for the last created access info entity
+    Then No exception was thrown
+    And I find no access info entity
+
+Scenario: Delete a access info entity with permissions and roles
+    It must be possible to delete an existing entity from the database.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And The permissions "read, write, execute"
+    And The role "test_role_1"
+    And I create the access info entity
+    When I delete the existing access info entity
+    And I search for the last created access info entity
+    Then I find no access info entity
+
+Scenario: Delete an access info entity twice
+    An attempt to delete the same entity multiple times should result 
+    in an exception.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And I create the access info entity
+    When I delete the existing access info entity
+    And I delete the existing access info entity
+    Then An exception was thrown
+
+Scenario: Delete an access info entity using the wrong scope ID
+    An attempt to delete an entity using the wrong scope ID must result 
+    in an exception.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And I create the access info entity
+    Given A scope with ID 20
+    When I delete the existing access info entity
+    Then No exception was thrown
+
+Scenario: Count access info entities in a specific scope
+    It must be possible to count the existing access info entities in various 
+    scopes.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    Then I create the access info entity
+    Then I create the access info entity
+    Then I create the access info entity
+    Given A scope with ID 20
+    Then I create the access info entity
+    Then I create the access info entity
+    Given A scope with ID 30
+    Then I create the access info entity
+    When I count the access info entities for scope 10
+    Then I get 3 as result
+    When I count the access info entities for scope 20
+    Then I get 2 as result
+    When I count the access info entities for scope 30
+    Then I get 1 as result
+    When I count the access info entities for scope 42
+    Then I get 0 as result
+
+Scenario: Query for all the access info entities of a specific user
+    It must be possible to find all the access info entities that belong 
+    to a specific user.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And I create the access info entity
+    And I create the access info entity
+    And I create the access info entity
+    And I create the access info entity
+    When I query for the access info entities for the last user
+    Then I get 4 as result
+    Given A user such as
+          | name     | displayName     | email              | phoneNumber     |
+          | kapua-u2 | Kapua User 2    | kapua_u2@kapua.com | +386 31 323 555 |
+    And I create the access info entity
+    And I create the access info entity
+    And I create the access info entity
+    When I query for the access info entities for the last user
+    Then I get 3 as result
+
+Scenario: Query for all the access info entities of an invalid user
+    If an invalid user is supplied for an entity count, the result list must be empty.
+    No exceptions should be thrown.
+ 
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And I create the access info entity
+    Given An invalid user
+    When I query for the access info entities for the last user
+    Then I get 0 as result
+


### PR DESCRIPTION
## CRUD tests for the Shiro Access Info service
This set of Access Info tests exercises parts of the main Access Info service (package org.eclipse.kapua.service.authorization.access.shiro). The implementation of cucumber based tests for the other packages that make up the Access Info service is in progress.
**Note**: The existing jUnit tests are still enabled since they do not conflict with the cucumber based implementations. They will be gradually removed as more cucumber based tests are implemented.

### Changes to Maven pom files
There is no change to the package pom files.

### Implementation changes
The implementation of the Shiro Access Info service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented to test CRUD operations on the Shiro Access Info service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>