### PR TITLE
fix negative number id generator (only positive number will be genera…

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/IdGenerator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/IdGenerator.java
@@ -38,9 +38,7 @@ public class IdGenerator {
      * @return
      */
     public static BigInteger generate() {
-        byte[] bytes = new byte[ID_SIZE];
-        SECURE_RANDOM.nextBytes(bytes);
-        return new BigInteger(bytes);
+        return new BigInteger(ID_SIZE, SECURE_RANDOM);
     }
 
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -167,7 +167,7 @@ public enum SystemSettingKey implements SettingKey {
     OSGI_CONTEXT("commons.osgi.context"),
 
     /**
-     * Set the Kapua key size
+     * Set the Kapua key size (the size is expressed in bits)
      */
     KAPUA_KEY_SIZE("commons.entity.key.size"),
 

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -58,6 +58,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-#set the generated ids size (in bits)
-commons.entity.key.size=64
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
 commons.entity.insert.max.retry=3

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -58,5 +58,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-commons.entity.key.size=8
+#set the generated ids size (in bits)
+commons.entity.key.size=64
 commons.entity.insert.max.retry=3

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
@@ -121,7 +121,7 @@ public class KapuaIdGeneratorTest extends AbstractCommonServiceTest {
     public void testIdGeneratorBound() throws Exception {
         int idSize = SystemSetting.getInstance().getInt(SystemSettingKey.KAPUA_KEY_SIZE);
         BigInteger upperLimit = BigInteger.valueOf(2).pow(idSize);
-        for (int i = 0; i < 100000000; i++) {
+        for (int i = 0; i < 1000; i++) {
             BigInteger generated = IdGenerator.generate();
             assertFalse("The generated id is out of the expected bounds!", generated.compareTo(BigInteger.ZERO) < 0 || generated.compareTo(upperLimit) != -1);
         }

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
@@ -13,11 +13,13 @@
 package org.eclipse.kapua.commons.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.math.BigInteger;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.IdGenerator;
 import org.eclipse.kapua.commons.model.misc.CollisionEntity;
 import org.eclipse.kapua.commons.model.misc.CollisionIdGenerator;
 import org.eclipse.kapua.commons.model.misc.CollisionServiceImpl;
@@ -107,6 +109,21 @@ public class KapuaIdGeneratorTest extends AbstractCommonServiceTest {
         } catch (KapuaException e) {
             assertEquals("The generated random identifiers count is wrong!", SystemSetting.getInstance().getInt(SystemSettingKey.KAPUA_INSERT_MAX_RETRY) + 3,
                     collisionIdGenerator.getGeneretedValuesCount());
+        }
+    }
+
+    @Test
+    /**
+     * Just generate few ids and check if the numbers are fitted into the expected limits
+     * 
+     * @throws Exception
+     */
+    public void testIdGeneratorBound() throws Exception {
+        int idSize = SystemSetting.getInstance().getInt(SystemSettingKey.KAPUA_KEY_SIZE);
+        BigInteger upperLimit = BigInteger.valueOf(2).pow(idSize);
+        for (int i = 0; i < 100000000; i++) {
+            BigInteger generated = IdGenerator.generate();
+            assertFalse("The generated id is out of the expected bounds!", generated.compareTo(BigInteger.ZERO) < 0 || generated.compareTo(upperLimit) != -1);
         }
     }
 }

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -59,6 +59,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-#set the generated ids size (in bits)
-commons.entity.key.size=64
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
 commons.entity.insert.max.retry=3

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -59,5 +59,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-commons.entity.key.size=8
+#set the generated ids size (in bits)
+commons.entity.key.size=64
 commons.entity.insert.max.retry=3

--- a/service/account/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/internal/src/test/resources/kapua-environment-setting.properties
@@ -55,8 +55,8 @@ broker.port=1884
 #
 # Entity settings
 #
-#set the generated ids size (in bits)
-commons.entity.key.size=64
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
 commons.entity.insert.max.retry=3
 
 character.encoding=UTF-8

--- a/service/account/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/internal/src/test/resources/kapua-environment-setting.properties
@@ -55,15 +55,10 @@ broker.port=1884
 #
 # Entity settings
 #
-commons.entity.key.size=8
+#set the generated ids size (in bits)
+commons.entity.key.size=64
 commons.entity.insert.max.retry=3
 
 character.encoding=UTF-8
 
 commons.osgi.context=false
-
-# 
-# Entity settings
-# 
-commons.entity.key.size=8
-commons.entity.insert.max.retry=3

--- a/service/datastore/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/internal/src/test/resources/kapua-environment-setting.properties
@@ -58,6 +58,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-#set the generated ids size (in bits)
-commons.entity.key.size=64
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
 commons.entity.insert.max.retry=3

--- a/service/datastore/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/internal/src/test/resources/kapua-environment-setting.properties
@@ -58,5 +58,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-commons.entity.key.size=8
+#set the generated ids size (in bits)
+commons.entity.key.size=64
 commons.entity.insert.max.retry=3

--- a/service/device/registry/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/internal/src/test/resources/kapua-environment-setting.properties
@@ -59,6 +59,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-#set the generated ids size (in bits)
-commons.entity.key.size=64
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
 commons.entity.insert.max.retry=3

--- a/service/device/registry/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/internal/src/test/resources/kapua-environment-setting.properties
@@ -59,5 +59,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-commons.entity.key.size=8
+#set the generated ids size (in bits)
+commons.entity.key.size=64
 commons.entity.insert.max.retry=3

--- a/service/security/shiro/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/shiro/src/test/resources/kapua-environment-setting.properties
@@ -60,5 +60,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-commons.entity.key.size=8
+#set the generated ids size (in bits)
+commons.entity.key.size=64
 commons.entity.insert.max.retry=3

--- a/service/security/shiro/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/shiro/src/test/resources/kapua-environment-setting.properties
@@ -60,6 +60,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-#set the generated ids size (in bits)
-commons.entity.key.size=64
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
 commons.entity.insert.max.retry=3

--- a/service/user/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/internal/src/test/resources/kapua-environment-setting.properties
@@ -59,6 +59,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-#set the generated ids size (in bits)
-commons.entity.key.size=64
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
 commons.entity.insert.max.retry=3

--- a/service/user/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/internal/src/test/resources/kapua-environment-setting.properties
@@ -59,5 +59,6 @@ commons.osgi.context=false
 # 
 # Entity settings
 # 
-commons.entity.key.size=8
+#set the generated ids size (in bits)
+commons.entity.key.size=64
 commons.entity.insert.max.retry=3


### PR DESCRIPTION
The previous version of the id generator generated also negative ids. This may be an issue for the incoming feature and also for the datastore operations.
So it is preferable to modify the implementation to generate only positive numbers.