### PR TITLE
Enable codecov.io integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ before_script:
 
 script: ./travis.sh
 
+after_script:
+  - bash <(curl -s https://codecov.io/bash)
+
 # The following upgrades Java during the build in
 # order to work around an older Java 8 compiler issue
 # which has problems infering types. Travis ships a

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: java
+
 jdk:
   - oraclejdk8
 
-before_script:
+sudo: false
+
+install:
   - echo ==== Setting up toolchain.xml ====
   - ls /usr/lib/jvm
   - ls
@@ -12,6 +15,8 @@ before_script:
   - mkdir maven
   - cd maven ; tar --strip-components 1 -xzf ../maven.tar.gz ; cd ..
   - chmod a+x maven/bin/mvn
+
+before_script:
   - export M2_HOME=$PWD/maven
   - export PATH=$PWD/maven/bin:${PATH}
   - hash -r

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>de.dentrassi.maven</groupId>
+                <artifactId>jacoco-extras</artifactId>
+                <version>0.0.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>xml</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>

--- a/travis.sh
+++ b/travis.sh
@@ -28,7 +28,8 @@ HEARTBEAT_PROCESS_PID=$!
 
 ### Build itself
 
-mvn -Dorg.eclipse.kapua.qa.waitMultiplier=2.0 -Dgwt.compiler.localWorkers=2 -Pjavadoc >> $OUTPUT 2>&1
+"$M2_HOME"/bin/mvn -v
+"$M2_HOME"/bin/mvn -Dorg.eclipse.kapua.qa.waitMultiplier=2.0 -Dgwt.compiler.localWorkers=2 -Pjavadoc >> $OUTPUT 2>&1
 tail_log
 
 ### Cleaning up heartbeat process


### PR DESCRIPTION
This PR enables the codecov integration. The jacoco XML reports already had been enabled for Kapua, so no additional change was necessary.