### PR TITLE
Adding Jackson as a direct dependency in REST APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <validation-api.version>1.1.0.Final</validation-api.version>
         <cucumber.version>1.2.4</cucumber.version>
         <elasticsearch.version>2.3.4</elasticsearch.version>
-
+        <jackson.version>2.8.6</jackson.version>
         <!-- Plugins versions -->
         <checkstyle-maven-plugin.version>2.17</checkstyle-maven-plugin.version>
         <checkstyle.version>7.6.1</checkstyle.version>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -83,6 +83,20 @@
 			<version>${shiro.version}</version>
 		</dependency>
 
+        <!-- Jackson -->
+        <!-- Needed to specify 2.8.x version, otherwise Datastore would 
+             bring in 2.6.x that is not compatible with Jersey 1.5.12 -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
 		<!-- -->
         <!-- Same version of the Servlet APIs supported in Apache Tomcat 
             8.0.x -->


### PR DESCRIPTION
Hi all,

This PR declares a direct dependency from the REST APIs to Jackson 2.8.6, needed to avoid conflicts with other Jackson versions coming from other projects.

Cheers!