### PR TITLE
Added tests for CryptoUtil

### DIFF
--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.commons.util;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -123,11 +124,10 @@ public class ArgumentValidatorTest extends Assert {
                 // Expected
             }
         }
-        for(int i=0;i<sizeOfPermittedStrings;i++){
-            try{
+        for (int i = 0; i < sizeOfPermittedStrings; i++) {
+            try {
                 ArgumentValidator.match(listOfPermittedStringsNameSpace[i], argRegExprNameSpace, "NAME_SPACE_REGEXP_test_case");
-            }
-            catch(Exception ex){
+            } catch (Exception ex) {
                 fail("No exception expected for: " + listOfPermittedStringsNameSpace[i]);
             }
         }

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.kapua.commons.util;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
-import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/CryptoUtilTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/CryptoUtilTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.commons.util;
+
+import java.lang.reflect.Constructor;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CryptoUtilTest extends Assert {
+
+    @Test
+    public void testConstructor() throws Exception{
+    Constructor<CryptoUtil> crypto = CryptoUtil.class.getDeclaredConstructor();
+        crypto.setAccessible(true);
+        CryptoUtil cryptoTest = crypto.newInstance();
+    }
+    
+    @Test
+    public void testSha1Hash() throws Exception{
+        StringBuilder longTest = new StringBuilder();
+        Random random = new Random();
+        String permittedSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890";
+        for (int i = 0; i < 500; i++) {
+            longTest.append(permittedSymbols.charAt(random.nextInt(permittedSymbols.length())));
+        }
+        String longName = longTest.toString();
+        String[] permittedStrings = new String[] {"a","ab","abc","123",longName};
+        int sizeOfPermittedStrings = permittedStrings.length;
+        String[] falseStrings = new String[] {null};
+        int sizeOfFalseStrings = falseStrings.length;
+        // Negative tests
+        for (int i = 0; i < sizeOfFalseStrings; i++) {
+            try {
+                CryptoUtil.sha1Hash(falseStrings[i]);
+                fail("Exception expected for: " + falseStrings[i]);
+            } catch (Exception ex) {
+                // Expected
+            }
+        }
+        // Positive tests
+        for (int i = 0; i < sizeOfPermittedStrings; i++) {
+            try {
+                CryptoUtil.sha1Hash(permittedStrings[i]);
+            } catch (Exception ex) {
+                fail("No exception expected for 'test string'");
+            }
+        }
+    }
+
+    @Test
+    public void testEncodeBase64() {
+        StringBuilder longTest = new StringBuilder();
+        Random random = new Random();
+        String permittedSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890";
+        for (int i = 0; i < 500; i++) {
+            longTest.append(permittedSymbols.charAt(random.nextInt(permittedSymbols.length())));
+        }
+        String longName = longTest.toString();
+        String[] permittedStrings = new String[]{"a","ab","abc","123",longName};
+        int sizeOfPermittedStrings = permittedStrings.length;
+        String[] falseStrings = new String[] { null };
+        int sizeOfFalseStrings = falseStrings.length;
+        // Negative tests
+        for (int i = 0; i < sizeOfFalseStrings; i++) {
+            try {
+                CryptoUtil.encodeBase64(falseStrings[i]);
+                fail("Exception expected for: " + falseStrings[i]);
+            } catch (Exception ex) {
+                // Expected
+            }
+        }
+
+        // Positive tests
+        for (int i = 0; i < sizeOfPermittedStrings; i++) {
+            try {
+                CryptoUtil.encodeBase64(permittedStrings[i]);
+            } catch (Exception ex) {
+                fail("No exception expected for 'test string'");
+            }
+        }
+    }
+
+    @Test
+    public void testDecodeBase64() {
+        StringBuilder longTest = new StringBuilder();
+        Random random = new Random();
+        String permittedSymbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890";
+        for (int i = 0; i < 500; i++) {
+            longTest.append(permittedSymbols.charAt(random.nextInt(permittedSymbols.length())));
+        }
+        String longName = longTest.toString();
+        String[] permittedStrings = new String[]{"a","ab","abc","123",longName};
+        int sizeOfPermittedStrings = permittedStrings.length;
+        String[] falseStrings = new String[] { null };
+        int sizeOfFalseStrings = falseStrings.length;
+        // Negative tests
+        for (int i = 0; i < sizeOfFalseStrings; i++) {
+            try {
+                CryptoUtil.decodeBase64(falseStrings[i]);
+                fail("Exception expected for: " + falseStrings[i]);
+            } catch (Exception ex) {
+                // Expected
+            }
+        }
+
+        // Positive tests
+        for (int i = 0; i < sizeOfPermittedStrings; i++) {
+            try {
+                CryptoUtil.decodeBase64(permittedStrings[i]);
+            } catch (Exception ex) {
+                fail("No exception expected for 'test string'");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added test for sha1Hash(), encodeBase64() and decodeBase64() for CryptoUtil, which cover all the methods in CryptoUtil.

Signed-off-by: Leonardo Gaube <leonardo.gaube@comtrade.com>