### PR TITLE
Modified test because Travis failure

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/BrokerSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/BrokerSteps.java
@@ -132,8 +132,9 @@ public class BrokerSteps extends Assert {
 
     @Before
     public void beforeScenario(Scenario scenario) throws Exception {
-
         container.startup();
+        locator = KapuaLocatorImpl.getInstance();
+
         //KapuaLocator locator = KapuaLocator.getInstance();
         devicePackageManagementService = locator.getService(DevicePackageManagementService.class);
         deviceRegistryService = locator.getService(DeviceRegistryService.class);
@@ -158,7 +159,7 @@ public class BrokerSteps extends Assert {
 
         this.stepData = null;
 
-        container.startup();
+        container.shutdown();
     }
 
     @When("^I start the Kura Mock")

--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -29,6 +29,7 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.locator.guice.KapuaLocatorImpl;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.qa.steps.DBHelper;
 import org.eclipse.kapua.service.StepData;
@@ -123,6 +124,8 @@ public class UserServiceSteps extends AbstractKapuaSteps {
 
     @Before
     public void beforeScenario(Scenario scenario) throws KapuaException {
+        container.startup();
+        locator = KapuaLocatorImpl.getInstance();
 
         // Services by default Locator
         KapuaLocator locator = KapuaLocator.getInstance();
@@ -144,6 +147,8 @@ public class UserServiceSteps extends AbstractKapuaSteps {
         } catch (Exception e) {
             logger.error("Failed to log out in @After", e);
         }
+
+        container.shutdown();
     }
 
     @Given("^Account$")

--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
@@ -31,6 +31,7 @@ import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.locator.guice.KapuaLocatorImpl;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaListResult;
@@ -113,8 +114,10 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     // Setup and tear-down steps
 
     @Before
-    public void beforeScenario(Scenario scenario)
-            throws Exception {
+    public void beforeScenario(Scenario scenario) throws Exception {
+        container.startup();
+        locator = KapuaLocatorImpl.getInstance();
+
         this.scenario = scenario;
         exceptionCaught = false;
 
@@ -160,6 +163,8 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
         scriptSession(AccountEntityManagerFactory.getInstance(), DROP_ACCOUNT_TABLES);
         KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
         KapuaSecurityUtils.clearSession();
+
+        container.shutdown();
     }
 
     // The Cucumber test steps

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/common/DeviceRegistryValidationTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/common/DeviceRegistryValidationTestSteps.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.id.KapuaIdFactoryImpl;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.locator.guice.KapuaLocatorImpl;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdFactory;
@@ -93,8 +94,10 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
     // Setup and tear-down steps
 
     @Before
-    public void beforeScenario(Scenario scenario)
-            throws Exception {
+    public void beforeScenario(Scenario scenario) throws Exception {
+        container.startup();
+        locator = KapuaLocatorImpl.getInstance();
+
         this.scenario = scenario;
         exceptionCaught = false;
 
@@ -130,6 +133,8 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
     public void afterScenario()
             throws Exception {
         KapuaSecurityUtils.clearSession();
+
+        container.shutdown();
     }
 
     // The Cucumber test steps

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceRegistryConnectionTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceRegistryConnectionTestSteps.java
@@ -26,6 +26,7 @@ import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.locator.guice.KapuaLocatorImpl;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Actions;
@@ -119,8 +120,10 @@ public class DeviceRegistryConnectionTestSteps extends AbstractKapuaSteps {
     // Setup and tear-down steps
 
     @Before
-    public void beforeScenario(Scenario scenario)
-            throws Exception {
+    public void beforeScenario(Scenario scenario) throws Exception {
+        container.startup();
+        locator = KapuaLocatorImpl.getInstance();
+
         this.scenario = scenario;
         exceptionCaught = false;
 
@@ -175,6 +178,8 @@ public class DeviceRegistryConnectionTestSteps extends AbstractKapuaSteps {
         scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
         KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
         KapuaSecurityUtils.clearSession();
+
+        container.shutdown();
     }
 
     // The Cucumber test steps

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceTestSteps.java
@@ -26,6 +26,7 @@ import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.locator.guice.KapuaLocatorImpl;
 import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.message.internal.KapuaPositionImpl;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -117,8 +118,10 @@ public class DeviceEventServiceTestSteps extends AbstractKapuaSteps {
     // Setup and tear-down steps
 
     @Before
-    public void beforeScenario(Scenario scenario)
-            throws Exception {
+    public void beforeScenario(Scenario scenario) throws Exception {
+        container.startup();
+        locator = KapuaLocatorImpl.getInstance();
+
         this.scenario = scenario;
         exceptionCaught = false;
 
@@ -172,6 +175,8 @@ public class DeviceEventServiceTestSteps extends AbstractKapuaSteps {
         scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
         KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
         KapuaSecurityUtils.clearSession();
+
+        container.shutdown();
     }
 
     // The Cucumber test steps

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceTestSteps.java
@@ -32,6 +32,7 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.locator.guice.KapuaLocatorImpl;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
@@ -130,8 +131,10 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
     // Setup and tear-down steps
 
     @Before
-    public void beforeScenario(Scenario scenario)
-            throws Exception {
+    public void beforeScenario(Scenario scenario) throws Exception {
+        container.startup();
+        locator = KapuaLocatorImpl.getInstance();
+
         this.scenario = scenario;
         exceptionCaught = false;
 
@@ -186,6 +189,8 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
         scriptSession(DeviceEntityManagerFactory.instance(), DROP_DEVICE_TABLES);
         KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
         KapuaSecurityUtils.clearSession();
+
+        container.shutdown();
     }
 
     // The Cucumber test steps

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AbstractAuthorizationServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AbstractAuthorizationServiceTest.java
@@ -15,6 +15,7 @@ import java.math.BigInteger;
 import java.util.Random;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.core.KapuaContainer;
 import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.commons.jpa.SimpleSqlScriptExecutor;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
@@ -32,7 +33,8 @@ public abstract class AbstractAuthorizationServiceTest extends Assert {
     private static String DEFAULT_PATH = "../../../dev-tools/src/main/database";
     private static String DROP_ALL_TABLES = "all_drop.sql";
 
-    protected static final KapuaLocator locator = KapuaLocator.getInstance();
+    protected KapuaContainer container;
+    protected KapuaLocator locator;
     protected static final KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
     protected static Random random = new Random();
 

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestSteps.java
@@ -17,10 +17,13 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import cucumber.api.java.After;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.core.KapuaContainer;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
 import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
@@ -116,6 +119,10 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
     @Before
     public void beforeScenario(Scenario scenario)
             throws Exception {
+        container = new KapuaContainer() {};
+        container.startup();
+        locator = KapuaLocator.getInstance();
+
         this.scenario = scenario;
 
         // Instantiate all the services and factories that are required by the tests
@@ -141,6 +148,11 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         // Clean up the test data scratchpads
         accessData.clearData();
         commonData.clearData();
+    }
+
+    @After
+    public void afterScenario() throws KapuaException {
+        container.shutdown();
     }
 
     // *************************************

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
@@ -20,10 +20,12 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
 
 import cucumber.api.Scenario;
+import cucumber.api.java.After;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.runtime.java.guice.ScenarioScoped;
+import org.eclipse.kapua.locator.guice.KapuaLocatorImpl;
 
 // Implementation of Gherkin steps used in various integration test scenarios.
 @ScenarioScoped
@@ -40,7 +42,15 @@ public class CommonTestSteps extends AbstractKapuaSteps {
     // Database setup and tear-down steps
     @Before
     public void beforeScenario(Scenario scenario) throws KapuaException {
+        container.startup();
+        locator = KapuaLocatorImpl.getInstance();
+
         commonData.clearData();
+    }
+
+    @After
+    public void afterScenario() throws KapuaException {
+        container.shutdown();
     }
 
     // Cucumber test steps

--- a/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/UserServiceSteps.java
+++ b/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/UserServiceSteps.java
@@ -31,6 +31,7 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.locator.guice.KapuaLocatorImpl;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -137,6 +138,8 @@ public class UserServiceSteps extends AbstractKapuaSteps {
 
     @Before
     public void beforeScenario(Scenario scenario) throws Exception {
+        container.startup();
+        locator = KapuaLocatorImpl.getInstance();
 
         this.scenario = scenario;
         this.isException = false;
@@ -185,6 +188,8 @@ public class UserServiceSteps extends AbstractKapuaSteps {
         KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
 
         KapuaSecurityUtils.clearSession();
+
+        container.shutdown();
     }
 
     @Given("^User with name \"(.*)\" in scope with id (\\d+)$")

--- a/test/src/main/java/org/eclipse/kapua/test/KapuaTest.java
+++ b/test/src/main/java/org/eclipse/kapua/test/KapuaTest.java
@@ -44,7 +44,7 @@ public class KapuaTest extends Assert {
 
     protected static Random random = new Random();
     protected static KapuaContainer container = new KapuaContainer() {};
-    protected static KapuaLocator locator = KapuaLocatorImpl.getInstance();
+    protected KapuaLocator locator;
 
     protected static KapuaId adminUserId;
     protected static KapuaId adminScopeId;
@@ -54,6 +54,8 @@ public class KapuaTest extends Assert {
     @Before
     public void setUp() throws SQLException {
         container.startup();
+        locator = KapuaLocatorImpl.getInstance();
+
         connection = DriverManager.getConnection("jdbc:h2:mem:kapua;MODE=MySQL", "kapua", "kapua");
 
         new KapuaLiquibaseClient("jdbc:h2:mem:kapua;MODE=MySQL", "kapua", "kapua").update();
@@ -92,7 +94,6 @@ public class KapuaTest extends Assert {
         }
 
         try {
-            KapuaLocator locator = KapuaLocator.getInstance();
             AuthenticationService authenticationService = locator.getService(AuthenticationService.class);
 
             authenticationService.logout();


### PR DESCRIPTION
Because tests fail on eclipse/kapua Travis CI, structure of creating
KapuaContext and instantiation of locator is changed.

Tests are running fine on local build and also on my muros-ct/kapua
fork Travis build.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>