### PR TITLE
Fixing tests that are dependent on MockedLocator

### DIFF
--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -15,20 +15,6 @@
 
     <artifactId>kapua-account-internal</artifactId>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <locator.class.impl>org.eclipse.kapua.test.MockedLocator</locator.class.impl>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <!-- Implemented service interfaces -->
         <dependency>

--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/RunTest.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/RunTest.java
@@ -11,15 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account.internal;
 
-import org.eclipse.kapua.test.cucumber.CucumberProperties;
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
 import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
-
-import cucumber.api.CucumberOptions;
 
 @RunWith(CucumberWithProperties.class)
 @CucumberOptions(features = "classpath:features", plugin = { "pretty", "html:target/cucumber",
         "json:target/cucumber.json" }, monochrome = true)
-@CucumberProperties(systemProperties="locator.class.impl=org.eclipse.kapua.test.MockedLocator")
+@CucumberProperty(key="locator.class.impl", value="org.eclipse.kapua.test.MockedLocator")
 public class RunTest {
 }

--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/RunTest.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/RunTest.java
@@ -11,13 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account.internal;
 
+import org.eclipse.kapua.test.cucumber.CucumberProperties;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
 
-@RunWith(Cucumber.class)
+@RunWith(CucumberWithProperties.class)
 @CucumberOptions(features = "classpath:features", plugin = { "pretty", "html:target/cucumber",
         "json:target/cucumber.json" }, monochrome = true)
+@CucumberProperties(systemProperties="locator.class.impl=org.eclipse.kapua.test.MockedLocator")
 public class RunTest {
 }

--- a/service/device/registry/internal/pom.xml
+++ b/service/device/registry/internal/pom.xml
@@ -16,20 +16,6 @@
     <artifactId>kapua-device-registry-internal</artifactId>
     <name>${project.artifactId}</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <locator.class.impl>org.eclipse.kapua.test.MockedLocator</locator.class.impl>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <!-- Internal dependencies -->
         <dependency>

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
@@ -11,12 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.internal;
 
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberProperties;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
-
-@RunWith(Cucumber.class)
+@RunWith(CucumberWithProperties.class)
 @CucumberOptions(features = "classpath:features",
         glue = { "org.eclipse.kapua.service.device.registry.common",
                 "org.eclipse.kapua.service.device.registry.internal",
@@ -26,7 +26,6 @@ import cucumber.api.junit.Cucumber;
                 "html:target/cucumber",
                 "json:target/cucumber.json" },
         monochrome = true)
-
+@CucumberProperties(systemProperties="locator.class.impl=org.eclipse.kapua.test.MockedLocator")
 public class RunTest {
-
 }

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.kapua.service.device.registry.internal;
 
 import cucumber.api.CucumberOptions;
-import org.eclipse.kapua.test.cucumber.CucumberProperties;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
 import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
@@ -26,6 +26,6 @@ import org.junit.runner.RunWith;
                 "html:target/cucumber",
                 "json:target/cucumber.json" },
         monochrome = true)
-@CucumberProperties(systemProperties="locator.class.impl=org.eclipse.kapua.test.MockedLocator")
+@CucumberProperty(key="locator.class.impl", value="org.eclipse.kapua.test.MockedLocator")
 public class RunTest {
 }

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -16,20 +16,6 @@
     <artifactId>kapua-user-internal</artifactId>
     <name>${project.artifactId}</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <locator.class.impl>org.eclipse.kapua.test.MockedLocator</locator.class.impl>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <!-- Implemented service interfaces -->
         <dependency>

--- a/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/RunTest.java
+++ b/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/RunTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.kapua.service.user.internal;
 
 import cucumber.api.CucumberOptions;
-import org.eclipse.kapua.test.cucumber.CucumberProperties;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
 import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
@@ -22,6 +22,6 @@ import org.junit.runner.RunWith;
         plugin = { "pretty", "html:target/cucumber",
                 "json:target/cucumber.json" },
         monochrome = true)
-@CucumberProperties(systemProperties="locator.class.impl=org.eclipse.kapua.test.MockedLocator")
+@CucumberProperty(key="locator.class.impl", value="org.eclipse.kapua.test.MockedLocator")
 public class RunTest {
 }

--- a/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/RunTest.java
+++ b/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/RunTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,17 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.internal;
 
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberProperties;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
-
-@RunWith(Cucumber.class)
+@RunWith(CucumberWithProperties.class)
 @CucumberOptions(
         features = "classpath:features",
         plugin = { "pretty", "html:target/cucumber",
                 "json:target/cucumber.json" },
         monochrome = true)
+@CucumberProperties(systemProperties="locator.class.impl=org.eclipse.kapua.test.MockedLocator")
 public class RunTest {
-
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -211,7 +211,7 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
-		
+
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-java</artifactId>
@@ -222,7 +222,12 @@
             <artifactId>cucumber-guice</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <optional>true</optional>
+        </dependency>
 
-    </dependencies>
+	</dependencies>
 
 </project>

--- a/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberProperties.java
+++ b/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberProperties.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.test.cucumber;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for CucumberWithProperties junit runner. It is used to set
+ * System properties on Cucumber tests.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface CucumberProperties {
+    String[] systemProperties() default {};
+}

--- a/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberProperty.java
+++ b/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberProperty.java
@@ -11,17 +11,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.test.cucumber;
 
-import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
 
 /**
- * Annotation for CucumberWithProperties junit runner. It is used to set
- * System properties on Cucumber tests.
+ * Used as CucumberProperty repeatable annotation on CucumberWithProperties junit runner.
+ * It is used to set System property on Cucumber tests.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-public @interface CucumberProperties {
-    String[] systemProperties() default {};
+@Repeatable(CucumberSystemProperties.class)
+public @interface CucumberProperty {
+    String key();
+
+    String value();
 }

--- a/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberSystemProperties.java
+++ b/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberSystemProperties.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.test.cucumber;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for CucumberWithProperties junit runner. It is used to set
+ * System properties as repeatable annotation on Cucumber tests.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface CucumberSystemProperties {
+    CucumberProperty[] value();
+}

--- a/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberWithProperties.java
+++ b/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberWithProperties.java
@@ -15,48 +15,31 @@ import cucumber.api.junit.Cucumber;
 import org.junit.runners.model.InitializationError;
 
 import java.io.IOException;
-import java.util.AbstractMap;
 
 /**
  * Extension of Cucumber junit runner that adds functionality of System properties
- * that are set with CucumberProperties annotation with systemProperties attribute.
+ * that are set with CucumberProperty repeatable annotation with key and value attribute
+ * that represents system property.
  */
 public class CucumberWithProperties extends Cucumber {
 
     public CucumberWithProperties(Class clazz) throws InitializationError, IOException {
         super(clazz);
 
-        CucumberProperties cucumberProperties = getProperties(clazz);
-        String[] systemProperties = cucumberProperties.systemProperties();
-        for (String property : systemProperties) {
-            AbstractMap.SimpleEntry<String, String> keyValue = extractKeyValue(property);
-            System.setProperty(keyValue.getKey(), keyValue.getValue());
+        CucumberProperty[] systemProperties = getProperties(clazz);
+        for (CucumberProperty property : systemProperties) {
+            System.setProperty(property.key(), property.value());
         }
     }
 
     /**
-     * Extract key / value pair from string that is split in two by equal sign.
-     * e.g. user.name=unknown
-     *
-     * @param property key / value pair separeted by equal sign
-     * @return key / value tuple
-     */
-    private AbstractMap.SimpleEntry extractKeyValue(String property) {
-        String[] tokens = property.split("=");
-        AbstractMap.SimpleEntry<String, String> keyValue =
-                new AbstractMap.SimpleEntry<String, String>(tokens[0],tokens[1]);
-
-        return keyValue;
-    }
-
-    /**
-     * Extract CucumberProperties from annotation on junit runner CucumberWithProperties
+     * Extract repeatable CucumberProperty from annotation on junit runner CucumberWithProperties
      *
      * @param clazz Class that is annotated
-     * @return properties array of key / value pairs
+     * @return property repeatable array of key / value pairs as CucumberProperty class
      */
-    private CucumberProperties getProperties(Class<?> clazz) {
+    private CucumberProperty[] getProperties(Class<?> clazz) {
 
-        return clazz.getAnnotation(CucumberProperties.class);
+        return clazz.getAnnotationsByType(CucumberProperty.class);
     }
 }

--- a/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberWithProperties.java
+++ b/test/src/main/java/org/eclipse/kapua/test/cucumber/CucumberWithProperties.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.test.cucumber;
+
+import cucumber.api.junit.Cucumber;
+import org.junit.runners.model.InitializationError;
+
+import java.io.IOException;
+import java.util.AbstractMap;
+
+/**
+ * Extension of Cucumber junit runner that adds functionality of System properties
+ * that are set with CucumberProperties annotation with systemProperties attribute.
+ */
+public class CucumberWithProperties extends Cucumber {
+
+    public CucumberWithProperties(Class clazz) throws InitializationError, IOException {
+        super(clazz);
+
+        CucumberProperties cucumberProperties = getProperties(clazz);
+        String[] systemProperties = cucumberProperties.systemProperties();
+        for (String property : systemProperties) {
+            AbstractMap.SimpleEntry<String, String> keyValue = extractKeyValue(property);
+            System.setProperty(keyValue.getKey(), keyValue.getValue());
+        }
+    }
+
+    /**
+     * Extract key / value pair from string that is split in two by equal sign.
+     * e.g. user.name=unknown
+     *
+     * @param property key / value pair separeted by equal sign
+     * @return key / value tuple
+     */
+    private AbstractMap.SimpleEntry extractKeyValue(String property) {
+        String[] tokens = property.split("=");
+        AbstractMap.SimpleEntry<String, String> keyValue =
+                new AbstractMap.SimpleEntry<String, String>(tokens[0],tokens[1]);
+
+        return keyValue;
+    }
+
+    /**
+     * Extract CucumberProperties from annotation on junit runner CucumberWithProperties
+     *
+     * @param clazz Class that is annotated
+     * @return properties array of key / value pairs
+     */
+    private CucumberProperties getProperties(Class<?> clazz) {
+
+        return clazz.getAnnotation(CucumberProperties.class);
+    }
+}


### PR DESCRIPTION
Custom cucumber runner for junit was created. This runner
accepts system properties that provided by annotating junit run class.

Pom files ware cleaned of this dependency to system property and all
the tests that were using MockedLocator ware corrected.

This fixes issue #531

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>