### PR TITLE
Fix UserService settings database seeding

### DIFF
--- a/service/user/internal/src/main/resources/liquibase/user.sql
+++ b/service/user/internal/src/main/resources/liquibase/user.sql
@@ -78,7 +78,7 @@ INSERT INTO sys_configuration (
   PROPERTIES)
 VALUES (1,
         2,
-        'org.eclipse.kapua.service.account.UserService',
+        'org.eclipse.kapua.service.user.UserService',
         CONCAT('#', CURRENT_TIMESTAMP(), CHAR(13), CHAR(10),
         'maxNumberChildEntities=0', CHAR(13), CHAR(10),
         'infiniteChildEntities=true'),


### PR DESCRIPTION
Hi all,

This PR fixes the System Configuration Database Seeding for UserService, that caused the initial configuration for such service to be incorrect and thus not applied.

Cheers!