### PR TITLE
Add EPL license detection 

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/about/AboutEntry.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/about/AboutEntry.java
@@ -23,14 +23,16 @@ public class AboutEntry {
         public static final License EPL;
 
         static {
-            URL url = null;
+            URL urlApache = null;
+            URL urlEpl = null;
             try {
-                url = new URL("http://www.apache.org/licenses/");
+                urlApache = new URL("http://www.apache.org/licenses/");
+                urlEpl = new URL("https://www.eclipse.org/legal/epl-v10.html");
             } catch (MalformedURLException e) {
             }
 
-            APL2 = new License("Apache License 2.0", null, url);
-            EPL =  new License("EPL","Eclipse Public License", url);
+            APL2 = new License("Apache License 2.0", null, urlApache);
+            EPL =  new License("EPL","Eclipse Public License", urlEpl);
         }
 
         private final String name;

--- a/commons/src/main/java/org/eclipse/kapua/commons/about/AboutEntry.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/about/AboutEntry.java
@@ -20,6 +20,7 @@ public class AboutEntry {
 
         public static final License UNKNOWN = new License("Unknown", null, null);
         public static final License APL2;
+        public static final License EPL;
 
         static {
             URL url = null;
@@ -29,6 +30,7 @@ public class AboutEntry {
             }
 
             APL2 = new License("Apache License 2.0", null, url);
+            EPL =  new License("EPL","Eclipse Public License", url);
         }
 
         private final String name;

--- a/commons/src/main/java/org/eclipse/kapua/commons/about/AboutScanner.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/about/AboutScanner.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation
+ *     Arthur Deschamps - EPL license detection
  *******************************************************************************/
 package org.eclipse.kapua.commons.about;
 
@@ -18,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.jar.Manifest;
@@ -112,20 +114,16 @@ public final class AboutScanner {
 
         about = processNotice(about, url, in);
 
-        final String[] keywords = {"epl","eclipse public license"};
+        final List<String> keywords = Arrays.asList("epl","eclipse public license");
+        final String fileContent = about.getNotice();
 
-        // Default license
-        about.setLicense(License.UNKNOWN);
-        
-
-            // Look for keywords
-            for (final String keyword : keywords) {
-                if (about.getNotice().toLowerCase().contains(keyword.toLowerCase())) {
-                    about.setLicense(License.EPL);
-                }
-            }
-
-
+        // Makes sure all the keywords are contained in the about.html file
+        if (keywords.stream().allMatch(keyword -> fileContent.toLowerCase().contains(keyword.toLowerCase()))) {
+            about.setLicense(License.EPL);
+        } else {
+            // Default license
+            about.setLicense(License.UNKNOWN);
+        }
 
         return  about;
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/about/AboutScanner.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/about/AboutScanner.java
@@ -48,7 +48,7 @@ public final class AboutScanner {
     }
 
     private static AboutEntry map(URL url) {
-
+        
         AboutEntry result = null;
 
         try (InputStream in = url.openStream();
@@ -66,7 +66,7 @@ public final class AboutScanner {
                 } else if ("META-INF/NOTICE".equals(entry.getName())) {
                     result = processNotice(result, url, zis);
                 } else if ("about.html".equals(entry.getName())) {
-                    result = processNotice(result, url, zis);
+                    result = processHtmlFile(result, url, zis);
                 } else if ("META-INF/LICENSE.txt".equals(entry.getName())) {
                     result = processLicense(result, url, zis);
                 } else if ("META-INF/LICENSE".equals(entry.getName())) {
@@ -103,6 +103,31 @@ public final class AboutScanner {
         }
 
         return about;
+    }
+
+    /**
+     * Detect if the underlying project is EPL licensed
+     */
+    private static AboutEntry processHtmlFile(AboutEntry about, final URL url, final InputStream in) {
+
+        about = processNotice(about, url, in);
+
+        final String[] keywords = {"epl","eclipse public license"};
+
+        // Default license
+        about.setLicense(License.UNKNOWN);
+        
+
+            // Look for keywords
+            for (final String keyword : keywords) {
+                if (about.getNotice().toLowerCase().contains(keyword.toLowerCase())) {
+                    about.setLicense(License.EPL);
+                }
+            }
+
+
+
+        return  about;
     }
 
     /**


### PR DESCRIPTION
closes #539 : EPL licenses are now detected and indicated in the "about" section of the console, for each EPL licensed project. 

Signed-off-by: Arthur Deschamps <arthur.deschamps1208@hotmail.com>
