### PR TITLE
Fix a few bugs in the guice locator implementation

### DIFF
--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/FactoryResolver.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/FactoryResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.locator.guice;
 
@@ -25,14 +26,14 @@ public class FactoryResolver<F extends KapuaObjectFactory, I extends F> {
         this.implementationClass = implementation;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static FactoryResolver newInstance(Class<?> factory, Class<?> implementation)
+    @SuppressWarnings("unchecked")
+    public static <F extends KapuaObjectFactory, I extends F> FactoryResolver<F, I> newInstance(Class<?> factory, Class<?> implementation)
             throws KapuaLocatorException {
         if (!factory.isAssignableFrom(implementation)) {
             throw new KapuaLocatorException(KapuaLocatorErrorCodes.FACTORY_PROVIDER_INVALID, implementation, factory);
         }
 
-        return new FactoryResolver(factory, implementation);
+        return new FactoryResolver<F,I>((Class<F>)factory, (Class<I>)implementation);
     }
 
     public Class<F> getFactoryClass() {

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
@@ -43,11 +43,22 @@ public class KapuaModule extends AbstractModule {
      */
     private static final String SERVICE_RESOURCE = "locator.xml";
 
+    private String resourceName;
+
+    
+    public KapuaModule() {
+        this(SERVICE_RESOURCE);
+    }
+    
+    public KapuaModule(final String resourceName) {
+        this.resourceName = resourceName;
+    }
+    
     @Override
     protected void configure() {
         try {
             // Find locator configuration file
-            List<URL> locatorConfigurations = Arrays.asList(ResourceUtils.getResource(SERVICE_RESOURCE));
+            List<URL> locatorConfigurations = Arrays.asList(ResourceUtils.getResource(resourceName));
             if (locatorConfigurations.isEmpty()) {
                 return;
             }
@@ -94,7 +105,6 @@ public class KapuaModule extends AbstractModule {
                 if (KapuaService.class.isAssignableFrom(kapuaObject)) {
                     for (Class<?> clazz : extendedClassInfo) {
                         if (kapuaObject.isAssignableFrom(clazz)) {
-                            @SuppressWarnings("unchecked")
                             ServiceResolver<KapuaService, ?> resolver = ServiceResolver.newInstance(kapuaObject, clazz);
                             bind(resolver.getServiceClass()).to(resolver.getImplementationClass()).in(Singleton.class);
                             logger.info("Bind Kapua service {} to {}", kapuaObject, clazz);
@@ -113,7 +123,6 @@ public class KapuaModule extends AbstractModule {
                 if (KapuaObjectFactory.class.isAssignableFrom(kapuaObject)) {
                     for (Class<?> clazz : extendedClassInfo) {
                         if (kapuaObject.isAssignableFrom(clazz)) {
-                            @SuppressWarnings("unchecked")
                             FactoryResolver<KapuaObjectFactory, ?> resolver = FactoryResolver.newInstance(kapuaObject, clazz);
                             bind(resolver.getFactoryClass()).to(resolver.getImplementationClass()).in(Singleton.class);
                             logger.info("Bind Kapua factory {} to {}", kapuaObject, clazz);

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ServiceResolver.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ServiceResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.locator.guice;
 
@@ -25,14 +26,15 @@ public class ServiceResolver<S extends KapuaService, I extends S> {
         this.implementationClass = implementation;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static ServiceResolver newInstance(Class<?> service, Class<?> implementation)
+    @SuppressWarnings("unchecked")
+    public static <S extends KapuaService, I extends S> ServiceResolver<S,I> newInstance(Class<?> service, Class<?> implementation)
             throws KapuaLocatorException {
+
         if (!service.isAssignableFrom(implementation)) {
             throw new KapuaLocatorException(KapuaLocatorErrorCodes.SERVICE_PROVIDER_INVALID, implementation, service);
         }
 
-        return new ServiceResolver(service, implementation);
+        return new ServiceResolver<S,I>((Class<S>)service, (Class<I>)implementation);
     }
 
     public Class<S> getServiceClass() {

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,8 +23,10 @@ import org.eclipse.kapua.locator.KapuaLocatorErrorCodes;
 import org.eclipse.kapua.locator.guice.GuiceLocatorImpl;
 import org.eclipse.kapua.locator.guice.TestService;
 import org.eclipse.kapua.locator.internal.guice.FactoryA;
+import org.eclipse.kapua.locator.internal.guice.FactoryB;
 import org.eclipse.kapua.locator.internal.guice.ServiceA;
 import org.eclipse.kapua.locator.internal.guice.ServiceB;
+import org.eclipse.kapua.locator.internal.guice.ServiceC;
 import org.eclipse.kapua.service.KapuaService;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -32,7 +34,7 @@ import org.junit.Test;
 
 public class GuiceLocatorImplTest {
 
-    KapuaLocator locator = GuiceLocatorImpl.getInstance();
+    private KapuaLocator locator = GuiceLocatorImpl.getInstance();
 
     @Ignore
     @Test
@@ -69,6 +71,18 @@ public class GuiceLocatorImplTest {
     }
 
     @Test
+    public void shouldNotFindFactory() {
+        try {
+            locator.getFactory(FactoryB.class);
+            Assert.fail("getFactory must throw an exception for un-bound factories");
+        } catch (KapuaRuntimeException e) {
+            Assert.assertEquals(KapuaLocatorErrorCodes.FACTORY_UNAVAILABLE, e.getCode());
+        } catch (Throwable e) {
+            Assert.fail("Exception must be of type: " + KapuaRuntimeException.class.getName());
+        }
+    }
+
+    @Test
     public void shouldProvideAll() {
         List<KapuaService> result = locator.getServices();
         Assert.assertEquals(1, result.size());
@@ -77,6 +91,12 @@ public class GuiceLocatorImplTest {
             KapuaService service = result.get(0);
             Assert.assertTrue(service instanceof ServiceA);
         }
+    }
+    
+    @Test(expected=KapuaRuntimeException.class)
+    public void shouldNotLoad () {
+        KapuaLocator locator = new GuiceLocatorImpl("locator-1.xml");
+        locator.getService(ServiceC.class);
     }
 
     static interface MyService extends KapuaService {

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/ResolverTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/ResolverTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.locator.internal;
+
+import org.eclipse.kapua.locator.KapuaLocatorException;
+import org.eclipse.kapua.locator.guice.ServiceResolver;
+import org.eclipse.kapua.locator.internal.guice.FactoryA;
+import org.eclipse.kapua.locator.internal.guice.FactoryAImpl;
+import org.eclipse.kapua.locator.internal.guice.FactoryC;
+import org.eclipse.kapua.locator.internal.guice.ServiceA;
+import org.eclipse.kapua.locator.internal.guice.ServiceAImpl;
+import org.eclipse.kapua.locator.internal.guice.ServiceC;
+import org.eclipse.kapua.locator.internal.guice.ServiceCImpl;
+import org.junit.Test;
+
+public class ResolverTest {
+    
+    @Test(expected=KapuaLocatorException.class)
+    public void testWrongServiceClass () throws KapuaLocatorException  {
+        ServiceResolver.newInstance(ServiceC.class, ServiceCImpl.class);
+    }
+    
+    @Test
+    public void testCorrectServiceClass () throws KapuaLocatorException  {
+        ServiceResolver.newInstance(ServiceA.class, ServiceAImpl.class);
+    }
+    
+    @Test(expected=KapuaLocatorException.class)
+    public void testWrongFactoryClass () throws KapuaLocatorException  {
+        ServiceResolver.newInstance(FactoryC.class, ServiceCImpl.class);
+    }
+    
+    @Test
+    public void testCorrectFactoryClass () throws KapuaLocatorException  {
+        ServiceResolver.newInstance(FactoryA.class, FactoryAImpl.class);
+    }
+}

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryB.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryB.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.locator.internal.guice;
+
+import org.eclipse.kapua.model.KapuaObjectFactory;
+
+public interface FactoryB extends KapuaObjectFactory {
+
+}

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryC.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryC.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.locator.internal.guice;
+
+import org.eclipse.kapua.model.KapuaObjectFactory;
+
+public interface FactoryC extends KapuaObjectFactory {
+
+}

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryCImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryCImpl.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.locator.internal.guice;
+
+import org.eclipse.kapua.locator.KapuaProvider;
+
+/**
+ * by name this factory claims to implement {@link FactoryC}, but it doesn'
+ */
+@KapuaProvider
+public class FactoryCImpl {
+
+}

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceC.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceC.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.locator.internal.guice;
+
+import org.eclipse.kapua.service.KapuaService;
+
+public interface ServiceC extends KapuaService {
+
+}

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceCImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceCImpl.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.locator.internal.guice;
+
+/**
+ * A service which is named to implement {@link ServiceC} but actually doesn't
+ */
+public class ServiceCImpl {
+
+}

--- a/locator/guice/src/test/resources/locator-1.xml
+++ b/locator/guice/src/test/resources/locator-1.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<!--
+    Copyright (c) 2017 Red Hat Inc and others
+   
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+   
+    Contributors:
+        Red Hat Inc - initial API and implementation
+ -->
+<locator-config>
+	<provided>
+		<api>org.eclipse.kapua.locator.internal.guice.ServiceC</api>
+		<provide>
+			<interceptor>annotation</interceptor>
+			<with>Impl</with>
+		</provide>
+	</provided>
+	<packages>
+		<package>org.eclipse.kapua.locator.internal.guice</package>
+	</packages>
+</locator-config>


### PR DESCRIPTION
This change adds a few unit tests to check for a set of bugs in the
guice locator implementation. Like a class/factory not implementing
its interface, throwing the wrong exception type or error code.

It also provides a more testable version of the guice locator, which
allows specifying the resource to load and refrains from using
global variables when possible.