### PR TITLE
User service integration tests: Introduced a generic step data storage

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/qa/steps/BasicSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/qa/steps/BasicSteps.java
@@ -13,19 +13,34 @@ package org.eclipse.kapua.qa.steps;
 
 import static java.time.Duration.ofSeconds;
 
+import org.eclipse.kapua.service.StepData;
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.inject.Inject;
+
 import cucumber.api.java.Before;
+import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
 
 @ScenarioScoped
-public class BasicSteps {
+public class BasicSteps extends Assert {
 
     private static final Logger logger = LoggerFactory.getLogger(BasicSteps.class);
 
     private static final double WAIT_MULTIPLIER = Double.parseDouble(System.getProperty("org.eclipse.kapua.qa.waitMultiplier", "1.0"));
+
+    /**
+     * Scenario scoped step data.
+     */
+    private StepData stepData;
+
+    @Inject
+    public BasicSteps(StepData stepData) {
+        this.stepData = stepData;
+    }
 
     @Before
     public void checkWaitMultipier() {
@@ -40,4 +55,23 @@ public class BasicSteps {
         Thread.sleep(ofSeconds((long) Math.ceil(effectiveSeconds)).toMillis());
     }
 
+    @Then("^An exception was thrown$")
+    public void exceptionCaught() {
+        assertTrue((boolean) stepData.get("ExceptionCaught"));
+    }
+
+    @Then("^No exception was thrown$")
+    public void noExceptionCaught() {
+        assertFalse((boolean) stepData.get("ExceptionCaught"));
+    }
+
+    @Then("^I get (\\d+)$")
+    public void checkCountResult(int num) {
+        assertEquals(num, (int) stepData.get("Count"));
+    }
+
+    @Then("^I get the text \"(.+)\"$")
+    public void checkStringResult(String text) {
+        assertEquals(text, (String) stepData.get("Text"));
+    }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/StepData.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/StepData.java
@@ -35,6 +35,10 @@ public class StepData {
         stepDataMap = new HashMap<>();
     }
 
+    public void clear() {
+        stepDataMap.clear();
+    }
+
     public void put(String key, Object value) {
         stepDataMap.put(key, value);
     }

--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceBrokerI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceBrokerI9nTest.java
@@ -19,12 +19,16 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = "classpath:features/broker",
+        features = {"classpath:features/broker"
+                   },
         glue = {"org.eclipse.kapua.qa.steps",
                 "org.eclipse.kapua.service.user.steps",
-                "org.eclipse.kapua.service.device.steps"},
-        plugin = {"pretty", "html:target/cucumber/DeviceBrokerI9n",
-                "json:target/DeviceBrokerI9n_cucumber.json"},
-        monochrome = true)
-public class RunDeviceBrokerI9nTest {
-}
+                "org.eclipse.kapua.service.device.steps"
+               },
+        plugin = {"pretty", 
+                  "html:target/cucumber/DeviceBrokerI9n",
+                  "json:target/DeviceBrokerI9n_cucumber.json"
+                 },
+        monochrome = true )
+
+public class RunDeviceBrokerI9nTest {}

--- a/qa/src/test/java/org/eclipse/kapua/service/user/integration/RunUserServiceI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/integration/RunUserServiceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,10 +20,13 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(
         features = "classpath:features/user",
-        glue = {
-                "org.eclipse.kapua.qa.steps",
-                "org.eclipse.kapua.service.user.steps" },
-        plugin = {"pretty", "html:target/cucumber/UserServiceI9n",
-                  "json:target/UserServiceI9n_cucumber.json"},
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps"
+               },
+        plugin = {"pretty", 
+                  "html:target/cucumber/UserServiceI9n",
+                  "json:target/UserServiceI9n_cucumber.json"
+                 },
         monochrome=true)
-public class RunUserServiceI9nTest { }
+
+public class RunUserServiceI9nTest {}

--- a/qa/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/src/test/resources/features/user/UserServiceI9n.feature
@@ -53,6 +53,9 @@ Feature: User Service Integration
       | user   | read   |
       | user   | write  |
       | user   | delete |
+    And A generic user
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-g | Kapua User G | kapua_g@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
     And Account
       | name      |
       | account-b |
@@ -77,8 +80,10 @@ Feature: User Service Integration
       | user   | delete |
     And I logout
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    When I try to delete user "kapua-g"
+    Then No exception was thrown
     When I try to delete user "kapua-b"
-    Then I get KapuaException
+    Then An exception was thrown
     And I logout
 
   Scenario: Deleting user in account that is higher in hierarchy
@@ -145,5 +150,5 @@ Feature: User Service Integration
     And I logout
     When I login as user with name "kapua-b" and password "ToManySecrets123#"
     When I try to delete user "kapua-a"
-    Then I get KapuaException
+    Then An exception was thrown
     And I logout


### PR DESCRIPTION
## User service integration tests
A small refactor of existing User service integration tests.
These tests originally used a custom object to store step data. This was migrated to a single hashmap that stores the step data for all the involved services. This should simplify the exchange of step data between all the services used in the tests.

### Test changes
The User service tests were modified to use the common StepData singleton.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>