### PR TITLE
Add option to specify IMAGE_VERSION in openshift deployments

### DIFF
--- a/dev-tools/src/main/openshift/openshift-deploy.sh
+++ b/dev-tools/src/main/openshift/openshift-deploy.sh
@@ -16,6 +16,7 @@ set -e
 
  : OPENSHIFT_PROJECT_NAME=${OPENSHIFT_PROJECT_NAME:=eclipse-kapua}
  : DOCKER_ACCOUNT=${DOCKER_ACCOUNT:=kapua}
+ : IMAGE_VERSION=${IMAGE_VERSION:=latest}
 
 # print error and exit when necessary
 
@@ -28,6 +29,6 @@ $OC describe "project/$OPENSHIFT_PROJECT_NAME" &>/dev/null || die "Project '$OPE
 ### Create Kapua from template
 
 echo Creating Kapua from template ...
-$OC new-app -n "$OPENSHIFT_PROJECT_NAME" -f kapua-template.yml -p "DOCKER_ACCOUNT=$DOCKER_ACCOUNT"
+$OC new-app -n "$OPENSHIFT_PROJECT_NAME" -f kapua-template.yml -p "DOCKER_ACCOUNT=$DOCKER_ACCOUNT" -p "IMAGE_VERSION=$IMAGE_VERSION"
 echo Creating Kapua from template ... done!
 


### PR DESCRIPTION
Add the possibility to specify a different version of the docker containers in the openshift deployments. This change just exposes the parameter already present in the template file.

Signed-off-by: Stefano Zilli <stefano.zilli@eurotech.com>