### PR TITLE
Change phases for docker container build/push

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -9,6 +9,7 @@
    
     Contributors:
         Red Hat Inc - initial API and implementation
+        Eurotech
  -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -56,14 +57,14 @@
                     <executions>
                         <execution>
                             <id>build</id>
-                            <phase>compile</phase>
+                            <phase>install</phase>
                             <goals>
                                 <goal>build</goal>
                             </goals>
                         </execution>
                         <execution>
                             <id>push</id>
-                            <phase>install</phase>
+                            <phase>deploy</phase>
                             <goals>
                                 <goal>push</goal>
                             </goals>


### PR DESCRIPTION
When running "mvn clean install -Pdocker" fabric8 tries to push the docker containers by default to DockerHub. I would expect this step to be executed only during the deploy phase. Also I think the creation of the container itself should be done during the install phase.