### PR TITLE
Additional CRUD tests for the Shiro Access Info service

### DIFF
--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestSteps.java
@@ -194,13 +194,6 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         assertNotNull(accessData.user.getId());
     }
 
-    @Given("^An invalid user$")
-    public void provideInvalidUserObject() {
-        accessData.user = new UserImpl(generateId(), generateId().toString());
-        accessData.user.setId(generateId());
-        assertNotNull(accessData.user);
-    }
-
     @Given("^The permission(?:|s) \"(.+)\"$")
     public void createPermissionsForDomain(String permList) {
         // Sanity checks
@@ -280,6 +273,36 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         assertEquals(1, accessData.roleIds.size());
     }
 
+    @Given("^An invalid user$")
+    public void provideInvalidUserObject() {
+        accessData.user = new UserImpl(generateId(), generateId().toString());
+        accessData.user.setId(generateId());
+        assertNotNull(accessData.user);
+    }
+
+    @When("^I create the access role$")
+    public void createAccessRole()
+            throws KapuaException {
+
+        assertNotNull(commonData.scopeId);
+
+        AccessRoleCreator tmpCreator = accessRoleFactory.newCreator(commonData.scopeId);
+        assertNotNull(tmpCreator);
+
+        tmpCreator.setAccessInfoId(generateId());
+        tmpCreator.setRoleId(generateId());
+
+        try {
+            commonData.exceptionCaught = false;
+            KapuaSecurityUtils.doPrivileged(() -> {
+                accessData.accessRole = accessRoleService.create(tmpCreator);
+                return null;
+            });
+        } catch (KapuaException e) {
+            commonData.exceptionCaught = true;
+        }
+    }
+
     @When("^I create the access info entity$")
     public void createAccessInfoEntity() {
 
@@ -356,7 +379,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
             return null;
         });
     }
-    
+
     @When("^I search for an access info entity by user ID$")
     public void findTheAccessInfoEntityByUserId()
             throws KapuaException {
@@ -368,6 +391,49 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
             accessData.accessInfoFound = accessInfoService.findByUserId(commonData.scopeId, accessData.user.getId());
             return null;
         });
+    }
+
+    @When("^I search for the last created access role entity$")
+    public void findLastCreatedAccessRole()
+            throws KapuaException {
+        assertNotNull(commonData.scopeId);
+        assertNotNull(accessData.accessRole);
+        assertNotNull(accessData.accessRole.getId());
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            accessData.accessRoleFound = accessRoleService.find(commonData.scopeId, accessData.accessRole.getId());
+            return null;
+        });
+    }
+
+    @When("^I count the access roles in scope (\\d+)$")
+    public void countAccesRolesInScope(Integer scope)
+            throws KapuaException {
+        assertNotNull(scope);
+        AccessRoleQuery tmpQuery = accessRoleFactory.newQuery(new KapuaEid(BigInteger.valueOf(scope)));
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            commonData.count = accessRoleService.count(tmpQuery);
+            return null;
+        });
+    }
+
+    @When("^I delete the last created access role entry$")
+    public void deleteLastCreatedAccessRoleEntry()
+            throws KapuaException {
+        assertNotNull(commonData.scopeId);
+        assertNotNull(accessData.accessRole);
+        assertNotNull(accessData.accessRole.getId());
+
+        try {
+            commonData.exceptionCaught = false;
+            KapuaSecurityUtils.doPrivileged(() -> {
+                accessRoleService.delete(commonData.scopeId, accessData.accessRole.getId());
+                return null;
+            });
+        } catch (KapuaException e) {
+            commonData.exceptionCaught = true;
+        }
     }
 
     @When("^I delete the existing access info entity$")
@@ -422,6 +488,186 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         }
     }
 
+    @When("^I create the permission(?:|s)$")
+    public void createPermissionEntries()
+            throws KapuaException {
+        assertNotNull(commonData.scopeId);
+        assertNotNull(accessData.permissions);
+        assertFalse(accessData.permissions.isEmpty());
+
+        accessData.accessPermissionCreator = accessPermissionFactory.newCreator(commonData.scopeId);
+        accessData.accessPermissionCreator.setAccessInfoId(generateId());
+
+        try {
+            commonData.exceptionCaught = false;
+            for (Permission tmpPerm : accessData.permissions) {
+                accessData.accessPermissionCreator.setPermission(tmpPerm);
+                KapuaSecurityUtils.doPrivileged(() -> {
+                    accessData.accessPermission = accessPermissionService.create(accessData.accessPermissionCreator);
+                    return null;
+                });
+            }
+        } catch (KapuaException ex) {
+            commonData.exceptionCaught = true;
+        }
+    }
+
+    @When("^I search for the last created permission$")
+    public void findTheLastCreatedAccessPermission()
+            throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            accessData.accessPermissionFound = accessPermissionService.find(commonData.scopeId, accessData.accessPermission.getId());
+            return null;
+        });
+    }
+
+    @When("^I delete the last created access permission$")
+    public void deleteLastCreatedPermission()
+            throws KapuaException {
+
+        assertNotNull(commonData.scopeId);
+        assertNotNull(accessData.accessPermission);
+
+        try {
+            commonData.exceptionCaught = false;
+            KapuaSecurityUtils.doPrivileged(() -> {
+                accessPermissionService.delete(commonData.scopeId, accessData.accessPermission.getId());
+                return null;
+            });
+        } catch (KapuaException ex) {
+            commonData.exceptionCaught = true;
+        }
+    }
+
+    @When("^I count the permissions in scope (\\d+)$")
+    public void countPermissionsForScope(Integer scope)
+            throws KapuaException {
+        assertNotNull(scope);
+        KapuaId tmpId = new KapuaEid(BigInteger.valueOf(scope));
+        assertNotNull(tmpId);
+
+        AccessPermissionQuery tmpQuery = accessPermissionFactory.newQuery(tmpId);
+        KapuaSecurityUtils.doPrivileged(() -> {
+            commonData.count = accessPermissionService.count(tmpQuery);
+            return null;
+        });
+    }
+
+    @When("^I check the sanity of the access info factory$")
+    public void accessInfoServiceSanityCheck() {
+        try {
+            commonData.exceptionCaught = false;
+
+            assertNotNull(accessInfoFactory.newCreator(generateId()));
+            assertNotNull(accessInfoFactory.newEntity(null));
+            assertNotNull(accessInfoFactory.newQuery(generateId()));
+            assertNotNull(accessInfoFactory.newListResult());
+
+            AccessInfoCreator tmpCreator = new AccessInfoCreatorImpl(generateId());
+            assertNotNull(tmpCreator);
+            tmpCreator.setUserId(generateId());
+            AccessInfoCreator tmpCreator_2 = new AccessInfoCreatorImpl(tmpCreator);
+            assertNotNull(tmpCreator_2);
+            assertEquals(tmpCreator.getUserId(), tmpCreator_2.getUserId());
+
+            AccessInfo tmpAccInfo = new AccessInfoImpl(generateId());
+            assertNotNull(tmpAccInfo);
+            tmpAccInfo.setUserId(generateId());
+
+            AccessInfo tmpAccInfo_2 = new AccessInfoImpl(tmpAccInfo);
+            assertNotNull(tmpAccInfo_2);
+            assertNotNull(tmpAccInfo_2.getUserId());
+
+            tmpAccInfo_2.setUserId(null);
+            assertNull(tmpAccInfo_2.getUserId());
+        } catch (KapuaException ex) {
+            commonData.exceptionCaught = true;
+        }
+    }
+
+    @When("^I check the sanity of the access permission factory$")
+    public void accessPermissionFactorySanityCheck() {
+        assertNotNull(accessPermissionFactory.newCreator(generateId()));
+        assertNotNull(accessPermissionFactory.newEntity(null));
+        assertNotNull(accessPermissionFactory.newEntity(generateId()));
+        assertNotNull(accessPermissionFactory.newQuery(generateId()));
+        assertNotNull(accessPermissionFactory.newListResult());
+
+        KapuaId tmpId = generateId();
+        AccessPermissionCreator tmpCreator = new AccessPermissionCreatorImpl(tmpId);
+        assertNotNull(tmpCreator);
+        assertNotNull(tmpCreator.getScopeId());
+        assertEquals(tmpId, tmpCreator.getScopeId());
+
+        AccessPermission tmpAccPerm = new AccessPermissionImpl(generateId());
+        assertNotNull(tmpAccPerm);
+        tmpAccPerm.setAccessInfoId(generateId());
+        tmpAccPerm.setPermission(new PermissionImpl("test_domain", Actions.read, generateId(), generateId()));
+
+        AccessPermission tmpAccPerm_2 = new AccessPermissionImpl(tmpAccPerm);
+        assertNotNull(tmpAccPerm_2);
+        assertEquals(tmpAccPerm.getAccessInfoId(), tmpAccPerm_2.getAccessInfoId());
+        assertEquals(tmpAccPerm.getPermission(), tmpAccPerm_2.getPermission());
+
+        tmpAccPerm.setAccessInfoId(null);
+        assertNull(tmpAccPerm.getAccessInfoId());
+
+        // No typo. This is by design. When an object permissions are null, when asked for them, a 
+        // new set of empty permissions is returned instead. 
+        tmpAccPerm.setPermission(null);
+        assertNotNull(tmpAccPerm.getPermission());
+    }
+
+    @When("^I check the sanity of the access role factory$")
+    public void accessRoleFactorySanityCheck() {
+        try {
+            commonData.exceptionCaught = false;
+            assertNotNull(accessRoleFactory.newCreator(generateId()));
+            assertNotNull(accessRoleFactory.newEntity(generateId()));
+            assertNotNull(accessRoleFactory.newQuery(generateId()));
+            assertNotNull(accessRoleFactory.newListResult());
+
+            KapuaId tmpId = generateId();
+            AccessRoleCreator tmpCreator = new AccessRoleCreatorImpl(tmpId);
+            assertNotNull(tmpCreator);
+            assertNotNull(tmpCreator.getScopeId());
+            assertEquals(tmpId, tmpCreator.getScopeId());
+
+            AccessRole tmpRole = new AccessRoleImpl(generateId());
+            assertNotNull(tmpRole);
+            tmpRole.setAccessInfoId(generateId());
+            tmpRole.setRoleId(generateId());
+            AccessRole tmpRole_2 = new AccessRoleImpl(tmpRole);
+            assertNotNull(tmpRole_2);
+            assertEquals(tmpRole.getRoleId(), tmpRole_2.getRoleId());
+            assertEquals(tmpRole.getAccessInfoId(), tmpRole_2.getAccessInfoId());
+
+            tmpRole.setAccessInfoId(null);
+            assertNull(tmpRole.getAccessInfoId());
+
+            tmpRole.setRoleId(null);
+            assertNull(tmpRole.getRoleId());
+        } catch (KapuaException ex) {
+            commonData.exceptionCaught = true;
+        }
+    }
+
+    @Then("^A role entity was created$")
+    public void checkThatRoleWasCreated() {
+        assertNotNull(accessData.role);
+    }
+
+    @Then("^An access role entity was created$")
+    public void checkThatAccessRoleWasCreated() {
+        assertNotNull(accessData.accessRole);
+    }
+
+    @Then("^I find an access role entity$")
+    public void checkThatAnAccessRoleEntityWasFound() {
+        assertNotNull(accessData.accessRoleFound);
+    }
+
     @Then("^An access info entity was created$")
     public void checkThatAccessInfoEntityExists() {
         assertNotNull(accessData.accessInfo);
@@ -431,12 +677,17 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
     public void checkThatAnAccessInfoEntityWasFound() {
         assertNotNull(accessData.accessInfoFound);
     }
-    
+
     @Then("^I find no access info entity$")
-    public void checkThatNoAccessInfoEntityWasFound() {
+    public void checkThatAnAccessInfoEntityWasNotFound() {
         assertNull(accessData.accessInfoFound);
     }
-    
+
+    @Then("^I find an access permission entity$")
+    public void checkThatAnAccessPermissionWasFound() {
+        assertNotNull(accessData.accessPermissionFound);
+    }
+
     @Then("^The entity matches the creator$")
     public void checkEntityAgainstCreator() {
         assertNotNull(accessData.accessInfoCreator);
@@ -464,5 +715,91 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         for (int i = 0; i < accessData.accessRoles.getSize(); i++) {
             assertTrue(accessData.accessInfoCreator.getRoleIds().contains(accessData.accessRoles.getItem(i).getRoleId()));
         }
+    }
+
+    // The following test step is more of a filler. The only purpose is to achieve some coverage
+    // of the Access Role object equals function.
+    // As such this step is of limited usefulness and should be taken with a grain of salt.
+    @Then("^I can compare access role objects$")
+    public void checkAccessRoleComparison()
+            throws KapuaException {
+
+        AccessRoleImpl accRole_1 = new AccessRoleImpl(generateId());
+        AccessRoleImpl accRole_2 = new AccessRoleImpl(generateId());
+
+        assertTrue(accRole_1.equals(accRole_1));
+        assertFalse(accRole_1.equals(null));
+        assertFalse(accRole_1.equals(new Integer(15)));
+
+        assertTrue(accRole_1.equals(accRole_2));
+
+        accRole_2.setAccessInfoId(generateId());
+        assertFalse(accRole_1.equals(accRole_2));
+
+        accRole_1.setAccessInfoId(generateId());
+        accRole_2.setAccessInfoId(null);
+        assertFalse(accRole_1.equals(accRole_2));
+
+        accRole_2.setAccessInfoId(accRole_1.getAccessInfoId());
+        assertTrue(accRole_1.equals(accRole_2));
+
+        accRole_2.setRoleId(generateId());
+        assertFalse(accRole_1.equals(accRole_2));
+
+        accRole_1.setRoleId(generateId());
+        accRole_2.setRoleId(null);
+        assertFalse(accRole_1.equals(accRole_2));
+
+        accRole_2.setRoleId(accRole_1.getRoleId());
+        assertTrue(accRole_1.equals(accRole_2));
+    }
+
+    // The following test step is more of a filler. The only purpose is to achieve some coverage
+    // of the Access Role object equals function.
+    // As such this step is of limited usefulness and should be taken with a grain of salt.
+    @Then("^I can compare access permission objects$")
+    public void checkAccessPermissionComparison()
+            throws KapuaException {
+
+        AccessPermissionImpl accPerm_1 = new AccessPermissionImpl(generateId());
+        AccessPermissionImpl accPerm_2 = new AccessPermissionImpl(generateId());
+        Permission tmpPerm_1 = new PermissionImpl("test_domain", Actions.read, rootScopeId, generateId());
+        Permission tmpPerm_2 = new PermissionImpl("test_domain", Actions.write, rootScopeId, generateId());
+
+        assertTrue(accPerm_1.equals(accPerm_1));
+        assertFalse(accPerm_1.equals(null));
+        assertFalse(accPerm_1.equals(new Integer(15)));
+
+        assertTrue(accPerm_1.equals(accPerm_2));
+
+        accPerm_1.setAccessInfoId(null);
+        accPerm_2.setAccessInfoId(generateId());
+        assertFalse(accPerm_1.equals(accPerm_2));
+
+        accPerm_1.setAccessInfoId(generateId());
+        accPerm_2.setAccessInfoId(null);
+        assertFalse(accPerm_1.equals(accPerm_2));
+
+        accPerm_1.setAccessInfoId(generateId());
+        accPerm_2.setAccessInfoId(generateId());
+        assertFalse(accPerm_1.equals(accPerm_2));
+
+        accPerm_2.setAccessInfoId(accPerm_1.getAccessInfoId());
+        assertTrue(accPerm_1.equals(accPerm_2));
+
+        accPerm_1.setPermission(null);
+        accPerm_2.setPermission(tmpPerm_2);
+        assertFalse(accPerm_1.equals(accPerm_2));
+
+        accPerm_1.setPermission(tmpPerm_1);
+        accPerm_2.setPermission(null);
+        assertFalse(accPerm_1.equals(accPerm_2));
+
+        accPerm_1.setPermission(tmpPerm_1);
+        accPerm_2.setPermission(tmpPerm_2);
+        assertFalse(accPerm_1.equals(accPerm_2));
+
+        accPerm_2.setPermission(accPerm_1.getPermission());
+        assertTrue(accPerm_1.equals(accPerm_2));
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
@@ -52,7 +52,7 @@ public class CommonTestSteps extends KapuaTest {
     }
 
     @Given("^A null scope$")
-    public void setNullScopId() {
+    public void setNullScopeId() {
         commonData.scopeId = null;
     }
     

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/MiscAuthorizationTestData.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/MiscAuthorizationTestData.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import javax.inject.Singleton;
+
+import org.eclipse.kapua.service.authorization.permission.Permission;
+
+@Singleton
+public class MiscAuthorizationTestData {
+
+    Permission permission;
+
+    public void clearData() {
+        permission = null;
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/MiscAuthorizationTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/MiscAuthorizationTestSteps.java
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import javax.inject.Inject;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionFactoryImpl;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+
+// Implementation of Gherkin steps used to test miscellaneous Shiro 
+// authorization functionality.
+
+@ScenarioScoped
+public class MiscAuthorizationTestSteps extends AbstractAuthorizationServiceTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger s_logger = LoggerFactory.getLogger(AccessInfoServiceTestSteps.class);
+
+    // Test data scratchpads
+    private CommonTestData commonData = null;
+    private MiscAuthorizationTestData miscData = null;
+
+    // Currently executing scenario.
+    private Scenario scenario;
+    
+    // Various Shiro Authorization related service references
+    private PermissionFactory permissionFactory = null;
+    
+    
+    @Inject
+    public MiscAuthorizationTestSteps(MiscAuthorizationTestData miscData, CommonTestData commonData) {
+        this.miscData = miscData;
+        this.commonData = commonData;
+    }
+
+    // Database setup and tear-down steps
+    @Before
+    public void beforeScenario(Scenario scenario) throws KapuaException {
+
+        this.scenario = scenario;
+        
+        // Clean up the database. A clean slate is needed for truly independent
+        // test case executions!
+        dropDatabase();
+        setupDatabase();
+
+        permissionFactory = new PermissionFactoryImpl();
+        
+        // Clean up the test data scratchpads
+        miscData.clearData();
+        commonData.clearData();
+    }
+
+    // Cucumber test steps
+
+    // The following test step is more of a filler. The only purpose is to achieve some coverage
+    // of the Authorization Permission factory.
+    // As such this step is of limited usefulness and should be taken with a grain of salt.
+    @Then("^The permission factory returns sane results$")
+    public void permissionFactorySanityChecks()
+            throws KapuaException {
+        
+        Permission tmpPerm = null;
+        Domain tmpDomain = new TestDomain();
+        
+        tmpPerm = permissionFactory.newPermission(tmpDomain, Actions.read, rootScopeId);
+        assertNotNull(tmpPerm);
+        assertNotNull(tmpPerm.getDomain());
+        assertEquals(tmpDomain.getName(), tmpPerm.getDomain());
+        assertEquals(Actions.read, tmpPerm.getAction());
+        
+        tmpPerm = permissionFactory.newPermission(tmpDomain, Actions.write, rootScopeId, generateId());
+        assertNotNull(tmpPerm);
+        assertNotNull(tmpPerm.getDomain());
+        assertEquals(tmpDomain.getName(), tmpPerm.getDomain());
+        assertEquals(Actions.write, tmpPerm.getAction());
+        
+        tmpPerm = permissionFactory.newPermission(null, Actions.execute, rootScopeId, generateId());
+        assertNotNull(tmpPerm);
+        assertEquals(Actions.execute, tmpPerm.getAction());
+        
+        tmpDomain.setName(null);
+        tmpPerm = permissionFactory.newPermission(tmpDomain, Actions.connect, rootScopeId, generateId());
+        assertNotNull(tmpPerm);
+        assertEquals(Actions.connect, tmpPerm.getAction());
+        
+        tmpPerm = permissionFactory.parseString("test_domain_1:read:1:15");
+        assertNotNull(tmpPerm);
+        assertNotNull(tmpPerm.getDomain());
+        assertEquals("test_domain_1", tmpPerm.getDomain());
+        assertEquals(Actions.read, tmpPerm.getAction());
+        assertNotNull(tmpPerm.getTargetScopeId());
+        assertEquals(rootScopeId, tmpPerm.getTargetScopeId());
+        assertNotNull(tmpPerm.getGroupId());
+        assertEquals(generateId(15), tmpPerm.getGroupId());
+
+        tmpPerm = permissionFactory.parseString("test_domain_1:*:1:15");
+        assertNotNull(tmpPerm);
+
+        tmpPerm = permissionFactory.parseString("test_domain_1:*:*:*");
+        assertNotNull(tmpPerm);
+        
+        tmpPerm = permissionFactory.parseString("test_domain_1");
+        assertNotNull(tmpPerm);
+        
+        tmpPerm = permissionFactory.parseString("test_domain_1:execute");
+        assertNotNull(tmpPerm);
+        
+        tmpPerm = permissionFactory.parseString("test_domain_1:execute:10");
+        assertNotNull(tmpPerm);
+        
+        try {
+            commonData.exceptionCaught = false;
+            tmpPerm = permissionFactory.parseString("");
+        } catch (KapuaException ex) {
+            commonData.exceptionCaught = true;
+        }
+        assertTrue(commonData.exceptionCaught);
+
+        try {
+            commonData.exceptionCaught = false;
+            tmpPerm = permissionFactory.parseString("test_domain_1:read:1:15:wrong");
+        } catch (KapuaException ex) {
+            commonData.exceptionCaught = true;
+        }
+        assertTrue(commonData.exceptionCaught);
+        
+        try {
+            commonData.exceptionCaught = false;
+            tmpPerm = permissionFactory.parseString("test_domain_1:garble");
+        } catch (Exception ex) {
+            commonData.exceptionCaught = true;
+        }
+        assertTrue(commonData.exceptionCaught);
+
+        try {
+            commonData.exceptionCaught = false;
+            tmpPerm = permissionFactory.parseString("test_domain_1:read:wrong");
+        } catch (Exception ex) {
+            commonData.exceptionCaught = true;
+        }
+        assertTrue(commonData.exceptionCaught);
+
+        try {
+            commonData.exceptionCaught = false;
+            tmpPerm = permissionFactory.parseString("test_domain_1:read:1:wrong");
+        } catch (Exception ex) {
+            commonData.exceptionCaught = true;
+        }
+        assertTrue(commonData.exceptionCaught);
+    }
+
+    // The following test step is more of a filler. The only purpose is to achieve some coverage
+    // of the Authorization Permission object equals function.
+    // As such this step is of limited usefulness and should be taken with a grain of salt.
+    @Then("^I can compare permission objects$")
+    public void checkPermissionComparison()
+            throws KapuaException {
+        
+        Permission perm_1 = new PermissionImpl("test_domain_1", Actions.read, generateId(10), generateId(100));
+        Permission perm_2 = new PermissionImpl("test_domain_1", Actions.read, generateId(10), generateId(100));
+        
+        assertTrue(perm_1.equals(perm_1));
+        assertFalse(perm_1.equals(null));
+        assertFalse(perm_1.equals(new Integer(10)));
+        
+        assertTrue(perm_1.equals(perm_2));
+        
+        perm_1.setDomain(null);
+        assertFalse(perm_1.equals(perm_2));
+        perm_2.setDomain(null);
+        assertTrue(perm_1.equals(perm_2));
+        perm_1.setDomain("test_1");
+        assertFalse(perm_1.equals(perm_2));
+        perm_2.setDomain("test_2");
+        assertFalse(perm_1.equals(perm_2));
+        
+        perm_1.setDomain("test");
+        perm_2.setDomain("test");
+        
+        perm_1.setTargetScopeId(null);
+        assertFalse(perm_1.equals(perm_2));
+        perm_2.setTargetScopeId(null);
+        assertTrue(perm_1.equals(perm_2));
+        perm_1.setTargetScopeId(generateId(10));
+        assertFalse(perm_1.equals(perm_2));
+        perm_2.setTargetScopeId(generateId(15));
+        assertFalse(perm_1.equals(perm_2));
+        
+        perm_1.setTargetScopeId(generateId(10));
+        perm_2.setTargetScopeId(generateId(10));
+
+        perm_1.setGroupId(null);
+        assertFalse(perm_1.equals(perm_2));
+        perm_2.setGroupId(null);
+        assertTrue(perm_1.equals(perm_2));
+        perm_1.setGroupId(generateId(100));
+        assertFalse(perm_1.equals(perm_2));
+        perm_2.setGroupId(generateId(101));
+        assertFalse(perm_1.equals(perm_2));
+        perm_2.setGroupId(generateId(100));
+        assertTrue(perm_1.equals(perm_2));
+
+        perm_1.setAction(Actions.read);
+        perm_2.setAction(Actions.write);
+        assertFalse(perm_1.equals(perm_2));
+    }
+}

--- a/service/security/shiro/src/test/resources/features/AccessInfoService.feature
+++ b/service/security/shiro/src/test/resources/features/AccessInfoService.feature
@@ -232,3 +232,167 @@ Scenario: Query for all the access info entities of an invalid user
     When I query for the access info entities for the last user
     Then I get 0 as result
 
+Scenario: Create regular access permissions
+    It must be possible to create sets of regular permissions.
+
+    Given A scope with ID 10
+    And The permissions "read, write, execute"
+    And I create the permissions
+    Given A scope with ID 20
+    And The permissions "read, execute"
+    And I create the permissions
+    When I count the permissions in scope 10
+    Then I get 3 as result
+    When I count the permissions in scope 20
+    Then I get 2 as result
+
+Scenario: Find last created permision
+    It must be possible to find a specific permission entry based on its ID.
+
+    Given A scope with ID 10
+    And The permissions "read, write, execute"
+    And I create the permissions
+    When I search for the last created permission
+    Then I find an access permission entity
+
+Scenario: Delete an existing access permission entity
+    It must be possibel to delete a specific permission entry.
+    
+    Given A scope with ID 10
+    And The permissions "read, write, execute"
+    And I create the permissions
+    When I count the permissions in scope 10
+    Then I get 3 as result
+    When I delete the last created access permission
+    And I count the permissions in scope 10
+    Then I get 2 as result
+
+Scenario: Delete a non existing permission entity
+    Atttempting to delete a non existing permission entry must result in 
+    an exception. In this case this is achieved by deleting the same entry twice.
+
+    Given A scope with ID 10
+    And The permission "read"
+    And I create the permission
+    When I count the permissions in scope 10
+    Then I get 1 as result
+    When I delete the last created access permission
+    And I delete the last created access permission
+    Then An exception was thrown
+
+Scenario: Regular creation of Access Role entity
+    It must be possible to create a regular role entity in the dataabse.
+    
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    When I create the access info entity
+    Then No exception was thrown
+    Given The permissions "read, write, execute"
+    And The role "test_role_1"
+    When I create the access role
+    Then No exception was thrown
+    And An access role entity was created
+
+Scenario: Creation of access role without an acess info entity
+    The creation of an access role entity without an already existing access info 
+    entry is permitted.
+
+    Given A scope with ID 10
+    And The permissions "read, write, execute"
+    And The role "test_role_1"
+    When I create the access role
+    Then No exception was thrown
+
+Scenario: Creation of access role with neither acess info and role entities
+    The creation of an access role entity with neither access info nor role
+    entries is permitted. 
+
+Given A scope with ID 10
+When I create the access role
+Then No exception was thrown
+
+Scenario: Find an existing access role entity
+    It must be possible to find an existing access role entry in the database 
+    based on its ID.
+
+    Given A scope with ID 10
+    When I create the access role
+    When I search for the last created access role entity
+    Then I find an access role entity
+
+Scenario: Count access role entities by scope
+    It must be possible to count all the access role entries in specific scopes. If the 
+    requested scope doesn't contain a role or doesn't exist altogether, only an empty
+    result list must be returned. No exception must be thrown.
+
+    Given A scope with ID 10
+    And I create the access role
+    And I create the access role
+    And I create the access role
+    Given A scope with ID 20
+    And I create the access role
+    And I create the access role
+    Given A scope with ID 30
+    And I create the access role
+    When I count the access roles in scope 10
+    Then I get 3 as result
+    When I count the access roles in scope 20
+    Then I get 2 as result
+    When I count the access roles in scope 30
+    Then I get 1 as result
+    When I count the access roles in scope 42
+    Then I get 0 as result
+
+Scenario: Delete an existing access role entry
+    It must be possible to delete an existing access role entry from the database.
+
+    Given A scope with ID 10
+    And I create the access role
+    And I create the access role
+    And I create the access role
+    When I count the access roles in scope 10
+    Then I get 3 as result
+    When I delete the last created access role entry
+    And I count the access roles in scope 10
+    Then I get 2 as result
+
+Scenario: Delete an existing role twice
+    Attempting to delete a non existing access role entry must result in an exception. In 
+    this case this is achieved by trying to delete the same entry twice.
+
+    Given A scope with ID 10
+    And I create the access role
+    When I delete the last created access role entry
+    And I delete the last created access role entry
+    Then An exception was thrown
+
+Scenario: Access info service sanity checks
+    Check the sanity of the various access info related factories.
+
+    Then I check the sanity of the access info factory
+    Then I check the sanity of the access permission factory
+    Then I check the sanity of the access role factory
+
+Scenario: Access service comparison sanity checks
+    Check the correctnes of the various object comparison functions.
+
+    Then I can compare access role objects
+    Then I can compare access permission objects
+
+Scenario: Create with permissions and a role in the wrong scope
+    Such a scenario should cause an exception to bo thrown. The keyword is 'should'.
+    In the current implementation RoleDAO.find will succcessfully find the role 
+    entity even if it was created in a different scope than the access info entity.
+
+    Given A scope with ID 10
+    And A user such as
+        | name     | displayName     | email              | phoneNumber     |
+        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    And The permissions "read, write, execute"
+    Given A scope with ID 20
+    And The role "test_role_1"
+    Given A scope with ID 10
+    When I create the access info entity
+    #Then An exception was thrown

--- a/service/security/shiro/src/test/resources/features/MiscAuthorization.feature
+++ b/service/security/shiro/src/test/resources/features/MiscAuthorization.feature
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+Feature: Misc Authorization functionality CRUD tests
+
+Scenario: Permission factory sanity checks
+	Then The permission factory returns sane results
+	Then I can compare permission objects


### PR DESCRIPTION
## Additional CRUD tests for the Shiro Access Info service
This additional set of Access Info tests exercises the majority of the main Access Info service (package org.eclipse.kapua.service.authorization.access.shiro).
**Note**: The existing jUnit tests are still enabled since they do not conflict with the cucumber based implementations. They will be gradually removed as more cucumber based tests are implemented.

### Changes to Maven pom files
There is no change to the package pom files.

### Implementation changes
The implementation of the Shiro Access Info service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented to test CRUD operations on the Shiro Access Info service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>