### PR TITLE
Fix/domain access check

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaId.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaId.java
@@ -15,6 +15,8 @@ import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Base64;
 
+import javax.xml.bind.annotation.XmlTransient;
+
 /**
  * Kapua identifier object.<br>
  * This object it's used to identify each entity.<br>
@@ -24,6 +26,9 @@ import java.util.Base64;
  *
  */
 public interface KapuaId extends Serializable {
+
+    @XmlTransient
+    public static final KapuaId ANY = new KapuaIdStatic(BigInteger.ONE.negate());
 
     /**
      * Get the identifier

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdStatic.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdStatic.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model.id;
+
+import java.math.BigInteger;
+
+public final class KapuaIdStatic implements KapuaId {
+
+    private static final long serialVersionUID = 8660393054811025101L;
+    private final BigInteger value;
+
+    public KapuaIdStatic(BigInteger value) {
+        if (null == value) {
+            throw new IllegalArgumentException();
+        }
+
+        this.value = value;
+    }
+
+    @Override
+    public BigInteger getId() {
+        return value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + getId().hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        KapuaIdStatic other = (KapuaIdStatic) obj;
+        if (!getId().equals(other.getId())) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainServiceImpl.java
@@ -94,7 +94,7 @@ public class DomainServiceImpl extends AbstractKapuaService implements DomainSer
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(domainDomain, Actions.read, null));
+        authorizationService.checkPermission(permissionFactory.newPermission(domainDomain, Actions.read, KapuaId.ANY));
 
         return entityManagerSession.onResult(em -> DomainDAO.find(em, domainId));
     }
@@ -109,7 +109,7 @@ public class DomainServiceImpl extends AbstractKapuaService implements DomainSer
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(domainDomain, Actions.read, null));
+        authorizationService.checkPermission(permissionFactory.newPermission(domainDomain, Actions.read, KapuaId.ANY));
 
         return entityManagerSession.onResult(em -> {
             DomainFactory domainFactory = locator.getFactory(DomainFactory.class);
@@ -136,7 +136,7 @@ public class DomainServiceImpl extends AbstractKapuaService implements DomainSer
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(domainDomain, Actions.read, null));
+        authorizationService.checkPermission(permissionFactory.newPermission(domainDomain, Actions.read, KapuaId.ANY));
 
         return entityManagerSession.onResult(em -> DomainDAO.query(em, query));
     }
@@ -151,7 +151,7 @@ public class DomainServiceImpl extends AbstractKapuaService implements DomainSer
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(domainDomain, Actions.read, null));
+        authorizationService.checkPermission(permissionFactory.newPermission(domainDomain, Actions.read, KapuaId.ANY));
 
         return entityManagerSession.onResult(em -> DomainDAO.count(em, query));
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
@@ -218,6 +218,10 @@ public class PermissionImpl extends WildcardPermission implements Permission, or
 
         Permission permission = (Permission) p;
 
+        if (KapuaId.ANY.equals(permission.getTargetScopeId())) {
+            setTargetScopeId(null);
+        }
+
         if (Group.ANY.equals(permission.getGroupId())) {
             setGroupId(null);
         }


### PR DESCRIPTION
Hi all ,

This PR fixes #571 .

Now less privileged account have granted READ operations on DomainService.
Create, Update and Delete actions are restricted to `kapua-sys` account.

The solution adopted is similar to the one used for the `ANY` group.

Regards, 

_Alberto_