### PR TITLE
Allow both strict and non-strict channel filtering 

### DIFF
--- a/console/src/main/java/org/eclipse/kapua/app/console/server/GwtDataServiceImpl.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/server/GwtDataServiceImpl.java
@@ -194,7 +194,7 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
     @Override
     public ListLoadResult<GwtHeader> findHeaders(LoadConfig config, String scopeId, GwtTopic topic) throws GwtKapuaException {
-        ChannelMatchPredicateImpl predicate = new ChannelMatchPredicateImpl(topic.getSemanticTopic());
+        ChannelMatchPredicateImpl predicate = new ChannelMatchPredicateImpl(topic.getSemanticTopic().replaceFirst("/#$", ""));
         return findHeaders(config, scopeId, predicate);
     }
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
@@ -35,7 +35,6 @@ import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.internal.model.query.AndPredicateImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.StorableFieldImpl;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.AndPredicate;
@@ -115,7 +114,7 @@ public class DataMessages extends AbstractKapuaResource {
             if (!Strings.isNullOrEmpty(channel)) {
                 StorablePredicate channelPredicate = null;
                 if (strictChannel) {
-                    channelPredicate = storablePredicateFactory.newTermPredicate(new StorableFieldImpl("channel"), channel);
+                    channelPredicate = storablePredicateFactory.newTermPredicate(ChannelInfoField.CHANNEL, channel);
                 } else {
                     channelPredicate = storablePredicateFactory.newChannelMatchPredicate(channel);
                 }

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
@@ -35,14 +35,15 @@ import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.internal.model.query.AndPredicateImpl;
+import org.eclipse.kapua.service.datastore.internal.model.query.StorableFieldImpl;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.AndPredicate;
-import org.eclipse.kapua.service.datastore.model.query.ChannelMatchPredicate;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.MetricPredicate;
 import org.eclipse.kapua.service.datastore.model.query.RangePredicate;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
+import org.eclipse.kapua.service.datastore.model.query.StorablePredicate;
 import org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory;
 import org.eclipse.kapua.service.datastore.model.query.TermPredicate;
 
@@ -70,6 +71,8 @@ public class DataMessages extends AbstractKapuaResource {
      *            The client id to filter results.
      * @param channel
      *            The channel id to filter results. It allows '#' wildcard in last channel level.
+     * @param strictChannel
+     *            Restrict the search only to this channel ignoring its children. Only meaningful if channel is set.
      * @param startDateParam
      *            The start date to filter the results. Must come before endDate parameter.
      * @param endDateParam
@@ -91,7 +94,8 @@ public class DataMessages extends AbstractKapuaResource {
     public <V extends Comparable<V>> MessageListResult simpleQuery(  //
             @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,//
             @ApiParam(value = "The client id to filter results") @QueryParam("clientId") String clientId, //
-            @ApiParam(value = "The channel to filter results. It allows '#' wildcard in last channel level") @QueryParam("channel") String channel,
+            @ApiParam(value = "The channel to filter results.") @QueryParam("channel") String channel,
+            @ApiParam(value = "Restrict the search only to this channel ignoring its children. Only meaningful if channel is set.") @QueryParam("strictChannel") boolean strictChannel,
             @ApiParam(value = "The start date to filter the results. Must come before endDate parameter") @QueryParam("startDate") DateParam startDateParam,
             @ApiParam(value = "The end date to filter the results. Must come after startDate parameter") @QueryParam("endDate") DateParam endDateParam,
             @ApiParam(value = "The metric name to filter results") @QueryParam("metricName") String metricName, //
@@ -109,7 +113,12 @@ public class DataMessages extends AbstractKapuaResource {
             }
 
             if (!Strings.isNullOrEmpty(channel)) {
-                ChannelMatchPredicate channelPredicate = storablePredicateFactory.newChannelMatchPredicate(channel);
+                StorablePredicate channelPredicate = null;
+                if (strictChannel) {
+                    channelPredicate = storablePredicateFactory.newTermPredicate(new StorableFieldImpl("channel"), channel);
+                } else {
+                    channelPredicate = storablePredicateFactory.newChannelMatchPredicate(channel);
+                }
                 andPredicate.getPredicates().add(channelPredicate);
             }
 


### PR DESCRIPTION
Hi all,

With this PR both strict and non-strict channel filtering will be allowed. Console will always use non-strict channel filtering (i.e. will show metrics of child channels when selecting a channels), while REST APIs will support both modes via a query parameter.

Cheers!