### PR TITLE
add random uuid to the kahaDB storage directory

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/qa/steps/EmbeddedBroker.java
+++ b/qa/src/test/java/org/eclipse/kapua/qa/steps/EmbeddedBroker.java
@@ -24,6 +24,7 @@ import org.apache.activemq.broker.BrokerFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.eclipse.kapua.qa.utils.Suppressed;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
+import org.elasticsearch.common.UUIDs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,10 @@ public class EmbeddedBroker {
 
     private static final Logger logger = LoggerFactory.getLogger(EmbeddedBroker.class);
 
+    private static final String DEFAULT_DATA_DIRECTORY_PREFIX = "target/activemq/" + UUIDs.randomBase64UUID();
+    private static final String DEFAULT_KAHA_DB_DIRECTORY = DEFAULT_DATA_DIRECTORY_PREFIX + "/kahaDB";
+    private static final String DEFAULT_DATA_DIRECTORY = DEFAULT_DATA_DIRECTORY_PREFIX + "/data";
+    private static final String KAHA_DB_DIRECTORY = "KAHA_DB_DIRECTORY";
     /**
      * Embedded broker configuration file from classpath resources.
      */
@@ -71,8 +76,10 @@ public class EmbeddedBroker {
             }
 
             // start the broker
-
+            System.setProperty(KAHA_DB_DIRECTORY, DEFAULT_KAHA_DB_DIRECTORY);
             broker = BrokerFactory.createBroker(ACTIVEMQ_XML);
+            broker.setDataDirectory(DEFAULT_DATA_DIRECTORY);
+            logger.info("Setting ActiveMQ data directory to {}", broker.getBrokerDataDirectory());
             broker.start();
 
             // wait for the broker

--- a/qa/src/test/resources/activemq.xml
+++ b/qa/src/test/resources/activemq.xml
@@ -120,7 +120,7 @@
                 indexCacheSize—(default 10000) specifies the size of the cache in units of pages (where one page is 4 KB by default).
                 https://access.redhat.com/documentation/en-US/Fuse_ESB_Enterprise/7.1/html/ActiveMQ_Tuning_Guide/files/PersTuning-KahaDB.html
             -->
-            <kahaDB directory="./kahadb"
+            <kahaDB directory="${KAHA_DB_DIRECTORY}"
                     journalMaxFileLength="32mb"
                     concurrentStoreAndDispatchQueues="true"
                     concurrentStoreAndDispatchTopics="false"


### PR DESCRIPTION
Currently the embedded ActiveMQ broker used by the qa tests is configured to use always the same directory for the KahaDB persistence. Since this directory resides outside the target directory, it will not be deleted every build (unless to use a new virtual machine every time or unless doing a manual cleanup).
To avoid that, the KahaDB persistence directory will point to a path inside compile target directory with a different random generated UUID for each run.
This make test more reliable.

Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>