### PR TITLE
Source external configurations files

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
@@ -38,7 +38,7 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractKapuaSetting.class);
 
-    private static final String EXTERNAL_CONFIG_FILE_PARAM = "kapua.config.file";
+    private static final String EXTERNAL_CONFIG_URL_PARAM = "kapua.config.url";
     private static final String EXTERNAL_CONFIG_DIR_PARAM = "kapua.config.dir";
 
     /**
@@ -59,15 +59,15 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
 
         try {
             // External configuration file loading
-            String externalConfigResourceName = System.getProperty(EXTERNAL_CONFIG_FILE_PARAM);
-            if (externalConfigResourceName != null) {
-                loadConfigResource(compositeConfig, externalConfigResourceName);
+            String externalConfigResourceUrl = System.getProperty(EXTERNAL_CONFIG_URL_PARAM);
+            if (externalConfigResourceUrl != null) {
+                loadConfigResource(compositeConfig, externalConfigResourceUrl);
             }
 
-            // External configuration folder loading
-            String externalConfigResourceFolder = System.getProperty(EXTERNAL_CONFIG_DIR_PARAM);
-            if (externalConfigResourceFolder != null) {
-                loadConfigResources(compositeConfig, externalConfigResourceFolder);
+            // External configuration directory loading
+            String externalConfigResourceDir = System.getProperty(EXTERNAL_CONFIG_DIR_PARAM);
+            if (externalConfigResourceDir != null) {
+                loadConfigResources(compositeConfig, externalConfigResourceDir);
             }
 
             // Default configuration file loading
@@ -81,29 +81,29 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
     }
 
     /**
-     * Search the configuration resources in the given folder name and loads them into the given {@link CompositeConfiguration} parameter.<br>
-     * If the given folder name refer to a file or a not existing folder an error will be thrown.
-     * If the folder exists and it is empty, no error will be thrown.
+     * Search the configuration resources in the given directory name and loads them into the given {@link CompositeConfiguration} parameter.<br>
+     * If the given directory name refer to a file or a not existing directory an error will be thrown.
+     * If the directory exists and it is empty, no error will be thrown.
      * Note that this can only work with local files.
      * 
      * @param compositeConfig
      *            The {@link CompositeConfiguration} where load the resources.
-     * @param configResourceFolderName
-     *            The folder path to scan.
+     * @param configResourceDirName
+     *            The directory path to scan.
      * @throws KapuaSettingException
-     *             When folder is not found, or loading them causes an exception.
+     *             When directory is not found, or loading them causes an exception.
      * 
      * @see #loadConfigResource(CompositeConfiguration, String)
      * 
      * @since 1.0.0
      */
-    private static void loadConfigResources(CompositeConfiguration compositeConfig, String configResourceFolderName) throws KapuaSettingException {
+    private static void loadConfigResources(CompositeConfiguration compositeConfig, String configResourceDirName) throws KapuaSettingException {
 
-        if (!configResourceFolderName.endsWith("/")) {
-            configResourceFolderName = configResourceFolderName.concat("/");
+        if (!configResourceDirName.endsWith("/")) {
+            configResourceDirName = configResourceDirName.concat("/");
         }
 
-        File configsDir = new File(configResourceFolderName);
+        File configsDir = new File(configResourceDirName);
         if (configsDir.exists() || configsDir.isDirectory()) {
             // Exclude hidden files
             String[] configFileNames = configsDir.list((dir, name) -> !name.startsWith("."));
@@ -111,7 +111,7 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
             if (configFileNames != null && configFileNames.length > 0) {
                 for (String configFileName : configFileNames) {
 
-                    String fileFullPath = String.join("", "file://", configResourceFolderName, configFileName);
+                    String fileFullPath = String.join("", "file://", configResourceDirName, configFileName);
 
                     // Ignore files that arent named '*.properties'
                     if (fileFullPath.endsWith(".properties")) {
@@ -121,11 +121,11 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
                     }
                 }
             } else {
-                LOG.warn(String.format("Empty config folder: '%s'", configResourceFolderName));
+                LOG.warn(String.format("Empty config directory: '%s'", configResourceDirName));
             }
         } else {
-            LOG.error(String.format("Unable to locate folder: '%s'", configResourceFolderName));
-            throw new KapuaSettingException(KapuaSettingErrorCodes.RESOURCE_NOT_FOUND, null, configResourceFolderName);
+            LOG.error(String.format("Unable to locate directory: '%s'", configResourceDirName));
+            throw new KapuaSettingException(KapuaSettingErrorCodes.RESOURCE_NOT_FOUND, null, configResourceDirName);
         }
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * Setting reference abstract implementation.
  *
  * @param <K>
- *            setting key type
+ *            Setting key type
  *
  * @since 1.0.0
  */
@@ -80,6 +80,23 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
         return new DataConfiguration(compositeConfig);
     }
 
+    /**
+     * Search the configuration resources in the given folder name and loads them into the given {@link CompositeConfiguration} parameter.<br>
+     * If the given folder name refer to a file or a not existing folder an error will be thrown.
+     * If the folder exists and it is empty, no error will be thrown.
+     * Note that this can only work with local files.
+     * 
+     * @param compositeConfig
+     *            The {@link CompositeConfiguration} where load the resources.
+     * @param configResourceFolderName
+     *            The folder path to scan.
+     * @throws KapuaSettingException
+     *             When folder is not found, or loading them causes an exception.
+     * 
+     * @see #loadConfigResource(CompositeConfiguration, String)
+     * 
+     * @since 1.0.0
+     */
     private static void loadConfigResources(CompositeConfiguration compositeConfig, String configResourceFolderName) throws KapuaSettingException {
 
         if (!configResourceFolderName.endsWith("/")) {
@@ -112,6 +129,20 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
         }
     }
 
+    /**
+     * Search the configuration resource name and loads it into the given {@link CompositeConfiguration} parameter.<br>
+     * It can handle resources on the class path and file in the file system (prefixed by 'file://')
+     * or file over HTTP/HTTPS (prefixed by 'http://'|'https://')
+     * 
+     * @param compositeConfig
+     *            The {@link CompositeConfiguration} where load the given resource.
+     * @param configResourceName
+     *            The resource name to search and load.
+     * @throws KapuaSettingException
+     *             When error occurs while loading setting resource.
+     * 
+     * @since 1.0.0
+     */
     private static void loadConfigResource(CompositeConfiguration compositeConfig, String configResourceName) throws KapuaSettingException {
 
         URL configUrl = null;
@@ -136,6 +167,21 @@ public abstract class AbstractKapuaSetting<K extends SettingKey> extends Abstrac
         }
     }
 
+    /**
+     * Scans the given string URL to check that contains a valid scheme.<br>
+     * Scheme accepted are:
+     * <ul>
+     * <li>file://</li>
+     * <li>http://</li>
+     * <li>https://</li>
+     * </ul>
+     * 
+     * @param stringURL
+     *            The URL in {@link String} form to check
+     * @return {@code true} if it is a valid {@link URL}, false otherwise
+     * 
+     * @since 1.0.0
+     */
     private static boolean hasValidScheme(String stringURL) {
         return stringURL != null && (stringURL.startsWith("file://") || stringURL.startsWith("http://") || stringURL.startsWith("https://"));
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.setting;
 
+import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.apache.commons.configuration.CompositeConfiguration;
+import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.DataConfiguration;
 import org.apache.commons.configuration.EnvironmentConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -29,38 +32,103 @@ import org.slf4j.LoggerFactory;
  * @param <K>
  *            setting key type
  *
- * @since 1.0
- *
+ * @since 1.0.0
  */
 public abstract class AbstractKapuaSetting<K extends SettingKey> extends AbstractBaseKapuaSetting<K> {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractKapuaSetting.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractKapuaSetting.class);
+
+    private static final String EXTERNAL_CONFIG_FILE_PARAM = "kapua.config.file";
+    private static final String EXTERNAL_CONFIG_DIR_PARAM = "kapua.config.dir";
+
+    /**
+     * Constructor.
+     *
+     * @param configResourceName
+     */
+    protected AbstractKapuaSetting(String configResourceName) {
+        super(createCompositeSource(configResourceName));
+    }
 
     private static DataConfiguration createCompositeSource(String configResourceName) throws ExceptionInInitializerError {
         CompositeConfiguration compositeConfig = new EnvFriendlyConfiguration();
         compositeConfig.addConfiguration(new SystemConfiguration());
         compositeConfig.addConfiguration(new EnvironmentConfiguration());
+
         try {
-            URL configLocalUrl = ResourceUtils.getResource(configResourceName);
-            if (configLocalUrl == null) {
-                logger.warn("Unable to locate resource '{}'", configResourceName);
-                throw new IllegalArgumentException(String.format("Unable to locate resource: '%s'", configResourceName));
+            // External configuration file loading
+            String externalConfigResourceName = System.getProperty(EXTERNAL_CONFIG_FILE_PARAM);
+            if (externalConfigResourceName != null) {
+                loadConfigResource(compositeConfig, externalConfigResourceName);
             }
-            compositeConfig.addConfiguration(new PropertiesConfiguration(configLocalUrl));
+
+            // External configuration folder loading
+            String externalConfigResourceFolder = System.getProperty(EXTERNAL_CONFIG_DIR_PARAM);
+            if (externalConfigResourceFolder != null) {
+                loadConfigResources(compositeConfig, externalConfigResourceFolder);
+            }
+
+            // Default configuration file loading
+            loadConfigResource(compositeConfig, configResourceName);
         } catch (Exception e) {
-            logger.error("Error loading PropertiesConfiguration", e);
+            LOG.error("Error loading PropertiesConfiguration", e);
             throw new ExceptionInInitializerError(e);
         }
 
         return new DataConfiguration(compositeConfig);
     }
 
-    /**
-     * Constructor
-     *
-     * @param configResourceName
-     */
-    protected AbstractKapuaSetting(String configResourceName) {
-        super(createCompositeSource(configResourceName));
+    private static void loadConfigResources(CompositeConfiguration compositeConfig, String configResourceFolderName) throws ConfigurationException, MalformedURLException {
+
+        if (!configResourceFolderName.endsWith("/")) {
+            configResourceFolderName = configResourceFolderName.concat("/");
+        }
+
+        File configsDir = new File(configResourceFolderName);
+        if (configsDir.exists() || configsDir.isDirectory()) {
+            // Exclude hidden files
+            String[] configFileNames = configsDir.list((dir, name) -> !name.startsWith("."));
+
+            if (configFileNames != null && configFileNames.length > 0) {
+                for (String configFileName : configFileNames) {
+
+                    String fileFullPath = String.join("", "file://", configResourceFolderName, configFileName);
+
+                    // Ignore files that arent named '*.properties'
+                    if (fileFullPath.endsWith(".properties")) {
+                        loadConfigResource(compositeConfig, fileFullPath);
+                    } else {
+                        LOG.warn(String.format("Ignored file: '%s'", fileFullPath));
+                    }
+                }
+            } else {
+                LOG.warn(String.format("Empty config folder: '%s'", configResourceFolderName));
+            }
+        } else {
+            LOG.error(String.format("Unable to locate folder: '%s'", configResourceFolderName));
+            throw new IllegalArgumentException(String.format("Unable to locate folder: '%s'", configResourceFolderName));
+        }
+    }
+
+    private static void loadConfigResource(CompositeConfiguration compositeConfig, String configResourceName) throws ConfigurationException, MalformedURLException {
+
+        URL configUrl;
+        if (hasValidScheme(configResourceName)) {
+            configUrl = new URL(configResourceName);
+        } else {
+            configUrl = ResourceUtils.getResource(configResourceName);
+        }
+
+        if (configUrl != null) {
+            compositeConfig.addConfiguration(new PropertiesConfiguration(configUrl));
+            LOG.debug("Loaded configuration resource: '{}'", configResourceName);
+        } else {
+            LOG.error("Unable to locate configuration resource: '{}'", configResourceName);
+            throw new IllegalArgumentException(String.format("Unable to locate resource: '%s'", configResourceName));
+        }
+    }
+
+    private static boolean hasValidScheme(String stringURL) {
+        return stringURL != null && (stringURL.startsWith("file://") || stringURL.startsWith("http://") || stringURL.startsWith("https://"));
     }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingErrorCodes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingErrorCodes.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.setting;
+
+import org.eclipse.kapua.KapuaErrorCode;
+
+/**
+ * Setting error codes
+ * 
+ * since 1.0.0
+ */
+public enum KapuaSettingErrorCodes implements KapuaErrorCode {
+    /**
+     * Code for a malformed URL or resource name is given, and this causes an error on loading.
+     * 
+     * @since 1.0.0
+     */
+    INVALID_RESOURCE_NAME,
+
+    /**
+     * Code for error while parsing the configuration file.
+     * 
+     * @since 1.0.0
+     */
+    INVALID_RESOURCE_FILE,
+
+    /**
+     * Code for a correctly former URL that refer to a not existing file/folder
+     */
+    RESOURCE_NOT_FOUND,
+
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingException.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingException.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.setting;
+
+import org.eclipse.kapua.KapuaException;
+
+/**
+ * Setting exception.
+ * 
+ * @since 1.0.0
+ * 
+ */
+public class KapuaSettingException extends KapuaException {
+
+    private static final long serialVersionUID = -6207605695086240243L;
+
+    private static final String KAPUA_ERROR_MESSAGES = "kapua-setting-service-error-messages";
+
+    /**
+     * Constructs the exception by error code
+     * 
+     * @param code
+     *            error code
+     */
+    public KapuaSettingException(KapuaSettingErrorCodes code) {
+        super(code);
+    }
+
+    /**
+     * Constructs the exception by error code and custom arguments
+     * 
+     * @param code
+     *            error code
+     * @param arguments
+     *            arguments
+     */
+    public KapuaSettingException(KapuaSettingErrorCodes code, Object... arguments) {
+        super(code, arguments);
+    }
+
+    /**
+     * Constructs the exception by error code, custom arguments and cause
+     * 
+     * @param code
+     *            error code
+     * @param cause
+     *            original cause
+     * @param arguments
+     *            arguments
+     */
+    public KapuaSettingException(KapuaSettingErrorCodes code, Throwable cause, Object... arguments) {
+        super(code, cause, arguments);
+    }
+
+    protected String getKapuaErrorMessagesBundle() {
+        return KAPUA_ERROR_MESSAGES;
+    }
+}

--- a/console/src/main/java/org/eclipse/kapua/app/console/setting/ConsoleSettingKeys.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/setting/ConsoleSettingKeys.java
@@ -15,28 +15,30 @@ package org.eclipse.kapua.app.console.setting;
 import org.eclipse.kapua.commons.setting.SettingKey;
 
 public enum ConsoleSettingKeys implements SettingKey {
-    SKIN_RESOURCE_DIR("skin.resource.dir"), //
-    LOGIN_BACKGROUND_CREDITS("login.background.credits"), //
-    LOGIN_GENERIC_SNIPPET("login.generic.snippet"), //
+    SKIN_RESOURCE_DIR("console.skin.resource.dir"), //
 
-    DEVICE_CONFIGURATION_ICON_FOLDER("device.configuration.icon.folder"), //
-    DEVICE_CONFIGURATION_ICON_CACHE_TIME("device.configuration.icon.cache.time"), //
-    DEVICE_CONFIGURATION_ICON_SIZE_MAX("device.configuration.icon.size.max"),
+    LOGIN_BACKGROUND_CREDITS("console.login.background.credits"), //
+    LOGIN_GENERIC_SNIPPET("console.login.generic.snippet"), //
 
-    DEVICE_CONFIGURATION_SERVICE_IGNORE("device.configuration.service.ignore"),//
+    DEVICE_CONFIGURATION_ICON_FOLDER("console.device.configuration.icon.folder"), //
+    DEVICE_CONFIGURATION_ICON_CACHE_TIME("console.device.configuration.icon.cache.time"), //
+    DEVICE_CONFIGURATION_ICON_SIZE_MAX("console.device.configuration.icon.size.max"),
 
-    DEVICE_MAP_TILE_URI("device.map.tile.uri"), //
+    DEVICE_CONFIGURATION_SERVICE_IGNORE("console.device.configuration.service.ignore"),//
 
-    FILE_UPLOAD_SIZE_MAX("file.upload.size.max"), //
-    FILE_UPLOAD_INMEMORY_SIZE_THRESHOLD("file.upload.inmemory.size.threshold"), //
+    DEVICE_MAP_TILE_URI("console.device.map.tile.uri"), //
 
-    SITE_HOME_URI("site.home.uri"),
-    SSO_ENABLE("sso.enabled"),
-    SSO_OPENID_SERVER_ENDPOINT_AUTH("sso.openid.server.endpoint.auth"),
-    SSO_OPENID_SERVER_ENDPOINT_TOKEN("sso.openid.server.endpoint.token"),
-    SSO_OPENID_CLIENT_ID("sso.openid.client.id"),
-    SSO_OPENID_CLIENT_SECRET("sso.openid.client.secret"),
-    SSO_OPENID_REDIRECT_URI("sso.openid.redirect.uri"),
+    FILE_UPLOAD_SIZE_MAX("console.file.upload.size.max"), //
+    FILE_UPLOAD_INMEMORY_SIZE_THRESHOLD("console.file.upload.inmemory.size.threshold"), //
+
+    SITE_HOME_URI("console.site.home.uri"), //
+    SSO_ENABLE("console.sso.enabled"), //
+    SSO_OPENID_SERVER_ENDPOINT_AUTH("console.sso.openid.server.endpoint.auth"), //
+    SSO_OPENID_SERVER_ENDPOINT_TOKEN("console.sso.openid.server.endpoint.token"), //
+    SSO_OPENID_CLIENT_ID("console.sso.openid.client.id"), //
+    SSO_OPENID_CLIENT_SECRET("console.sso.openid.client.secret"), //
+    SSO_OPENID_REDIRECT_URI("console.sso.openid.redirect.uri"), //
+
     ;
 
     private String key;

--- a/console/src/main/resources/console-setting.properties
+++ b/console/src/main/resources/console-setting.properties
@@ -11,24 +11,24 @@
 #     Red Hat Inc
 ###############################################################################
 
-login.background.credits=Photo by <a href='https://unsplash.com/@danist07' target='_blank'>\u8D1D\u8389\u513F NG</a>
-login.generic.snippet=
+console.login.background.credits=Photo by <a href='https://unsplash.com/@danist07' target='_blank'>\u8D1D\u8389\u513F NG</a>
+console.login.generic.snippet=
 
-device.configuration.icon.folder=iconResources
-device.configuration.icon.cache.time=600000
-device.configuration.icon.size.max=102400
+console.device.configuration.icon.folder=iconResources
+console.device.configuration.icon.cache.time=600000
+console.device.configuration.icon.size.max=102400
 
-device.configuration.service.ignore=com.eurotech.framework.net.NetworkAdminService
-device.configuration.service.ignore=com.eurotech.framework.net.admin.NetworkConfigurationService
+console.device.configuration.service.ignore=com.eurotech.framework.net.NetworkAdminService
+console.device.configuration.service.ignore=com.eurotech.framework.net.admin.NetworkConfigurationService
 
-device.map.tile.uri=
+console.device.map.tile.uri=
 
-file.upload.size.max=5242880
-file.upload.inmemory.size.threshold=10240
+console.file.upload.size.max=5242880
+console.file.upload.inmemory.size.threshold=10240
 
-site.home.uri=http://localhost:8889/console.jsp?gwt.codesvr=127.0.0.1:9997
-sso.enabled=false
-sso.openid.server.endpoint.auth=http://localhost:9090/auth/realms/master/protocol/openid-connect/auth
-sso.openid.server.endpoint.token=http://localhost:9090/auth/realms/master/protocol/openid-connect/token
-sso.openid.client.id=console
-sso.openid.redirect.uri=http://localhost:8889/sso/callback
+console.site.home.uri=http://localhost:8889/console.jsp?gwt.codesvr=127.0.0.1:9997
+console.sso.enabled=false
+console.sso.openid.server.endpoint.auth=http://localhost:9090/auth/realms/master/protocol/openid-connect/auth
+console.sso.openid.server.endpoint.token=http://localhost:9090/auth/realms/master/protocol/openid-connect/token
+console.sso.openid.client.id=console
+console.sso.openid.redirect.uri=http://localhost:8889/sso/callback


### PR DESCRIPTION
Hi all ,

this PR closes #556 

You can now specify system properties called

- `kapua.config.file` : The file path specified will be loaded as a config file. Path MUST have schema (so `file://` or `https://`)
- `kapua.config.dir` : The dir name specified will be scanned for all files that not start with `.` (hidden files) and ends with `.properties` (regular Java properties files).

Both options can be specified. 

If `kapua.config.file` is not found an error will be thrown. If it is empty no property override will be loaded

If `kapua.config.dir` is not found or is not a directory an error wil lbe thrown. If empty dir no error will occur.

Regards, 

_Alberto_