### PR TITLE
Changed data tabs layout

### DIFF
--- a/console/src/main/java/org/eclipse/kapua/app/console/client/data/AssetTabItem.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/client/data/AssetTabItem.java
@@ -45,10 +45,12 @@ public class AssetTabItem extends TabItem {
     private static final ConsoleDataMessages MSGS = GWT.create(ConsoleDataMessages.class);
 
     private GwtSession currentSession;
-    private DeviceTable deviceTable;
-    private Button queryButton;
-    private ResultsTable resultsTable;
 
+    private DeviceTable deviceTable;
+
+    private Button queryButton;
+
+    private ResultsTable resultsTable;
     private AssetTable assetTable;
     private MetricsTable metricsTable;
 
@@ -62,7 +64,9 @@ public class AssetTabItem extends TabItem {
     @Override
     protected void onRender(Element parent, int index) {
         super.onRender(parent, index);
-        this.setWidth("100%");
+
+        setWidth("100%");
+
         BorderLayoutData messageLayout = new BorderLayoutData(LayoutRegion.NORTH, 0.06f);
         messageLayout.setMargins(new Margins(5));
         Text welcomeMessage = new Text();
@@ -71,10 +75,11 @@ public class AssetTabItem extends TabItem {
 
         LayoutContainer tables = new LayoutContainer(new BorderLayout());
         BorderLayoutData tablesLayout = new BorderLayoutData(LayoutRegion.CENTER);
+        tablesLayout.setMargins(new Margins(0, 5, 0, 5));
         tablesLayout.setMinSize(250);
         add(tables, tablesLayout);
 
-        BorderLayoutData deviceLayout = new BorderLayoutData(LayoutRegion.WEST, 0.3f);
+        BorderLayoutData deviceLayout = new BorderLayoutData(LayoutRegion.WEST, 0.33f);
         deviceTable = new DeviceTable(currentSession);
         deviceLayout.setMargins(new Margins(0, 5, 0, 0));
         deviceLayout.setSplit(true);
@@ -87,20 +92,20 @@ public class AssetTabItem extends TabItem {
         });
         tables.add(deviceTable, deviceLayout);
 
-        BorderLayoutData assetLayout = new BorderLayoutData(LayoutRegion.CENTER, 0.3f);
+        BorderLayoutData assetLayout = new BorderLayoutData(LayoutRegion.CENTER, 0.34f);
         assetLayout.setMargins(new Margins(0, 5, 0, 5));
         assetLayout.setSplit(true);
         assetTable = new AssetTable(currentSession);
         assetTable.addSelectionChangedListener(new SelectionChangedListener<GwtDatastoreAsset>() {
 
-               @Override
-               public void selectionChanged(SelectionChangedEvent<GwtDatastoreAsset> selectedAsset) {
-                   metricsTable.refresh(selectedAsset.getSelectedItem());
-               }
+            @Override
+            public void selectionChanged(SelectionChangedEvent<GwtDatastoreAsset> selectedAsset) {
+                metricsTable.refresh(selectedAsset.getSelectedItem());
+            }
         });
         tables.add(assetTable, assetLayout);
 
-        BorderLayoutData channelLayout = new BorderLayoutData(LayoutRegion.EAST, 0.3f);
+        BorderLayoutData channelLayout = new BorderLayoutData(LayoutRegion.EAST, 0.33f);
         channelLayout.setMargins(new Margins(0, 0, 0, 5));
         channelLayout.setSplit(true);
         metricsTable = new MetricsTable(currentSession, MetricsTable.Type.ASSET);
@@ -108,7 +113,7 @@ public class AssetTabItem extends TabItem {
 
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtHeader> se) {
-                if(!se.getSelection().isEmpty()){
+                if (!se.getSelection().isEmpty()) {
                     queryButton.enable();
                 } else {
                     queryButton.disable();
@@ -135,11 +140,14 @@ public class AssetTabItem extends TabItem {
         queryButtonContainer.add(queryButton, new TableData());
         tables.add(queryButtonContainer, queryButtonLayout);
 
-        BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH);
+        BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.5f);
         resultsLayout.setSplit(true);
-        resultsLayout.setMargins(new Margins(5, 0, 0, 0));
 
         TabPanel resultsTabPanel = new TabPanel();
+        resultsTabPanel.setPlain(true);
+        resultsTabPanel.setBorders(false);
+        resultsTabPanel.setBodyBorder(false);
+
         resultsTable = new ResultsTable(currentSession);
         TabItem resultsTableTabItem = new TabItem(MSGS.resultsTableTabItemTitle(), new KapuaIcon(IconSet.TABLE));
         resultsTableTabItem.setLayout(new FitLayout());

--- a/console/src/main/java/org/eclipse/kapua/app/console/client/data/DeviceTabItem.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/client/data/DeviceTabItem.java
@@ -39,74 +39,78 @@ import com.extjs.gxt.ui.client.widget.layout.TableLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 
-
 public class DeviceTabItem extends TabItem {
-   
-    private static final ConsoleDataMessages MSGS = GWT.create(ConsoleDataMessages.class);
-    
-    private GwtSession currentSession;
-    private DeviceTable deviceTable;
-    private Button queryButton;
-    private MetricsTable metricsTable;
 
+    private static final ConsoleDataMessages MSGS = GWT.create(ConsoleDataMessages.class);
+
+    private GwtSession currentSession;
+
+    private DeviceTable deviceTable;
+
+    private Button queryButton;
+
+    private MetricsTable metricsTable;
     private ResultsTable resultsTable;
-    
+
     public DeviceTabItem(GwtSession currentSession) {
         super(MSGS.deviceTabItemTitle(), null);
         this.currentSession = currentSession;
         this.setBorders(false);
         this.setLayout(new BorderLayout());
     }
-    
-   
+
     @Override
     protected void onRender(Element parent, int index) {
         super.onRender(parent, index);
-        this.setWidth("100%");
+
+        setWidth("100%");
+
         BorderLayoutData messageLayout = new BorderLayoutData(LayoutRegion.NORTH, 0.06f);
         messageLayout.setMargins(new Margins(5));
         Text welcomeMessage = new Text();
         welcomeMessage.setText(MSGS.deviceTabItemMessage());
         add(welcomeMessage, messageLayout);
-        
+
         LayoutContainer tables = new LayoutContainer(new BorderLayout());
         BorderLayoutData tablesLayout = new BorderLayoutData(LayoutRegion.CENTER);
+        tablesLayout.setMargins(new Margins(0, 5, 0, 5));
         tablesLayout.setMinSize(250);
         add(tables, tablesLayout);
-        
+
         BorderLayoutData deviceLayout = new BorderLayoutData(LayoutRegion.WEST, 0.5f);
         deviceTable = new DeviceTable(currentSession);
+        deviceTable.setBorders(false);
         deviceLayout.setMargins(new Margins(0, 5, 0, 0));
         deviceLayout.setSplit(true);
         deviceTable.addSelectionChangedListener(new SelectionChangedListener<GwtDatastoreDevice>() {
-            
+
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtDatastoreDevice> selectedDevice) {
                 metricsTable.refresh(selectedDevice.getSelectedItem());
             }
         });
         tables.add(deviceTable, deviceLayout);
-        
-        BorderLayoutData metricLayout = new BorderLayoutData(LayoutRegion.CENTER, 0.5f);
+
+        BorderLayoutData metricLayout = new BorderLayoutData(LayoutRegion.CENTER);
+        metricLayout.setMargins(new Margins(0, 0, 0, 5));
         metricsTable = new MetricsTable(currentSession, MetricsTable.Type.DEVICE);
         metricsTable.addSelectionListener(new SelectionChangedListener<GwtHeader>() {
-            
+
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtHeader> se) {
-                if(!se.getSelection().isEmpty()){
+                if (!se.getSelection().isEmpty()) {
                     queryButton.enable();
                 } else {
                     queryButton.disable();
                 }
             }
         });
-        metricLayout.setMargins(new Margins(0, 0, 0, 5));
         tables.add(metricsTable, metricLayout);
 
         BorderLayoutData queryButtonLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.1f);
         queryButtonLayout.setMargins(new Margins(5));
         queryButton = new Button(MSGS.deviceTabItemQueryButtonText(), new KapuaIcon(IconSet.SEARCH), new SelectionListener<ButtonEvent>() {
-            
+
             @Override
             public void componentSelected(ButtonEvent ce) {
                 GwtDatastoreDevice gwtDevice = deviceTable.getSelectedDevice();
@@ -121,24 +125,20 @@ public class DeviceTabItem extends TabItem {
         queryButtonContainer.add(queryButton, new TableData());
         tables.add(queryButtonContainer, queryButtonLayout);
 
-        BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH);
+        BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.5f);
         resultsLayout.setSplit(true);
-        resultsLayout.setMargins(new Margins(5, 0, 0, 0));
 
-        
         TabPanel resultsTabPanel = new TabPanel();
+        resultsTabPanel.setPlain(true);
+        resultsTabPanel.setBorders(false);
+        resultsTabPanel.setBodyBorder(false);
+
         resultsTable = new ResultsTable(currentSession);
         TabItem resultsTableTabItem = new TabItem(MSGS.resultsTableTabItemTitle(), new KapuaIcon(IconSet.TABLE));
         resultsTableTabItem.setLayout(new FitLayout());
         resultsTableTabItem.add(resultsTable);
         resultsTabPanel.add(resultsTableTabItem);
-//        ResultsChart resultsChart = new ResultsChart(currentSession);
-//        TabItem resultsChartTabItem = new TabItem(MSGS.resultsChartTabItemTitle(), new KapuaIcon(IconSet.LINE_CHART));
-//        resultsChartTabItem.setLayout(new FitLayout());
-//        resultsChartTabItem.add(resultsChart);
-//        resultsTabPanel.add(resultsChartTabItem);
-        
+
         add(resultsTabPanel, resultsLayout);
     }
-    
 }

--- a/console/src/main/java/org/eclipse/kapua/app/console/client/data/TopicsTabItem.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/client/data/TopicsTabItem.java
@@ -42,11 +42,14 @@ import com.google.gwt.user.client.Element;
 public class TopicsTabItem extends TabItem {
 
     private static final ConsoleDataMessages MSGS = GWT.create(ConsoleDataMessages.class);
+
     private GwtSession currentSession;
+
     private Button queryButton;
+
     private TopicsTable topicTable;
+
     private MetricsTable metricsTable;
-    // private ResultsChart resultsChart;
     private ResultsTable resultsTable;
 
     public TopicsTabItem(GwtSession currentSession) {
@@ -54,14 +57,14 @@ public class TopicsTabItem extends TabItem {
         this.currentSession = currentSession;
         this.setBorders(false);
         this.setLayout(new BorderLayout());
-
     }
 
     @Override
     protected void onRender(Element parent, int index) {
         super.onRender(parent, index);
-        // this.setHeight("100%");
-        this.setWidth("100%");
+
+        setWidth("100%");
+
         BorderLayoutData messageLayout = new BorderLayoutData(LayoutRegion.NORTH, 0.06f);
         messageLayout.setMargins(new Margins(5));
         Text welcomeMessage = new Text();
@@ -70,16 +73,17 @@ public class TopicsTabItem extends TabItem {
 
         LayoutContainer tables = new LayoutContainer(new BorderLayout());
         BorderLayoutData tablesLayout = new BorderLayoutData(LayoutRegion.CENTER);
-        // tablesLayout.setMargins(new Margins(0, 0, 5, 0));
+        tablesLayout.setMargins(new Margins(0, 5, 0, 5));
         tablesLayout.setMinSize(250);
         add(tables, tablesLayout);
 
         BorderLayoutData topicLayout = new BorderLayoutData(LayoutRegion.WEST, 0.5f);
         topicTable = new TopicsTable(currentSession);
+        topicTable.setBorders(false);
         topicLayout.setMargins(new Margins(0, 5, 0, 0));
         topicLayout.setSplit(true);
         topicTable.addSelectionChangedListener(new SelectionChangedListener<GwtTopic>() {
-            
+
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtTopic> selectedTopic) {
                 metricsTable.refresh(selectedTopic.getSelectedItem());
@@ -87,14 +91,14 @@ public class TopicsTabItem extends TabItem {
         });
         tables.add(topicTable, topicLayout);
 
-        BorderLayoutData metricLayout = new BorderLayoutData(LayoutRegion.CENTER, 0.5f);
+        BorderLayoutData metricLayout = new BorderLayoutData(LayoutRegion.CENTER);
         metricLayout.setMargins(new Margins(0, 0, 0, 5));
         metricsTable = new MetricsTable(currentSession, MetricsTable.Type.TOPIC);
         metricsTable.addSelectionListener(new SelectionChangedListener<GwtHeader>() {
-            
+
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtHeader> se) {
-                if(!se.getSelection().isEmpty()){
+                if (!se.getSelection().isEmpty()) {
                     queryButton.enable();
                 } else {
                     queryButton.disable();
@@ -121,27 +125,20 @@ public class TopicsTabItem extends TabItem {
         queryButtonContainer.add(queryButton, new TableData());
         tables.add(queryButtonContainer, queryButtonLayout);
 
-        BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH);
+        BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.5f);
         resultsLayout.setSplit(true);
-        // resultsLayout.setMargins(new Margins(5, 0, 0, 0));
 
         TabPanel resultsTabPanel = new TabPanel();
-        resultsTabPanel.setPlain(false);
+        resultsTabPanel.setPlain(true);
         resultsTabPanel.setBorders(false);
         resultsTabPanel.setBodyBorder(false);
+
         resultsTable = new ResultsTable(currentSession);
         TabItem resultsTableTabItem = new TabItem(MSGS.resultsTableTabItemTitle(), new KapuaIcon(IconSet.TABLE));
         resultsTableTabItem.setLayout(new FitLayout());
         resultsTableTabItem.add(resultsTable);
         resultsTabPanel.add(resultsTableTabItem);
-//        resultsChart = new ResultsChart(currentSession);
-//        TabItem resultsChartTabItem = new TabItem(MSGS.resultsChartTabItemTitle(), new KapuaIcon(IconSet.LINE_CHART));
-//        resultsChartTabItem.setLayout(new FitLayout());
-//        resultsChartTabItem.add(resultsChart);
-//        resultsTabPanel.add(resultsChartTabItem);
 
         add(resultsTabPanel, resultsLayout);
-
     }
-
 }


### PR DESCRIPTION
Changed a bit the layout of the data view to be more proportionate in the sections and removed some double borders.

Now is:
![screen shot 2017-05-26 at 2 35 56 pm](https://cloud.githubusercontent.com/assets/3942036/26494790/ba455866-4220-11e7-9aa7-508f6d5b29cb.png)

After changes:
![screen shot 2017-05-26 at 12 47 06 pm](https://cloud.githubusercontent.com/assets/3942036/26494543/749d371c-421f-11e7-82d8-6a8ffbf7c21f.png)

Device view and Asset view have the same changes.

Regards, 

_Alberto_
