### PR TITLE
Replaced X-Access-Token header with Authorization in CORS filter

### DIFF
--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/CORSResponseFilter.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/CORSResponseFilter.java
@@ -25,6 +25,6 @@ public class CORSResponseFilter implements ContainerResponseFilter {
         MultivaluedMap<String, Object> headers = responseContext.getHeaders();
         headers.add("Access-Control-Allow-Origin", "*");
         headers.add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
-        headers.add("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, X-Access-Token");
+        headers.add("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, Authorization");
     }
 }


### PR DESCRIPTION
Hi all,

This PR replaces the `X-Access-Token` HTTP header with the `Authorization` header in the `Access-Control-Allow-Headers` REST API CORS filter.

Fixes #525 