### PR TITLE
Device registry CRUD integration tests; First batch

### DIFF
--- a/dev-tools/cucumber-reports/src/main/resources/html/cucumber/index.html
+++ b/dev-tools/cucumber-reports/src/main/resources/html/cucumber/index.html
@@ -67,6 +67,7 @@
                   </p>
                   <ul>
                     <li><a href="user-service-i9n/index.html">User service</a></li>
+                    <li><a href="device-service-i9n/index.html">Device service</a></li>
                     <li><a href="device-broker-i9n/index.html">Device registration with active MQTT broker</a></li>
                     <!--li>Other service</li-->
                   </ul>

--- a/docker/api/src/main/descriptors/kapua-cucumber-report.xml
+++ b/docker/api/src/main/descriptors/kapua-cucumber-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -50,10 +50,15 @@
             <outputDirectory>/authorization-service</outputDirectory>
             <directory>../service/security/shiro/target/cucumber</directory>
         </fileSet>
-        
+
         <fileSet>
             <outputDirectory>/user-service-i9n</outputDirectory>
             <directory>../qa/target/cucumber/UserServiceI9n</directory>
+        </fileSet>
+
+         <fileSet>
+            <outputDirectory>/device-service-i9n</outputDirectory>
+            <directory>../qa/target/cucumber/DeviceServiceI9n</directory>
         </fileSet>
 
         <fileSet>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
    
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -41,6 +41,10 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-user-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-api</artifactId>
         </dependency>
 
         <!-- Internal dependencies -->

--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceI9nTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.integration;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = {"classpath:features/device"
+                   },
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps"
+               },
+        plugin = {"pretty", 
+                  "html:target/cucumber/DeviceI9n",
+                  "json:target/DeviceI9n_cucumber.json"
+                 },
+        monochrome = true )
+
+public class RunDeviceI9nTest {}

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/CucDevice.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/CucDevice.java
@@ -1,0 +1,272 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.steps;
+
+import java.math.BigInteger;
+
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.device.registry.DeviceCredentialsMode;
+import org.eclipse.kapua.service.device.registry.DeviceStatus;
+
+/**
+ * Data object used in Gherkin to input Device parameters.
+ * The data setters intentionally use only cucumber-friendly data types and
+ * generate the resulting Kapua types internally.
+ */
+public class CucDevice {
+
+    Integer scopeId = null;
+    KapuaId kScopeId = null;
+    Integer groupId = null;
+    KapuaId kGroupId = null;
+    Integer connectionId = null;
+    KapuaId kConnectionId = null;
+    Integer preferredUserId = null;
+    KapuaId kPreferredUserId = null;
+    String clientId = null;
+    String displayName = null;
+    String status = null;
+    DeviceStatus kStatus = null;
+    String modelId = null;
+    String serialNumber = null;
+    String imei = null;
+    String imsi = null;
+    String iccid = null;
+    String biosVersion = null;
+    String firmwareVersion = null;
+    String osVersion = null;
+    String jvmVersion = null;
+    String osgiFrameworkVersion = null;
+    String applicationFrameworkVersion = null;
+    String applicationIdentifiers = null;
+    String acceptEncoding = null;
+    String credentialsMode = null;
+    DeviceCredentialsMode kCredentialsMode = null;
+
+    public void parse() {
+        if (scopeId != null) {
+            kScopeId = new KapuaEid(BigInteger.valueOf(scopeId));
+        }
+
+        if (groupId != null) {
+            kGroupId = new KapuaEid(BigInteger.valueOf(groupId));
+        }
+
+        if (connectionId != null) {
+            kConnectionId = new KapuaEid(BigInteger.valueOf(connectionId));
+        }
+
+        if (preferredUserId != null) {
+            kPreferredUserId = new KapuaEid(BigInteger.valueOf(preferredUserId));
+        }
+
+        if (status != null) {
+            switch (status.trim().toUpperCase()) {
+            case "DISABLED":
+                kStatus = DeviceStatus.DISABLED;
+                break;
+            case "ENABLED":
+                kStatus = DeviceStatus.ENABLED;
+                break;
+            default:
+                kStatus = null;
+                break;
+            }
+        }
+
+        if (credentialsMode != null) {
+            switch (credentialsMode.trim().toUpperCase()) {
+            case "INHERITED":
+                kCredentialsMode = DeviceCredentialsMode.INHERITED;
+                break;
+            case "LOOSE":
+                kCredentialsMode = DeviceCredentialsMode.LOOSE;
+                break;
+            case "STRICT":
+                kCredentialsMode = DeviceCredentialsMode.STRICT;
+                break;
+            default:
+                kCredentialsMode = null;
+                break;
+            }
+        }
+    }
+
+    public KapuaId getScopeId() {
+        return kScopeId;
+    }
+
+    public void setScopeId(KapuaId scopeId) {
+        kScopeId = scopeId;
+    }
+
+    public KapuaId getGroupId() {
+        return kGroupId;
+    }
+
+    public void setGroupId(KapuaId groupId) {
+        kGroupId = groupId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public KapuaId getConnectionId() {
+        return kConnectionId;
+    }
+
+    public void setConnectionId(KapuaId connectionId) {
+        kConnectionId = connectionId;
+    }
+
+    public KapuaId getPreferredUserId() {
+        return kPreferredUserId;
+    }
+
+    public void setPreferredUserId(KapuaId preferredUserId) {
+        kPreferredUserId = preferredUserId;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public DeviceStatus getStatus() {
+        return kStatus;
+    }
+
+    public void setStatus(DeviceStatus status) {
+        this.kStatus = status;
+    }
+
+    public String getModelId() {
+        return modelId;
+    }
+
+    public void setModelId(String modelId) {
+        this.modelId = modelId;
+    }
+
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+    public String getImei() {
+        return imei;
+    }
+
+    public void setImei(String imei) {
+        this.imei = imei;
+    }
+
+    public String getImsi() {
+        return imsi;
+    }
+
+    public void setImsi(String imsi) {
+        this.imsi = imsi;
+    }
+
+    public String getIccid() {
+        return iccid;
+    }
+
+    public void setIccid(String iccid) {
+        this.iccid = iccid;
+    }
+
+    public String getBiosVersion() {
+        return biosVersion;
+    }
+
+    public void setBiosVersion(String biosVersion) {
+        this.biosVersion = biosVersion;
+    }
+
+    public String getFirmwareVersion() {
+        return firmwareVersion;
+    }
+
+    public void setFirmwareVersion(String firmwareVersion) {
+        this.firmwareVersion = firmwareVersion;
+    }
+
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    public void setOsVersion(String osVersion) {
+        this.osVersion = osVersion;
+    }
+
+    public String getJvmVersion() {
+        return jvmVersion;
+    }
+
+    public void setJvmVersion(String jvmVersion) {
+        this.jvmVersion = jvmVersion;
+    }
+
+    public String getOsgiFrameworkVersion() {
+        return osgiFrameworkVersion;
+    }
+
+    public void setOsgiFrameworkVersion(String osgiFrameworkVersion) {
+        this.osgiFrameworkVersion = osgiFrameworkVersion;
+    }
+
+    public String getApplicationFrameworkVersion() {
+        return applicationFrameworkVersion;
+    }
+
+    public void setApplicationFrameworkVersion(String applicationFrameworkVersion) {
+        this.applicationFrameworkVersion = applicationFrameworkVersion;
+    }
+
+    public String getApplicationIdentifiers() {
+        return applicationIdentifiers;
+    }
+
+    public void setApplicationIdentifiers(String applicationIdentifiers) {
+        this.applicationIdentifiers = applicationIdentifiers;
+    }
+
+    public String getAcceptEncoding() {
+        return acceptEncoding;
+    }
+
+    public void setAcceptEncoding(String acceptEncoding) {
+        this.acceptEncoding = acceptEncoding;
+    }
+
+    public DeviceCredentialsMode getCredentialsMode() {
+        return kCredentialsMode;
+    }
+
+    public void setCredentialsMode(DeviceCredentialsMode credentialsMode) {
+        kCredentialsMode = credentialsMode;
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/CucDevice.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/CucDevice.java
@@ -25,33 +25,33 @@ import org.eclipse.kapua.service.device.registry.DeviceStatus;
  */
 public class CucDevice {
 
-    Integer scopeId = null;
-    KapuaId kScopeId = null;
-    Integer groupId = null;
-    KapuaId kGroupId = null;
-    Integer connectionId = null;
-    KapuaId kConnectionId = null;
-    Integer preferredUserId = null;
-    KapuaId kPreferredUserId = null;
-    String clientId = null;
-    String displayName = null;
-    String status = null;
-    DeviceStatus kStatus = null;
-    String modelId = null;
-    String serialNumber = null;
-    String imei = null;
-    String imsi = null;
-    String iccid = null;
-    String biosVersion = null;
-    String firmwareVersion = null;
-    String osVersion = null;
-    String jvmVersion = null;
-    String osgiFrameworkVersion = null;
-    String applicationFrameworkVersion = null;
-    String applicationIdentifiers = null;
-    String acceptEncoding = null;
-    String credentialsMode = null;
-    DeviceCredentialsMode kCredentialsMode = null;
+    Integer scopeId;
+    KapuaId kScopeId;
+    Integer groupId;
+    KapuaId kGroupId;
+    Integer connectionId;
+    KapuaId kConnectionId;
+    Integer preferredUserId;
+    KapuaId kPreferredUserId;
+    String clientId;
+    String displayName;
+    String status;
+    DeviceStatus kStatus;
+    String modelId;
+    String serialNumber;
+    String imei;
+    String imsi;
+    String iccid;
+    String biosVersion;
+    String firmwareVersion;
+    String osVersion;
+    String jvmVersion;
+    String osgiFrameworkVersion;
+    String applicationFrameworkVersion;
+    String applicationIdentifiers;
+    String acceptEncoding;
+    String credentialsMode;
+    DeviceCredentialsMode kCredentialsMode;
 
     public void parse() {
         if (scopeId != null) {

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
@@ -1,0 +1,433 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.steps;
+
+import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsEqualTo;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Vector;
+
+import javax.inject.Inject;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.model.query.FieldSortCriteria;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.lifecycle.KapuaBirthChannel;
+import org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage;
+import org.eclipse.kapua.message.device.lifecycle.KapuaBirthPayload;
+import org.eclipse.kapua.message.internal.KapuaPositionImpl;
+import org.eclipse.kapua.message.internal.device.lifecycle.KapuaBirthChannelImpl;
+import org.eclipse.kapua.message.internal.device.lifecycle.KapuaBirthMessageImpl;
+import org.eclipse.kapua.message.internal.device.lifecycle.KapuaBirthPayloadImpl;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.steps.DBHelper;
+import org.eclipse.kapua.service.StepData;
+import org.eclipse.kapua.service.TestJAXBContextProvider;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceCreator;
+import org.eclipse.kapua.service.device.registry.DeviceCredentialsMode;
+import org.eclipse.kapua.service.device.registry.DeviceFactory;
+import org.eclipse.kapua.service.device.registry.DeviceListResult;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.device.registry.DeviceStatus;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventQuery;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventListResultImpl;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventQueryImpl;
+import org.eclipse.kapua.service.device.registry.internal.DeviceListResultImpl;
+import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService;
+import org.eclipse.kapua.service.user.steps.TestConfig;
+import org.eclipse.kapua.test.KapuaTest;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+
+// Implementation of Gherkin steps used in DeviceRegistryI9n.feature scenarios.
+@ScenarioScoped
+public class DeviceServiceSteps extends KapuaTest {
+
+    // Device registry services
+    private DeviceRegistryService deviceRegistryService = null;
+    private DeviceEventService deviceEventsService = null;
+    private DeviceLifeCycleService deviceLifeCycleService = null;
+
+    // Scenario scoped Device Registry test data
+    StepData stepData = null;
+
+    // Single point to database access.
+    private DBHelper dbHelper = null;
+
+    @Inject
+    public DeviceServiceSteps(StepData stepData, DBHelper dbHelper) {
+        this.dbHelper = dbHelper;
+        this.stepData = stepData;
+    }
+
+    // Database setup and tear-down steps
+    @Before
+    public void beforeScenario(Scenario scenario) throws KapuaException {
+
+        // Find all the required services with the default Locator
+        KapuaLocator locator = KapuaLocator.getInstance();
+        deviceRegistryService = locator.getService(DeviceRegistryService.class);
+        deviceEventsService = locator.getService(DeviceEventService.class);
+        deviceLifeCycleService = locator.getService(DeviceLifeCycleService.class);
+
+        // Initialize the database
+        dbHelper.setup();
+
+        XmlUtil.setContextProvider(new TestJAXBContextProvider());
+    }
+
+    @After
+    public void afterScenario() throws Exception {
+
+        // Clean up the database
+        dbHelper.deleteAll();
+        KapuaSecurityUtils.clearSession();
+    }
+
+    // Cucumber test steps
+
+    @Given("^A birth message from device \"(.+)\"$")
+    public void createABirthMessage(String clientId)
+            throws KapuaException {
+
+        Account tmpAccount = (Account) stepData.get("LastAccount");
+
+        assertNotNull(clientId);
+        assertFalse(clientId.isEmpty());
+        assertNotNull(tmpAccount);
+        assertNotNull(tmpAccount.getId());
+
+        Device tmpDev = null;
+        List<String> tmpSemParts = new ArrayList<>();
+        KapuaBirthMessage tmpMsg = new KapuaBirthMessageImpl();
+        KapuaBirthChannel tmpChan = new KapuaBirthChannelImpl();
+        KapuaBirthPayload tmpPayload = prepareDefaultBirthPayload();
+
+        tmpChan.setClientId(clientId);
+        tmpSemParts.add("part1");
+        tmpSemParts.add("part2");
+        tmpChan.setSemanticParts(tmpSemParts);
+
+        tmpMsg.setChannel(tmpChan);
+        tmpMsg.setPayload(tmpPayload);
+        tmpMsg.setScopeId(tmpAccount.getId());
+        tmpMsg.setClientId(clientId);
+        tmpMsg.setId(UUID.randomUUID());
+        tmpMsg.setReceivedOn(new Date());
+        tmpMsg.setPosition(getDefaultPosition());
+
+        tmpDev = deviceRegistryService.findByClientId(tmpAccount.getId(), clientId);
+        if (tmpDev != null) {
+            tmpMsg.setDeviceId(tmpDev.getId());
+        } else {
+            tmpMsg.setDeviceId(null);
+        }
+
+        deviceLifeCycleService.birth(generateRandomId(), tmpMsg);
+    }
+
+    @When("^I configure the device service$")
+    public void setDeviceServiceConfig(List<TestConfig> testConfigs)
+            throws KapuaException {
+
+        Account tmpAccount = (Account) stepData.get("LastAccount");
+        Map<String, Object> valueMap = new HashMap<>();
+
+        for (TestConfig config : testConfigs) {
+            config.addConfigToMap(valueMap);
+        }
+        try {
+            stepData.put("ExceptionCaught", false);
+            deviceRegistryService.setConfigValues(tmpAccount.getId(), tmpAccount.getScopeId(), valueMap);
+        } catch (KapuaException ex) {
+            stepData.put("ExceptionCaught", true);
+        }
+    }
+
+    @Given("^A device such as$")
+    public void createADeviceAsSpecified(List<CucDevice> devLst)
+            throws KapuaException {
+
+        assertNotNull(devLst);
+        assertEquals(1, devLst.size());
+
+        CucDevice tmpCDev = devLst.get(0);
+        tmpCDev.parse();
+        DeviceCreator devCr = prepareDeviceCreatorFromCucDevice(tmpCDev);
+
+        stepData.put("LastDevice", deviceRegistryService.create(devCr));
+    }
+
+    @When("^I search for the device \"(.+)\" in account \"(.+)\"$")
+    public void searchForDeviceWithClientID(String clientId, String Account)
+            throws KapuaException {
+
+        Account tmpAcc = null;
+        Device tmpDev = null;
+        DeviceListResult tmpList = new DeviceListResultImpl();
+
+        tmpAcc = KapuaLocator.getInstance().getService(AccountService.class).findByName(Account);
+        assertNotNull(tmpAcc);
+        assertNotNull(tmpAcc.getId());
+
+        tmpDev = deviceRegistryService.findByClientId(tmpAcc.getId(), clientId);
+        if (tmpDev != null) {
+            Vector<Device> dv = new Vector<>();
+            dv.add(tmpDev);
+            tmpList.addItems(dv);
+            stepData.put("Device", tmpDev);
+            stepData.put("DeviceList", tmpList);
+        }
+    }
+
+    @When("^I search for events from device \"(.+)\" in account \"(.+)\"$")
+    public void searchForEventsFromDeviceWithClientID(String clientId, String Account)
+            throws KapuaException {
+
+        DeviceEventQuery tmpQuery = null;
+        Device tmpDev = null;
+        DeviceEventListResult tmpList = null;
+        Account tmpAcc = null;
+
+        tmpAcc = KapuaLocator.getInstance().getService(AccountService.class).findByName(Account);
+        assertNotNull(tmpAcc);
+        assertNotNull(tmpAcc.getId());
+
+        tmpDev = deviceRegistryService.findByClientId(tmpAcc.getId(), clientId);
+        assertNotNull(tmpDev);
+        assertNotNull(tmpDev.getId());
+
+        tmpQuery = new DeviceEventQueryImpl(tmpAcc.getId());
+        tmpQuery.setPredicate(attributeIsEqualTo("deviceId", tmpDev.getId()));
+        tmpQuery.setSortCriteria(new FieldSortCriteria("receivedOn", FieldSortCriteria.SortOrder.ASCENDING));
+        tmpList = deviceEventsService.query(tmpQuery);
+        assertNotNull(tmpList);
+        stepData.put("DeviceEventList", tmpList);
+    }
+
+    @Then("^I find (\\d+) events?$")
+    public void checkEventListLength(int cnt) {
+        assertNotNull(stepData.get("DeviceEventList"));
+        assertEquals(cnt, ((DeviceEventListResultImpl) stepData.get("DeviceEventList")).getSize());
+    }
+
+    @Then("^I find (\\d+) devices?$")
+    public void checkDeviceListLength(int cnt) {
+        assertNotNull(stepData.get("DeviceList"));
+        assertEquals(cnt, ((DeviceListResultImpl) stepData.get("DeviceList")).getSize());
+    }
+
+    @Then("^The type of the last event is \"(.+)\"$")
+    public void checkLastEventType(String type) {
+        DeviceEventListResult tmpList = null;
+
+        assertNotNull(stepData.get("DeviceEventList"));
+        assertNotEquals(0, ((DeviceEventListResultImpl) stepData.get("DeviceEventList")).getSize());
+        tmpList = (DeviceEventListResultImpl) stepData.get("DeviceEventList");
+        assertEquals(type.trim().toUpperCase(), tmpList.getItem(tmpList.getSize() - 1).getResource().trim().toUpperCase());
+
+    }
+
+    // *******************
+    // * Private Helpers *
+    // *******************
+
+    private KapuaPosition getDefaultPosition() {
+        KapuaPosition tmpPos = new KapuaPositionImpl();
+
+        tmpPos.setAltitude(250.0);
+        tmpPos.setHeading(90.0);
+        tmpPos.setLatitude(45.5);
+        tmpPos.setLongitude(13.6);
+        tmpPos.setPrecision(0.3);
+        tmpPos.setSatellites(12);
+        tmpPos.setSpeed(120.0);
+        tmpPos.setStatus(2);
+        tmpPos.setTimestamp(new Date());
+
+        return tmpPos;
+    }
+
+    private KapuaBirthPayload prepareDefaultBirthPayload() {
+        KapuaBirthPayload tmpPayload = new KapuaBirthPayloadImpl(
+                "500", // uptime
+                "ReliaGate 10-20", // displayName
+                "ReliaGate", // modelName
+                "ReliaGate 10-20", // modelId
+                "ABC123456", // partNumber
+                "12312312312", // serialNumber
+                "Kura", // firmware
+                "2.0", // firmwareVersion
+                "BIOStm", // bios
+                "1.2.3", // biosVersion
+                "linux", // os
+                "4.9.18", // osVersion
+                "J9", // jvm
+                "2.4", // jvmVersion
+                "J8SE", // jvmProfile
+                "OSGi", // containerFramework
+                "1.2.3", // containerFrameworkVersion
+                "Kura", // applicationFramework
+                "2.0", // applicationFrameworkVersion
+                "eth0", // connectionInterface
+                "192.168.1.2", // connectionIp
+                "gzip", // acceptEncoding
+                "CLOUD-V1", // applicationIdentifiers
+                "1", // availableProcessors
+                "1024", // totalMemory
+                "linux", // osArch
+                "123456789ABCDEF", // modemImei
+                "123456789", // modemImsi
+                "ABCDEF" // modemIccid
+        );
+
+        return tmpPayload;
+    }
+
+    private DeviceCreator prepareDeviceCreatorFromCucDevice(CucDevice dev) {
+        Account tmpAccount = (Account) stepData.get("LastAccount");
+        DeviceCreator tmpCr = null;
+        KapuaId tmpScope = null;
+
+        if (dev.scopeId != null) {
+            tmpScope = dev.getScopeId();
+        } else {
+            assertNotNull(tmpAccount);
+            assertNotNull(tmpAccount.getId());
+            tmpScope = tmpAccount.getId();
+        }
+
+        assertNotNull(dev.clientId);
+        assertNotEquals(0, dev.clientId.length());
+
+        tmpCr = prepareDefaultDeviceCreator(tmpScope, dev.clientId);
+
+        if (dev.groupId != null) {
+            tmpCr.setGroupId(dev.getGroupId());
+        }
+        if (dev.connectionId != null) {
+            tmpCr.setConnectionId(dev.getConnectionId());
+        }
+        if (dev.preferredUserId != null) {
+            tmpCr.setPreferredUserId(dev.getPreferredUserId());
+        }
+        if (dev.displayName != null) {
+            tmpCr.setDisplayName(dev.displayName);
+        }
+        if (dev.status != null) {
+            tmpCr.setStatus(dev.getStatus());
+        }
+        if (dev.modelId != null) {
+            tmpCr.setModelId(dev.modelId);
+        }
+        if (dev.serialNumber != null) {
+            tmpCr.setSerialNumber(dev.serialNumber);
+        }
+        if (dev.imei != null) {
+            tmpCr.setImei(dev.imei);
+        }
+        if (dev.imsi != null) {
+            tmpCr.setImsi(dev.imsi);
+        }
+        if (dev.iccid != null) {
+            tmpCr.setIccid(dev.iccid);
+        }
+        if (dev.biosVersion != null) {
+            tmpCr.setBiosVersion(dev.biosVersion);
+        }
+        if (dev.firmwareVersion != null) {
+            tmpCr.setFirmwareVersion(dev.firmwareVersion);
+        }
+        if (dev.osVersion != null) {
+            tmpCr.setOsVersion(dev.osVersion);
+        }
+        if (dev.jvmVersion != null) {
+            tmpCr.setJvmVersion(dev.jvmVersion);
+        }
+        if (dev.osgiFrameworkVersion != null) {
+            tmpCr.setOsgiFrameworkVersion(dev.osgiFrameworkVersion);
+        }
+        if (dev.applicationFrameworkVersion != null) {
+            tmpCr.setApplicationFrameworkVersion(dev.applicationFrameworkVersion);
+        }
+        if (dev.applicationIdentifiers != null) {
+            tmpCr.setApplicationIdentifiers(dev.applicationIdentifiers);
+        }
+        if (dev.acceptEncoding != null) {
+            tmpCr.setAcceptEncoding(dev.acceptEncoding);
+        }
+        if (dev.credentialsMode != null) {
+            tmpCr.setCredentialsMode(dev.getCredentialsMode());
+        }
+
+        return tmpCr;
+    }
+
+    private DeviceCreator prepareDefaultDeviceCreator(KapuaId scopeId, String clientId) {
+        DeviceCreator tmpCr = null;
+
+        tmpCr = KapuaLocator.getInstance().getFactory(DeviceFactory.class).newCreator(
+                scopeId,
+                clientId);
+
+        tmpCr.setConnectionId(generateRandomId());
+        tmpCr.setDisplayName("display_name");
+        tmpCr.setSerialNumber("serialNumber");
+        tmpCr.setModelId("modelId");
+        tmpCr.setImei(String.valueOf(random.nextInt()));
+        tmpCr.setImsi(String.valueOf(random.nextInt()));
+        tmpCr.setIccid(String.valueOf(random.nextInt()));
+        tmpCr.setBiosVersion("biosVersion");
+        tmpCr.setFirmwareVersion("firmwareVersion");
+        tmpCr.setOsVersion("osVersion");
+        tmpCr.setJvmVersion("jvmVersion");
+        tmpCr.setOsgiFrameworkVersion("osgiFrameworkVersion");
+        tmpCr.setApplicationFrameworkVersion("kapuaVersion");
+        tmpCr.setApplicationIdentifiers("applicationIdentifiers");
+        tmpCr.setAcceptEncoding("acceptEncoding");
+        tmpCr.setCustomAttribute1("customAttribute1");
+        tmpCr.setCustomAttribute2("customAttribute2");
+        tmpCr.setCustomAttribute3("customAttribute3");
+        tmpCr.setCustomAttribute4("customAttribute4");
+        tmpCr.setCustomAttribute5("customAttribute5");
+        tmpCr.setCredentialsMode(DeviceCredentialsMode.LOOSE);
+        tmpCr.setPreferredUserId(generateRandomId());
+        tmpCr.setStatus(DeviceStatus.ENABLED);
+
+        return tmpCr;
+    }
+
+    private KapuaId generateRandomId() {
+        return new KapuaEid(BigInteger.valueOf(random.nextLong()));
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
@@ -74,15 +74,15 @@ import cucumber.runtime.java.guice.ScenarioScoped;
 public class DeviceServiceSteps extends KapuaTest {
 
     // Device registry services
-    private DeviceRegistryService deviceRegistryService = null;
-    private DeviceEventService deviceEventsService = null;
-    private DeviceLifeCycleService deviceLifeCycleService = null;
+    private DeviceRegistryService deviceRegistryService;
+    private DeviceEventService deviceEventsService;
+    private DeviceLifeCycleService deviceLifeCycleService;
 
     // Scenario scoped Device Registry test data
-    StepData stepData = null;
+    StepData stepData;
 
     // Single point to database access.
-    private DBHelper dbHelper = null;
+    private DBHelper dbHelper;
 
     @Inject
     public DeviceServiceSteps(StepData stepData, DBHelper dbHelper) {

--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -1,0 +1,79 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+Feature: Device Registry Integration 
+    Device Registy integration test scenarios. These scenarios test higher level device service functionality
+    with all services live.
+
+Scenario: Birth message handling from a new device
+    A birth message is received. The referenced device does not yet exist and is created on-the-fly. After the
+    message is processed a new device must be created and a BIRTH event inserted in the database.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account
+      | name      | scopeId |
+      | AccountA  | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | UserA   | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I configure the device service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    And A birth message from device "device_1"
+    When I search for the device "device_1" in account "AccountA"
+    Then I find 1 device
+    When I search for events from device "device_1" in account "AccountA"
+    Then I find 1 event
+    And The type of the last event is "BIRTH"
+    And I logout
+
+Scenario: Birth message handling from an existing device
+    A BIRTH message is received from an already existing device. A new BIRTH event must be 
+    inserted into the database.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account
+      | name      | scopeId |
+      | AccountA  | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | UserA   | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I configure the device service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    And A device such as
+      | clientId | displayName | modelId         | serialNumber |
+      | device_1 | testGateway | ReliaGate 10-20 | 12341234ABC  |
+    And A birth message from device "device_1"
+    When I search for events from device "device_1" in account "AccountA"
+    Then I find 1 event
+    And The type of the last event is "BIRTH"
+    And I logout


### PR DESCRIPTION
## Device Registry integration tests - CRUD operations
This is the first set Device Registry integration tests that are designed to test the CRUD operations of the Device Registry service in a live Kapua environment (no mock services). The tests are cucumber based.
Additional test cases will be added to increase the coverage and cover more corner cases.

### Changes to Maven pom files
Added the required dependencies in the qa pom.xml.

### Implementation changes
The implementation of the Device Registry service has not been changed.

### Test changes
A new set of Cucumber based integration tests is implemented to test CRUD operations on the Device Registry service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>