### PR TITLE
Fix/feature file ide warnings

### DIFF
--- a/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -1,3 +1,14 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
 Feature: Device Broker Integration
   Device Service integration scenarios with running broker service.
   Each Scenario starts with BIRTH of device and then the communication over MQTT

--- a/qa/src/test/resources/features/broker/DeviceData.feature
+++ b/qa/src/test/resources/features/broker/DeviceData.feature
@@ -1,3 +1,14 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
 Feature: Device data scenarios
 
 Scenario: Connect to the system and publish some data

--- a/qa/src/test/resources/features/broker/DeviceLifecycle.feature
+++ b/qa/src/test/resources/features/broker/DeviceLifecycle.feature
@@ -1,3 +1,14 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
 Feature: Device lifecycle scenarios
 
 Scenario: Starting and stopping the simulator should create a device entry and properly set its status

--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: Device Registry Integration
     Device Registy integration test scenarios. These scenarios test higher level device service functionality

--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: Device Registry Integration
     Device Registy integration test scenarios. These scenarios test higher level device service functionality
     with all services live.

--- a/qa/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/src/test/resources/features/user/UserServiceI9n.feature
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: User Service Integration
   User Service integration scenarios

--- a/qa/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/src/test/resources/features/user/UserServiceI9n.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: User Service Integration
   User Service integration scenarios
 

--- a/service/account/internal/src/test/resources/features/AccountService.feature
+++ b/service/account/internal/src/test/resources/features/AccountService.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: User Account Service
     The User Account Service is responsible for CRUD operations for user accounts in the Kapua
     database.

--- a/service/account/internal/src/test/resources/features/AccountService.feature
+++ b/service/account/internal/src/test/resources/features/AccountService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: User Account Service
     The User Account Service is responsible for CRUD operations for user accounts in the Kapua

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistry.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistry.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: Device Registry Service
     The Device registry Service is responsible for CRUD operations for devices in the Kapua

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistry.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistry.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: Device Registry Service
     The Device registry Service is responsible for CRUD operations for devices in the Kapua
     database.

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistryConnection.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistryConnection.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: Device Registry Connection tests
     The Device Registry Connection service is responsible for performing CRUD operations 

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistryValidation.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistryValidation.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: Device Registry Validation Tests
     The Device Registry Validation helper is responsible for validating parameters 

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistryValidation.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistryValidation.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: Device Registry Validation Tests
     The Device Registry Validation helper is responsible for validating parameters 
     and permissions before any operation is performed on the database.

--- a/service/security/shiro/src/test/resources/features/AccessInfoService.feature
+++ b/service/security/shiro/src/test/resources/features/AccessInfoService.feature
@@ -9,7 +9,6 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
-
 Feature: Access Info Service CRUD tests
 
 Scenario: Simple create

--- a/service/security/shiro/src/test/resources/features/DomainService.feature
+++ b/service/security/shiro/src/test/resources/features/DomainService.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: Domain Service CRUD tests
 
 Scenario: Count domains in a blank database

--- a/service/security/shiro/src/test/resources/features/DomainService.feature
+++ b/service/security/shiro/src/test/resources/features/DomainService.feature
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: Domain Service CRUD tests
 

--- a/service/security/shiro/src/test/resources/features/GroupService.feature
+++ b/service/security/shiro/src/test/resources/features/GroupService.feature
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: Group Service CRUD tests
 

--- a/service/security/shiro/src/test/resources/features/GroupService.feature
+++ b/service/security/shiro/src/test/resources/features/GroupService.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: Group Service CRUD tests
 
 Scenario: Count groups in a blank database

--- a/service/security/shiro/src/test/resources/features/MiscAuthorization.feature
+++ b/service/security/shiro/src/test/resources/features/MiscAuthorization.feature
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: Misc Authorization functionality CRUD tests
 

--- a/service/security/shiro/src/test/resources/features/MiscAuthorization.feature
+++ b/service/security/shiro/src/test/resources/features/MiscAuthorization.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: Misc Authorization functionality CRUD tests
 
 Scenario: Permission factory sanity checks

--- a/service/user/internal/src/test/resources/features/UserService.feature
+++ b/service/user/internal/src/test/resources/features/UserService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,6 @@
 #
 # Contributors:
 #     Eurotech - initial API and implementation
-#
 ###############################################################################
 Feature: User Service
     User Service is responsible for CRUD operations on User objects in Kapua

--- a/service/user/internal/src/test/resources/features/UserService.feature
+++ b/service/user/internal/src/test/resources/features/UserService.feature
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
 Feature: User Service
     User Service is responsible for CRUD operations on User objects in Kapua
     database.


### PR DESCRIPTION
Hi all, 

this PR fixes some Eclipse IDE warning. 
Cucumber plugin was complaining about blank line at the beginning of the file.
I've also added missing copyright headers.

Regards, 

_Alberto_ 