### PR TITLE
Allow permission wildcard domain

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -730,7 +730,7 @@ public class ServiceDAO {
 
                         for (AccessPermission ap : accessPermissions.getItems()) {
                             Permission p = ap.getPermission();
-                            if (domain.getName().equals(p.getDomain())) {
+                            if (p.getDomain() == null || domain.getName().equals(p.getDomain())) {
                                 if (p.getAction() == null || Actions.read.equals(p.getAction())) {
                                     if (p.getGroupId() == null) {
                                         groupPermissions.clear();
@@ -754,7 +754,7 @@ public class ServiceDAO {
                             for (RolePermission rp : rolePermissions.getItems()) {
 
                                 Permission p = rp.getPermission();
-                                if (domain.getName().equals(p.getDomain())) {
+                                if (p.getDomain() == null || domain.getName().equals(p.getDomain())) {
                                     if (p.getAction() == null || Actions.read.equals(p.getAction())) {
                                         if (p.getGroupId() == null) {
                                             groupPermissions.clear();

--- a/console/src/main/java/org/eclipse/kapua/app/console/client/role/dialog/RolePermissionAddDialog.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/client/role/dialog/RolePermissionAddDialog.java
@@ -55,6 +55,8 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
     protected GwtRole selectedRole;
     
     private final GwtGroup allGroup;
+    private final GwtDomain allDomain = GwtDomain.ALL;
+    private final GwtAction allAction = GwtAction.ALL;
 
     public RolePermissionAddDialog(GwtSession currentSession) {
         super(currentSession);
@@ -77,10 +79,10 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onSuccess(List<GwtDomain> domainslist) {
+                domainCombo.getStore().removeAll();
+                domainCombo.add(allDomain);
                 domainCombo.add(domainslist);
-                if (!domainslist.isEmpty()) {
-                    domainCombo.setSimpleValue(domainslist.get(0));
-                }
+                domainCombo.setSimpleValue(allDomain);
                 refreshActions();
             }
 
@@ -147,10 +149,9 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
             @Override
             public void onSuccess(List<GwtAction> actionslist) {
                 actionCombo.getStore().removeAll();
+                actionCombo.add(allAction);
                 actionCombo.add(actionslist);
-                if (!actionslist.isEmpty()) {
-                    actionCombo.setSimpleValue(actionslist.get(0));
-                }
+                actionCombo.setSimpleValue(allAction);
             }
 
             @Override

--- a/console/src/main/java/org/eclipse/kapua/app/console/client/user/tabs/permission/PermissionAddDialog.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/client/user/tabs/permission/PermissionAddDialog.java
@@ -55,6 +55,8 @@ public class PermissionAddDialog extends EntityAddEditDialog {
     private ComboBox<GwtGroup> groupsCombo;
 
     private final GwtGroup allGroup;
+    private final GwtDomain allDomain = GwtDomain.ALL;
+    private final GwtAction allAction = GwtAction.ALL;
     
     private String accessInfoId;
 
@@ -152,7 +154,9 @@ public class PermissionAddDialog extends EntityAddEditDialog {
 
                     @Override
                     public void onSuccess(List<GwtDomain> result) {
+                        domainsCombo.add(allDomain);
                         domainsCombo.add(result);
+                        domainsCombo.setSimpleValue(allDomain);
                         actionsCombo.enable();
                     }
                 });
@@ -173,7 +177,9 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                     @Override
                     public void onSuccess(List<GwtAction> result) {
                         actionsCombo.removeAll();
+                        actionsCombo.add(allAction);
                         actionsCombo.add(result);
+                        actionsCombo.setSimpleValue(allAction);
                     }
                 });
                 
@@ -223,6 +229,7 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                 groupsCombo.getStore().removeAll();
                 groupsCombo.getStore().add(allGroup);
                 groupsCombo.getStore().add(result);
+                groupsCombo.setValue(allGroup);
             }
         });
         permissionFormPanel.add(groupsCombo);

--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/model/GwtPermission.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/model/GwtPermission.java
@@ -37,7 +37,8 @@ public class GwtPermission extends KapuaBaseModel {
         group, //
         role, //
         user, //
-
+        
+        ALL; //
     }
 
     /**
@@ -48,7 +49,9 @@ public class GwtPermission extends KapuaBaseModel {
         write, //
         delete, //
         connect, //
-        execute;
+        execute,
+        
+        ALL;
 
         @Override
         public String toString() {
@@ -104,8 +107,13 @@ public class GwtPermission extends KapuaBaseModel {
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append(getDomainEnum().name());
-
+        
+        if (getAction() != null) {
+            sb.append(getDomainEnum().name());
+        } else {
+            sb.append("*");
+        }
+        
         sb.append(":");
         if (getAction() != null) {
             sb.append(getActionEnum().name());

--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/model/authorization/GwtAccessPermission.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/model/authorization/GwtAccessPermission.java
@@ -32,7 +32,7 @@ public class GwtAccessPermission extends GwtUpdatableEntityModel {
     }
 
     public void setPermissionDomain(String permissionDomain) {
-        set("permissionDomain", permissionDomain);
+        set("permissionDomain", permissionDomain == null ? "ALL" : permissionDomain);
     }
 
     public String getPermissionAction() {
@@ -40,7 +40,7 @@ public class GwtAccessPermission extends GwtUpdatableEntityModel {
     }
 
     public void setPermissionAction(String permissionAction) {
-        set("permissionAction", permissionAction);
+        set("permissionAction", permissionAction == null ? "ALL" : permissionAction);
     }
 
     public String getPermissionTargetScopeId() {
@@ -48,7 +48,7 @@ public class GwtAccessPermission extends GwtUpdatableEntityModel {
     }
 
     public void setPermissionTargetScopeId(String permissionTargetScopeId) {
-        set("permissionTargetScopeId", permissionTargetScopeId);
+        set("permissionTargetScopeId", permissionTargetScopeId == null ? "ALL" : permissionTargetScopeId);
     }
 
     public String getPermissionGroupId() {
@@ -56,7 +56,7 @@ public class GwtAccessPermission extends GwtUpdatableEntityModel {
     }
 
     public void setPermissionGroupId(String permissionGroupId) {
-        set("permissionGroupId", permissionGroupId);
+        set("permissionGroupId", permissionGroupId == null ? "ALL" : permissionGroupId);
     }
 
     /**

--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/model/authorization/GwtRolePermission.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/model/authorization/GwtRolePermission.java
@@ -57,7 +57,7 @@ public class GwtRolePermission extends GwtEntityModel {
     }
 
     public void setDomain(String domain) {
-        set("domain", domain);
+        set("domain", domain == null ? "ALL" : domain);
     }
 
     /**
@@ -73,7 +73,7 @@ public class GwtRolePermission extends GwtEntityModel {
     }
 
     public void setAction(String action) {
-        set("action", action);
+        set("action", action == null ? "ALL" : action);
     }
 
     /**
@@ -85,7 +85,7 @@ public class GwtRolePermission extends GwtEntityModel {
     }
 
     public void setTargetScopeId(String targetScopeId) {
-        set("targetScopeId", targetScopeId);
+        set("targetScopeId", targetScopeId == null ? "ALL" : targetScopeId);
     }
     
     /**
@@ -97,6 +97,6 @@ public class GwtRolePermission extends GwtEntityModel {
     }
 
     public void setGroupId(String groupId) {
-        set("groupId", groupId);
+        set("groupId", groupId == null ? "ALL" : groupId);
     }
 }

--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/util/GwtKapuaModelConverter.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/util/GwtKapuaModelConverter.java
@@ -521,6 +521,9 @@ public class GwtKapuaModelConverter {
             case write:
                 action = Actions.write;
                 break;
+            case ALL:
+                action = null;
+                break;
             }
         }
         return action;
@@ -584,6 +587,9 @@ public class GwtKapuaModelConverter {
                 break;
             case user:
                 domain = new UserDomain();
+                break;
+            case ALL:
+                domain = null;
                 break;
             }
         }

--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/util/KapuaGwtModelConverter.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/util/KapuaGwtModelConverter.java
@@ -172,16 +172,23 @@ public class KapuaGwtModelConverter {
 
         gwtAccessPermission.setAccessInfoId(accessPermission.getAccessInfoId().toCompactId());
         gwtAccessPermission.setPermissionDomain(accessPermission.getPermission().getDomain());
-        gwtAccessPermission.setPermissionAction(accessPermission.getPermission().getAction().toString());
+
+        if (accessPermission.getPermission().getAction() != null) {
+            gwtAccessPermission.setPermissionAction(accessPermission.getPermission().getAction().toString());
+        } else {
+            gwtAccessPermission.setPermissionAction("ALL");
+        }
+        
         if (accessPermission.getPermission().getTargetScopeId() != null) {
             gwtAccessPermission.setPermissionTargetScopeId(accessPermission.getPermission().getTargetScopeId().toCompactId());
         } else {
-            gwtAccessPermission.setPermissionTargetScopeId("*");
+            gwtAccessPermission.setPermissionTargetScopeId("ALL");
         }
+        
         if (accessPermission.getPermission().getGroupId() != null) {
             gwtAccessPermission.setPermissionGroupId(accessPermission.getPermission().getGroupId().toCompactId());
         } else {
-            gwtAccessPermission.setPermissionGroupId("*");
+            gwtAccessPermission.setPermissionGroupId("ALL");
         }
 
         //

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -42,7 +42,7 @@ public interface Domain extends KapuaEntity {
 
     public static final String TYPE = "domain";
 
-    default public String getType() {
+    public default String getType() {
         return TYPE;
     }
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionImpl.java
@@ -76,7 +76,7 @@ public class AccessPermissionImpl extends AbstractKapuaEntity implements AccessP
 
     @Override
     public void setAccessInfoId(KapuaId accessInfo) {
-        this.accessInfoId = accessInfo != null ? (accessInfo instanceof KapuaEid  ? (KapuaEid) accessInfo : new KapuaEid(accessInfo)): null;
+        this.accessInfoId = accessInfo != null ? (accessInfo instanceof KapuaEid ? (KapuaEid) accessInfo : new KapuaEid(accessInfo)) : null;
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionImpl.java
@@ -76,12 +76,8 @@ public class AccessPermissionImpl extends AbstractKapuaEntity implements AccessP
     }
 
     @Override
-    public void setAccessInfoId(KapuaId userId) {
-        if (userId != null) {
-            this.accessInfoId = new KapuaEid(userId);
-        } else {
-            this.accessInfoId = null;
-        }
+    public void setAccessInfoId(KapuaId accessInfo) {
+        this.accessInfoId = accessInfo != null ? (accessInfo instanceof KapuaEid  ? (KapuaEid) accessInfo : new KapuaEid(accessInfo)): null;
     }
 
     @Override
@@ -91,17 +87,13 @@ public class AccessPermissionImpl extends AbstractKapuaEntity implements AccessP
 
     @Override
     public void setPermission(Permission permission) {
-        if (permission != null) {
-            this.permission = new PermissionImpl(permission);
-        } else {
-            this.permission = null;
-        }
+        this.permission = permission != null ? (permission instanceof PermissionImpl ? (PermissionImpl) permission : new PermissionImpl(permission)) : null;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public Permission getPermission() {
-        return permission;
+        return permission != null ? permission : new PermissionImpl(null, null, null, null);
     }
 
     @Override
@@ -127,10 +119,10 @@ public class AccessPermissionImpl extends AbstractKapuaEntity implements AccessP
                 return false;
         } else if (!accessInfoId.equals(other.accessInfoId))
             return false;
-        if (permission == null) {
-            if (other.permission != null)
+        if (getPermission() == null) {
+            if (other.getPermission() != null)
                 return false;
-        } else if (!permission.equals(other.permission))
+        } else if (!getPermission().equals(other.getPermission()))
             return false;
         return true;
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,6 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access.shiro;
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
@@ -37,9 +37,9 @@ import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
 /**
- * Permission implementation.
+ * {@link Permission} implementation.
  * 
- * @since 1.0
+ * @since 1.0.0
  */
 @Embeddable
 public class PermissionImpl extends WildcardPermission implements Permission, org.apache.shiro.authz.Permission, Serializable {
@@ -47,22 +47,22 @@ public class PermissionImpl extends WildcardPermission implements Permission, or
     private static final long serialVersionUID = 1480557438886065675L;
 
     @Basic
-    @Column(name = "domain", nullable = false, updatable = false)
+    @Column(name = "domain", nullable = true, updatable = false)
     private String domain;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "action", updatable = false)
+    @Column(name = "action", nullable = true, updatable = false)
     private Actions action;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "eid", column = @Column(name = "target_scope_id", updatable = false))
+            @AttributeOverride(name = "eid", column = @Column(name = "target_scope_id", nullable = true, updatable = false))
     })
     private KapuaEid targetScopeId;
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "eid", column = @Column(name = "group_id", updatable = false))
+            @AttributeOverride(name = "eid", column = @Column(name = "group_id", nullable = true, updatable = false))
     })
     private KapuaEid groupId;
 
@@ -95,6 +95,8 @@ public class PermissionImpl extends WildcardPermission implements Permission, or
      * @param action
      * @param targetScopeId
      * @param groupId
+     * 
+     * @since 1.0.0
      */
     public PermissionImpl(String domain, Actions action, KapuaId targetScopeId, KapuaId groupId) {
 
@@ -128,11 +130,7 @@ public class PermissionImpl extends WildcardPermission implements Permission, or
 
     @Override
     public void setTargetScopeId(KapuaId targetScopeId) {
-        if (targetScopeId != null) {
-            this.targetScopeId = new KapuaEid(targetScopeId);
-        } else {
-            this.targetScopeId = null;
-        }
+        this.targetScopeId = targetScopeId != null ? (targetScopeId instanceof KapuaEid ? (KapuaEid) targetScopeId : new KapuaEid(targetScopeId)) : null;
     }
 
     @Override
@@ -142,11 +140,7 @@ public class PermissionImpl extends WildcardPermission implements Permission, or
 
     @Override
     public void setGroupId(KapuaId groupId) {
-        if (groupId != null) {
-            this.groupId = new KapuaEid(groupId);
-        } else {
-            this.groupId = null;
-        }
+        this.groupId = groupId != null ? (groupId instanceof KapuaEid ? (KapuaEid) groupId : new KapuaEid(groupId)) : null;
     }
 
     @Override
@@ -185,7 +179,7 @@ public class PermissionImpl extends WildcardPermission implements Permission, or
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(domain) //
+        sb.append(domain != null ? domain : Permission.WILDCARD) //
                 .append(Permission.SEPARATOR) //
                 .append(action != null ? action.name() : Permission.WILDCARD) //
                 .append(Permission.SEPARATOR) //

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,6 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
- *
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.permission.shiro;
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
@@ -24,6 +24,7 @@ import javax.persistence.Enumerated;
 
 import org.apache.shiro.authz.UnauthorizedException;
 import org.apache.shiro.authz.permission.WildcardPermission;
+import org.apache.shiro.subject.Subject;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.KapuaEntityCreator;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionImpl.java
@@ -90,7 +90,7 @@ public class RolePermissionImpl extends AbstractKapuaEntity implements RolePermi
 
     @Override
     public void setRoleId(KapuaId roleId) {
-        this.roleId = roleId != null ? new KapuaEid(roleId.getId()) : null;
+        this.roleId = roleId != null ? (roleId instanceof KapuaEid ? (KapuaEid) roleId : new KapuaEid(roleId)) : null;
     }
 
     @Override
@@ -100,18 +100,18 @@ public class RolePermissionImpl extends AbstractKapuaEntity implements RolePermi
 
     @Override
     public void setPermission(Permission permission) {
-        this.permission = permission != null ? new PermissionImpl(permission) : null;
+        this.permission = permission != null ? (permission instanceof PermissionImpl ? (PermissionImpl) permission : new PermissionImpl(permission)) : null;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public Permission getPermission() {
-        return permission;
+        return permission != null ? permission : new PermissionImpl(null, null, null, null);
     }
 
     @Override
     public String toString() {
-        return permission.toString();
+        return getPermission().toString();
     }
 
     @PreUpdate
@@ -144,15 +144,15 @@ public class RolePermissionImpl extends AbstractKapuaEntity implements RolePermi
         if (getClass() != obj.getClass())
             return false;
         RolePermissionImpl other = (RolePermissionImpl) obj;
-        if (permission == null) {
-            if (other.permission != null)
-                return false;
-        } else if (!permission.equals(other.permission))
-            return false;
         if (roleId == null) {
             if (other.roleId != null)
                 return false;
         } else if (!roleId.equals(other.roleId))
+            return false;
+        if (getPermission() == null) {
+            if (other.getPermission() != null)
+                return false;
+        } else if (!getPermission().equals(other.getPermission()))
             return false;
         return true;
     }

--- a/service/security/shiro/src/main/resources/liquibase/athz_access_permission.sql
+++ b/service/security/shiro/src/main/resources/liquibase/athz_access_permission.sql
@@ -22,7 +22,7 @@ CREATE TABLE athz_access_permission (
   
   access_info_id			BIGINT(21) 	  UNSIGNED NOT NULL,
   
-  domain					VARCHAR(64)	  NOT NULL,
+  domain					VARCHAR(64),
   action					VARCHAR(64),
   target_scope_id			BIGINT(21)	  UNSIGNED,
   group_id             	    BIGINT(21) 	  UNSIGNED,
@@ -36,4 +36,4 @@ CREATE INDEX idx_scopeId_accessId_domain_action_targetScopeId_groupId ON athz_ac
 
 INSERT INTO athz_access_permission
 	VALUES
-		(1, 1, NOW(), 1, 2, 'broker', 'connect', 1, null); -- kapua-broker assigned of permission: broker:connect:1
+		(1, 1, NOW(), 1, 2, 'broker', 'connect', 1, null); -- kapua-broker assigned of permission: broker:connect:1:*

--- a/service/security/shiro/src/main/resources/liquibase/athz_access_permission.sql
+++ b/service/security/shiro/src/main/resources/liquibase/athz_access_permission.sql
@@ -22,7 +22,7 @@ CREATE TABLE athz_access_permission (
   
   access_info_id			BIGINT(21) 	  UNSIGNED NOT NULL,
   
-  domain					VARCHAR(64),
+  domain					VARCHAR(64)	  NOT NULL,
   action					VARCHAR(64),
   target_scope_id			BIGINT(21)	  UNSIGNED,
   group_id             	    BIGINT(21) 	  UNSIGNED,
@@ -37,3 +37,7 @@ CREATE INDEX idx_scopeId_accessId_domain_action_targetScopeId_groupId ON athz_ac
 INSERT INTO athz_access_permission
 	VALUES
 		(1, 1, NOW(), 1, 2, 'broker', 'connect', 1, null); -- kapua-broker assigned of permission: broker:connect:1:*
+
+--changeset access_permission:2
+
+ALTER TABLE athz_access_permission MODIFY COLUMN domain VARCHAR(64) NULL;

--- a/service/security/shiro/src/main/resources/liquibase/athz_access_permission.sql
+++ b/service/security/shiro/src/main/resources/liquibase/athz_access_permission.sql
@@ -1,5 +1,5 @@
 -- *******************************************************************************
--- Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+-- Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 --
 -- All rights reserved. This program and the accompanying materials
 -- are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/athz_role_permission.sql
+++ b/service/security/shiro/src/main/resources/liquibase/athz_role_permission.sql
@@ -22,7 +22,7 @@ CREATE TABLE athz_role_permission (
 
   role_id             	    BIGINT(21) 	  UNSIGNED,
   
-  domain					VARCHAR(64)   NOT NULL,
+  domain					VARCHAR(64),
   action					VARCHAR(64),
   target_scope_id		    BIGINT(21)	  UNSIGNED,
   group_id             	    BIGINT(21) 	  UNSIGNED,
@@ -35,27 +35,4 @@ CREATE UNIQUE INDEX idx_role_permission_scope_id ON athz_role_permission (role_i
 
 INSERT INTO athz_role_permission
 	VALUES
-		(1,  1, NOW(), 1, 1, 'account', 			null, null, null),
-
-		(1,  2, NOW(), 1, 1, 'broker', 				null, null, null),
-
-		(1,  3, NOW(), 1, 1, 'device',				null, null, null),
-		(1,  4, NOW(), 1, 1, 'device_connection', 	null, null, null),
-		(1,  5, NOW(), 1, 1, 'device_event', 		null, null, null),
-		(1,  6, NOW(), 1, 1, 'device_lifecycle', 	null, null, null),
-
-		(1,  7, NOW(), 1, 1, 'device_management',	null, null, null),
-
-		(1,  8, NOW(), 1, 1, 'datastore', 				null, null, null),
-
-		(1,  9, NOW(), 1, 1, 'credential',			null, null, null),
-		(1,	10, NOW(), 1, 1, 'access_token',		null, null, null),
-
-		(1, 11, NOW(), 1, 1, 'access_info',			null, null, null),
-		(1, 12, NOW(), 1, 1, 'role',				null, null, null),
-
-		(1, 13, NOW(), 1, 1, 'user',				null, null, null),
-
-		(1, 14, NOW(), 1, 1, 'domain',				null, null, null),
-
-		(1, 15, NOW(), 1, 1, 'group',       null, null, null),
+		(1,  1, NOW(), 1, 1, null, null, null, null); -- kapua-sys assigned of permission: *:*:1:*

--- a/service/security/shiro/src/main/resources/liquibase/athz_role_permission.sql
+++ b/service/security/shiro/src/main/resources/liquibase/athz_role_permission.sql
@@ -22,7 +22,7 @@ CREATE TABLE athz_role_permission (
 
   role_id             	    BIGINT(21) 	  UNSIGNED,
   
-  domain					VARCHAR(64),
+  domain					VARCHAR(64)   NOT NULL,
   action					VARCHAR(64),
   target_scope_id		    BIGINT(21)	  UNSIGNED,
   group_id             	    BIGINT(21) 	  UNSIGNED,
@@ -35,4 +35,35 @@ CREATE UNIQUE INDEX idx_role_permission_scope_id ON athz_role_permission (role_i
 
 INSERT INTO athz_role_permission
 	VALUES
-		(1,  1, NOW(), 1, 1, null, null, null, null); -- kapua-sys assigned of permission: *:*:1:*
+		(1,  1, NOW(), 1, 1, 'account', 			null, null, null),
+
+		(1,  2, NOW(), 1, 1, 'broker', 				null, null, null),
+
+		(1,  3, NOW(), 1, 1, 'device',				null, null, null),
+		(1,  4, NOW(), 1, 1, 'device_connection', 	null, null, null),
+		(1,  5, NOW(), 1, 1, 'device_event', 		null, null, null),
+		(1,  6, NOW(), 1, 1, 'device_lifecycle', 	null, null, null),
+
+		(1,  7, NOW(), 1, 1, 'device_management',	null, null, null),
+
+		(1,  8, NOW(), 1, 1, 'datastore', 				null, null, null),
+
+		(1,  9, NOW(), 1, 1, 'credential',			null, null, null),
+		(1,	10, NOW(), 1, 1, 'access_token',		null, null, null),
+
+		(1, 11, NOW(), 1, 1, 'access_info',			null, null, null),
+		(1, 12, NOW(), 1, 1, 'role',				null, null, null),
+
+		(1, 13, NOW(), 1, 1, 'user',				null, null, null),
+
+		(1, 14, NOW(), 1, 1, 'domain',				null, null, null),
+
+		(1, 15, NOW(), 1, 1, 'group',       null, null, null);
+
+--changeset role_permission:2
+
+ALTER TABLE athz_role_permission MODIFY COLUMN domain VARCHAR(64) NULL;
+
+DELETE FROM athz_role_permission WHERE scope_id = 1;
+
+INSERT INTO athz_role_permission VALUES (1,  1, NOW(), 1, 1, null, null, null, null); -- kapua-sys assigned of permission: *:*:*:*

--- a/service/security/shiro/src/main/resources/liquibase/athz_role_permission.sql
+++ b/service/security/shiro/src/main/resources/liquibase/athz_role_permission.sql
@@ -1,5 +1,5 @@
 -- *******************************************************************************
--- Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+-- Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 --
 -- All rights reserved. This program and the accompanying materials
 -- are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
Hi all, 

this PR is to make assigning of the permissions.
Now it is possible to use * as domain level. 
So you can assign to the default admin role of an account the permission `*:*:{scopeId}:*` instead of having to create a single permission for each domain available.

Regards, 

_Alberto_