### PR TITLE
Fixed embeded datastore tests

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/DataSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/DataSteps.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.internal.model.query.AndPredicateImpl;
 import org.eclipse.kapua.service.datastore.internal.model.query.MessageQueryImpl;
@@ -151,8 +152,8 @@ public class DataSteps {
             query.setPredicate(new TermPredicateImpl(MessageField.CLIENT_ID, currentDevice.getClientId()));
 
             // set query options
-
             query.setAskTotalCount(true);
+            query.setLimit((int)numberOfMessages);
 
             // perform query
 
@@ -195,6 +196,7 @@ public class DataSteps {
             field.setSortDirection(SortDirection.DESC);
 
             query.setSortFields(Arrays.asList(field));
+            query.setLimit(1);
 
             // perform the query
 
@@ -217,4 +219,10 @@ public class DataSteps {
             Assert.assertEquals(toData(expectedMetrics), properties);
         });
     }
+
+    @When("^I refresh all indices$")
+    public void refreshIndeces() throws Throwable {
+        DatastoreMediator.getInstance().refreshAllIndexes();
+    }
+
 }

--- a/service/datastore/client-embedded/src/main/java/org/eclipse/kapua/service/datastore/client/embedded/EsEmbeddedEngine.java
+++ b/service/datastore/client-embedded/src/main/java/org/eclipse/kapua/service/datastore/client/embedded/EsEmbeddedEngine.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.datastore.client.embedded;
 import java.io.IOException;
 
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 //import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.node.Node;
@@ -31,7 +32,7 @@ public class EsEmbeddedEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(EsEmbeddedEngine.class);
 
-    private static final String DEFAULT_DATA_DIRECTORY = "target/elasticsearch/data";
+    private static final String DEFAULT_DATA_DIRECTORY = "target/elasticsearch/data"+ UUIDs.randomBase64UUID();
 
     private static Node node;
 


### PR DESCRIPTION
Added UUID to datastore persistence file.
Datastore step for refresh of ES is added.
Steps that retrive and evaluate data are configured with data retrieval
limit.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>