### PR TITLE
Fix for unit test failures in Windows environment

### DIFF
--- a/service/liquibase/src/main/java/org/eclipse/kapua/service/liquibase/KapuaLiquibaseClient.java
+++ b/service/liquibase/src/main/java/org/eclipse/kapua/service/liquibase/KapuaLiquibaseClient.java
@@ -97,7 +97,9 @@ public class KapuaLiquibaseClient {
                 LOG.trace("Creating parent dir: {}", changelogFile.getParentFile().getAbsolutePath());
                 changelogFile.getParentFile().mkdirs();
             }
-            IOUtils.write(IOUtils.toString(scriptUrl), new FileOutputStream(changelogFile));
+            try (FileOutputStream tmpStream = new FileOutputStream(changelogFile)) {
+                IOUtils.write(IOUtils.toString(scriptUrl), tmpStream);
+            }
             LOG.trace("Copied file: {}", changelogFile.getAbsolutePath());
         }
 


### PR DESCRIPTION
## Fix for unit test failures in Windows
This is a potential fix for the consistent failures of unit tests in several packages.
The issue seems to be the reluctance of Windows to delete files that still have open output streams associated with them.
This fix should guarantee that the output streams are reliably closed before proceeding.

### Changes to Maven pom files
There are no changes in pom files.

### Implementation changes
The _KapuaLiquibaseClient_ method _loadResourcesStatic_ is modified to close the output stream before proceeding.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>