### PR TITLE
Added tests for tagName and MAC address check

### DIFF
--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.util;
 
+import java.util.Random;
+
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -116,7 +118,7 @@ public class ArgumentValidatorTest extends Assert {
                 "A1B","A b", "A-ab1","A_1","ab-","___","---","   ", "_- ","ab ","12 ","12_","2-1","abcd1234-_ "};
         int sizeOfPermittedStrings = listOfPermittedStringsNameSpace.length;
         for (int i = 0; i < sizeOfFalseStrings; i++) {
-            try{
+            try {
                 ArgumentValidator.match(listOfFalseStringsNameSpace[i], argRegExprNameSpace, "NAME_SPACE_REGEXP_test_case");
                 fail("Exception expected for: " + listOfFalseStringsNameSpace[i]);
             } catch (KapuaIllegalArgumentException e) {
@@ -128,6 +130,89 @@ public class ArgumentValidatorTest extends Assert {
                 ArgumentValidator.match(listOfPermittedStringsNameSpace[i], argRegExprNameSpace, "NAME_SPACE_REGEXP_test_case");
             } catch (Exception ex) {
                 fail("No exception expected for: " + listOfPermittedStringsNameSpace[i]);
+            }
+        }
+    }
+
+    @Test
+    public void testIllegalCharacterTagNameRegExp() throws Exception {
+        String argRegExprTagNameRegExp = "[A-Za-z0-9-_@#!$%^&*+=?<>]{3,255}";
+        StringBuilder tagName = new StringBuilder();
+        StringBuilder tagTooLong = new StringBuilder();
+        Random random = new Random();
+        String permittedSymbols = "abcdefghijklmnopqrstuvxwyzABCDEFGHIJKLMNOPQRSTUVXYZ1234567890-_@#!$%^&*+=?<>";
+        for (int i = 0; i < 254; i++) {
+            tagName.append(permittedSymbols.charAt(random.nextInt(permittedSymbols.length())));
+        }
+        for (int i = 0; i < 256; i++) {
+            tagTooLong.append(permittedSymbols.charAt(random.nextInt(permittedSymbols.length())));
+        }
+        String tagNameOk = tagName.toString();
+        String tagNameTooLong = tagTooLong.toString();
+        String[] listOfFalseStringsTagNameRegExp = new String[] {"abc_ABC123'","abc_ABC123(","abc_ABC123)",
+                "abc_ABC123;","abc_ABC123:","abc_ABC123,","abc_ABC123.","abc_ABC123¡","abc_ABC123™","abc_ABC123£","abc_ABC123¢",
+                "abc_ABC123∞","abc_ABC123§","abc_ABC123¶","abc_ABC123•","abc_ABC123º","abc_ABC123≠","abc_ABC123œ","abc_ABC123∑",
+                "abc_ABC123´","abc_ABC123®","abc_ABC123†","abc_ABC123¨","abc_ABC123ø","abc_ABC123π","abc_ABC123[","abc_ABC123]",
+                "abc_ABC123å","abc_ABC123ß","abc_ABC123∂","abc_ABC123ƒ","abc_ABC123©","abc_ABC123 ̏","abc_ABC123∆","abc_ABC123¬",
+                "abc_ABC123…","abc_ABC123\"","abc_ABC123`","abc_ABC123Ω","abc_ABC123≈","abc_ABC123¿","abc_ABC123ç","abc_ABC123√",
+                "abc_ABC123∫","abc_ABC123~","abc_ABC123µ","abc_ABC123≤","abc_ABC123≥","abc_ABC123÷","abc_ABC123⁄","abc_ABC123‹",
+                "abc_ABC123›","abc_ABC123€","abc_ABC123ı","abc_ABC123–","abc_ABC123°","abc_ABC123±","abc_ABC123Œ","abc_ABC123„",
+                "abc_ABC123‰","abc_ABC123“","abc_ABC123‘","abc_ABC123 ","abc_ABC123”","abc_ABC123’","abc_ABC123É","abc_ABC123Ø",
+                "abc_ABC123∏","abc_ABC123{","abc_ABC123}","abc_ABC123Å","abc_ABC123Í","abc_ABC123Î","abc_ABC123Ï","abc_ABC123Ì",
+                "abc_ABC123Ó","abc_ABC123Ô","abc_ABC123","abc_ABC123Ò","abc_ABC123æ","abc_ABC123Æ","abc_ABC123|","abc_ABC123~",
+                "abc_ABC123«","abc_ABC123»","abc_ABC123Ç","abc_ABC123◊","abc_ABC123Ñ","abc_ABC123ˆ","abc_ABC123¯","abc_ABC123È",
+                "abc_ABC123ˇ", tagNameTooLong};
+        int sizeOfFalseStrings = listOfFalseStringsTagNameRegExp.length;
+        String[] listOfPermittedStringTagNameRegExp = new String[]{tagNameOk,"abc_ABC123-","abc_ABC123_","abc_ABC123@","abc_ABC123#",
+                "abc_ABC123!","abc_ABC123$","abc_ABC123%","abc_ABC123^","abc_ABC123&","abc_ABC123*","abc_ABC123+","abc_ABC123=","abc_ABC123?",
+                "abc_ABC123<","abc_ABC123>","abc","ABC","123","abc_ABC123","%&$&!","&av231j","123"};
+        int sizeOfPermittedStrings = listOfPermittedStringTagNameRegExp.length;
+        for (int i = 0; i < sizeOfFalseStrings; i++) {
+            try {
+                ArgumentValidator.match(listOfFalseStringsTagNameRegExp[i], argRegExprTagNameRegExp, "TAGE_NAME_test_case");
+                fail("Exception expected for: " + listOfFalseStringsTagNameRegExp[i]);
+            } catch (KapuaIllegalArgumentException ex) {
+                // Expected
+            }
+        }
+        for (int i = 0; i < sizeOfPermittedStrings; i++) {
+            try {
+                ArgumentValidator.match(listOfPermittedStringTagNameRegExp[i], argRegExprTagNameRegExp, "TAGE_NAME_test_case");
+            } catch (Exception ex) {
+                fail("No exception expected for: " + listOfPermittedStringTagNameRegExp[i]);
+            }
+        }
+    }
+
+    @Test
+    public void testIllegalCharacterMacAddressRegExp() throws Exception {
+        String argRegExprMACaddress = "^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$";
+        String[] listOfFalseStringsMACaddressRegExp = new String[]{"00:11:22:33:44","00:11:22:33:44:55:66",
+                "00-11-22-33-44","00-11-22-33-44-55-66","00:11:22:33:44:55:","00-11-22-33-44-55-","0:11:22:33:44:55","00:1:22:33:44:55",
+                "00:11:2:33:44:55","00:11:22:3:44:55","00:11:22:33:4:55","00:11:22:33:44:5","0-11-22-33-44-55","00-1-22-33-44-55",
+                "00-11-2-33-44-55","00-11-22-3-44-55","00-11-22-33-4-55","00-11-22-33-44-5","01:23:45:6:78:90","34:56:78:90:A:BC",
+                "000:11:22:33:44:55","00:111:AB:CD:EF:34","00:11:ABC:DE:F1:34","00:11:AB:CDE:F1:34","00:11:AB:CD:EF1:34","00:11:AB:CD:EF1:34",
+                "00:11:AB:CD:EF:345","000-11-AB-CD-EF-34","00-111-AB-CD-EF-34","00-11-ABC-DE-F1-34","00-AA-AB-CDE-F1-34","00-11-AB-CD-EF1-34",
+                "00-11-AB-CD-EF-345","AB:CD:eF.AB.CD.EF","56:78:90:aB:CD:EF","12:34:56:78:G1:12","H1:00:12:23:AB:CD","12:34-56-:78:AB:CD",
+                ":00:11:22:33:44:55","-00-11-22-33-44-55","12-34-56-78_90-AB","12.34.56.78.90.AB","AV:CD:EF:12:34:56","AB:CS:EF-12-34-45"};
+        int sizeOfFalseStringsMACaddress = listOfFalseStringsMACaddressRegExp.length;
+        String[] listOfPermittedStringsMACaddressRegExp = new String[]{"00:11:22:33:44:55","00-11-22-33-44-55","0A:BC:DE:12:34:56",
+                "0A-BC-DE-12-34-56","01:23:45:67:89:AB","00:00:00:00:00:00","FF:FF:FF:FF:FF:FF","01-23:45-67:89:A0","00:13:25:AF:AF:AF",
+                "00-11-22-33-44-55","0A-2B-3C-4D-5F-1E"};
+        int sizeOfPermittedStringsMACaddress = listOfPermittedStringsMACaddressRegExp.length;
+        for (int i = 0; i < sizeOfFalseStringsMACaddress; i++) {
+            try {
+                ArgumentValidator.match(listOfFalseStringsMACaddressRegExp[i], argRegExprMACaddress, "MAC_ADDRESS_test_case");
+                fail("Exception expected for: " + listOfFalseStringsMACaddressRegExp[i]);
+            } catch (KapuaIllegalArgumentException ex) {
+                // Expected
+            }
+        }
+        for (int i = 0; i < sizeOfPermittedStringsMACaddress; i++) {
+            try {
+                ArgumentValidator.match(listOfPermittedStringsMACaddressRegExp[i], argRegExprMACaddress, "MAC_ADDRESS_test_case");
+            } catch (Exception ex) {
+                fail("No exception expected for: " + listOfPermittedStringsMACaddressRegExp[i]);
             }
         }
     }

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.commons.util;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -123,11 +124,10 @@ public class ArgumentValidatorTest extends Assert {
                 // Expected
             }
         }
-        for(int i=0;i<sizeOfPermittedStrings;i++){
-            try{
+        for (int i = 0; i < sizeOfPermittedStrings; i++) {
+            try {
                 ArgumentValidator.match(listOfPermittedStringsNameSpace[i], argRegExprNameSpace, "NAME_SPACE_REGEXP_test_case");
-            }
-            catch(Exception ex){
+            } catch (Exception ex) {
                 fail("No exception expected for: " + listOfPermittedStringsNameSpace[i]);
             }
         }

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.kapua.commons.util;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
-import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Added tests for checking format of tagName and MAC address. 
Tests include checks for length, format and permitted symbols.

Signed-off-by: Leonardo Gaube <leonardo.gaube@comtrade.com>