### PR TITLE
Fix/datastore index not found exception

### DIFF
--- a/console/src/main/java/org/eclipse/kapua/app/console/client/KapuaCloudConsole.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/client/KapuaCloudConsole.java
@@ -91,7 +91,6 @@ public class KapuaCloudConsole implements EntryPoint {
          * Install an UncaughtExceptionHandler which will produce <code>FATAL</code> log messages
          */
         Log.setUncaughtExceptionHandler();
-        System.out.println("---->");
 
         // Use deferred command to catch initialization exceptions in onModuleLoad2
         Scheduler.get().scheduleDeferred(new ScheduledCommand() {
@@ -189,7 +188,6 @@ public class KapuaCloudConsole implements EntryPoint {
         td.setHorizontalAlign(HorizontalAlignment.LEFT);
         TableData tdVersion = new TableData();
         tdVersion.setHorizontalAlign(HorizontalAlignment.RIGHT);
-
 
         Label copyright = new Label(MSGS.copyright(Integer.toString(Years.getCurrentYear())));
         copyright.setStyleName("x-form-label");

--- a/console/src/main/java/org/eclipse/kapua/app/console/client/data/TopicsTable.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/client/data/TopicsTable.java
@@ -36,7 +36,6 @@ import com.extjs.gxt.ui.client.widget.treegrid.TreeGrid;
 import com.extjs.gxt.ui.client.widget.treegrid.TreeGridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public class TopicsTable extends LayoutContainer {
@@ -103,18 +102,17 @@ public class TopicsTable extends LayoutContainer {
 
         store = new TreeStore<GwtTopic>();
         AsyncCallback<List<GwtTopic>> topicsCallback = new AsyncCallback<List<GwtTopic>>() {
-            
+
             @Override
             public void onSuccess(List<GwtTopic> topics) {
                 store.add(topics, true);
                 topicInfoGrid.unmask();
             }
-            
+
             @Override
             public void onFailure(Throwable t) {
                 FailureHandler.handle(t);
                 topicInfoGrid.unmask();
-                Window.alert(MSGS.noDataMessage());
             }
         };
         dataService.findTopicsTree(currentSession.getSelectedAccount().getId(), topicsCallback);
@@ -130,9 +128,9 @@ public class TopicsTable extends LayoutContainer {
 
         GridSelectionModel<GwtTopic> selectionModel = new GridSelectionModel<GwtTopic>();
         selectionModel.setSelectionMode(SelectionMode.SINGLE);
-        for(SelectionChangedListener<GwtTopic> listener : listeners){
+        for (SelectionChangedListener<GwtTopic> listener : listeners) {
             selectionModel.addSelectionChangedListener(listener);
-         }
+        }
         topicInfoGrid.setSelectionModel(selectionModel);
     }
 


### PR DESCRIPTION
Hi all,

this fixes the throwing of `IndexNotFoundException` by Elasticsearch when querying a index that doesn't exist (when no data has been published yet into an account).

Regards, 

_Alberto_