### PR TITLE
fix indexed fields mapping to be compliant with ES 5.x syntax

### DIFF
--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaKeys.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaKeys.java
@@ -64,10 +64,6 @@ public class SchemaKeys {
      */
     public final static String KEY_FORMAT = "format";
     /**
-     * Keyword key
-     */
-    public final static String KEY_KEYWORD = "keyword";
-    /**
      * Index ky
      */
     public final static String KEY_INDEX = "index";
@@ -124,13 +120,20 @@ public class SchemaKeys {
      */
     public final static String TYPE_STRING = "string";
     /**
-     * Not analyzed field value
+     * Object keyword type (Structured string that can be indexed with new ES version)<br>
+     * <b>Please leave the "index" property for the keyword fields to false (default value) otherwise the value will be analyzed and indexed for the search operation)<br>
+     * (see https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html)</b>
      */
-    public final static String VALUE_FIELD_INDEXING_NOT_ANALYZED = "not_analyzed";
+    public final static String TYPE_KEYWORD = "keyword";
+
     /**
-     * "No" field value
+     * "false" field value
      */
-    public final static String VALUE_NO = "no";
+    public final static String VALUE_FALSE = "false";
+    /**
+     * "true" field value
+     */
+    public final static String VALUE_TRUE = "true";
 
     /**
      * Refresh interval (for schema definition)
@@ -145,6 +148,14 @@ public class SchemaKeys {
      */
     public final static String KEY_REPLICA_NUMBER = "number_of_replicas";
 
+    /**
+     * Message field
+     */
+    public final static String FIELD_NAME_MESSAGE = "message";
+    /**
+     * Metrics field
+     */
+    public final static String FIELD_NAME_METRICS = "metrics";
     /**
      * Position field
      */

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -23,8 +23,8 @@ import static org.eclipse.kapua.service.datastore.client.SchemaKeys.KEY_INDEX;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.KEY_TYPE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.KEY_SOURCE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_DATE;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_STRING;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_FIELD_INDEXING_NOT_ANALYZED;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_KEYWORD;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_TRUE;
 
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 
@@ -86,19 +86,19 @@ public class ChannelInfoSchema {
 
         ObjectNode propertiesNode = SchemaUtil.getObjectNode();
         ObjectNode channelScopeId = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(CHANNEL_SCOPE_ID, channelScopeId);
         ObjectNode channelClientId = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(CHANNEL_CLIENT_ID, channelClientId);
         ObjectNode channelName = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(CHANNEL_NAME, channelName);
         ObjectNode channelTimestamp = SchemaUtil.getField(
                 new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_DATE), new KeyValueEntry(KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
         propertiesNode.set(CHANNEL_TIMESTAMP, channelTimestamp);
         ObjectNode channelMessageId = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(CHANNEL_MESSAGE_ID, channelMessageId);
         channelNode.set("properties", propertiesNode);
         rootNode.set(CHANNEL_TYPE_NAME, channelNode);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -23,8 +23,8 @@ import static org.eclipse.kapua.service.datastore.client.SchemaKeys.KEY_INDEX;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.KEY_TYPE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.KEY_SOURCE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_DATE;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_STRING;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_FIELD_INDEXING_NOT_ANALYZED;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_KEYWORD;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_TRUE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.FIELD_NAME_PROPERTIES;
 
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
@@ -81,13 +81,13 @@ public class ClientInfoSchema {
         clientNodeName.set(KEY_ALL, allClient);
 
         ObjectNode propertiesNode = SchemaUtil.getObjectNode();
-        ObjectNode clientId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+        ObjectNode clientId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(CLIENT_ID, clientId);
         ObjectNode clientTimestamp = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_DATE), new KeyValueEntry(KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
         propertiesNode.set(CLIENT_TIMESTAMP, clientTimestamp);
-        ObjectNode clientScopeId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+        ObjectNode clientScopeId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(CLIENT_SCOPE_ID, clientScopeId);
-        ObjectNode clientMessageId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+        ObjectNode clientMessageId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(CLIENT_MESSAGE_ID, clientMessageId);
         clientNodeName.set(FIELD_NAME_PROPERTIES, propertiesNode);
         rootNode.set(CLIENT_TYPE_NAME, clientNodeName);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -31,10 +31,10 @@ import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_DOUBLE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_GEO_POINT;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_INTEGER;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_IP;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_KEYWORD;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_OBJECT;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_STRING;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_NO;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_FIELD_INDEXING_NOT_ANALYZED;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_FALSE;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_TRUE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.FIELD_NAME_POSITION;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.FIELD_NAME_PROPERTIES;
 
@@ -211,16 +211,16 @@ public class MessageSchema {
                 new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_IP) });
         propertiesNode.set(MESSAGE_IP_ADDRESS, messageIp);
         ObjectNode messageScopeId = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(MESSAGE_SCOPE_ID, messageScopeId);
         ObjectNode messageDeviceId = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(MESSAGE_DEVICE_ID, messageDeviceId);
         ObjectNode messageClientId = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(MESSAGE_CLIENT_ID, messageClientId);
         ObjectNode messageChannel = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(MESSAGE_CHANNEL, messageChannel);
         ObjectNode messageCapturedOn = SchemaUtil.getField(
                 new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_DATE), new KeyValueEntry(KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
@@ -268,7 +268,7 @@ public class MessageSchema {
         propertiesNode.set(MESSAGE_METRICS, messageMetrics);
 
         ObjectNode messageBody = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_BINARY), new KeyValueEntry(KEY_INDEX, VALUE_NO) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_BINARY), new KeyValueEntry(KEY_INDEX, VALUE_FALSE) });
         propertiesNode.set(MESSAGE_BODY, messageBody);
 
         return messageNode;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
@@ -26,9 +26,9 @@ import static org.eclipse.kapua.service.datastore.client.SchemaKeys.KEY_TYPE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.KEY_SOURCE;
 
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_DATE;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_KEYWORD;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_OBJECT;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.TYPE_STRING;
-import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_FIELD_INDEXING_NOT_ANALYZED;
+import static org.eclipse.kapua.service.datastore.client.SchemaKeys.VALUE_TRUE;
 import static org.eclipse.kapua.service.datastore.client.SchemaKeys.FIELD_NAME_PROPERTIES;
 
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
@@ -127,13 +127,13 @@ public class MetricInfoSchema {
 
         ObjectNode propertiesNode = SchemaUtil.getObjectNode();
         ObjectNode metricAccount = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(METRIC_SCOPE_ID, metricAccount);
         ObjectNode metricClientId = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(METRIC_CLIENT_ID, metricClientId);
         ObjectNode metricChannel = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         propertiesNode.set(METRIC_CHANNEL, metricChannel);
 
         ObjectNode metricMtrNode = SchemaUtil.getField(
@@ -141,19 +141,19 @@ public class MetricInfoSchema {
                         new KeyValueEntry(KEY_DYNAMIC, false), new KeyValueEntry(KEY_INCLUDE_IN_ALL, false) });
         ObjectNode metricMtrPropertiesNode = SchemaUtil.getObjectNode();
         ObjectNode metricMtrNameNode = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         metricMtrPropertiesNode.set(METRIC_MTR_NAME, metricMtrNameNode);
         ObjectNode metricMtrTypeNode = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         metricMtrPropertiesNode.set(METRIC_MTR_TYPE, metricMtrTypeNode);
         ObjectNode metricMtrValueNode = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         metricMtrPropertiesNode.set(METRIC_MTR_VALUE, metricMtrValueNode);
         ObjectNode metricMtrTimestampNode = SchemaUtil.getField(
                 new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_DATE), new KeyValueEntry(KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
         metricMtrPropertiesNode.set(METRIC_MTR_TIMESTAMP, metricMtrTimestampNode);
         ObjectNode metricMtrMsgIdNode = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_STRING), new KeyValueEntry(KEY_INDEX, VALUE_FIELD_INDEXING_NOT_ANALYZED) });
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
         metricMtrPropertiesNode.set(METRIC_MTR_MSG_ID, metricMtrMsgIdNode);
         metricMtrNode.set(FIELD_NAME_PROPERTIES, metricMtrPropertiesNode);
         propertiesNode.set(METRIC_MTR, metricMtrNode);


### PR DESCRIPTION
As in the title. The indexed fields mapping is changed according to ES 5.x syntax.
See: https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html

Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>