### PR TITLE
Additional integration level CRUD tests for the Device Service

### DIFF
--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -11,7 +11,7 @@
 #
 ###############################################################################
 
-Feature: Device Registry Integration 
+Feature: Device Registry Integration
     Device Registy integration test scenarios. These scenarios test higher level device service functionality
     with all services live.
 
@@ -47,7 +47,7 @@ Scenario: Birth message handling from a new device
     And I logout
 
 Scenario: Birth message handling from an existing device
-    A BIRTH message is received from an already existing device. A new BIRTH event must be 
+    A BIRTH message is received from an already existing device. A new BIRTH event must be
     inserted into the database.
 
     When I login as user with name "kapua-sys" and password "kapua-password"
@@ -76,4 +76,156 @@ Scenario: Birth message handling from an existing device
     When I search for events from device "device_1" in account "AccountA"
     Then I find 1 event
     And The type of the last event is "BIRTH"
+    And I logout
+
+Scenario: Handling of 2 birth messages
+    Two BIRTH messages are received from a device. No exception should be thrown and there should be
+    2 BIRTH events in the database.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account
+      | name      | scopeId |
+      | AccountA  | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | UserA   | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I configure the device service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    And A birth message from device "device_1"
+    And A birth message from device "device_1"
+    When I search for events from device "device_1" in account "AccountA"
+    Then I find 2 events
+    And The type of the last event is "BIRTH"
+    And I logout
+
+Scenario: Handling of a disconnect message from a non existing device
+    Reception of a DISCONNECT message with a nonexistent client ID should result in an exception.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account
+      | name      | scopeId |
+      | AccountA  | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | UserA   | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I configure the device service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    When A disconnect message from device "device_1"
+    Then An exception was thrown
+    And I logout
+
+Scenario: Birth and death message handling
+    Reception of a BIRTH-DISCONNECT pair. The first message (BIRTH) should cause a device to be
+    created in the database, allowing the successive DISCONNECT message to be successsfully
+    processsed. After the messages the database should contain two events (both BIRTH
+    and DISCONNECT).
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account
+      | name      | scopeId |
+      | AccountA  | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | UserA   | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I configure the device service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    Given A birth message from device "device_1"
+    And A disconnect message from device "device_1"
+    When I search for events from device "device_1" in account "AccountA"
+    Then I find 2 events
+    And The type of the last event is "DEATH"
+    And I logout
+
+Scenario: Birth and missing event handling
+    Reception of a BIRTH-MISSING pair. The first message (BIRTH) should cause a device to be
+    created in the database, allowing the successive MISSING message to be successsfully
+    processsed. After the messages the database should contain two events (both BIRTH
+    and MISSING).
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account
+      | name      | scopeId |
+      | AccountA  | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | UserA   | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I configure the device service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    Given A birth message from device "device_1"
+    And A missing message from device "device_1"
+    When I search for events from device "device_1" in account "AccountA"
+    Then I find 2 events
+    And The type of the last event is "MISSING"
+    And I logout
+
+Scenario: Birth and applications event handling
+    Reception of a BIRTH-APPLICATION pair. The first message (BIRTH) should cause a device to be
+    created in the database, allowing the successive APPLICATION message to be successsfully
+    processsed. After the messages the database should contain two events (both BIRTH
+    and APPLICATION).
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account
+      | name      | scopeId |
+      | AccountA  | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | UserA   | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I configure the device service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    Given A birth message from device "device_1"
+    And An application message from device "device_1"
+    When I search for events from device "device_1" in account "AccountA"
+    Then I find 2 events
+    And The type of the last event is "APPLICATION"
     And I logout


### PR DESCRIPTION
## Device Registry integration tests - CRUD operations
This is an additional set Device Registry integration tests that are designed to test the CRUD operations of the Device Registry service in a live Kapua environment (no mock services). The tests are cucumber based.
Additional test cases will be added to increase the coverage and cover more corner cases.

### Changes to Maven pom files
No pom file has been changed.

### Implementation changes
The implementation of the Device Registry service has not been changed.

### Test changes
An additional set of Cucumber based integration tests is implemented to test CRUD operations on the Device Registry service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>