### PR TITLE
Fix datastore deletes

### DIFF
--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoRegistryService.java
@@ -65,26 +65,4 @@ public interface ChannelInfoRegistryService extends KapuaService, KapuaConfigura
     public long count(ChannelInfoQuery query)
             throws KapuaException;
 
-    /**
-     * Delete channel information by identifier
-     * 
-     * @param scopeId
-     * @param id
-     * @throws KapuaException
-     * 
-     * @since 1.0.0
-     */
-    public void delete(KapuaId scopeId, StorableId id)
-            throws KapuaException;
-
-    /**
-     * Delete channels informations matching the given query
-     * 
-     * @param query
-     * @throws KapuaException
-     * 
-     * @since 1.0.0
-     */
-    public void delete(ChannelInfoQuery query)
-            throws KapuaException;
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoRegistryService.java
@@ -65,26 +65,4 @@ public interface ClientInfoRegistryService extends KapuaService, KapuaConfigurab
     public long count(ClientInfoQuery query)
             throws KapuaException;
 
-    /**
-     * Delete client information by identifier
-     * 
-     * @param scopeId
-     * @param id
-     * @throws KapuaException
-     * 
-     * @since 1.0.0
-     */
-    public void delete(KapuaId scopeId, StorableId id)
-            throws KapuaException;
-
-    /**
-     * Delete clients informations matching the given query
-     * 
-     * @param query
-     * @throws KapuaException
-     * 
-     * @since 1.0.0
-     */
-    public void delete(ClientInfoQuery query)
-            throws KapuaException;
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoRegistryService.java
@@ -67,24 +67,4 @@ public interface MetricInfoRegistryService extends KapuaService,
     public long count(MetricInfoQuery query)
             throws KapuaException;
 
-    /**
-     * Delete metric information by identifier
-     * 
-     * @param scopeId
-     * @param id
-     * @throws KapuaException
-     * 
-     * @since 1.0.0
-     */
-    public void delete(KapuaId scopeId, StorableId id)
-            throws KapuaException;
-
-    /**
-     * Delete metrics informations matching the given query
-     * 
-     * @param query
-     * @throws KapuaException
-     */
-    public void delete(MetricInfoQuery query)
-            throws KapuaException;
 }

--- a/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/TransportDatastoreClient.java
+++ b/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/TransportDatastoreClient.java
@@ -385,7 +385,6 @@ public class TransportDatastoreClient implements org.eclipse.kapua.service.datas
                     .setVersion(true)
                     .setScroll(scrollTimeout)
                     .setSource(toSearchSourceBuilder(queryMap))
-                    .setSize(100)
                     .get(queryTimeout);
         } catch (IndexNotFoundException infe) {
             logger.warn("Cannot find index '{}'", typeDescriptor.getIndex());

--- a/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/TransportDatastoreClient.java
+++ b/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/TransportDatastoreClient.java
@@ -406,8 +406,7 @@ public class TransportDatastoreClient implements org.eclipse.kapua.service.datas
                 for (SearchHit hit : scrollResponse.getHits().hits()) {
                     DeleteRequest delete = new DeleteRequest().index(hit.index())
                             .type(hit.type())
-                            .id(hit.id())
-                            .version(hit.version());
+                            .id(hit.id());
                     bulkRequest.add(delete);
                 }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -127,7 +127,9 @@ public class ChannelInfoRegistryFacade {
     }
 
     /**
-     * Delete channel information by identifier
+     * Delete channel information by identifier.<br>
+     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
+     * It just deletes the channel info registry entry by id without checking the consistency of the others registries or the message store.</b>
      * 
      * @param scopeId
      * @param id
@@ -253,7 +255,9 @@ public class ChannelInfoRegistryFacade {
     }
 
     /**
-     * Delete channels informations count matching the given query
+     * Delete channels informations count matching the given query.<br>
+     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
+     * It just deletes the channel info registry entries that matching the query without checking the consistency of the others registries or the message store.</b>
      * 
      * @param query
      * @throws KapuaIllegalArgumentException

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -265,7 +265,7 @@ public class ChannelInfoRegistryFacade {
      * @throws ConfigurationException
      * @throws ClientException
      */
-    public void delete(ChannelInfoQuery query)
+    void delete(ChannelInfoQuery query)
             throws KapuaIllegalArgumentException,
             QueryMappingException,
             ConfigurationException,

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
@@ -98,20 +98,6 @@ public class ChannelInfoRegistryServiceImpl extends AbstractKapuaConfigurableSer
     }
 
     @Override
-    public void delete(KapuaId scopeId, StorableId id)
-            throws KapuaException {
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(id, "id");
-
-        checkDataAccess(scopeId, Actions.delete);
-        try {
-            channelInfoRegistryFacade.delete(scopeId, id);
-        } catch (Exception e) {
-            throw KapuaException.internalError(e);
-        }
-    }
-
-    @Override
     public ChannelInfo find(KapuaId scopeId, StorableId id)
             throws KapuaException {
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -165,8 +151,20 @@ public class ChannelInfoRegistryServiceImpl extends AbstractKapuaConfigurableSer
         }
     }
 
-    @Override
-    public void delete(ChannelInfoQuery query)
+    void delete(KapuaId scopeId, StorableId id)
+            throws KapuaException {
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(id, "id");
+
+        checkDataAccess(scopeId, Actions.delete);
+        try {
+            channelInfoRegistryFacade.delete(scopeId, id);
+        } catch (Exception e) {
+            throw KapuaException.internalError(e);
+        }
+    }
+
+    void delete(ChannelInfoQuery query)
             throws KapuaException {
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
@@ -127,7 +127,9 @@ public class ClientInfoRegistryFacade {
     }
 
     /**
-     * Delete client information by identifier
+     * Delete client information by identifier.<br>
+     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
+     * It just deletes the client info registry entry by id without checking the consistency of the others registries or the message store.</b>
      * 
      * @param scopeId
      * @param id
@@ -149,7 +151,7 @@ public class ClientInfoRegistryFacade {
             return;
         }
 
-        String indexName = SchemaUtil.getDataIndexName(scopeId);
+        String indexName = SchemaUtil.getKapuaIndexName(scopeId);
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ClientInfoSchema.CLIENT_TYPE_NAME);
         client.delete(typeDescriptor, id.toString());
     }
@@ -247,7 +249,9 @@ public class ClientInfoRegistryFacade {
     }
 
     /**
-     * Delete clients informations count matching the given query
+     * Delete clients informations count matching the given query.<br>
+     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
+     * It just deletes the client info registry entries that matching the query without checking the consistency of the others registries or the message store.</b>
      * 
      * @param query
      * @throws KapuaIllegalArgumentException

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
@@ -98,20 +98,6 @@ public class ClientInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
     }
 
     @Override
-    public void delete(KapuaId scopeId, StorableId id)
-            throws KapuaException {
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(id, "id");
-
-        checkAccess(scopeId, Actions.delete);
-        try {
-            clientInfoRegistryFacade.delete(scopeId, id);
-        } catch (Exception e) {
-            throw KapuaException.internalError(e);
-        }
-    }
-
-    @Override
     public ClientInfo find(KapuaId scopeId, StorableId id)
             throws KapuaException {
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -165,8 +151,7 @@ public class ClientInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
         }
     }
 
-    @Override
-    public void delete(ClientInfoQuery query)
+    void delete(ClientInfoQuery query)
             throws KapuaException {
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
@@ -174,6 +159,19 @@ public class ClientInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
         checkAccess(query.getScopeId(), Actions.delete);
         try {
             clientInfoRegistryFacade.delete(query);
+        } catch (Exception e) {
+            throw KapuaException.internalError(e);
+        }
+    }
+
+    void delete(KapuaId scopeId, StorableId id)
+            throws KapuaException {
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(id, "id");
+
+        checkAccess(scopeId, Actions.delete);
+        try {
+            clientInfoRegistryFacade.delete(scopeId, id);
         } catch (Exception e) {
             throw KapuaException.internalError(e);
         }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -52,7 +52,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
     private final AccountService accountService = LOCATOR.getService(AccountService.class);
     private final AuthorizationService authorizationService = LOCATOR.getService(AuthorizationService.class);
     private final PermissionFactory permissionFactory = LOCATOR.getFactory(PermissionFactory.class);
-    private final static Integer MAX_ENTRYES_ON_DELETE = DatastoreSettings.getInstance().get(Integer.class, DatastoreSettingKey.CONFIG_MAX_ENTRIES_ON_DELETE);
+    private final static Integer MAX_ENTRIES_ON_DELETE = DatastoreSettings.getInstance().get(Integer.class, DatastoreSettingKey.CONFIG_MAX_ENTRIES_ON_DELETE);
 
     private final MessageStoreFacade messageStoreFacade;
 
@@ -141,7 +141,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
             throws KapuaException {
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
-        ArgumentValidator.numRange(query.getLimit(), 0, MAX_ENTRYES_ON_DELETE, "limit");
+        ArgumentValidator.numRange(query.getLimit(), 0, MAX_ENTRIES_ON_DELETE, "limit");
         
         checkDataAccess(query.getScopeId(), Actions.delete);
         try {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -29,6 +29,8 @@ import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
 import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
+import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettingKey;
+import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettings;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.StorableId;
@@ -50,6 +52,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
     private final AccountService accountService = LOCATOR.getService(AccountService.class);
     private final AuthorizationService authorizationService = LOCATOR.getService(AuthorizationService.class);
     private final PermissionFactory permissionFactory = LOCATOR.getFactory(PermissionFactory.class);
+    private final static Integer MAX_ENTRYES_ON_DELETE = DatastoreSettings.getInstance().get(Integer.class, DatastoreSettingKey.CONFIG_MAX_ENTRIES_ON_DELETE);
 
     private final MessageStoreFacade messageStoreFacade;
 
@@ -138,7 +141,8 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
             throws KapuaException {
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
-
+        ArgumentValidator.numRange(query.getLimit(), 0, MAX_ENTRYES_ON_DELETE, "limit");
+        
         checkDataAccess(query.getScopeId(), Actions.delete);
         try {
             messageStoreFacade.delete(query);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
@@ -189,7 +189,9 @@ public class MetricInfoRegistryFacade {
     }
 
     /**
-     * Delete metric information by identifier
+     * Delete metric information by identifier.<br>
+     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
+     * It just deletes the metric info registry entry by id without checking the consistency of the others registries or the message store.</b>
      *
      * @param scopeId
      * @param id
@@ -311,7 +313,9 @@ public class MetricInfoRegistryFacade {
     }
 
     /**
-     * Delete metrics informations count matching the given query
+     * Delete metrics informations count matching the given query.<br>
+     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
+     * It just deletes the metric info registry entries that matching the query without checking the consistency of the others registries or the message store.</b>
      * 
      * @param query
      * @throws KapuaIllegalArgumentException

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
@@ -100,20 +100,6 @@ public class MetricInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
     }
 
     @Override
-    public void delete(KapuaId scopeId, StorableId id)
-            throws KapuaException {
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(id, "id");
-
-        checkDataAccess(scopeId, Actions.delete);
-        try {
-            metricInfoRegistryFacade.delete(scopeId, id);
-        } catch (Exception e) {
-            throw KapuaException.internalError(e);
-        }
-    }
-
-    @Override
     public MetricInfo find(KapuaId scopeId, StorableId id)
             throws KapuaException {
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -168,8 +154,7 @@ public class MetricInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
         }
     }
 
-    @Override
-    public void delete(MetricInfoQuery query)
+    void delete(MetricInfoQuery query)
             throws KapuaException {
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
@@ -177,6 +162,19 @@ public class MetricInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
         checkDataAccess(query.getScopeId(), Actions.delete);
         try {
             metricInfoRegistryFacade.delete(query);
+        } catch (Exception e) {
+            throw KapuaException.internalError(e);
+        }
+    }
+
+    void delete(KapuaId scopeId, StorableId id)
+            throws KapuaException {
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(id, "id");
+
+        checkDataAccess(scopeId, Actions.delete);
+        try {
+            metricInfoRegistryFacade.delete(scopeId, id);
         } catch (Exception e) {
             throw KapuaException.internalError(e);
         }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
@@ -32,9 +32,6 @@ import org.eclipse.kapua.service.datastore.internal.model.ChannelInfoImpl;
 import org.eclipse.kapua.service.datastore.internal.model.ClientInfoImpl;
 import org.eclipse.kapua.service.datastore.internal.model.MetricInfoImpl;
 import org.eclipse.kapua.service.datastore.internal.model.StorableIdImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.ChannelMatchPredicateImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.MessageQueryImpl;
-import org.eclipse.kapua.service.datastore.internal.model.query.MetricInfoQueryImpl;
 import org.eclipse.kapua.service.datastore.internal.schema.Metadata;
 import org.eclipse.kapua.service.datastore.internal.schema.Schema;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
@@ -124,7 +121,6 @@ public class DatastoreMediator implements MessageStoreMediator,
         this.metricInfoStoreFacade = metricInfoStoreFacade;
     }
 
-
     /*
      * 
      * Message Store Mediator methods
@@ -192,7 +188,6 @@ public class DatastoreMediator implements MessageStoreMediator,
         metricInfoStoreFacade.upstore(messageMetrics);
     }
 
-
     /*
      * 
      * ClientInfo Store Mediator methods
@@ -202,9 +197,10 @@ public class DatastoreMediator implements MessageStoreMediator,
             throws KapuaIllegalArgumentException,
             ConfigurationException,
             ClientException {
-        messageStoreFacade.delete(scopeId, clientInfo.getFirstMessageId());
+        // nothing to do at the present
+        // the datastore coherence will be guarantee by a periodic task that will scan the datastore looking for a no more referenced info registry record
+        // otherwise the computational cost for each delete operation will be too high
     }
-
 
     /*
      * 
@@ -216,20 +212,16 @@ public class DatastoreMediator implements MessageStoreMediator,
             ConfigurationException,
             QueryMappingException,
             ClientException {
-        ChannelMatchPredicateImpl predicate = new ChannelMatchPredicateImpl(channelInfo.getName());
-
-        MessageQueryImpl messageQuery = new MessageQueryImpl(channelInfo.getScopeId());
-        messageQuery.setPredicate(predicate);
-        messageStoreFacade.delete(messageQuery);
-
-        MetricInfoQueryImpl metricInfoQuery = new MetricInfoQueryImpl(channelInfo.getScopeId());
-        metricInfoQuery.setPredicate(predicate);
-        metricInfoStoreFacade.delete(metricInfoQuery);
+        // nothing to do at the present
+        // the datastore coherence will be guarantee by a periodic task that will scan the datastore looking for a no more referenced info registry record
+        // otherwise the computational cost for each delete operation will be too high
     }
 
     @Override
     public void onAfterChannelInfoDelete(ChannelInfo channelInfo) {
-        // to be implemented
+        // nothing to do at the present
+        // the datastore coherence will be guarantee by a periodic task that will scan the datastore looking for a no more referenced info registry record
+        // otherwise the computational cost for each delete operation will be too high
     }
 
     /*
@@ -238,7 +230,9 @@ public class DatastoreMediator implements MessageStoreMediator,
      */
     @Override
     public void onAfterMetricInfoDelete(KapuaId scopeId, MetricInfo metricInfo) {
-     // to be implemented
+        // nothing to do at the present
+        // the datastore coherence will be guarantee by a periodic task that will scan the datastore looking for a no more referenced info registry record
+        // otherwise the computational cost for each delete operation will be too high
     }
 
     public void refreshAllIndexes() throws ClientException {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
@@ -146,7 +146,7 @@ public class SchemaUtil {
         } else if (value instanceof StorableId) {
             node.set(name, FACTORY.textNode(((StorableId) value).toString()));
         } else {
-            throw new DatamodelMappingException(String.format(UNSUPPORTED_OBJECT_TYPE_ERROR_MSG, value.getClass()));
+            throw new DatamodelMappingException(String.format(UNSUPPORTED_OBJECT_TYPE_ERROR_MSG, value != null ? value.getClass() : "null"));
         }
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
@@ -57,7 +57,11 @@ public enum DatastoreSettingKey implements SettingKey {
     /**
      * Replicas count
      */
-    INDEX_REPLICA_NUMBER("datastore.index.number_of_replicas");
+    INDEX_REPLICA_NUMBER("datastore.index.number_of_replicas"),
+    /**
+     * Elasticsearch index refresh interval (the data is available for a search operation only if it is indexed)
+     */
+    CONFIG_MAX_ENTRIES_ON_DELETE("datastore.delete.max_entries_on_delete");
 
     private String key;
 

--- a/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
@@ -17,8 +17,15 @@
 #      - a static getInstance method that creates the instance (if not previously initialized) and returns the instance)
 datastore.client.class=org.eclipse.kapua.service.datastore.client.transport.TransportDatastoreClient
 
-# Index refresh interval in seconds
+# Index parameters
+#refresh interval (in seconds)
 datastore.index.refresh_interval=5
+datastore.index.number_of_shards=1
+datastore.index.number_of_replicas=0
+
+#
+#maximum entries to be deleted in a single delete call
+datastore.delete.max_entries_on_delete=100
 
 #
 # Local cache setting

--- a/service/datastore/internal/src/test/resources/kapua-datastore-setting.properties
+++ b/service/datastore/internal/src/test/resources/kapua-datastore-setting.properties
@@ -24,6 +24,10 @@ datastore.index.number_of_shards=1
 datastore.index.number_of_replicas=0
 
 #
+#maximum entries to be deleted in a single delete call
+datastore.delete.max_entries_on_delete=100
+
+#
 # Local cache setting
 
 # Expire timeout for the registry services cache in seconds


### PR DESCRIPTION
Fix some minor issue for the delete operations. Remove the delete operation from the registries apis to avoid external call that may make datastore inconsistent.
