### PR TITLE
ACL broker tests initial commit

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunBrokerACLI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunBrokerACLI9nTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.integration;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = {"classpath:features/broker/acl"
+                   },
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps"
+               },
+        plugin = {"pretty", 
+                  "html:target/cucumber/BrokerACLI9n",
+                  "json:target/BrokerACLI9n_cucumber.json"
+                 },
+        monochrome = true )
+
+public class RunBrokerACLI9nTest {
+}

--- a/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -1,0 +1,29 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+Feature: Broker ACL tests
+  These tests are validating correct access control rights of broker security.
+  User with one or more profile connects to the broker and tries to issue actions such as
+  publish and subscribe to topics, manage topic. Based on his profile these actions are
+  successful or not.
+
+  Scenario: User with admin rights publishes arbitrary message to arbitrary topic
+  and is successful.
+    Given I start Mqtt Device
+      And I wait 5 seconds for broker to start
+      And I login as user with name "kapua-sys" and password "kapua-password"
+    When I connect to broker with clientId "client-1" and user "kapua-sys" and password "kapua-password" and listening on topic "#"
+      And I publish string "Hello world" to topic "/foo/bar"
+      And I wait 5 seconds for message to arrive
+    Then I receive string "Hello world" on topic "/foo/bar"
+    Then I disconnect client
+      And I stop Mqtt Device
+      And I logout


### PR DESCRIPTION
This is first example of simple ACL test for broker.

Cucumber scenario is written that connects client as system user and
publishes message to topic. Assertion is made that it recieves this
message back from broker.

Additional tests will check for ACL that are based on regular user
connection to broker and performing operations that are or not permited
for his profile.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>