### PR TITLE
Send Request, Publish and Store REST API

### DIFF
--- a/assembly/broker/src/main/descriptors/kapua-broker.xml
+++ b/assembly/broker/src/main/descriptors/kapua-broker.xml
@@ -235,6 +235,8 @@
                 <include>${pom.groupId}:kapua-device-packages-internal</include>
                 <include>${pom.groupId}:kapua-device-registry-api</include>
                 <include>${pom.groupId}:kapua-device-registry-internal</include>
+                <include>${pom.groupId}:kapua-device-request-api</include>
+                <include>${pom.groupId}:kapua-device-request-internal</include>
                 <include>${pom.groupId}:kapua-device-asset-api</include>
                 <include>${pom.groupId}:kapua-device-asset-internal</include>
                 <include>${pom.groupId}:kapua-sso-jwt</include>

--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -128,6 +128,14 @@
 			<artifactId>kapua-device-commons</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-request-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-request-internal</artifactId>
+		</dependency>
 		<!-- activemq -->
 		<dependency>
 			<groupId>org.apache.activemq</groupId>

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceMessageListener.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceMessageListener.java
@@ -74,7 +74,7 @@ public class DeviceMessageListener extends AbstractListener {
             // //republish BA
             // Date now = new Date();
             // KapuaPayload kapuaPayload = birthMessage.getMessage().getPayload();
-            // kapuaPayload.getProperties().put("server_event_time", Long.toString(now.getTime()));
+            // kapuaPayload.getMetrics().put("server_event_time", Long.toString(now.getTime()));
             //
             // birthMessage.getMessage().setSemanticChannel(BIRTH_SEMANTIC_TOPIC);
             // try {

--- a/console/src/main/java/org/eclipse/kapua/app/console/servlet/DataExporterCsv.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/servlet/DataExporterCsv.java
@@ -73,9 +73,9 @@ public class DataExporterCsv extends DataExporter {
                 columns.add(BLANK);
             }
 
-            if (message.getPayload() != null && message.getPayload().getProperties() != null) {
+            if (message.getPayload() != null && message.getPayload().getMetrics() != null) {
                 for (String header : headers) {
-                    columns.add(valueOf(message.getPayload().getProperties().get(header)));
+                    columns.add(valueOf(message.getPayload().getMetrics().get(header)));
                 }
             }
 

--- a/console/src/main/java/org/eclipse/kapua/app/console/servlet/DataExporterExcel.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/servlet/DataExporterExcel.java
@@ -102,9 +102,9 @@ public class DataExporterExcel extends DataExporter {
                 topic = semanticTopic.toString();
             }
             row.createCell(iColCount++).setCellValue(valueOf(topic));
-            if (message.getPayload() != null && message.getPayload().getProperties() != null) {
+            if (message.getPayload() != null && message.getPayload().getMetrics() != null) {
                 for (String header : headers) {
-                    row.createCell(iColCount++).setCellValue(valueOf(message.getPayload().getProperties().get(header)));
+                    row.createCell(iColCount++).setCellValue(valueOf(message.getPayload().getMetrics().get(header)));
                 }
             }
             if (rowCount >= MAX_ROWS) {

--- a/console/src/main/java/org/eclipse/kapua/app/console/shared/util/KapuaGwtModelConverter.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/shared/util/KapuaGwtModelConverter.java
@@ -686,7 +686,7 @@ public class KapuaGwtModelConverter {
         gwtMessage.setClientId(message.getClientId());
         gwtMessage.setTimestamp(message.getTimestamp());
         for (GwtHeader header : headers) {
-            gwtMessage.set(header.getName(), message.getPayload().getProperties().get(header.getName()));
+            gwtMessage.set(header.getName(), message.getPayload().getMetrics().get(header.getName()));
         }
         return gwtMessage;
     }

--- a/message/api/src/main/java/org/eclipse/kapua/message/Channel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Channel.java
@@ -11,11 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.message;
 
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
+
+import javax.xml.bind.annotation.XmlType;
+
 /**
  * Channel definition.
  *
  * @since 1.0
  */
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaChannel") //
 public interface Channel {
 
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaChannel.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.message;
 
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
@@ -19,6 +25,11 @@ import java.util.List;
  *
  * @since 1.0
  */
+@XmlRootElement(name = "channel")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(propOrder = { //
+        "semanticParts" //
+}, factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaChannel") //
 public interface KapuaChannel extends Channel {
 
     /**

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessage.java
@@ -18,9 +18,12 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
@@ -44,7 +47,8 @@ import org.eclipse.kapua.model.id.KapuaIdAdapter;
         "position", //
         "channel", //
         "payload", //
-}) //
+}, factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaMessage") //
+@XmlSeeAlso(KapuaDataMessage.class)
 public interface KapuaMessage<C extends KapuaChannel, P extends KapuaPayload> extends Message<C, P> {
 
     /**

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessageFactory.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessageFactory.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.message;
 
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.model.KapuaObjectFactory;
 
 /**
@@ -27,6 +28,12 @@ public interface KapuaMessageFactory extends KapuaObjectFactory {
      * @return
      */
     public KapuaMessage<?,?> newMessage();
+
+    /**
+     * Creates and returns a new {@link KapuaDataMessage}
+     * @return
+     */
+    public KapuaDataMessage newKapuaDataMessage();
 
     /**
      * Creates and returns a new {@link KapuaChannel}

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessageFactory.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessageFactory.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.message;
 
+import org.eclipse.kapua.message.device.data.KapuaDataChannel;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
 import org.eclipse.kapua.model.KapuaObjectFactory;
 
 /**
@@ -56,4 +58,7 @@ public interface KapuaMessageFactory extends KapuaObjectFactory {
      */
     public KapuaPosition newPosition();
 
+    KapuaDataChannel newKapuaDataChannel();
+
+    KapuaDataPayload newKapuaDataPayload();
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
@@ -31,7 +31,10 @@ import org.eclipse.kapua.message.xml.MetricsXmlAdapter;
  */
 @XmlRootElement(name = "payload")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newPayload")
+@XmlType(propOrder = { //
+        "metrics", //
+        "body" //
+}, factoryClass = MessageXmlRegistry.class, factoryMethod = "newPayload")
 public interface KapuaPayload extends Payload {
 
     /**
@@ -41,14 +44,14 @@ public interface KapuaPayload extends Payload {
      */
     @XmlElement(name = "metrics")
     @XmlJavaTypeAdapter(MetricsXmlAdapter.class)
-    public Map<String, Object> getProperties();
+    public Map<String, Object> getMetrics();
 
     /**
      * Set the metrics map
      *
      * @param metrics
      */
-    public void setProperties(Map<String, Object> metrics);
+    public void setMetrics(Map<String, Object> metrics);
 
     /**
      * Get the message body

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaPosition.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaPosition.java
@@ -21,6 +21,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
 /**
@@ -40,7 +41,7 @@ import org.eclipse.kapua.model.xml.DateXmlAdapter;
         "timestamp", //
         "satellites", //
         "status", //
-})
+}, factoryClass = MessageXmlRegistry.class, factoryMethod = "newPosition")
 public interface KapuaPosition extends Position, Serializable {
 
     /**

--- a/message/api/src/main/java/org/eclipse/kapua/message/Message.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Message.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.message;
 
+import org.eclipse.kapua.KapuaSerializable;
+
 /**
  * Message definition.
  *
@@ -18,6 +20,6 @@ package org.eclipse.kapua.message;
  * @param <P> payload type
  * @since 1.0
  */
-public interface Message<C extends Channel, P extends Payload> {
+public interface Message<C extends Channel, P extends Payload> extends KapuaSerializable {
 
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/Payload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Payload.java
@@ -11,11 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.message;
 
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
+
+import javax.xml.bind.annotation.XmlType;
+
 /**
  * Message payload definition.
  *
  * @since 1.0
  */
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newPayload") //
 public interface Payload {
 
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/Position.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Position.java
@@ -16,6 +16,12 @@ package org.eclipse.kapua.message;
  *
  * @since 1.0
  */
-public interface Position {
+
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newPosition")
+        public interface Position {
 
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataChannel.java
@@ -12,6 +12,9 @@
 package org.eclipse.kapua.message.device.data;
 
 import org.eclipse.kapua.message.KapuaChannel;
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
+
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kapua data message channel object definition.
@@ -19,5 +22,6 @@ import org.eclipse.kapua.message.KapuaChannel;
  * @since 1.0
  *
  */
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaDataChannel")
 public interface KapuaDataChannel extends KapuaChannel {
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataMessage.java
@@ -12,6 +12,9 @@
 package org.eclipse.kapua.message.device.data;
 
 import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
+
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kapua data message object definition.
@@ -19,6 +22,7 @@ import org.eclipse.kapua.message.KapuaMessage;
  * @since 1.0
  *
  */
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaDataMessage")
 public interface KapuaDataMessage extends KapuaMessage<KapuaDataChannel, KapuaDataPayload> {
 
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataPayload.java
@@ -12,6 +12,9 @@
 package org.eclipse.kapua.message.device.data;
 
 import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
+
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kapua data message payload object definition.
@@ -19,6 +22,7 @@ import org.eclipse.kapua.message.KapuaPayload;
  * @since 1.0
  *
  */
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaDataPayload")
 public interface KapuaDataPayload extends KapuaPayload {
 
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/MessageXmlRegistry.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/MessageXmlRegistry.java
@@ -19,7 +19,9 @@ import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.data.KapuaDataChannel;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
 
 /**
  * Message xml factory class
@@ -51,6 +53,14 @@ public class MessageXmlRegistry {
 
     public KapuaPosition newPosition() {
         return factory.newPosition();
+    }
+
+    public KapuaDataChannel newKapuaDataChannel() {
+        return factory.newKapuaDataChannel();
+    }
+
+    public KapuaDataPayload newKapuaDataPayload() {
+        return factory.newKapuaDataPayload();
     }
 
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/MessageXmlRegistry.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/MessageXmlRegistry.java
@@ -14,8 +14,12 @@ package org.eclipse.kapua.message.xml;
 import javax.xml.bind.annotation.XmlRegistry;
 
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.message.KapuaChannel;
+import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 
 /**
  * Message xml factory class
@@ -32,4 +36,21 @@ public class MessageXmlRegistry {
     public KapuaPayload newPayload() {
         return factory.newPayload();
     }
+
+    public KapuaMessage newKapuaMessage() {
+        return factory.newMessage();
+    }
+
+    public KapuaDataMessage newKapuaDataMessage() {
+        return factory.newKapuaDataMessage();
+    }
+
+    public KapuaChannel newKapuaChannel() {
+        return factory.newChannel();
+    }
+
+    public KapuaPosition newPosition() {
+        return factory.newPosition();
+    }
+
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/MetricsXmlAdapter.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/MetricsXmlAdapter.java
@@ -33,7 +33,7 @@ public class MetricsXmlAdapter extends XmlAdapter<XmlAdaptedMetrics, Map<String,
                 XmlAdaptedMetric adaptedMapItem = new XmlAdaptedMetric();
 
                 adaptedMapItem.setName(sourceEntry.getKey());
-                adaptedMapItem.setType(sourceEntry.getValue().getClass());
+                adaptedMapItem.setValueType(sourceEntry.getValue().getClass());
                 adaptedMapItem.setValue(ObjectValueConverter.toString(sourceEntry.getValue()));
 
                 adaptedMapItems.add(adaptedMapItem);
@@ -54,7 +54,7 @@ public class MetricsXmlAdapter extends XmlAdapter<XmlAdaptedMetrics, Map<String,
 
         for (XmlAdaptedMetric sourceItem : sourceAdapter.getAdaptedMetrics()) {
             String name = sourceItem.getName();
-            Object value = ObjectValueConverter.fromString(sourceItem.getValue(), sourceItem.getType());
+            Object value = ObjectValueConverter.fromString(sourceItem.getValue(), sourceItem.getValueType());
 
             map.put(name, value);
         }

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/XmlAdaptedMetric.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/XmlAdaptedMetric.java
@@ -23,6 +23,6 @@ import org.eclipse.kapua.model.xml.XmlAdaptedNameTypeValueObject;
 public class XmlAdaptedMetric extends XmlAdaptedNameTypeValueObject {
 
     public Object getCastedValue() {
-        return ObjectValueConverter.fromString(getValue(), getType());
+        return ObjectValueConverter.fromString(getValue(), getValueType());
     }
 }

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
@@ -18,8 +18,12 @@ import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.data.KapuaDataChannel;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataChannelImpl;
 import org.eclipse.kapua.message.internal.device.data.KapuaDataMessageImpl;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataPayloadImpl;
 
 @KapuaProvider
 public class KapuaMessageFactoryImpl implements KapuaMessageFactory {
@@ -49,4 +53,11 @@ public class KapuaMessageFactoryImpl implements KapuaMessageFactory {
         return new KapuaPositionImpl();
     }
 
+    @Override public KapuaDataChannel newKapuaDataChannel() {
+        return new KapuaDataChannelImpl();
+    }
+
+    @Override public KapuaDataPayload newKapuaDataPayload() {
+        return new KapuaDataPayloadImpl();
+    }
 }

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
@@ -18,13 +18,20 @@ import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataMessageImpl;
 
 @KapuaProvider
 public class KapuaMessageFactoryImpl implements KapuaMessageFactory {
 
     @Override
     public KapuaMessage<?, ?> newMessage() {
-        return new KapuaMessageImpl<KapuaChannel, KapuaPayload>();
+        return new KapuaMessageImpl<>();
+    }
+
+    @Override
+    public KapuaDataMessage newKapuaDataMessage() {
+        return new KapuaDataMessageImpl();
     }
 
     @Override
@@ -38,7 +45,6 @@ public class KapuaMessageFactoryImpl implements KapuaMessageFactory {
     }
 
     @Override
-
     public KapuaPosition newPosition() {
         return new KapuaPositionImpl();
     }

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaPayloadImpl.java
@@ -26,7 +26,7 @@ import org.eclipse.kapua.message.KapuaPayload;
  */
 public class KapuaPayloadImpl implements KapuaPayload {
 
-    private Map<String, Object> properties;
+    private Map<String, Object> metrics;
     private byte[] body;
 
     /**
@@ -36,17 +36,17 @@ public class KapuaPayloadImpl implements KapuaPayload {
     }
 
     @Override
-    public Map<String, Object> getProperties() {
-        if (properties == null) {
-            properties = new HashMap<>();
+    public Map<String, Object> getMetrics() {
+        if (metrics == null) {
+            metrics = new HashMap<>();
         }
 
-        return properties;
+        return metrics;
     }
 
     @Override
-    public void setProperties(Map<String, Object> properties) {
-        this.properties = properties;
+    public void setMetrics(Map<String, Object> metrics) {
+        this.metrics = metrics;
     }
 
     @Override
@@ -61,6 +61,6 @@ public class KapuaPayloadImpl implements KapuaPayload {
 
     @Override
     public String toDisplayString() {
-        return Payloads.toDisplayString(properties);
+        return Payloads.toDisplayString(metrics);
     }
 }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
@@ -47,7 +47,7 @@ public class KapuaMessageUtil {
         Map<String, Object> metrics = new HashMap<>();
         metrics.put("key1", "value1");
         metrics.put("key2", "value2");
-        kapuaPayload.setProperties(metrics);
+        kapuaPayload.setMetrics(metrics);
         byte[] body = { 'b', 'o', 'd', 'y' };
         kapuaPayload.setBody(body);
     }
@@ -68,7 +68,7 @@ public class KapuaMessageUtil {
         metrics.put("String", "Big brown fox");
         metrics.put("byte", new byte[] { 'b', 'o', 'd', 'y', 0 });
         metrics.put("unknown", new BigDecimal("42.42"));
-        kapuaPayload.setProperties(metrics);
+        kapuaPayload.setMetrics(metrics);
     }
 
     /**

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
@@ -37,7 +37,7 @@ public class KapuaPayloadTest extends Assert {
 
     @Test
     public void neverGetNull() {
-        assertNotNull(new KapuaPayloadImpl().getProperties());
+        assertNotNull(new KapuaPayloadImpl().getMetrics());
     }
 
     @Test
@@ -45,7 +45,7 @@ public class KapuaPayloadTest extends Assert {
         KapuaPayload kapuaPayload = new KapuaPayloadImpl();
         populatePayload(kapuaPayload);
 
-        Map<String, Object> properties = kapuaPayload.getProperties();
+        Map<String, Object> properties = kapuaPayload.getMetrics();
         byte[] body = kapuaPayload.getBody();
         assertEquals("value1", properties.get("key1"));
         assertEquals("value2", properties.get("key2"));
@@ -63,7 +63,7 @@ public class KapuaPayloadTest extends Assert {
         final KapuaPayload kapuaPayload = new KapuaPayloadImpl();
 
         populatePayloadWithAllTypesOfMetrics(kapuaPayload);
-        kapuaPayload.getProperties().put("null", null);
+        kapuaPayload.getMetrics().put("null", null);
 
         String displayStr = kapuaPayload.toDisplayString();
         assertEquals(PAYLOAD_DISPLAY_STR, displayStr);

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
@@ -54,7 +54,7 @@ public class KapuaMetricTest extends Assert {
         XmlAdaptedMetric kapuaMetric = new XmlAdaptedMetric();
 
         kapuaMetric.setName("name");
-        kapuaMetric.setType(String.class);
+        kapuaMetric.setValueType(String.class);
         kapuaMetric.setValue("value");
 
         assertEquals("name", kapuaMetric.getName());
@@ -67,12 +67,12 @@ public class KapuaMetricTest extends Assert {
         XmlAdaptedMetric kapuaMetric = new XmlAdaptedMetric();
 
         kapuaMetric.setName("name");
-        kapuaMetric.setType(Double.class);
+        kapuaMetric.setValueType(Double.class);
         kapuaMetric.setValue("42.42");
 
         assertEquals("name", kapuaMetric.getName());
         assertEquals(Double.valueOf("42.42"), kapuaMetric.getCastedValue());
-        assertEquals(kapuaMetric.getType(), Double.class);
+        assertEquals(kapuaMetric.getValueType(), Double.class);
     }
 
     @Test
@@ -80,12 +80,12 @@ public class KapuaMetricTest extends Assert {
         XmlAdaptedMetric kapuaMetric = new XmlAdaptedMetric();
 
         kapuaMetric.setName("name");
-        kapuaMetric.setType(Integer.class);
+        kapuaMetric.setValueType(Integer.class);
         kapuaMetric.setValue("42");
 
         assertEquals("name", kapuaMetric.getName());
         assertEquals(Integer.valueOf(42), kapuaMetric.getCastedValue());
-        assertEquals(kapuaMetric.getType(), Integer.class);
+        assertEquals(kapuaMetric.getValueType(), Integer.class);
     }
 
     @Test
@@ -93,12 +93,12 @@ public class KapuaMetricTest extends Assert {
         XmlAdaptedMetric kapuaMetric = new XmlAdaptedMetric();
 
         kapuaMetric.setName("name");
-        kapuaMetric.setType(Float.class);
+        kapuaMetric.setValueType(Float.class);
         kapuaMetric.setValue("42.42");
 
         assertEquals("name", kapuaMetric.getName());
         assertEquals(Float.valueOf("42.42"), kapuaMetric.getCastedValue());
-        assertEquals(kapuaMetric.getType(), Float.class);
+        assertEquals(kapuaMetric.getValueType(), Float.class);
     }
 
     @Test
@@ -106,12 +106,12 @@ public class KapuaMetricTest extends Assert {
         XmlAdaptedMetric kapuaMetric = new XmlAdaptedMetric();
 
         kapuaMetric.setName("name");
-        kapuaMetric.setType(Long.class);
+        kapuaMetric.setValueType(Long.class);
         kapuaMetric.setValue("42");
 
         assertEquals("name", kapuaMetric.getName());
         assertEquals(Long.valueOf("42"), kapuaMetric.getCastedValue());
-        assertEquals(kapuaMetric.getType(), Long.class);
+        assertEquals(kapuaMetric.getValueType(), Long.class);
     }
 
     @Test
@@ -119,12 +119,12 @@ public class KapuaMetricTest extends Assert {
         XmlAdaptedMetric kapuaMetric = new XmlAdaptedMetric();
 
         kapuaMetric.setName("name");
-        kapuaMetric.setType(Boolean.class);
+        kapuaMetric.setValueType(Boolean.class);
         kapuaMetric.setValue("true");
 
         assertEquals("name", kapuaMetric.getName());
         assertEquals(Boolean.TRUE, kapuaMetric.getCastedValue());
-        assertEquals(kapuaMetric.getType(), Boolean.class);
+        assertEquals(kapuaMetric.getValueType(), Boolean.class);
     }
 
     @Test
@@ -132,12 +132,12 @@ public class KapuaMetricTest extends Assert {
         XmlAdaptedMetric kapuaMetric = new XmlAdaptedMetric();
 
         kapuaMetric.setName("name");
-        kapuaMetric.setType(byte[].class);
+        kapuaMetric.setValueType(byte[].class);
         kapuaMetric.setValue(BASE64_BYTES);
 
         assertEquals("name", kapuaMetric.getName());
         assertArrayEquals(BYTES, (byte[]) kapuaMetric.getCastedValue());
-        assertEquals(kapuaMetric.getType(), byte[].class);
+        assertEquals(kapuaMetric.getValueType(), byte[].class);
     }
 
     @Test
@@ -145,13 +145,13 @@ public class KapuaMetricTest extends Assert {
         XmlAdaptedMetric kapuaMetric = new XmlAdaptedMetric();
 
         kapuaMetric.setName("name");
-        kapuaMetric.setType(BigDecimal.class);
+        kapuaMetric.setValueType(BigDecimal.class);
         kapuaMetric.setValue("10");
 
         assertEquals("name", kapuaMetric.getName());
         assertEquals("10", kapuaMetric.getCastedValue());
         assertEquals(kapuaMetric.getValue().getClass(), String.class);
-        assertEquals(kapuaMetric.getType(), BigDecimal.class);
+        assertEquals(kapuaMetric.getValueType(), BigDecimal.class);
     }
     //
     // @Test

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
@@ -32,7 +32,7 @@ public class KapuaMetricsMapAdapterTest extends Assert {
                     "<payload>" + NEWLINE +
                     "   <metrics>" + NEWLINE +
                     "      <metric>" + NEWLINE +
-                    "         <type>string</type>" + NEWLINE +
+                    "         <valueType>string</valueType>" + NEWLINE +
                     "         <value>value1</value>" + NEWLINE +
                     "         <name>key1</name>" + NEWLINE +
                     "      </metric>" + NEWLINE +
@@ -49,7 +49,7 @@ public class KapuaMetricsMapAdapterTest extends Assert {
         KapuaPayload metricsMap = new KapuaPayloadImpl();
         Map<String, Object> metrics = new HashMap<>();
         metrics.put(String.valueOf("key1"), String.valueOf("value1"));
-        metricsMap.setProperties(metrics);
+        metricsMap.setMetrics(metrics);
 
         StringWriter strWriter = new StringWriter();
         XmlUtil.marshal(metricsMap, strWriter);
@@ -61,10 +61,10 @@ public class KapuaMetricsMapAdapterTest extends Assert {
         KapuaPayload metricsMap = new KapuaPayloadImpl();
         Map<String, Object> metrics = new HashMap<>();
         metrics.put(String.valueOf("key1"), String.valueOf("value1"));
-        metricsMap.setProperties(metrics);
+        metricsMap.setMetrics(metrics);
 
         KapuaPayload metricsMapResp = XmlUtil.unmarshal(METRICS_XML_STR, KapuaPayload.class);
-        assertEquals(metricsMap.getProperties().get("key1"), metricsMapResp.getProperties().get("key1"));
+        assertEquals(metricsMap.getMetrics().get("key1"), metricsMapResp.getMetrics().get("key1"));
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -539,6 +539,16 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-device-request-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-device-request-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-security-authorization-api</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,15 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-stream-api</artifactId>
+                <version>${project.version}</version>
+            </dependency><dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-stream-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-security-authorization-api</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -162,6 +162,22 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-broker-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-stream-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-stream-internal</artifactId>
+        </dependency>
 
         <!-- External dependencies -->
         <dependency>

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/DataSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/DataSteps.java
@@ -215,7 +215,7 @@ public class DataSteps {
 
                 // assert metrics data
 
-                final Map<String, Object> properties = payload.getProperties();
+                final Map<String, Object> properties = payload.getMetrics();
                 Assert.assertEquals(toData(expectedMetrics), properties);
             });
         });

--- a/qa/src/test/resources/locator.xml
+++ b/qa/src/test/resources/locator.xml
@@ -65,6 +65,9 @@
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
         <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
 
+        <api>org.eclipse.kapua.service.device.management.KapuaRequestMessageFactory</api>
+        <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
+
         <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService</api>
         <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
         <api>org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService</api>
@@ -75,6 +78,7 @@
         <api>org.eclipse.kapua.service.device.management.packages.DevicePackageFactory</api>
         <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService</api>
         <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory</api>
+        <api>org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService</api>
 
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>

--- a/qa/src/test/resources/locator.xml
+++ b/qa/src/test/resources/locator.xml
@@ -83,6 +83,8 @@
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 
+        <api>org.eclipse.kapua.service.stream.StreamService</api>
+        
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>

--- a/qa/src/test/resources/locator.xml
+++ b/qa/src/test/resources/locator.xml
@@ -84,7 +84,7 @@
         <api>org.eclipse.kapua.service.user.UserService</api>
 
         <api>org.eclipse.kapua.service.stream.StreamService</api>
-        
+
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -239,12 +239,10 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-request-api</artifactId>
-            <version>0.2.0-SNAPSHOT</version>
         </dependency>
 		<dependency>
 			<groupId>org.eclipse.kapua</groupId>
 			<artifactId>kapua-device-request-internal</artifactId>
-			<version>0.2.0-SNAPSHOT</version>
 		</dependency>
     </dependencies>
 	<build>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -244,6 +244,13 @@
 			<groupId>org.eclipse.kapua</groupId>
 			<artifactId>kapua-device-request-internal</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-stream-api</artifactId>
+        </dependency><dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-stream-internal</artifactId>
+		</dependency>
     </dependencies>
 	<build>
 		<finalName>api</finalName>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -236,7 +236,17 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-to-slf4j</artifactId>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-api</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-request-internal</artifactId>
+			<version>0.2.0-SNAPSHOT</version>
+		</dependency>
+    </dependencies>
 	<build>
 		<finalName>api</finalName>
 		<plugins>

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
@@ -24,6 +24,8 @@ import org.eclipse.kapua.app.api.exception.model.IllegalArgumentExceptionInfo;
 import org.eclipse.kapua.app.api.exception.model.IllegalNullArgumentExceptionInfo;
 import org.eclipse.kapua.app.api.exception.model.ThrowableInfo;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.xml.MessageXmlRegistry;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTicon;
 import org.eclipse.kapua.model.config.metatype.KapuaTmetadata;
@@ -85,6 +87,7 @@ import org.eclipse.kapua.service.datastore.ChannelInfoXmlRegistry;
 import org.eclipse.kapua.service.datastore.ClientInfoXmlRegistry;
 import org.eclipse.kapua.service.datastore.DatastoreMessageXmlRegistry;
 import org.eclipse.kapua.service.datastore.MetricInfoXmlRegistry;
+import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
@@ -205,6 +208,9 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     MessageListResult.class,
                     MessageQuery.class,
                     DatastoreMessageXmlRegistry.class,
+                    KapuaDataMessage.class,
+                    InsertResponse.class,
+                    MessageXmlRegistry.class,
 
                     // Device
                     Device.class,

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
@@ -24,7 +24,9 @@ import org.eclipse.kapua.app.api.exception.model.IllegalArgumentExceptionInfo;
 import org.eclipse.kapua.app.api.exception.model.IllegalNullArgumentExceptionInfo;
 import org.eclipse.kapua.app.api.exception.model.ThrowableInfo;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
+import org.eclipse.kapua.message.device.data.KapuaDataChannel;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
 import org.eclipse.kapua.message.xml.MessageXmlRegistry;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTicon;
@@ -297,6 +299,9 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     GenericResponsePayload.class,
                     GenericResponseMessage.class,
                     GenericRequestXmlRegistry.class,
+                    KapuaDataChannel.class,
+                    KapuaDataPayload.class,
+                    KapuaDataMessage.class,
 
                     AuthenticationCredentials.class,
                     AuthenticationXmlRegistry.class,

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
@@ -105,6 +105,7 @@ import org.eclipse.kapua.service.device.call.kura.model.configuration.KuraDevice
 import org.eclipse.kapua.service.device.call.kura.model.deploy.KuraDeploymentPackage;
 import org.eclipse.kapua.service.device.call.kura.model.deploy.KuraDeploymentPackages;
 import org.eclipse.kapua.service.device.call.kura.model.snapshot.KuraSnapshotIds;
+import org.eclipse.kapua.service.device.management.RequestMessageXmlRegistry;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetXmlRegistry;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundle;
@@ -124,6 +125,18 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackages
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallRequest;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
+import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshot;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotXmlRegistry;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshots;
@@ -269,6 +282,21 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     DevicePackageInstallRequest.class,
                     DevicePackageUninstallRequest.class,
                     DevicePackageXmlRegistry.class,
+
+                    // Device Management Requests
+                    KapuaRequestMessage.class,
+                    KapuaResponseMessage.class,
+                    KapuaRequestChannel.class,
+                    KapuaResponseChannel.class,
+                    KapuaRequestPayload.class,
+                    RequestMessageXmlRegistry.class,
+                    GenericRequestChannel.class,
+                    GenericRequestPayload.class,
+                    GenericRequestMessage.class,
+                    GenericResponseChannel.class,
+                    GenericResponsePayload.class,
+                    GenericResponseMessage.class,
+                    GenericRequestXmlRegistry.class,
 
                     AuthenticationCredentials.class,
                     AuthenticationXmlRegistry.class,

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
@@ -165,7 +165,10 @@ public class DataMessages extends AbstractKapuaResource {
     @ApiOperation(value = "Stores a new KapuaDataMessage", //
             notes = "Stores a new KapuaDataMessage under the account of the currently connected user. In this case, the provided message will only be stored in the back-end database and it will not be forwarded to the message broker.", //
             response = InsertResponse.class)
-    public InsertResponse storeMessage(@ApiParam(value = "The KapuaDataMessage to be stored") KapuaDataMessage message) throws Exception {
+    public InsertResponse storeMessage(
+            @ApiParam(value = "The ScopeId in which to store the message", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,//
+            @ApiParam(value = "The KapuaDataMessage to be stored") KapuaDataMessage message) throws Exception {
+        message.setScopeId(scopeId);
         return MESSAGE_STORE_SERVICE.store(message);
     }
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
@@ -29,10 +29,12 @@ import org.eclipse.kapua.app.api.v1.resources.model.MetricType;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.app.api.v1.resources.model.StorableEntityId;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.model.type.ObjectValueConverter;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.datastore.DatastoreObjectFactory;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
@@ -143,6 +145,28 @@ public class DataMessages extends AbstractKapuaResource {
         query.setLimit(limit);
 
         return query(scopeId, query);
+    }
+
+    /**
+     * Stores a new Message under the account of the currently connected user.
+     * In this case, the provided message will only be stored in the back-end
+     * database and it will not be forwarded to the message broker.
+     *
+     * @param message The {@KapuaDataMessage } to be stored
+     * @return an {@InsertResponse} object encapsulating the response from
+     *         the datastore
+     * @throws Exception
+     *         Whenever something bad happens. See specific
+     *         {@link KapuaService} exceptions.
+     */
+    @POST
+    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    @ApiOperation(value = "Stores a new KapuaDataMessage", //
+            notes = "Stores a new KapuaDataMessage under the account of the currently connected user. In this case, the provided message will only be stored in the back-end database and it will not be forwarded to the message broker.", //
+            response = InsertResponse.class)
+    public InsertResponse storeMessage(@ApiParam(value = "The KapuaDataMessage to be stored") KapuaDataMessage message) throws Exception {
+        return MESSAGE_STORE_SERVICE.store(message);
     }
 
     /**

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
@@ -152,8 +152,8 @@ public class DataMessages extends AbstractKapuaResource {
      * In this case, the provided message will only be stored in the back-end
      * database and it will not be forwarded to the message broker.
      *
-     * @param message The {@KapuaDataMessage } to be stored
-     * @return an {@InsertResponse} object encapsulating the response from
+     * @param message The {@link KapuaDataMessage } to be stored
+     * @return an {@link InsertResponse} object encapsulating the response from
      *         the datastore
      * @throws Exception
      *         Whenever something bad happens. See specific

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
@@ -97,7 +97,7 @@ public class DeviceManagementRequests extends AbstractKapuaResource {
     @POST
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Executes a command", notes = "Sends a request message to a device", response = DeviceCommandOutput.class)
+    @ApiOperation(value = "Sends a request", notes = "Sends a request message to a device", response = DeviceCommandOutput.class)
     public KapuaResponseMessage sendCommand(
             @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
             @ApiParam(value = "The id of the device", required = true) @PathParam("deviceId") EntityId deviceId,

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
@@ -84,6 +84,8 @@ public class DeviceManagementRequests extends AbstractKapuaResource {
             @ApiParam(value = "The id of the device", required = true) @PathParam("deviceId") EntityId deviceId,
             @ApiParam(value = "The timeout of the command execution") @QueryParam("timeout") Long timeout,
             @ApiParam(value = "The input command", required = true) GenericRequestMessage requestMessage) throws Exception {
-        return requestService.exec(scopeId, deviceId, requestMessage, timeout);
+        requestMessage.setScopeId(scopeId);
+        requestMessage.setDeviceId(deviceId);
+        return requestService.exec(requestMessage, timeout);
     }
 }

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
@@ -33,7 +33,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 @Api("Devices")
-@Path("{scopeId}/devices/{deviceId}/sendRequest")
+@Path("{scopeId}/devices/{deviceId}/requests")
 public class DeviceManagementRequests extends AbstractKapuaResource {
 
     private final KapuaLocator locator = KapuaLocator.getInstance();

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.v1.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
+import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.device.management.command.DeviceCommandOutput;
+import org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.device.registry.Device;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Api("Devices")
+@Path("{scopeId}/devices/{deviceId}/sendRequest")
+public class DeviceManagementRequests extends AbstractKapuaResource {
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final DeviceRequestManagementService requestService = locator.getService(DeviceRequestManagementService.class);
+
+    /**
+     * Executes a remote command on a device and return the command output.
+     * <p>
+     * <p>
+     * Example to list all files in the current working directory:
+     * <p>
+     * 
+     * <pre>
+     * Client client = client();
+     * WebResource apisWeb = client.resource(APIS_TEST_URL);
+     * WebResource.Builder deviceCommandWebXml = apisWeb.path(&quot;devices&quot;)
+     *         .path(s_clientId)
+     *         .path(&quot;command&quot;)
+     *         .accept(MediaType.APPLICATION_XML)
+     *         .type(MediaType.APPLICATION_XML);
+     *
+     * DeviceCommandInput commandInput = new DeviceCommandInput();
+     * commandInput.setCommand(&quot;ls&quot;);
+     * commandInput.setArguments(new String[] { &quot;-l&quot;, &quot;-a&quot; });
+     *
+     * DeviceCommandOutput commandOutput = deviceCommandWebXml.post(DeviceCommandOutput.class, commandInput);
+     * </pre>
+     *
+     * @param scopeId
+     *            The {@link ScopeId} of the {@link Device}.
+     * @param deviceId
+     *            The {@link Device} ID.
+     * @param timeout
+     *            The timeout of the command execution
+     * @param requestMessage
+     *            The input command
+     * @return The command output.
+     * @throws Exception
+     *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @ApiOperation(value = "Executes a command", notes = "Executes a remote command on a device and return the command output.", response = DeviceCommandOutput.class)
+    public KapuaResponseMessage sendCommand(
+            @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The id of the device", required = true) @PathParam("deviceId") EntityId deviceId,
+            @ApiParam(value = "The timeout of the command execution") @QueryParam("timeout") Long timeout,
+            @ApiParam(value = "The input command", required = true) GenericRequestMessage requestMessage) throws Exception {
+        return requestService.exec(scopeId, deviceId, requestMessage, timeout);
+    }
+}

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
@@ -40,26 +40,45 @@ public class DeviceManagementRequests extends AbstractKapuaResource {
     private final DeviceRequestManagementService requestService = locator.getService(DeviceRequestManagementService.class);
 
     /**
-     * Executes a remote command on a device and return the command output.
+     * Sends a request message to a device.
+     * This call is generally used to perform remote management of resources
+     * attached to the device such sensors and registries.
      * <p>
      * <p>
-     * Example to list all files in the current working directory:
+     * Example to send a request to the Kura Command application:
      * <p>
      * 
      * <pre>
-     * Client client = client();
-     * WebResource apisWeb = client.resource(APIS_TEST_URL);
-     * WebResource.Builder deviceCommandWebXml = apisWeb.path(&quot;devices&quot;)
-     *         .path(s_clientId)
-     *         .path(&quot;command&quot;)
-     *         .accept(MediaType.APPLICATION_XML)
-     *         .type(MediaType.APPLICATION_XML);
-     *
-     * DeviceCommandInput commandInput = new DeviceCommandInput();
-     * commandInput.setCommand(&quot;ls&quot;);
-     * commandInput.setArguments(new String[] { &quot;-l&quot;, &quot;-a&quot; });
-     *
-     * DeviceCommandOutput commandOutput = deviceCommandWebXml.post(DeviceCommandOutput.class, commandInput);
+     * {
+     *   "type": "genericRequestMessage",
+     *   "position": {
+     *     "type": "kapuaPosition"
+     *   },
+     *   "channel": {
+     *     "type": "genericRequestChannel",
+     *     "method": "EXECUTE",
+     *     "appName": "CMD",
+     *     "version": "V1",
+     *     "resources": ["command"]
+     *   },
+     *   "payload": {
+     *     "type": "genericRequestPayload",
+     *     "metrics": {
+     *       "metric": [
+     *         {
+     *           "valueType": "string",
+     *           "value": "ls",
+     *           "name": "command.command"
+     *         },
+     *         {
+     *           "valueType": "string",
+     *           "value": "-lisa",
+     *           "name": "command.argument0"
+     *         }
+     *       ]
+     *     }
+     *   }
+     * }
      * </pre>
      *
      * @param scopeId
@@ -67,10 +86,10 @@ public class DeviceManagementRequests extends AbstractKapuaResource {
      * @param deviceId
      *            The {@link Device} ID.
      * @param timeout
-     *            The timeout of the command execution
+     *            The timeout of the request execution
      * @param requestMessage
-     *            The input command
-     * @return The command output.
+     *            The input request
+     * @return The response output.
      * @throws Exception
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
@@ -78,12 +97,12 @@ public class DeviceManagementRequests extends AbstractKapuaResource {
     @POST
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Executes a command", notes = "Executes a remote command on a device and return the command output.", response = DeviceCommandOutput.class)
+    @ApiOperation(value = "Executes a command", notes = "Sends a request message to a device", response = DeviceCommandOutput.class)
     public KapuaResponseMessage sendCommand(
             @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
             @ApiParam(value = "The id of the device", required = true) @PathParam("deviceId") EntityId deviceId,
-            @ApiParam(value = "The timeout of the command execution") @QueryParam("timeout") Long timeout,
-            @ApiParam(value = "The input command", required = true) GenericRequestMessage requestMessage) throws Exception {
+            @ApiParam(value = "The timeout of the request execution") @QueryParam("timeout") Long timeout,
+            @ApiParam(value = "The input request", required = true) GenericRequestMessage requestMessage) throws Exception {
         requestMessage.setScopeId(scopeId);
         requestMessage.setDeviceId(deviceId);
         return requestService.exec(requestMessage, timeout);

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
@@ -98,7 +98,7 @@ public class DeviceManagementRequests extends AbstractKapuaResource {
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Sends a request", notes = "Sends a request message to a device", response = DeviceCommandOutput.class)
-    public KapuaResponseMessage sendCommand(
+    public KapuaResponseMessage sendRequest(
             @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
             @ApiParam(value = "The id of the device", required = true) @PathParam("deviceId") EntityId deviceId,
             @ApiParam(value = "The timeout of the request execution") @QueryParam("timeout") Long timeout,

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Streams.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Streams.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.v1.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.service.stream.StreamService;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Api("Streams")
+@Path("{scopeId}/streams/publish")
+public class Streams extends AbstractKapuaResource {
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final StreamService streamService = locator.getService(StreamService.class);
+
+    /**
+     * Publishes a fire-and-forget message to a topic composed of:
+     * [account-name] / [client-id] / [semtantic-parts]
+     * In such a schema, the parts are defined as follows:
+     * <ul>
+     *     <li>account-name: the name of the current scope</li>
+     *     <li>client-id: from the "clientId" property in the body</li>
+     *     <li>semantic-parts: array of strings in the "channel" property in the body</li>
+     * </ul>
+     * For example, the following JSON body will publish on the &quot;kapua-sys/AA:BB:CC:DD:EE:FF/one/two/three&quot; topic:
+     * <pre>
+     * {
+     *   "type": "kapuaDataMessage",
+     *   "position": {
+     *   "type": "kapuaPosition",
+     *     "latitude": 0,
+     *     "longitude": 0
+     *   },
+     *   "clientId": "AA:BB:CC:DD:EE:FF",
+     *   "channel": {
+     *     "type": "kapuaDataChannel",
+     *     "semanticParts": ["one", "two", "three"]
+     *   },
+     *   "payload": {
+     *     "type": "kapuaDataPayload",
+     *     "metrics": {
+     *       "metric": [
+     *         {
+     *           "valueType": "string",
+     *           "value": "aaa",
+     *           "name": "metric-1"
+     *         },
+     *         {
+     *           "valueType": "string",
+     *           "value": "bbb",
+     *           "name": "metric-2"
+     *         }
+     *       ]
+     *     }
+     *   }
+     * }
+     * </pre>
+     * @param scopeId
+     * @param timeout
+     * @param requestMessage
+     * @return
+     * @throws Exception
+     */
+    @POST
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @ApiOperation(value = "Publishes a fire-and-forget message", notes = "Publishes a fire-and-forget message to a topic composed of [account-name] / [client-id] / [semtantic-parts]")
+    public Response sendCommand(
+            @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The timeout of the request execution") @QueryParam("timeout") Long timeout,
+            @ApiParam(value = "The input request", required = true) KapuaDataMessage requestMessage) throws Exception {
+        requestMessage.setScopeId(scopeId);
+        streamService.publish(requestMessage, timeout);
+        return Response.ok().build();
+    }
+}

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Streams.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Streams.java
@@ -29,7 +29,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Api("Streams")
-@Path("{scopeId}/streams/publish")
+@Path("{scopeId}/streams")
 public class Streams extends AbstractKapuaResource {
 
     private final KapuaLocator locator = KapuaLocator.getInstance();
@@ -84,10 +84,11 @@ public class Streams extends AbstractKapuaResource {
      * @throws Exception
      */
     @POST
+    @Path("messages")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Publishes a fire-and-forget message", notes = "Publishes a fire-and-forget message to a topic composed of [account-name] / [client-id] / [semtantic-parts]")
-    public Response sendCommand(
+    public Response publish(
             @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
             @ApiParam(value = "The timeout of the request execution") @QueryParam("timeout") Long timeout,
             @ApiParam(value = "The input request", required = true) KapuaDataMessage requestMessage) throws Exception {

--- a/rest-api/src/main/resources/locator.xml
+++ b/rest-api/src/main/resources/locator.xml
@@ -52,6 +52,9 @@
 
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
 
+        <api>org.eclipse.kapua.service.device.management.KapuaRequestMessageFactory</api>
+        <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
+
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
         <!-- <api>org.eclipse.kapua.service.device.management.channel.DeviceChannelFactory</api> -->
@@ -70,6 +73,8 @@
 
         <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService</api>
         <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory</api>
+
+        <api>org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService</api>
 
         <api>org.eclipse.kapua.service.datastore.MessageStoreService</api>
         <api>org.eclipse.kapua.service.datastore.ClientInfoRegistryService</api>

--- a/rest-api/src/main/resources/locator.xml
+++ b/rest-api/src/main/resources/locator.xml
@@ -86,6 +86,8 @@
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 
+        <api>org.eclipse.kapua.service.stream.StreamService</api>
+
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
 
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>

--- a/rest-api/src/main/resources/shiro.ini
+++ b/rest-api/src/main/resources/shiro.ini
@@ -87,6 +87,7 @@ securityManager.rememberMeManager.cookie.maxAge = 0
 /v1/*/roles.xml					= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/roles.json				= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/roles/**					= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/streams/**                = kapuaAuthcAccessToken, noSessionCreation
 /v1/*/users.json				= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/users.xml					= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/users/**					= kapuaAuthcAccessToken, noSessionCreation

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObject.java
@@ -20,8 +20,8 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class XmlAdaptedTypeValueObject {
 
     @XmlJavaTypeAdapter(ObjectTypeXmlAdapter.class)
-    @XmlElement(name = "type")
-    private Class<?> type;
+    @XmlElement(name = "valueType")
+    private Class<?> valueType;
 
     @XmlElement(name = "value")
     private String value;
@@ -30,12 +30,12 @@ public class XmlAdaptedTypeValueObject {
         // Required by JAXB
     }
 
-    public Class<?> getType() {
-        return type;
+    public Class<?> getValueType() {
+        return valueType;
     }
 
-    public void setType(Class<?> type) {
-        this.type = type;
+    public void setValueType(Class<?> type) {
+        this.valueType = type;
     }
 
     public String getValue() {

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Storable.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Storable.java
@@ -11,11 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
+import org.eclipse.kapua.KapuaSerializable;
+
 /**
  * Storable object definition
  * 
  * @since 1.0
  */
-public interface Storable {
+public interface Storable extends KapuaSerializable {
 
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/InsertResponse.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/InsertResponse.java
@@ -11,12 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.client.model;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
 /**
  * Insert response
  *
  * @since 1.0
  */
+@XmlType(name = "insertResponse")
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class InsertResponse extends Response {
+
+    public InsertResponse() {
+        super(null, null);
+    }
 
     /**
      * Default constructor

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/Response.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/Response.java
@@ -11,12 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.client.model;
 
+import org.eclipse.kapua.KapuaSerializable;
+
 /**
  * Base response object
  * 
  * @since 1.0
  */
-public abstract class Response {
+public abstract class Response implements KapuaSerializable {
 
     /**
      * Record id (it should set by the datastore client component)

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/TypeDescriptor.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/TypeDescriptor.java
@@ -16,6 +16,10 @@ public class TypeDescriptor {
     private String index;
     private String type;
 
+    public TypeDescriptor() {
+
+    }
+
     public TypeDescriptor(String index, String type) {
         this.index = index;
         this.type = type;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -150,8 +150,8 @@ public final class MessageStoreFacade {
         InsertRequest insertRequest = new InsertRequest(typeDescriptor, messageToStore);
         // Possibly update the schema with new metric mappings
         Map<String, Metric> metrics = new HashMap<>();
-        if (message.getPayload()!=null && message.getPayload().getProperties()!=null && message.getPayload().getProperties().size()>0) {
-            Map<String, Object> messageMetrics = message.getPayload().getProperties();
+        if (message.getPayload()!=null && message.getPayload().getMetrics()!=null && message.getPayload().getMetrics().size()>0) {
+            Map<String, Object> messageMetrics = message.getPayload().getMetrics();
             Iterator<String> metricsIterator = messageMetrics.keySet().iterator();
             while (metricsIterator.hasNext()) {
                 String kapuaMetricName = metricsIterator.next();

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/ModelContextImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/ModelContextImpl.java
@@ -218,7 +218,7 @@ public class ModelContextImpl implements ModelContext {
                     payloadMetrics.put(DatastoreUtils.restoreMetricName(metricsName), DatastoreUtils.convertToCorrectType(valueTypes[0], value));
                 }
             }
-            payload.setProperties(payloadMetrics);
+            payload.setMetrics(payloadMetrics);
         }
         if (fetchStyle.equals(StorableFetchStyle.SOURCE_SELECT)) {
             return message;
@@ -326,7 +326,7 @@ public class ModelContextImpl implements ModelContext {
             return unmarshalledMessage;
         }
         unmarshalledMessage.put(MessageSchema.MESSAGE_BODY, payload.getBody());
-        Map<String, Object> kapuaMetrics = payload.getProperties();
+        Map<String, Object> kapuaMetrics = payload.getMetrics();
         if (kapuaMetrics != null) {
             Map<String, Object> metrics = new HashMap<String, Object>();
             String[] metricNames = kapuaMetrics.keySet().toArray(new String[] {});

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
@@ -166,7 +166,7 @@ public class DatastoreMediator implements MessageStoreMediator,
             return;
         }
 
-        Map<String, Object> metrics = payload.getProperties();
+        Map<String, Object> metrics = payload.getMetrics();
         if (metrics == null) {
             return;
         }

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
@@ -168,7 +168,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         metrics.put("double", (double) 0.01);
         metrics.put("long", (long) (10000000000000l));
         metrics.put("string_value", Integer.toString(1000));
-        messagePayload.setProperties(metrics);
+        messagePayload.setMetrics(metrics);
 
         messagePayload.setBody(payload);
         Date receivedOn = Date.from(KapuaDateUtils.getKapuaSysDate());
@@ -264,7 +264,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
             metrics.put("double", (double) 0.01);
             metrics.put("long", (long) (10000000000000l));
             metrics.put("string_value", Integer.toString(1000));
-            messagePayload.setProperties(metrics);
+            messagePayload.setMetrics(metrics);
 
             messagePayload.setBody(payload);
             Date receivedOn = Date.from(KapuaDateUtils.getKapuaSysDate());
@@ -360,7 +360,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
             byte[] payload = ArrayUtils.addAll(randomPayload, stringPayload.getBytes());
 
             KapuaDataPayloadImpl messagePayload = new KapuaDataPayloadImpl();
-            messagePayload.setProperties(getMetrics(message, i));
+            messagePayload.setMetrics(getMetrics(message, i));
             messagePayload.setBody(payload);
             Date receivedOn = Date.from(capturedOnDate.plusMillis(i * 1000));
             Date sentOn = new Date(new SimpleDateFormat("dd/MM/yyyy").parse("01/01/2015").getTime());
@@ -390,8 +390,8 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
                 checkMessageId(message, messageStoredIds.get(i));
                  checkTopic(message, messageToCompare.getChannel().toString());
                  checkMessageBody(message, messageToCompare.getPayload().getBody());
-                 checkMetricsSize(message, messageToCompare.getPayload().getProperties().size());
-                 checkMetrics(message, messageToCompare.getPayload().getProperties());
+                 checkMetricsSize(message, messageToCompare.getPayload().getMetrics().size());
+                 checkMetrics(message, messageToCompare.getPayload().getMetrics());
                  checkPosition(message, messageToCompare.getPosition());
              }
         } catch (KapuaException e) {
@@ -464,7 +464,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         metrics.put("double", (double) 0.01);
         metrics.put("long", (long) (10000000000000l));
         metrics.put("string_value", Integer.toString(1000));
-        messagePayload.setProperties(metrics);
+        messagePayload.setMetrics(metrics);
 
         messagePayload.setBody(payload);
         Date receivedOn = Date.from(KapuaDateUtils.getKapuaSysDate());
@@ -571,7 +571,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
             metrics.put("date_value_ls", dateLA);
             metrics.put("date_value_hk", dateHK);
             metrics.put("date_value_sydney", dateSydney);
-            messagePayload.setProperties(metrics);
+            messagePayload.setMetrics(metrics);
 
             messagePayload.setBody(payload);
             Date receivedOn = new Date();
@@ -1028,14 +1028,14 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         KapuaDataMessage message1 = createMessage(clientIds[0], account.getId(), device.getId(), receivedOn, capturedOn, sentOn);
         setChannel(message1, semanticTopic[0]);
         initMetrics(message1);
-        message1.getPayload().getProperties().put(metrics[0], Double.valueOf(123));
-        message1.getPayload().getProperties().put(metrics[1], Integer.valueOf(123));
+        message1.getPayload().getMetrics().put(metrics[0], Double.valueOf(123));
+        message1.getPayload().getMetrics().put(metrics[1], Integer.valueOf(123));
         message1.setReceivedOn(messageTime);
         KapuaDataMessage message2 = createMessage(clientIds[1], account.getId(), device.getId(), receivedOn, capturedOn, sentOn);
         setChannel(message2, semanticTopic[0]);
         initMetrics(message2);
-        message2.getPayload().getProperties().put(metrics[2], String.valueOf("123"));
-        message2.getPayload().getProperties().put(metrics[3], Boolean.valueOf(true));
+        message2.getPayload().getMetrics().put(metrics[2], String.valueOf("123"));
+        message2.getPayload().getMetrics().put(metrics[3], Boolean.valueOf(true));
         message2.setReceivedOn(messageTime);
         updateConfiguration(MESSAGE_STORE_SERVICE, account.getId(), account.getScopeId(), DataIndexBy.DEVICE_TIMESTAMP, MetricsIndexBy.TIMESTAMP, 30, true);
         insertMessages(message1, message2);
@@ -1078,26 +1078,26 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         KapuaDataMessage message1 = createMessage(clientIds[0], account.getId(), device.getId(), receivedOn, capturedOn, sentOn);
         setChannel(message1, semanticTopic[0]);
         initMetrics(message1);
-        message1.getPayload().getProperties().put(metrics[0], Double.valueOf(123));
-        message1.getPayload().getProperties().put(metrics[1], Integer.valueOf(123));
+        message1.getPayload().getMetrics().put(metrics[0], Double.valueOf(123));
+        message1.getPayload().getMetrics().put(metrics[1], Integer.valueOf(123));
         message1.setReceivedOn(messageTime);
         KapuaDataMessage message2 = createMessage(clientIds[1], account.getId(), device.getId(), receivedOn, capturedOn, sentOn);
         setChannel(message2, semanticTopic[0]);
         initMetrics(message2);
-        message2.getPayload().getProperties().put(metrics[2], "123");
-        message2.getPayload().getProperties().put(metrics[3], Boolean.TRUE);
+        message2.getPayload().getMetrics().put(metrics[2], "123");
+        message2.getPayload().getMetrics().put(metrics[3], Boolean.TRUE);
         message2.setReceivedOn(messageTime);
         KapuaDataMessage message3 = createMessage(clientIds[1], account.getId(), device.getId(), receivedOn, capturedOnSecondMessage, sentOn);
         setChannel(message3, semanticTopic[0]);
         initMetrics(message3);
-        message3.getPayload().getProperties().put(metrics[2], "123");
-        message3.getPayload().getProperties().put(metrics[3], Boolean.TRUE);
+        message3.getPayload().getMetrics().put(metrics[2], "123");
+        message3.getPayload().getMetrics().put(metrics[3], Boolean.TRUE);
         message3.setReceivedOn(messageTime);
         KapuaDataMessage message4 = createMessage(clientIds[1], account.getId(), device.getId(), receivedOn, capturedOnThirdMessage, sentOn);
         setChannel(message4, semanticTopic[0]);
         initMetrics(message4);
-        message4.getPayload().getProperties().put(metrics[2], "123");
-        message4.getPayload().getProperties().put(metrics[3], Boolean.TRUE);
+        message4.getPayload().getMetrics().put(metrics[2], "123");
+        message4.getPayload().getMetrics().put(metrics[3], Boolean.TRUE);
         message4.setReceivedOn(messageTime);
 
         updateConfiguration(MESSAGE_STORE_SERVICE, account.getId(), account.getScopeId(), DataIndexBy.DEVICE_TIMESTAMP, MetricsIndexBy.TIMESTAMP, 30, true);
@@ -1157,20 +1157,20 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         KapuaDataMessage message1 = createMessage(clientIds[0], account.getId(), device.getId(), receivedOn, capturedOn, sentOn);
         setChannel(message1, semanticTopic[0]);
         initMetrics(message1);
-        message1.getPayload().getProperties().put(metrics[0], Double.valueOf(123));
-        message1.getPayload().getProperties().put(metrics[1], Integer.valueOf(123));
+        message1.getPayload().getMetrics().put(metrics[0], Double.valueOf(123));
+        message1.getPayload().getMetrics().put(metrics[1], Integer.valueOf(123));
         message1.setReceivedOn(messageTime);
         KapuaDataMessage message2 = createMessage(clientIds[0], account.getId(), device.getId(), receivedOn, capturedOn, sentOn);
         setChannel(message2, semanticTopic[0]);
         initMetrics(message2);
-        message2.getPayload().getProperties().put(metrics[2], "123");
-        message2.getPayload().getProperties().put(metrics[3], Boolean.TRUE);
+        message2.getPayload().getMetrics().put(metrics[2], "123");
+        message2.getPayload().getMetrics().put(metrics[3], Boolean.TRUE);
         message2.setReceivedOn(messageTime);
         KapuaDataMessage message3 = createMessage(clientIds[1], account.getId(), device.getId(), receivedOn, capturedOn, sentOn);
         setChannel(message3, semanticTopic[0]);
         initMetrics(message3);
-        message3.getPayload().getProperties().put(metrics[2], Double.valueOf(123));
-        message3.getPayload().getProperties().put(metrics[3], Integer.valueOf(123));
+        message3.getPayload().getMetrics().put(metrics[2], Double.valueOf(123));
+        message3.getPayload().getMetrics().put(metrics[3], Integer.valueOf(123));
         message3.setReceivedOn(messageTime);
         updateConfiguration(MESSAGE_STORE_SERVICE, account.getId(), account.getScopeId(), DataIndexBy.DEVICE_TIMESTAMP, MetricsIndexBy.TIMESTAMP, 30, true);
         insertMessages(message1, message2, message3);
@@ -1262,12 +1262,12 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
             setChannel(message, semanticTopic[i % semanticTopic.length]);
             // insert metrics
             initMetrics(message);
-            message.getPayload().getProperties().put(metrics[0], metricsValuesDate[i % metricsValuesDate.length]);
-            message.getPayload().getProperties().put(metrics[1], metricsValuesString[i % metricsValuesString.length]);
-            message.getPayload().getProperties().put(metrics[2], metricsValuesInt[i % metricsValuesInt.length]);
-            message.getPayload().getProperties().put(metrics[3], metricsValuesFloat[i % metricsValuesFloat.length]);
-            message.getPayload().getProperties().put(metrics[4], metricsValuesBoolean[i % metricsValuesBoolean.length]);
-            message.getPayload().getProperties().put(metrics[5], metricsValuesDouble[i % metricsValuesDouble.length]);
+            message.getPayload().getMetrics().put(metrics[0], metricsValuesDate[i % metricsValuesDate.length]);
+            message.getPayload().getMetrics().put(metrics[1], metricsValuesString[i % metricsValuesString.length]);
+            message.getPayload().getMetrics().put(metrics[2], metricsValuesInt[i % metricsValuesInt.length]);
+            message.getPayload().getMetrics().put(metrics[3], metricsValuesFloat[i % metricsValuesFloat.length]);
+            message.getPayload().getMetrics().put(metrics[4], metricsValuesBoolean[i % metricsValuesBoolean.length]);
+            message.getPayload().getMetrics().put(metrics[5], metricsValuesDouble[i % metricsValuesDouble.length]);
             insertMessages(message);
         }
 
@@ -1983,7 +1983,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         capturedOn.checkValue(message.getCapturedOn());
         receivedOn.checkValue(message.getReceivedOn());
         assertNotNull("Message payload is null!", message.getPayload());
-        assertNotNull("Message prorperties are null!", message.getPayload().getProperties());
+        assertNotNull("Message prorperties are null!", message.getPayload().getMetrics());
     }
 
     /**
@@ -1994,10 +1994,10 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
      */
     private void checkMetricsSize(DatastoreMessage message, int metricsSize) {
         if (metricsSize < 0) {
-            assertNull("Message metrics is not null!", message.getPayload().getProperties());
+            assertNull("Message metrics is not null!", message.getPayload().getMetrics());
         } else {
-            assertNotNull("Message metrics shouldn't be null!", message.getPayload().getProperties());
-            assertEquals("Message metrics size doesn't match!", metricsSize, message.getPayload().getProperties().size());
+            assertNotNull("Message metrics shouldn't be null!", message.getPayload().getMetrics());
+            assertEquals("Message metrics size doesn't match!", metricsSize, message.getPayload().getMetrics().size());
         }
     }
 
@@ -2025,7 +2025,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
      */
     private void checkMetrics(DatastoreMessage message, Map<String, Object> metrics) {
         // assuming metrics size is already checked by the checkMetricsSize
-        Map<String, Object> messageProperties = message.getPayload().getProperties();
+        Map<String, Object> messageProperties = message.getPayload().getMetrics();
         Iterator<String> metricsKeys = metrics.keySet().iterator();
         while (metricsKeys.hasNext()) {
             String key = metricsKeys.next();
@@ -2220,8 +2220,8 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         checkMessageId(messageToCheck, correctId);
         checkTopic(messageToCheck, correctMessage.getChannel().toString());
         checkMessageBody(messageToCheck, correctMessage.getPayload().getBody());
-        checkMetricsSize(messageToCheck, correctMessage.getPayload().getProperties().size());
-        checkMetrics(messageToCheck, correctMessage.getPayload().getProperties());
+        checkMetricsSize(messageToCheck, correctMessage.getPayload().getMetrics().size());
+        checkMetrics(messageToCheck, correctMessage.getPayload().getMetrics());
         checkPosition(messageToCheck, correctMessage.getPosition());
         checkMessageDate(messageToCheck, new Range<Date>("timestamp", correctMessage.getCapturedOn()), new Range<Date>("sentOn", correctMessage.getSentOn()),
                 new Range<Date>("capturedOn", correctMessage.getCapturedOn()),
@@ -2559,13 +2559,13 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
 
         metrics.put("distance", 1L);
         metrics.put("label", "goofy");
-        messagePayload.setProperties(metrics);
+        messagePayload.setMetrics(metrics);
 
         messagePosition.setAltitude(1.0);
         messagePosition.setTimestamp(now);
         message.setPosition(messagePosition);
 
-        messagePayload.setProperties(metrics);
+        messagePayload.setMetrics(metrics);
         message.setPayload(messagePayload);
         message.setClientId(clientId);
 

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaAppProperties.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaAppProperties.java
@@ -11,12 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management;
 
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
 /**
  * Kapua application property definition.
  * 
  * @since 1.0
  *
  */
+@XmlJavaTypeAdapter(KapuaAppPropertiesXmlAdapter.class)
 public interface KapuaAppProperties {
 
     /**

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaAppPropertiesXmlAdapter.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaAppPropertiesXmlAdapter.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+public class KapuaAppPropertiesXmlAdapter extends XmlAdapter<String, KapuaAppProperties>{
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final KapuaRequestMessageFactory REQUEST_MESSAGE_FACTORY = LOCATOR.getFactory(KapuaRequestMessageFactory.class);
+
+    @Override public KapuaAppProperties unmarshal(String v) throws Exception {
+        return REQUEST_MESSAGE_FACTORY.newAppProperties(v);
+    }
+
+    @Override public String marshal(KapuaAppProperties v) throws Exception {
+        return v.getValue();
+    }
+}

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaRequestMessageFactory.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/KapuaRequestMessageFactory.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management;
+
+import org.eclipse.kapua.model.KapuaObjectFactory;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
+
+public interface KapuaRequestMessageFactory extends KapuaObjectFactory {
+    KapuaRequestChannel newRequestChannel();
+
+    KapuaRequestMessage newRequestMessage();
+
+    KapuaRequestPayload newRequestPayload();
+
+    KapuaAppProperties newAppProperties(String value);
+}

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/RequestMessageXmlRegistry.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/RequestMessageXmlRegistry.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class RequestMessageXmlRegistry {
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final KapuaRequestMessageFactory factory = locator.getFactory(KapuaRequestMessageFactory.class);
+
+    public KapuaRequestChannel newRequestChannel() {
+        return factory.newRequestChannel();
+    }
+
+    public KapuaRequestMessage newRequestMessage() {
+        return factory.newRequestMessage();
+    }
+
+    public KapuaRequestPayload newRequestPayload() {
+        return factory.newRequestPayload();
+    }
+}

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestChannel.java
@@ -12,7 +12,11 @@
 package org.eclipse.kapua.service.device.management.request;
 
 import org.eclipse.kapua.service.device.management.KapuaAppChannel;
+import org.eclipse.kapua.service.device.management.RequestMessageXmlRegistry;
 import org.eclipse.kapua.service.device.management.KapuaMethod;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kapua request message channel definition.<br>
@@ -22,18 +26,20 @@ import org.eclipse.kapua.service.device.management.KapuaMethod;
  * @since 1.0
  *
  */
+@XmlRootElement(name = "channel")
+@XmlType(propOrder = { "method" }, factoryClass = RequestMessageXmlRegistry.class, factoryMethod = "newRequestChannel")
 public interface KapuaRequestChannel extends KapuaAppChannel {
 
     /**
      * Get the request method
-     * 
+     *
      * @return
      */
     public KapuaMethod getMethod();
 
     /**
      * Set the request method
-     * 
+     *
      * @param method
      */
     public void setMethod(KapuaMethod method);

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestMessage.java
@@ -12,9 +12,13 @@
 package org.eclipse.kapua.service.device.management.request;
 
 import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.service.device.management.RequestMessageXmlRegistry;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
+
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kapua request message definition.<br>
@@ -24,6 +28,8 @@ import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload
  * @since 1.0
  *
  */
+
+@XmlType(factoryClass = RequestMessageXmlRegistry.class, factoryMethod = "newRequestMessage")
 public interface KapuaRequestMessage<C extends KapuaRequestChannel, P extends KapuaRequestPayload> extends KapuaMessage<C, P> {
 
     /**
@@ -31,6 +37,7 @@ public interface KapuaRequestMessage<C extends KapuaRequestChannel, P extends Ka
      * 
      * @return
      */
+    @XmlTransient
     public <M extends KapuaRequestMessage<C, P>> Class<M> getRequestClass();
 
     /**
@@ -38,6 +45,7 @@ public interface KapuaRequestMessage<C extends KapuaRequestChannel, P extends Ka
      * 
      * @return
      */
+    @XmlTransient
     public <RSC extends KapuaResponseChannel, RSP extends KapuaResponsePayload, M extends KapuaResponseMessage<RSC, RSP>> Class<M> getResponseClass();
 
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestPayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/request/KapuaRequestPayload.java
@@ -12,6 +12,10 @@
 package org.eclipse.kapua.service.device.management.request;
 
 import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.service.device.management.RequestMessageXmlRegistry;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kapua request message payload definition.<br>
@@ -21,6 +25,8 @@ import org.eclipse.kapua.message.KapuaPayload;
  * @since 1.0
  *
  */
+@XmlRootElement(name = "payload")
+@XmlType(factoryClass = RequestMessageXmlRegistry.class, factoryMethod = "newRequestPayload")
 public interface KapuaRequestPayload extends KapuaPayload {
 
 }

--- a/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/DeviceAssetChannelXmlAdapter.java
+++ b/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/DeviceAssetChannelXmlAdapter.java
@@ -32,7 +32,7 @@ public class DeviceAssetChannelXmlAdapter extends XmlAdapter<XmlAdaptedDeviceAss
 
         XmlAdaptedDeviceAssetChannel xmlAdaptedDeviceAssetChannel = new XmlAdaptedDeviceAssetChannel();
         xmlAdaptedDeviceAssetChannel.setName(deviceAssetChannel.getName());
-        xmlAdaptedDeviceAssetChannel.setType(deviceAssetChannel.getType());
+        xmlAdaptedDeviceAssetChannel.setValueType(deviceAssetChannel.getType());
         xmlAdaptedDeviceAssetChannel.setValue(ObjectValueConverter.toString(deviceAssetChannel.getValue()));
         xmlAdaptedDeviceAssetChannel.setMode(deviceAssetChannel.getMode());
         xmlAdaptedDeviceAssetChannel.setError(deviceAssetChannel.getError());
@@ -46,7 +46,7 @@ public class DeviceAssetChannelXmlAdapter extends XmlAdapter<XmlAdaptedDeviceAss
 
         DeviceAssetChannel adaptedDeviceAssetChannel = factory.newDeviceAssetChannel();
         adaptedDeviceAssetChannel.setName(xmlAdaptedDeviceAssetChannel.getName());
-        adaptedDeviceAssetChannel.setType(xmlAdaptedDeviceAssetChannel.getType());
+        adaptedDeviceAssetChannel.setType(xmlAdaptedDeviceAssetChannel.getValueType());
         adaptedDeviceAssetChannel.setValue(ObjectValueConverter.fromString(xmlAdaptedDeviceAssetChannel.getValue(), adaptedDeviceAssetChannel.getType()));
         adaptedDeviceAssetChannel.setMode(xmlAdaptedDeviceAssetChannel.getMode());
         adaptedDeviceAssetChannel.setError(xmlAdaptedDeviceAssetChannel.getError());

--- a/service/device/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestChannel.java
+++ b/service/device/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestChannel.java
@@ -11,9 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.asset.message.internal;
 
-import org.eclipse.kapua.service.device.management.KapuaMethod;
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
-import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
 
 /**
  * Device asset information request channel.
@@ -21,21 +19,10 @@ import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
  * @since 1.0
  * 
  */
-public class AssetRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel {
+public class AssetRequestChannel extends KapuaRequestChannelImpl {
 
-    private KapuaMethod method;
     private boolean read;
     private boolean write;
-
-    @Override
-    public KapuaMethod getMethod() {
-        return method;
-    }
-
-    @Override
-    public void setMethod(KapuaMethod method) {
-        this.method = method;
-    }
 
     public boolean isRead() {
         return read;

--- a/service/device/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseChannel.java
+++ b/service/device/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseChannel.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.asset.message.internal;
 
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
 /**

--- a/service/device/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestPayload.java
+++ b/service/device/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestPayload.java
@@ -32,7 +32,7 @@ public class ChannelRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         int i = 0;
         for (String channelName : channelNames) {
             if (channelName != null) {
-                getProperties().put(CHANNEL_NAME_PREFIX_DOT + i++, channelName);
+                getMetrics().put(CHANNEL_NAME_PREFIX_DOT + i++, channelName);
             }
         }
     }
@@ -42,7 +42,7 @@ public class ChannelRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         List<String> names = new ArrayList<>();
         String name;
         do {
-            name = (String) getProperties().get(CHANNEL_NAME_PREFIX_DOT + i++);
+            name = (String) getMetrics().get(CHANNEL_NAME_PREFIX_DOT + i++);
             if (name != null) {
                 names.add(name);
             }

--- a/service/device/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseChannel.java
+++ b/service/device/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseChannel.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.channel.message.internal;
 
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
 /**

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestChannel.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestChannel.java
@@ -11,9 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.bundle.message.internal;
 
-import org.eclipse.kapua.service.device.management.KapuaMethod;
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
-import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
 
 /**
  * Device bundle information request channel.
@@ -21,21 +19,10 @@ import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
  * @since 1.0
  * 
  */
-public class BundleRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel {
+public class BundleRequestChannel extends KapuaRequestChannelImpl {
 
-    private KapuaMethod method;
     private String bundleId;
     private boolean start;
-
-    @Override
-    public KapuaMethod getMethod() {
-        return method;
-    }
-
-    @Override
-    public void setMethod(KapuaMethod method) {
-        this.method = method;
-    }
 
     /**
      * Get the bundle identifier

--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.bundle.message.internal;
 
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
 /**

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DeviceMessage.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DeviceMessage.java
@@ -49,4 +49,10 @@ public interface DeviceMessage<C extends DeviceChannel, P extends DevicePayload>
      * @return
      */
     public Date getTimestamp();
+
+    void setChannel(C channel);
+
+    void setPayload(P payload);
+
+    void setTimestamp(Date timestamp);
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DevicePayload.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DevicePayload.java
@@ -53,6 +53,14 @@ public interface DevicePayload extends Payload {
      */
     public byte[] getBody();
 
+    void setTimestamp(Date timestamp);
+
+    void setPosition(DevicePosition position);
+
+    void setMetrics(Map<String, Object> metrics);
+
+    void setBody(byte[] body);
+
     //
     // Encode/Decode stuff
     //

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraMessage.java
@@ -68,7 +68,16 @@ public class KuraMessage<C extends KuraChannel, P extends KuraPayload> implement
      * 
      * @param timestamp
      */
+    @Override
     public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
+    }
+
+    @Override public void setChannel(C channel) {
+        this.channel = channel;
+    }
+
+    @Override public void setPayload(P payload) {
+        this.payload = payload;
     }
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/KuraPayload.java
@@ -84,6 +84,10 @@ public class KuraPayload implements DevicePayload {
         return metrics;
     }
 
+    @Override public void setMetrics(Map<String, Object> metrics) {
+        this.metrics = metrics;
+    }
+
     @Override
     public byte[] getBody() {
         return body;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataChannel.java
@@ -26,6 +26,14 @@ public class KuraDataChannel extends KuraChannel implements DeviceDataChannel {
 
     private List<String> semanticChannelParts;
 
+    public KuraDataChannel() {
+        this(null, null);
+    }
+
+    public KuraDataChannel(String scopeNamespace, String clientId) {
+        super(scopeNamespace, clientId);
+    }
+
     @Override
     public List<String> getSemanticChannelParts() {
         return semanticChannelParts;

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataMessage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataMessage.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.call.message.kura.data;
 import java.util.Date;
 
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
+import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
 
 /**
  * Kura device message implementation.
@@ -21,7 +22,7 @@ import org.eclipse.kapua.service.device.call.message.DeviceMessage;
  * @since 1.0
  * 
  */
-public class KuraDataMessage implements DeviceMessage<KuraDataChannel, KuraDataPayload> {
+public class KuraDataMessage extends KuraMessage<KuraDataChannel, KuraDataPayload> implements DeviceMessage<KuraDataChannel, KuraDataPayload> {
 
     protected KuraDataChannel channel;
     protected Date timestamp;
@@ -63,11 +64,20 @@ public class KuraDataMessage implements DeviceMessage<KuraDataChannel, KuraDataP
         return timestamp;
     }
 
+    @Override public void setChannel(KuraDataChannel channel) {
+        this.channel = channel;
+    }
+
+    @Override public void setPayload(KuraDataPayload payload) {
+        this.payload = payload;
+    }
+
     /**
      * Set the message timestamp
      * 
      * @param timestamp
      */
+    @Override
     public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/data/KuraDataPayload.java
@@ -21,6 +21,7 @@ import org.eclipse.kapua.message.internal.MessageErrorCodes;
 import org.eclipse.kapua.message.internal.MessageException;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
 import org.eclipse.kapua.service.device.call.message.DevicePosition;
+import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
 import org.eclipse.kapua.service.device.call.message.kura.KuraPosition;
 import org.eclipse.kapua.service.device.call.message.kura.proto.KuraPayloadProto;
 import org.eclipse.kapua.service.device.call.message.kura.utils.GZIPUtils;
@@ -36,7 +37,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
  * @since 1.0
  *
  */
-public class KuraDataPayload implements DevicePayload {
+public class KuraDataPayload extends KuraPayload implements DevicePayload {
 
     private static final Logger logger = LoggerFactory.getLogger(KuraDataPayload.class);
 
@@ -62,6 +63,7 @@ public class KuraDataPayload implements DevicePayload {
      *
      * @param timestamp
      */
+    @Override
     public void setTimestamp(Date timestamp) {
         this.timestamp = timestamp;
     }
@@ -76,6 +78,7 @@ public class KuraDataPayload implements DevicePayload {
      *
      * @param position
      */
+    @Override
     public void setPosition(DevicePosition position) {
         this.position = position;
     }
@@ -83,6 +86,10 @@ public class KuraDataPayload implements DevicePayload {
     @Override
     public Map<String, Object> getMetrics() {
         return metrics;
+    }
+
+    @Override public void setMetrics(Map<String, Object> metrics) {
+        this.metrics = metrics;
     }
 
     @Override
@@ -95,6 +102,7 @@ public class KuraDataPayload implements DevicePayload {
      *
      * @param body
      */
+    @Override
     public void setBody(byte[] body) {
         this.body = body;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraPayload.java
@@ -84,6 +84,10 @@ public class KuraPayload implements DevicePayload {
         return metrics;
     }
 
+    @Override public void setMetrics(Map<String, Object> metrics) {
+        this.metrics = metrics;
+    }
+
     @Override
     public byte[] getBody() {
         return body;

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
@@ -16,8 +16,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 
 /**
- * Id generator service implementation.<br>
- * This implementation return a sequence.
+ * Device bundle service definition.
  * 
  * @since 1.0
  *

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestChannel.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestChannel.java
@@ -11,9 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.command.message.internal;
 
-import org.eclipse.kapua.service.device.management.KapuaMethod;
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
-import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
 
 /**
  * Device command request channel.
@@ -21,18 +19,6 @@ import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
  * @since 1.0
  * 
  */
-public class CommandRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel {
-
-    private KapuaMethod method;
-
-    @Override
-    public KapuaMethod getMethod() {
-        return method;
-    }
-
-    @Override
-    public void setMethod(KapuaMethod method) {
-        this.method = method;
-    }
+public class CommandRequestChannel extends KapuaRequestChannelImpl {
 
 }

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestPayload.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestPayload.java
@@ -35,7 +35,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         List<String> argumentsList = new ArrayList<>();
 
         for (int i = 0;; i++) {
-            String value = (String) getProperties().get(CommandAppProperties.APP_PROPERTY_ARG.getValue() + i);
+            String value = (String) getMetrics().get(CommandAppProperties.APP_PROPERTY_ARG.getValue() + i);
             if (value != null) {
                 argumentsList.add(value);
             } else {
@@ -58,7 +58,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     public void setArguments(String[] arguments) {
         if (arguments != null) {
             for (int i = 0; i < arguments.length; i++) {
-                getProperties().put(CommandAppProperties.APP_PROPERTY_ARG.getValue() + i, arguments[i]);
+                getMetrics().put(CommandAppProperties.APP_PROPERTY_ARG.getValue() + i, arguments[i]);
             }
         }
     }
@@ -72,7 +72,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
         List<String> v = new ArrayList<>();
 
         for (int i = 0;; i++) {
-            String value = (String) getProperties().get(CommandAppProperties.APP_PROPERTY_ENVP.getValue() + i);
+            String value = (String) getMetrics().get(CommandAppProperties.APP_PROPERTY_ENVP.getValue() + i);
             if (value != null) {
                 v.add(value);
             } else {
@@ -95,7 +95,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     public void setEnvironmentPairs(String[] environmentPairs) {
         if (environmentPairs != null) {
             for (int i = 0; i < environmentPairs.length; i++) {
-                getProperties().put(CommandAppProperties.APP_PROPERTY_ENVP.getValue() + i, environmentPairs[i]);
+                getMetrics().put(CommandAppProperties.APP_PROPERTY_ENVP.getValue() + i, environmentPairs[i]);
             }
         }
     }
@@ -106,7 +106,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getWorkingDir() {
-        return (String) getProperties().get(CommandAppProperties.APP_PROPERTY_DIR.getValue());
+        return (String) getMetrics().get(CommandAppProperties.APP_PROPERTY_DIR.getValue());
     }
 
     /**
@@ -116,7 +116,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setWorkingDir(String workingDir) {
         if (workingDir != null) {
-            getProperties().put(CommandAppProperties.APP_PROPERTY_DIR.getValue(), workingDir);
+            getMetrics().put(CommandAppProperties.APP_PROPERTY_DIR.getValue(), workingDir);
         }
     }
 
@@ -126,7 +126,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getStdin() {
-        return (String) getProperties().get(CommandAppProperties.APP_PROPERTY_STDIN.getValue());
+        return (String) getMetrics().get(CommandAppProperties.APP_PROPERTY_STDIN.getValue());
     }
 
     /**
@@ -136,7 +136,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setStdin(String stdin) {
         if (stdin != null) {
-            getProperties().put(CommandAppProperties.APP_PROPERTY_STDIN.getValue(), stdin);
+            getMetrics().put(CommandAppProperties.APP_PROPERTY_STDIN.getValue(), stdin);
         }
     }
 
@@ -146,7 +146,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public Integer getTimeout() {
-        return (Integer) getProperties().get(CommandAppProperties.APP_PROPERTY_TOUT.getValue());
+        return (Integer) getMetrics().get(CommandAppProperties.APP_PROPERTY_TOUT.getValue());
     }
 
     /**
@@ -155,7 +155,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @param timeout
      */
     public void setTimeout(int timeout) {
-        getProperties().put(CommandAppProperties.APP_PROPERTY_TOUT.getValue(), Integer.valueOf(timeout));
+        getMetrics().put(CommandAppProperties.APP_PROPERTY_TOUT.getValue(), Integer.valueOf(timeout));
     }
 
     /**
@@ -164,7 +164,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public Boolean isRunAsync() {
-        return (Boolean) getProperties().get(CommandAppProperties.APP_PROPERTY_ASYNC.getValue());
+        return (Boolean) getMetrics().get(CommandAppProperties.APP_PROPERTY_ASYNC.getValue());
     }
 
     /**
@@ -173,7 +173,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @param runAsync
      */
     public void setRunAsync(boolean runAsync) {
-        getProperties().put(CommandAppProperties.APP_PROPERTY_ASYNC.getValue(), Boolean.valueOf(runAsync));
+        getMetrics().put(CommandAppProperties.APP_PROPERTY_ASYNC.getValue(), Boolean.valueOf(runAsync));
     }
 
     /**
@@ -182,7 +182,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @param cmd
      */
     public void setCommand(String cmd) {
-        getProperties().put(CommandAppProperties.APP_PROPERTY_CMD.getValue(), cmd);
+        getMetrics().put(CommandAppProperties.APP_PROPERTY_CMD.getValue(), cmd);
     }
 
     /**
@@ -191,7 +191,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getCommand() {
-        return (String) getProperties().get(CommandAppProperties.APP_PROPERTY_CMD.getValue());
+        return (String) getMetrics().get(CommandAppProperties.APP_PROPERTY_CMD.getValue());
     }
 
     /**
@@ -200,7 +200,7 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @param password
      */
     public void setPassword(String password) {
-        getProperties().put(CommandAppProperties.APP_PROPERTY_PASSWORD.getValue(), password);
+        getMetrics().put(CommandAppProperties.APP_PROPERTY_PASSWORD.getValue(), password);
     }
 
     /**
@@ -209,6 +209,6 @@ public class CommandRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getPassword() {
-        return (String) getProperties().get(CommandAppProperties.APP_PROPERTY_PASSWORD.getValue());
+        return (String) getMetrics().get(CommandAppProperties.APP_PROPERTY_PASSWORD.getValue());
     }
 }

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.command.message.internal;
 
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
 /**

--- a/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
+++ b/service/device/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
@@ -48,7 +48,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
      * @return
      */
     public String getStderr() {
-        return (String) getProperties().get(APP_PROPERTY_STDERR);
+        return (String) getMetrics().get(APP_PROPERTY_STDERR);
     }
 
     /**
@@ -57,7 +57,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
      * @param stderr
      */
     public void setStderr(String stderr) {
-        getProperties().put(APP_PROPERTY_STDERR, stderr);
+        getMetrics().put(APP_PROPERTY_STDERR, stderr);
     }
 
     /**
@@ -66,7 +66,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
      * @return
      */
     public String getStdout() {
-        return (String) getProperties().get(APP_PROPERTY_STDOUT);
+        return (String) getMetrics().get(APP_PROPERTY_STDOUT);
     }
 
     /**
@@ -75,7 +75,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
      * @param stdout
      */
     public void setStdout(String stdout) {
-        getProperties().put(APP_PROPERTY_STDOUT, stdout);
+        getMetrics().put(APP_PROPERTY_STDOUT, stdout);
     }
 
     /**
@@ -84,7 +84,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
      * @return
      */
     public Integer getExitCode() {
-        return (Integer) getProperties().get(APP_PROPERTY_EXIT_CODE);
+        return (Integer) getMetrics().get(APP_PROPERTY_EXIT_CODE);
     }
 
     /**
@@ -93,7 +93,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
      * @param exitCode
      */
     public void setExitCode(Integer exitCode) {
-        getProperties().put(APP_PROPERTY_EXIT_CODE, exitCode);
+        getMetrics().put(APP_PROPERTY_EXIT_CODE, exitCode);
     }
 
     /**
@@ -102,7 +102,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
      * @return
      */
     public Boolean hasTimedout() {
-        return (Boolean) getProperties().get(APP_PROPERTY_TIMEDOUT);
+        return (Boolean) getMetrics().get(APP_PROPERTY_TIMEDOUT);
     }
 
     /**
@@ -111,7 +111,7 @@ public class CommandResponsePayload extends KapuaResponsePayloadImpl implements 
      * @param timedout
      */
     public void setTimedout(boolean timedout) {
-        getProperties().put(APP_PROPERTY_TIMEDOUT, timedout);
+        getMetrics().put(APP_PROPERTY_TIMEDOUT, timedout);
     }
 
 }

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/KapuaAppPropertiesImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/KapuaAppPropertiesImpl.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons;
+
+import org.eclipse.kapua.service.device.management.KapuaAppProperties;
+
+public class KapuaAppPropertiesImpl implements KapuaAppProperties {
+
+    protected String value;
+
+    public KapuaAppPropertiesImpl(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaAppChannelImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaAppChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,7 +9,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.service.device.management.commons.message.response;
+package org.eclipse.kapua.service.device.management.commons.message;
 
 import java.util.List;
 

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaRequestMessageFactoryImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaRequestMessageFactoryImpl.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons.message;
+
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.service.device.management.KapuaAppProperties;
+import org.eclipse.kapua.service.device.management.KapuaRequestMessageFactory;
+import org.eclipse.kapua.service.device.management.commons.KapuaAppPropertiesImpl;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestMessageImpl;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestPayloadImpl;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
+
+@KapuaProvider
+public class KapuaRequestMessageFactoryImpl implements KapuaRequestMessageFactory {
+
+    @Override
+    public KapuaRequestChannel newRequestChannel() {
+        return new KapuaRequestChannelImpl();
+    }
+
+    @Override
+    public KapuaRequestMessage newRequestMessage() {
+        return new KapuaRequestMessageImpl();
+    }
+
+    @Override
+    public KapuaRequestPayload newRequestPayload() {
+        return new KapuaRequestPayloadImpl();
+    }
+
+    @Override
+    public KapuaAppProperties newAppProperties(String value) {
+        return new KapuaAppPropertiesImpl(value);
+    }
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestChannelImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestChannelImpl.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons.message.request;
+
+import org.eclipse.kapua.service.device.management.KapuaMethod;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+
+public class KapuaRequestChannelImpl extends KapuaAppChannelImpl implements KapuaRequestChannel {
+
+    protected KapuaMethod method;
+
+    @Override
+    public KapuaMethod getMethod() {
+        return method;
+    }
+
+    @Override
+    public void setMethod(KapuaMethod method) {
+        this.method = method;
+    }
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestMessageImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestMessageImpl.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons.message.request;
+
+import org.eclipse.kapua.message.internal.KapuaMessageImpl;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+
+public class KapuaRequestMessageImpl<C extends KapuaRequestChannel, P extends KapuaRequestPayload> extends KapuaMessageImpl<C, P> implements KapuaRequestMessage<C, P> {
+
+    @Override
+    public Class<KapuaRequestMessage> getRequestClass() {
+        return KapuaRequestMessage.class;
+    }
+
+    @Override
+    public Class<KapuaResponseMessage> getResponseClass() {
+        return KapuaResponseMessage.class;
+    }
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestPayloadImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestPayloadImpl.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons.message.request;
+
+import org.eclipse.kapua.message.internal.KapuaPayloadImpl;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
+
+public class KapuaRequestPayloadImpl extends KapuaPayloadImpl implements KapuaRequestPayload {
+
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponseChannelImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponseChannelImpl.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons.message.response;
+
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
+
+public class KapuaResponseChannelImpl extends KapuaAppChannelImpl implements KapuaResponseChannel {
+
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponseMessageImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponseMessageImpl.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons.message.response;
+
+import org.eclipse.kapua.message.internal.KapuaMessageImpl;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
+
+public class KapuaResponseMessageImpl extends KapuaMessageImpl<KapuaResponseChannel, KapuaResponsePayload> implements KapuaResponseMessage<KapuaResponseChannel, KapuaResponsePayload>{
+
+    private KapuaResponseCode responseCode;
+
+    @Override
+    public KapuaResponseCode getResponseCode() {
+        return responseCode;
+    }
+
+    @Override
+    public void setResponseCode(KapuaResponseCode responseCode) {
+        this.responseCode = responseCode;
+    }
+
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
@@ -25,22 +25,22 @@ public class KapuaResponsePayloadImpl extends KapuaPayloadImpl implements KapuaR
 
     @Override
     public String getExceptionMessage() {
-        return (String) getProperties().get(ResponseProperties.RESP_PROPERTY_EXCEPTION_MESSAGE.getValue());
+        return (String) getMetrics().get(ResponseProperties.RESP_PROPERTY_EXCEPTION_MESSAGE.getValue());
     }
 
     @Override
     public void setExceptionMessage(String setExecptionMessage) {
-        getProperties().put(ResponseProperties.RESP_PROPERTY_EXCEPTION_MESSAGE.getValue(), setExecptionMessage);
+        getMetrics().put(ResponseProperties.RESP_PROPERTY_EXCEPTION_MESSAGE.getValue(), setExecptionMessage);
     }
 
     @Override
     public String getExceptionStack() {
-        return (String) getProperties().get(ResponseProperties.RESP_PROPERTY_EXCEPTION_STACK.getValue());
+        return (String) getMetrics().get(ResponseProperties.RESP_PROPERTY_EXCEPTION_STACK.getValue());
     }
 
     @Override
     public void setExceptionStack(String setExecptionStack) {
-        getProperties().put(ResponseProperties.RESP_PROPERTY_EXCEPTION_STACK.getValue(), setExecptionStack);
+        getMetrics().put(ResponseProperties.RESP_PROPERTY_EXCEPTION_STACK.getValue(), setExecptionStack);
     }
 
 }

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestChannel.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestChannel.java
@@ -11,9 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration.message.internal;
 
-import org.eclipse.kapua.service.device.management.KapuaMethod;
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
-import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
 
 /**
  * Device configuration request channel.
@@ -21,21 +19,10 @@ import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
  * @since 1.0
  * 
  */
-public class ConfigurationRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel {
+public class ConfigurationRequestChannel extends KapuaRequestChannelImpl {
 
-    private KapuaMethod method;
     private String configurationId;
     private String componentId;
-
-    @Override
-    public KapuaMethod getMethod() {
-        return method;
-    }
-
-    @Override
-    public void setMethod(KapuaMethod method) {
-        this.method = method;
-    }
 
     /**
      * Get the device configuration identifier

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration.message.internal;
 
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
 /**

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotRequestChannel.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotRequestChannel.java
@@ -11,9 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration.snapshot.internal;
 
-import org.eclipse.kapua.service.device.management.KapuaMethod;
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
-import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
 
 /**
  * Device snapshot request channel.
@@ -21,20 +19,9 @@ import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
  * @since 1.0
  * 
  */
-public class SnapshotRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel {
+public class SnapshotRequestChannel extends KapuaRequestChannelImpl {
 
-    private KapuaMethod method;
     private String snapshotId;
-
-    @Override
-    public KapuaMethod getMethod() {
-        return method;
-    }
-
-    @Override
-    public void setMethod(KapuaMethod method) {
-        this.method = method;
-    }
 
     /**
      * Get the snapshot identifier

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotResponseChannel.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/snapshot/internal/SnapshotResponseChannel.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration.snapshot.internal;
 
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
 /**

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
@@ -11,9 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.message.internal;
 
-import org.eclipse.kapua.service.device.management.KapuaMethod;
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
-import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
 
 /**
  * Package request message channel.
@@ -21,20 +19,9 @@ import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
  * @since 1.0
  *
  */
-public class PackageRequestChannel extends KapuaAppChannelImpl implements KapuaRequestChannel {
+public class PackageRequestChannel extends KapuaRequestChannelImpl {
 
-    private KapuaMethod method;
     private PackageResource packageResource;
-
-    @Override
-    public KapuaMethod getMethod() {
-        return method;
-    }
-
-    @Override
-    public void setMethod(KapuaMethod method) {
-        this.method = method;
-    }
 
     /**
      * Get package resource

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
@@ -31,7 +31,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public KapuaId getOperationId() {
-        return (KapuaId) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue());
+        return (KapuaId) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue());
     }
 
     /**
@@ -41,7 +41,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setOperationId(KapuaId operationId) {
         if (operationId != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue(), operationId);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue(), operationId);
         }
     }
 
@@ -51,7 +51,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public Boolean isReboot() {
-        return (Boolean) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT.getValue());
+        return (Boolean) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT.getValue());
     }
 
     /**
@@ -61,7 +61,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setReboot(Boolean reboot) {
         if (reboot != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT.getValue(), reboot);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT.getValue(), reboot);
         }
     }
 
@@ -71,7 +71,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public Integer getRebootDelay() {
-        return (Integer) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT_DELAY.getValue());
+        return (Integer) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT_DELAY.getValue());
     }
 
     /**
@@ -81,7 +81,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setRebootDelay(Integer rebootDelay) {
         if (rebootDelay != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT_DELAY.getValue(), rebootDelay);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_REBOOT_DELAY.getValue(), rebootDelay);
         }
     }
 
@@ -94,7 +94,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public URI getPackageDownloadURI() {
-        return (URI) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_URI.getValue());
+        return (URI) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_URI.getValue());
     }
 
     /**
@@ -104,7 +104,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setPackageDownloadURI(URI uri) {
         if (uri != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_URI.getValue(), uri);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_URI.getValue(), uri);
         }
     }
 
@@ -114,7 +114,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getPackageDownloadName() {
-        return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_NAME.getValue());
+        return (String) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_NAME.getValue());
     }
 
     /**
@@ -124,7 +124,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setPackageDownloadName(String packageName) {
         if (packageName != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_NAME.getValue(), packageName);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_NAME.getValue(), packageName);
         }
     }
 
@@ -134,7 +134,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getPackageDownloadVersion() {
-        return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_VERSION.getValue());
+        return (String) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_VERSION.getValue());
     }
 
     /**
@@ -144,7 +144,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setPackageDownloadVersion(String packageVersion) {
         if (packageVersion != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_VERSION.getValue(), packageVersion);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_VERSION.getValue(), packageVersion);
         }
     }
 
@@ -154,7 +154,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public Boolean isPackageDownloadnstall() {
-        return (Boolean) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL.getValue());
+        return (Boolean) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL.getValue());
     }
 
     /**
@@ -164,7 +164,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setPackageDownloadnstall(Boolean packageDownloadnstall) {
         if (packageDownloadnstall != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL.getValue(), packageDownloadnstall);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL.getValue(), packageDownloadnstall);
         }
     }
 
@@ -177,7 +177,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getPackageInstallName() {
-        return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_NAME.getValue());
+        return (String) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_NAME.getValue());
     }
 
     /**
@@ -187,7 +187,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setPackageInstallName(String packageName) {
         if (packageName != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_NAME.getValue(), packageName);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_NAME.getValue(), packageName);
         }
     }
 
@@ -197,7 +197,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getPackageInstallVersion() {
-        return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_VERSION.getValue());
+        return (String) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_VERSION.getValue());
     }
 
     /**
@@ -207,7 +207,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setPackageInstallVersion(String packageVersion) {
         if (packageVersion != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_VERSION.getValue(), packageVersion);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_INSTALL_PACKAGE_VERSION.getValue(), packageVersion);
         }
     }
 
@@ -220,7 +220,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getPackageUninstallName() {
-        return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_NAME.getValue());
+        return (String) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_NAME.getValue());
     }
 
     /**
@@ -230,7 +230,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setPackageUninstallName(String packageName) {
         if (packageName != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_NAME.getValue(), packageName);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_NAME.getValue(), packageName);
         }
     }
 
@@ -240,7 +240,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      * @return
      */
     public String getPackageUninstallVersion() {
-        return (String) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_VERSION.getValue());
+        return (String) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_VERSION.getValue());
     }
 
     /**
@@ -250,7 +250,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
      */
     public void setPackageUninstallVersion(String packageVersion) {
         if (packageVersion != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_VERSION.getValue(), packageVersion);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_UNINSTALL_PACKAGE_VERSION.getValue(), packageVersion);
         }
     }
 

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.message.internal;
 
-import org.eclipse.kapua.service.device.management.commons.message.response.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 
 /**

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
@@ -31,7 +31,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
      */
     public void setPackageDownloadOperationId(KapuaId operationId) {
         if (operationId != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue(), operationId);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue(), operationId);
         }
     }
 
@@ -41,7 +41,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
      * @return
      */
     public KapuaId getPackageDownloadOperationId() {
-        return (KapuaId) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue());
+        return (KapuaId) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_OPERATION_ID.getValue());
     }
 
     /**
@@ -51,7 +51,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
      */
     public void setPackageDownloadOperationStatus(DevicePackageDownloadStatus status) {
         if (status != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_STATUS.getValue(), status);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_STATUS.getValue(), status);
         }
     }
 
@@ -61,7 +61,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
      * @return
      */
     public DevicePackageDownloadStatus getPackageDownloadOperationStatus() {
-        return (DevicePackageDownloadStatus) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_STATUS.getValue());
+        return (DevicePackageDownloadStatus) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_STATUS.getValue());
     }
 
     /**
@@ -71,7 +71,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
      */
     public void setPackageDownloadOperationSize(Integer size) {
         if (size != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_SIZE.getValue(), size);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_SIZE.getValue(), size);
         }
     }
 
@@ -81,7 +81,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
      * @return
      */
     public Integer getPackageDownloadOperationSize() {
-        return (Integer) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_SIZE.getValue());
+        return (Integer) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_SIZE.getValue());
     }
 
     /**
@@ -91,7 +91,7 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
      */
     public void setPackageDownloadOperationProgress(Integer progress) {
         if (progress != null) {
-            getProperties().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PROGRESS.getValue(), progress);
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PROGRESS.getValue(), progress);
         }
     }
 
@@ -101,6 +101,6 @@ public class PackageResponsePayload extends KapuaResponsePayloadImpl implements 
      * @return
      */
     public Integer getPackageDownloadOperationProgress() {
-        return (Integer) getProperties().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PROGRESS.getValue());
+        return (Integer) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PROGRESS.getValue());
     }
 }

--- a/service/device/pom.xml
+++ b/service/device/pom.xml
@@ -34,6 +34,7 @@
         <module>registry</module>
         <module>bundle</module>
         <module>command</module>
+        <module>request</module>
     </modules>
 
 </project>

--- a/service/device/request/api/pom.xml
+++ b/service/device/request/api/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2017 Eurotech and/or its affiliates and others
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     Eurotech - initial API and implementation
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <parent>
+        <artifactId>kapua-device-request</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-device-request-api</artifactId>
+    <name>${project.artifactId}</name>
+
+</project>

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
@@ -12,7 +12,6 @@
 package org.eclipse.kapua.service.device.management.request;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
@@ -23,12 +22,12 @@ public interface DeviceRequestManagementService extends KapuaService {
     /**
      * Execute the given device request with the provided options
      *
-     * @param scopeId
-     * @param deviceId
      * @param requestInput
+     *            request input
      * @param timeout
-     *            command timeout
-     * @return
+     *            request timeout
+     * @return    response output
+     *
      * @throws KapuaException
      */
      KapuaResponseMessage<KapuaResponseChannel, KapuaResponsePayload> exec(GenericRequestMessage requestInput, Long timeout)

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
+
+public interface DeviceRequestManagementService extends KapuaService {
+    /**
+     * Execute the given device request with the provided options
+     *
+     * @param scopeId
+     * @param deviceId
+     * @param requestInput
+     * @param timeout
+     *            command timeout
+     * @return
+     * @throws KapuaException
+     */
+     KapuaResponseMessage<KapuaResponseChannel, KapuaResponsePayload> exec(KapuaId scopeId, KapuaId deviceId, GenericRequestMessage requestInput, Long timeout)
+            throws KapuaException;
+}

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
@@ -31,6 +31,6 @@ public interface DeviceRequestManagementService extends KapuaService {
      * @return
      * @throws KapuaException
      */
-     KapuaResponseMessage<KapuaResponseChannel, KapuaResponsePayload> exec(KapuaId scopeId, KapuaId deviceId, GenericRequestMessage requestInput, Long timeout)
+     KapuaResponseMessage<KapuaResponseChannel, KapuaResponsePayload> exec(GenericRequestMessage requestInput, Long timeout)
             throws KapuaException;
 }

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/GenericRequestFactory.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/GenericRequestFactory.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request;
+
+import org.eclipse.kapua.model.KapuaObjectFactory;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
+
+public interface GenericRequestFactory extends KapuaObjectFactory {
+
+    GenericRequestChannel newRequestChannel();
+
+    GenericRequestPayload newRequestPayload();
+
+    GenericRequestMessage newRequestMessage();
+
+    GenericResponseChannel newResponseChannel();
+
+    GenericResponsePayload newResponsePayload();
+
+    GenericResponseMessage newResponseMessage();
+}

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/GenericRequestXmlRegistry.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/GenericRequestXmlRegistry.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class GenericRequestXmlRegistry {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final GenericRequestFactory FACTORY = LOCATOR.getFactory(GenericRequestFactory.class);
+
+    public GenericRequestChannel newRequestChannel() {
+        return FACTORY.newRequestChannel();
+    }
+
+    public GenericRequestPayload newRequestPayload() {
+        return FACTORY.newRequestPayload();
+    }
+
+    public GenericRequestMessage newRequestMessage() {
+        return FACTORY.newRequestMessage();
+    }
+
+    public GenericResponseChannel newResponseChannel() {
+        return FACTORY.newResponseChannel();
+    }
+
+    public GenericResponsePayload newResponsePayload() {
+        return FACTORY.newResponsePayload();
+    }
+
+    public GenericResponseMessage newResponseMessage() {
+        return FACTORY.newResponseMessage();
+    }
+}

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestChannel.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestChannel.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.message.request;
+
+import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestChannel;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(propOrder = {"resources"}, factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newRequestChannel")
+public interface GenericRequestChannel extends KapuaRequestChannel {
+
+    /**
+     * Get the resources
+     *
+     * @return resources
+     */
+    String[] getResources();
+
+    /**
+     * Set the resources
+     *
+     * @param resources
+     */
+    void setResources(String[] resources);
+}

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestMessage.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestMessage.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.message.request;
+
+import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestMessage;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newRequestMessage")
+public interface GenericRequestMessage extends KapuaRequestMessage<GenericRequestChannel, GenericRequestPayload> {
+
+}

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestPayload.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestPayload.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.message.request;
+
+import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
+import org.eclipse.kapua.service.device.management.request.KapuaRequestPayload;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newRequestPayload")
+public interface GenericRequestPayload extends KapuaRequestPayload {
+
+}

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseChannel.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseChannel.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.message.response;
+
+import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newResponseChannel")
+public interface GenericResponseChannel extends KapuaResponseChannel {
+
+}

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseMessage.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseMessage.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.message.response;
+
+import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newResponseMessage")
+public interface GenericResponseMessage extends KapuaResponseMessage<GenericResponseChannel, GenericResponsePayload> {
+
+}

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponsePayload.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponsePayload.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.message.response;
+
+import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
+import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
+
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newResponsePayload")
+public interface GenericResponsePayload extends KapuaResponsePayload {
+
+}

--- a/service/device/request/internal/pom.xml
+++ b/service/device/request/internal/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2017 Eurotech and/or its affiliates and others
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     Eurotech - initial API and implementation
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-api</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-commons</artifactId>
+        </dependency>
+    </dependencies>
+
+    <parent>
+        <artifactId>kapua-device-request</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-device-request-internal</artifactId>
+    <name>${project.artifactId}</name>
+
+</project>

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
@@ -15,7 +15,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
-import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
@@ -43,21 +42,18 @@ public class DeviceRequestManagementServiceImpl implements DeviceRequestManageme
     private static final GenericRequestFactory FACTORY = LOCATOR.getFactory(GenericRequestFactory.class);
 
     @Override public KapuaResponseMessage exec(
-            KapuaId scopeId, KapuaId deviceId,
             GenericRequestMessage requestInput,
             Long timeout) throws KapuaException {
         //
         // Argument Validation
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(deviceId, "deviceId");
-        ArgumentValidator.notNull(requestInput, "commandInput");
+        ArgumentValidator.notNull(requestInput, "requestInput");
 
         //
         // Check Access
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(DEVICE_MANAGEMENT_DOMAIN, Actions.execute, requestInput.getScopeId()));
 
         //
         // Prepare the request
@@ -72,8 +68,8 @@ public class DeviceRequestManagementServiceImpl implements DeviceRequestManageme
         genericRequestPayload.setBody(requestInput.getPayload().getBody());
 
         GenericRequestMessage genericRequestMessage = FACTORY.newRequestMessage();
-        genericRequestMessage.setScopeId(scopeId);
-        genericRequestMessage.setDeviceId(deviceId);
+        genericRequestMessage.setScopeId(requestInput.getScopeId());
+        genericRequestMessage.setDeviceId(requestInput.getDeviceId());
         genericRequestMessage.setCapturedOn(new Date());
         genericRequestMessage.setChannel(genericRequestChannel);
         genericRequestMessage.setPayload(genericRequestPayload);
@@ -89,7 +85,7 @@ public class DeviceRequestManagementServiceImpl implements DeviceRequestManageme
         DeviceEventService deviceEventService = locator.getService(DeviceEventService.class);
         DeviceEventFactory deviceEventFactory = locator.getFactory(DeviceEventFactory.class);
 
-        DeviceEventCreator deviceEventCreator = deviceEventFactory.newCreator(scopeId, deviceId, responseMessage.getReceivedOn(), requestInput.getChannel().getAppName().getValue());
+        DeviceEventCreator deviceEventCreator = deviceEventFactory.newCreator(requestInput.getScopeId(), requestInput.getDeviceId(), responseMessage.getReceivedOn(), requestInput.getChannel().getAppName().getValue());
         deviceEventCreator.setPosition(responseMessage.getPosition());
         deviceEventCreator.setSentOn(responseMessage.getSentOn());
         deviceEventCreator.setAction(KapuaMethod.EXECUTE);

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.device.management.KapuaMethod;
+import org.eclipse.kapua.service.device.management.commons.DeviceManagementDomain;
+import org.eclipse.kapua.service.device.management.commons.call.DeviceCallExecutor;
+import org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService;
+import org.eclipse.kapua.service.device.management.request.GenericRequestFactory;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
+
+import java.util.Date;
+
+@KapuaProvider
+public class DeviceRequestManagementServiceImpl implements DeviceRequestManagementService {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final Domain DEVICE_MANAGEMENT_DOMAIN = new DeviceManagementDomain();
+    private static final GenericRequestFactory FACTORY = LOCATOR.getFactory(GenericRequestFactory.class);
+
+    @Override public KapuaResponseMessage exec(
+            KapuaId scopeId, KapuaId deviceId,
+            GenericRequestMessage requestInput,
+            Long timeout) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(deviceId, "deviceId");
+        ArgumentValidator.notNull(requestInput, "commandInput");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
+
+        //
+        // Prepare the request
+        GenericRequestChannel genericRequestChannel = FACTORY.newRequestChannel();
+        genericRequestChannel.setAppName(requestInput.getChannel().getAppName());
+        genericRequestChannel.setVersion(requestInput.getChannel().getVersion());
+        genericRequestChannel.setMethod(requestInput.getChannel().getMethod());
+        genericRequestChannel.setResources(requestInput.getChannel().getResources());
+
+        GenericRequestPayload genericRequestPayload = FACTORY.newRequestPayload();
+        genericRequestPayload.setMetrics(requestInput.getPayload().getMetrics());
+        genericRequestPayload.setBody(requestInput.getPayload().getBody());
+
+        GenericRequestMessage genericRequestMessage = FACTORY.newRequestMessage();
+        genericRequestMessage.setScopeId(scopeId);
+        genericRequestMessage.setDeviceId(deviceId);
+        genericRequestMessage.setCapturedOn(new Date());
+        genericRequestMessage.setChannel(genericRequestChannel);
+        genericRequestMessage.setPayload(genericRequestPayload);
+        genericRequestMessage.setPosition(requestInput.getPosition());
+
+        //
+        // Do exec
+        DeviceCallExecutor deviceApplicationCall = new DeviceCallExecutor(genericRequestMessage, timeout);
+        KapuaResponseMessage responseMessage = deviceApplicationCall.send();
+
+        //
+        // Create event
+        DeviceEventService deviceEventService = locator.getService(DeviceEventService.class);
+        DeviceEventFactory deviceEventFactory = locator.getFactory(DeviceEventFactory.class);
+
+        DeviceEventCreator deviceEventCreator = deviceEventFactory.newCreator(scopeId, deviceId, responseMessage.getReceivedOn(), requestInput.getChannel().getAppName().getValue());
+        deviceEventCreator.setPosition(responseMessage.getPosition());
+        deviceEventCreator.setSentOn(responseMessage.getSentOn());
+        deviceEventCreator.setAction(KapuaMethod.EXECUTE);
+        deviceEventCreator.setResponseCode(responseMessage.getResponseCode());
+        deviceEventCreator.setEventMessage(responseMessage.getPayload().toDisplayString());
+
+        deviceEventService.create(deviceEventCreator);
+
+        return responseMessage;
+    }
+}

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
@@ -11,7 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.request.internal;
 
+import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
@@ -19,7 +21,6 @@ import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
-import org.eclipse.kapua.service.device.management.KapuaMethod;
 import org.eclipse.kapua.service.device.management.commons.DeviceManagementDomain;
 import org.eclipse.kapua.service.device.management.commons.call.DeviceCallExecutor;
 import org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService;
@@ -41,7 +42,8 @@ public class DeviceRequestManagementServiceImpl implements DeviceRequestManageme
     private static final Domain DEVICE_MANAGEMENT_DOMAIN = new DeviceManagementDomain();
     private static final GenericRequestFactory FACTORY = LOCATOR.getFactory(GenericRequestFactory.class);
 
-    @Override public KapuaResponseMessage exec(
+    @Override
+    public KapuaResponseMessage exec(
             GenericRequestMessage requestInput,
             Long timeout) throws KapuaException {
         //
@@ -53,7 +55,26 @@ public class DeviceRequestManagementServiceImpl implements DeviceRequestManageme
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DEVICE_MANAGEMENT_DOMAIN, Actions.execute, requestInput.getScopeId()));
+        Actions action;
+        switch (requestInput.getChannel().getMethod()) {
+            case EXECUTE:
+                action = Actions.execute;
+                break;
+            case READ:
+            case OPTIONS:
+                action = Actions.read;
+                break;
+            case CREATE:
+            case WRITE:
+                action = Actions.write;
+                break;
+            case DELETE:
+                action = Actions.delete;
+                break;
+            default:
+                throw new KapuaRuntimeException(KapuaErrorCodes.OPERATION_NOT_SUPPORTED);
+        }
+        authorizationService.checkPermission(permissionFactory.newPermission(DEVICE_MANAGEMENT_DOMAIN, action, requestInput.getScopeId()));
 
         //
         // Prepare the request
@@ -85,10 +106,11 @@ public class DeviceRequestManagementServiceImpl implements DeviceRequestManageme
         DeviceEventService deviceEventService = locator.getService(DeviceEventService.class);
         DeviceEventFactory deviceEventFactory = locator.getFactory(DeviceEventFactory.class);
 
-        DeviceEventCreator deviceEventCreator = deviceEventFactory.newCreator(requestInput.getScopeId(), requestInput.getDeviceId(), responseMessage.getReceivedOn(), requestInput.getChannel().getAppName().getValue());
+        DeviceEventCreator deviceEventCreator = deviceEventFactory
+                .newCreator(requestInput.getScopeId(), requestInput.getDeviceId(), responseMessage.getReceivedOn(), requestInput.getChannel().getAppName().getValue());
         deviceEventCreator.setPosition(responseMessage.getPosition());
         deviceEventCreator.setSentOn(responseMessage.getSentOn());
-        deviceEventCreator.setAction(KapuaMethod.EXECUTE);
+        deviceEventCreator.setAction(genericRequestChannel.getMethod());
         deviceEventCreator.setResponseCode(responseMessage.getResponseCode());
         deviceEventCreator.setEventMessage(responseMessage.getPayload().toDisplayString());
 

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericAppProperties.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericAppProperties.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal;
+
+import org.eclipse.kapua.service.device.management.commons.KapuaAppPropertiesImpl;
+
+public class GenericAppProperties extends KapuaAppPropertiesImpl {
+
+    public GenericAppProperties(String value) {
+        super(value);
+    }
+
+    @Override
+    public String getValue() {
+        return super.getValue();
+    }
+
+    @Override
+    public void setValue(String value) {
+        super.setValue(value);
+    }
+}

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericRequestFactoryImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericRequestFactoryImpl.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal;
+
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.service.device.management.request.GenericRequestFactory;
+import org.eclipse.kapua.service.device.management.request.internal.message.request.GenericRequestChannelImpl;
+import org.eclipse.kapua.service.device.management.request.internal.message.request.GenericRequestMessageImpl;
+import org.eclipse.kapua.service.device.management.request.internal.message.request.GenericRequestPayloadImpl;
+import org.eclipse.kapua.service.device.management.request.internal.message.response.GenericResponseChannelImpl;
+import org.eclipse.kapua.service.device.management.request.internal.message.response.GenericResponseMessageImpl;
+import org.eclipse.kapua.service.device.management.request.internal.message.response.GenericResponsePayloadImpl;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
+
+@KapuaProvider
+public class GenericRequestFactoryImpl implements GenericRequestFactory {
+
+    @Override
+    public GenericRequestChannel newRequestChannel() {
+        return new GenericRequestChannelImpl();
+    }
+
+    @Override
+    public GenericRequestPayload newRequestPayload() {
+        return new GenericRequestPayloadImpl();
+    }
+
+    @Override
+    public GenericRequestMessage newRequestMessage() {
+        return new GenericRequestMessageImpl();
+    }
+
+    @Override public GenericResponseChannel newResponseChannel() {
+        return new GenericResponseChannelImpl();
+    }
+
+    @Override public GenericResponsePayload newResponsePayload() {
+        return new GenericResponsePayloadImpl();
+    }
+
+    @Override public GenericResponseMessage newResponseMessage() {
+        return new GenericResponseMessageImpl();
+    }
+}

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestChannelImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestChannelImpl.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal.message.request;
+
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+
+public class GenericRequestChannelImpl extends KapuaRequestChannelImpl implements GenericRequestChannel {
+
+    private String[] resources;
+
+    @Override
+    public String[] getResources() {
+        return resources;
+    }
+
+    @Override
+    public void setResources(String[] resources) {
+        this.resources = resources;
+    }
+}

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestMessageImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestMessageImpl.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal.message.request;
+
+import org.eclipse.kapua.message.internal.KapuaMessageImpl;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+
+public class GenericRequestMessageImpl extends KapuaMessageImpl<GenericRequestChannel, GenericRequestPayload> implements GenericRequestMessage {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<GenericRequestMessage> getRequestClass() {
+        return GenericRequestMessage.class;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<GenericResponseMessage> getResponseClass() {
+        return GenericResponseMessage.class;
+    }
+}

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestPayloadImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestPayloadImpl.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal.message.request;
+
+import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestPayloadImpl;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+
+public class GenericRequestPayloadImpl extends KapuaRequestPayloadImpl implements GenericRequestPayload {
+
+}

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponseChannelImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponseChannelImpl.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal.message.response;
+
+import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+
+public class GenericResponseChannelImpl extends KapuaAppChannelImpl implements GenericResponseChannel {
+
+}

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponseMessageImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponseMessageImpl.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal.message.response;
+
+import org.eclipse.kapua.message.internal.KapuaMessageImpl;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseCode;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+
+public class GenericResponseMessageImpl extends KapuaMessageImpl<GenericResponseChannel, GenericResponsePayload>
+        implements KapuaResponseMessage<GenericResponseChannel, GenericResponsePayload>, GenericResponseMessage {
+
+    private KapuaResponseCode responseCode;
+
+    @Override
+    public KapuaResponseCode getResponseCode() {
+        return responseCode;
+    }
+
+    @Override
+    public void setResponseCode(KapuaResponseCode responseCode) {
+        this.responseCode = responseCode;
+    }
+}

--- a/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponsePayloadImpl.java
+++ b/service/device/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponsePayloadImpl.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal.message.response;
+
+import org.eclipse.kapua.service.device.management.commons.message.response.KapuaResponsePayloadImpl;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
+
+public class GenericResponsePayloadImpl extends KapuaResponsePayloadImpl implements GenericResponsePayload {
+
+}

--- a/service/device/request/pom.xml
+++ b/service/device/request/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2017 Eurotech and/or its affiliates and others
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     Eurotech - initial API and implementation
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>kapua-device</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-device-request</artifactId>
+    <name>${project.artifactId}</name>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>api</module>
+        <module>internal</module>
+    </modules>
+
+</project>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -33,6 +33,7 @@
         <module>user</module>
         <module>account</module>
         <module>liquibase</module>
+        <module>stream</module>
     </modules>
 
 </project>

--- a/service/stream/api/pom.xml
+++ b/service/stream/api/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2017 Eurotech and/or its affiliates and others
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     Eurotech - initial API and implementation
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kapua-stream</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kapua-stream-api</artifactId>
+    <name>${project.artifactId}</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-call-kura</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamService.java
+++ b/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamService.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.stream;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+
+public interface StreamService extends KapuaService {
+    KapuaResponseMessage publish(KapuaDataMessage message, Long timeout)
+            throws KapuaException;
+}

--- a/service/stream/internal/pom.xml
+++ b/service/stream/internal/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2017 Eurotech and/or its affiliates and others
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     Eurotech - initial API and implementation
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kapua-stream</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kapua-stream-internal</artifactId>
+    <name>${project.artifactId}</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-stream-api</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-transport-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-call-kura</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/service/stream/internal/src/main/java/org/eclipse/kapua/service/stream/internal/StreamServiceImpl.java
+++ b/service/stream/internal/src/main/java/org/eclipse/kapua/service/stream/internal/StreamServiceImpl.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.stream.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.service.device.call.kura.exception.KuraMqttDeviceCallErrorCodes;
+import org.eclipse.kapua.service.device.call.kura.exception.KuraMqttDeviceCallException;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
+import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.stream.StreamService;
+import org.eclipse.kapua.translator.Translator;
+import org.eclipse.kapua.transport.TransportClientFactory;
+import org.eclipse.kapua.transport.TransportFacade;
+import org.eclipse.kapua.transport.message.TransportMessage;
+
+import java.util.Date;
+
+@KapuaProvider
+public class StreamServiceImpl implements StreamService {
+
+    @Override public KapuaResponseMessage publish(KapuaDataMessage requestMessage, Long timeout)
+            throws KapuaException {
+        TransportFacade transportFacade = null;
+        try {
+            ArgumentValidator.notNull(requestMessage.getClientId(), "clientId");
+            ArgumentValidator.notNull(requestMessage.getScopeId(), "scopeId");
+
+            //
+            // Borrow a KapuaClient
+            transportFacade = borrowClient();
+
+            //
+            // Get Kura to transport translator for the request and vice versa
+            Translator<KapuaDataMessage, KuraDataMessage> translatorKapuaKura = getTranslator(KapuaDataMessage.class, KuraDataMessage.class);
+            Translator translatorKuraTransport = getTranslator(KuraDataMessage.class, transportFacade.getMessageClass());
+
+            KuraDataMessage kuraDataMessage = translatorKapuaKura.translate(requestMessage);
+
+            //
+            // Do send
+            try {
+                // Set current timestamp
+                kuraDataMessage.setTimestamp(new Date());
+
+                // Send
+                transportFacade.sendAsync((TransportMessage) translatorKuraTransport.translate(kuraDataMessage));
+
+            } catch (KapuaException e) {
+                throw new KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes.CLIENT_SEND_ERROR,
+                        e,
+                        (Object[]) null);
+            }
+        } catch (KapuaException ke) {
+            throw new KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes.CALL_ERROR,
+                    ke,
+                    (Object[]) null);
+        } finally {
+            if (transportFacade != null) {
+                transportFacade.clean();
+            }
+        }
+
+        return null;
+    }
+
+    //
+    // Private methods
+    //
+    private TransportFacade borrowClient()
+            throws KuraMqttDeviceCallException {
+        TransportFacade transportFacade;
+        try {
+            KapuaLocator locator = KapuaLocator.getInstance();
+            TransportClientFactory transportClientFactory = locator.getFactory(TransportClientFactory.class);
+            transportFacade = transportClientFactory.getFacade();
+        } catch (Exception e) {
+            throw new KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes.CALL_ERROR,
+                    e,
+                    (Object[]) null);
+        }
+        return transportFacade;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Translator getTranslator(Class from, Class to)
+            throws KuraMqttDeviceCallException {
+        Translator translator;
+        try {
+            translator = Translator.getTranslatorFor(from, to);
+        } catch (KapuaException e) {
+            throw new KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes.CALL_ERROR,
+                    e,
+                    (Object[]) null);
+        }
+        return translator;
+    }
+}

--- a/service/stream/pom.xml
+++ b/service/stream/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ Copyright (c) 2017 Eurotech and/or its affiliates and others
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v10.html
+  ~
+  ~ Contributors:
+  ~     Eurotech - initial API and implementation
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kapua-service</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kapua-stream</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>pom</packaging>
+    <modules>
+        <module>api</module>
+        <module>internal</module>
+    </modules>
+
+
+</project>

--- a/translator/kapua/kura/pom.xml
+++ b/translator/kapua/kura/pom.xml
@@ -90,6 +90,14 @@
             <artifactId>kapua-device-packages-internal</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-internal</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.moxy</artifactId>
         </dependency>

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/AbstractTranslatorKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/AbstractTranslatorKapuaKura.java
@@ -43,12 +43,14 @@ public abstract class AbstractTranslatorKapuaKura<FROM_C extends KapuaChannel, F
         AccountService accountService = locator.getService(AccountService.class);
         Account account = accountService.find(kapuaMessage.getScopeId());
 
+        Device device = null;
         DeviceRegistryService deviceService = locator.getService(DeviceRegistryService.class);
-        Device device = deviceService.find(kapuaMessage.getScopeId(), kapuaMessage.getDeviceId());
-
+        if (kapuaMessage.getDeviceId() != null) {
+            device = deviceService.find(kapuaMessage.getScopeId(), kapuaMessage.getDeviceId());
+        }
         KuraRequestChannel kuraRequestChannel = translateChannel(kapuaMessage.getChannel());
         kuraRequestChannel.setScope(account.getName());
-        kuraRequestChannel.setClientId(device.getClientId());
+        kuraRequestChannel.setClientId(device != null ? device.getClientId() : kapuaMessage.getClientId());
 
         //
         // Kura payload

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorDataKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorDataKapuaKura.java
@@ -80,7 +80,7 @@ public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessag
 
     private KuraPayload translate(KapuaPayload kapuaPayload) throws KapuaException {
         KuraPayload kuraPayload = new KuraPayload();
-        kuraPayload.getMetrics().putAll(kapuaPayload.getProperties());
+        kuraPayload.getMetrics().putAll(kapuaPayload.getMetrics());
         kuraPayload.setBody(kapuaPayload.getBody());
 
         //

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorDataKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorDataKapuaKura.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,109 +11,99 @@
  *******************************************************************************/
 package org.eclipse.kapua.translator.kapua.kura;
 
-import java.util.Date;
-
+import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.message.KapuaChannel;
-import org.eclipse.kapua.message.KapuaMessage;
-import org.eclipse.kapua.message.KapuaPayload;
-import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.data.KapuaDataChannel;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
-import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
-import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
-import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
-import org.eclipse.kapua.service.device.call.message.kura.KuraPosition;
 import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataChannel;
-import org.eclipse.kapua.service.device.registry.Device;
-import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataPayload;
 import org.eclipse.kapua.translator.Translator;
 
+import java.util.HashMap;
+
 /**
- * Messages translator implementation from {@link KapuaMessage} to {@link KuraMessage}
- * 
+ * Messages translator implementation from {@link KuraDataMessage} to {@link KapuaDataMessage}
+ *
  * @since 1.0
  *
  */
-@SuppressWarnings("rawtypes")
-public class TranslatorDataKapuaKura extends Translator<KapuaMessage, KuraMessage> {
+public class TranslatorDataKapuaKura extends Translator<KapuaDataMessage, KuraDataMessage> {
 
     @Override
-    public KuraMessage translate(KapuaMessage kapuaMessage)
+    public KuraDataMessage translate(KapuaDataMessage kapuaDataMessage)
             throws KapuaException {
-        //
-        // Kura channel
-        KuraChannel kuraChannel = translate(kapuaMessage.getChannel());
-
         KapuaLocator locator = KapuaLocator.getInstance();
         AccountService accountService = locator.getService(AccountService.class);
-        DeviceRegistryService deviceRegistryService = locator.getService(DeviceRegistryService.class);
+        Account account = accountService.find(kapuaDataMessage.getScopeId());
 
-        Account account = accountService.find(kapuaMessage.getScopeId());
-        Device device = deviceRegistryService.find(account.getId(),
-                kapuaMessage.getDeviceId());
-
-        kuraChannel.setScope(account.getName());
-        kuraChannel.setClientId(device.getClientId());
+        if (account == null) {
+            throw new KapuaEntityNotFoundException(Account.TYPE, kapuaDataMessage.getScopeId());
+        }
 
         //
-        // Kura payload
-        KuraPayload kuraPayload = translate(kapuaMessage.getPayload());
-        kuraPayload.setPosition(translate(kapuaMessage.getPosition()));
+        // Kapua Channel
+        KuraDataChannel kuraDataChannel = translate(kapuaDataMessage.getChannel());
+        kuraDataChannel.setClientId(kapuaDataMessage.getClientId());
+        kuraDataChannel.setScope(account.getName());
 
         //
-        // Kura Message
-        return new KuraMessage<KuraChannel, KuraPayload>(kuraChannel,
-                new Date(),
-                kuraPayload);
+        // Kapua payload
+        KuraDataPayload kuraDataPayload = translate(kapuaDataMessage.getPayload());
+        kuraDataPayload.setBody(kapuaDataMessage.getPayload().getBody());
+        kuraDataPayload.setMetrics(kapuaDataMessage.getPayload().getMetrics());
+        kuraDataPayload.setPosition(TranslatorKapuaKuraUtils.translate(kapuaDataMessage.getPosition()));
+        kuraDataPayload.setTimestamp(kapuaDataMessage.getSentOn());
+
+        //
+        // Kapua message
+        KuraDataMessage kuraDataMessage = new KuraDataMessage();
+        kuraDataMessage.setChannel(kuraDataChannel);
+        kuraDataMessage.setPayload(kuraDataPayload);
+
+        // Return Kapua Message
+        return kuraDataMessage;
     }
 
-    private KuraDataChannel translate(KapuaChannel kapuaChannel) throws KapuaException {
+    private KuraDataChannel translate(KapuaDataChannel kapuaChannel)
+            throws KapuaException {
         KuraDataChannel kuraChannel = new KuraDataChannel();
         kuraChannel.setSemanticChannelParts(kapuaChannel.getSemanticParts());
 
         //
-        // Return Kura Channel
+        // Return Kapua Channel
         return kuraChannel;
     }
 
-    private KuraPayload translate(KapuaPayload kapuaPayload) throws KapuaException {
-        KuraPayload kuraPayload = new KuraPayload();
-        kuraPayload.getMetrics().putAll(kapuaPayload.getMetrics());
-        kuraPayload.setBody(kapuaPayload.getBody());
+    private KuraDataPayload translate(KapuaDataPayload kapuaPayload)
+            throws KapuaException {
+        KuraDataPayload kuraPayload = new KuraDataPayload();
+
+        if (kapuaPayload.getMetrics() != null) {
+            kuraPayload.setMetrics(new HashMap<>(kapuaPayload.getMetrics()));
+        }
+
+        if (kapuaPayload.getBody() != null) {
+            kuraPayload.setBody(kapuaPayload.getBody());
+        }
 
         //
-        // Return Kura Payload
+        // Return Kura payload
         return kuraPayload;
     }
 
-    private KuraPosition translate(KapuaPosition position) {
-        KuraPosition kuraPosition = new KuraPosition();
-
-        kuraPosition.setAltitude(position.getAltitude());
-        kuraPosition.setHeading(position.getHeading());
-        kuraPosition.setLatitude(position.getLatitude());
-        kuraPosition.setLongitude(position.getLongitude());
-        kuraPosition.setPrecision(position.getPrecision());
-        kuraPosition.setSatellites(position.getSatellites());
-        kuraPosition.setSpeed(position.getSpeed());
-        kuraPosition.setStatus(position.getStatus());
-        kuraPosition.setTimestamp(position.getTimestamp());
-
-        //
-        // Return Kura Position
-        return kuraPosition;
+    @Override
+    public Class<KapuaDataMessage> getClassFrom() {
+        return KapuaDataMessage.class;
     }
 
     @Override
-    public Class<KapuaMessage> getClassFrom() {
-        return KapuaMessage.class;
-    }
-
-    @Override
-    public Class<KuraMessage> getClassTo() {
-        return KuraMessage.class;
+    public Class<KuraDataMessage> getClassTo() {
+        return KuraDataMessage.class;
     }
 
 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorGenericRequestKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorGenericRequestKapuaKura.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.translator.kapua.kura;
 
-import com.google.common.base.Strings;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestChannel;

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorGenericRequestKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorGenericRequestKapuaKura.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kapua.kura;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestChannel;
+import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestMessage;
+import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestPayload;
+import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSetting;
+import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSettingKeys;
+import org.eclipse.kapua.service.device.management.asset.message.internal.AssetRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+
+/**
+ * Messages translator implementation from {@link AssetRequestMessage} to {@link KuraRequestMessage}
+ * 
+ * @since 1.0.0
+ */
+public class TranslatorGenericRequestKapuaKura extends AbstractTranslatorKapuaKura<GenericRequestChannel, GenericRequestPayload, GenericRequestMessage> {
+
+    private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
+
+    protected KuraRequestChannel translateChannel(GenericRequestChannel kapuaChannel) throws KapuaException {
+        KuraRequestChannel kuraRequestChannel = new KuraRequestChannel();
+        kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
+
+        StringBuilder appIdSb = new StringBuilder();
+        appIdSb.append(kapuaChannel.getAppName().getValue())
+                .append("-")
+                .append(kapuaChannel.getVersion().getValue());
+
+        kuraRequestChannel.setAppId(appIdSb.toString());
+        kuraRequestChannel.setMethod(MethodDictionaryKapuaKura.get(kapuaChannel.getMethod()));
+
+        kuraRequestChannel.setResources(kapuaChannel.getResources());
+
+        return kuraRequestChannel;
+    }
+
+    protected KuraRequestPayload translatePayload(GenericRequestPayload kapuaPayload) throws KapuaException {
+        KuraRequestPayload kuraRequestPayload = new KuraRequestPayload();
+
+        //
+        // Payload translation
+        kuraRequestPayload.getMetrics().putAll(kapuaPayload.getMetrics());
+
+        //
+        // Body translation
+        kuraRequestPayload.setBody(kapuaPayload.getBody());
+
+        //
+        // Return Kura Payload
+        return kuraRequestPayload;
+    }
+
+    @Override
+    public Class<GenericRequestMessage> getClassFrom() {
+        return GenericRequestMessage.class;
+    }
+
+    @Override
+    public Class<KuraRequestMessage> getClassTo() {
+        return KuraRequestMessage.class;
+    }
+
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorGenericRequestKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorGenericRequestKapuaKura.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.translator.kapua.kura;
 
+import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestChannel;
 import org.eclipse.kapua.service.device.call.message.app.request.kura.KuraRequestMessage;
@@ -36,9 +38,12 @@ public class TranslatorGenericRequestKapuaKura extends AbstractTranslatorKapuaKu
         kuraRequestChannel.setMessageClassification(CONTROL_MESSAGE_CLASSIFIER);
 
         StringBuilder appIdSb = new StringBuilder();
-        appIdSb.append(kapuaChannel.getAppName().getValue())
-                .append("-")
-                .append(kapuaChannel.getVersion().getValue());
+        appIdSb.append(kapuaChannel.getAppName().getValue());
+        if (kapuaChannel.getVersion() != null && StringUtils.isNotEmpty(kapuaChannel.getVersion().getValue())) {
+            appIdSb.append("-")
+                    .append(kapuaChannel.getVersion().getValue());
+        }
+
 
         kuraRequestChannel.setAppId(appIdSb.toString());
         kuraRequestChannel.setMethod(MethodDictionaryKapuaKura.get(kapuaChannel.getMethod()));

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorGenericRequestKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorGenericRequestKapuaKura.java
@@ -43,7 +43,6 @@ public class TranslatorGenericRequestKapuaKura extends AbstractTranslatorKapuaKu
                     .append(kapuaChannel.getVersion().getValue());
         }
 
-
         kuraRequestChannel.setAppId(appIdSb.toString());
         kuraRequestChannel.setMethod(MethodDictionaryKapuaKura.get(kapuaChannel.getMethod()));
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorKapuaKuraUtils.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorKapuaKuraUtils.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kapua.kura;
+
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.service.device.call.message.DevicePosition;
+import org.eclipse.kapua.service.device.call.message.kura.KuraPosition;
+
+/**
+ * Messages translator utilities.<br>
+ * It provides helpful methods for translate position and response code.
+ *
+ * @since 1.0
+ *
+ */
+public final class TranslatorKapuaKuraUtils {
+
+
+    private TranslatorKapuaKuraUtils() {
+    }
+    
+    /**
+     * Translate {@link DevicePosition} to {@link KapuaPosition}
+     *
+     * @param kapuaPosition
+     * @return
+     */
+    public static DevicePosition translate(KapuaPosition kapuaPosition) {
+        DevicePosition kuraPosition = null;
+
+        if (kapuaPosition != null) {
+
+            kuraPosition = new KuraPosition();
+            kuraPosition.setAltitude(kapuaPosition.getAltitude());
+            kuraPosition.setHeading(kapuaPosition.getHeading());
+            kuraPosition.setLatitude(kapuaPosition.getLatitude());
+            kuraPosition.setLongitude(kapuaPosition.getLongitude());
+            kuraPosition.setPrecision(kapuaPosition.getPrecision());
+            kuraPosition.setSatellites(kapuaPosition.getSatellites());
+            kuraPosition.setSpeed(kapuaPosition.getSpeed());
+            kuraPosition.setStatus(kapuaPosition.getStatus());
+            kuraPosition.setTimestamp(kapuaPosition.getTimestamp());
+        }
+
+        return kuraPosition;
+    }
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractSimpleTranslatorResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractSimpleTranslatorResponseKuraKapua.java
@@ -12,15 +12,21 @@
 package org.eclipse.kapua.translator.kura.kapua;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseChannel;
 import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseMessage;
 import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponsePayload;
+import org.eclipse.kapua.service.device.management.request.GenericRequestFactory;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseChannel;
 import org.eclipse.kapua.service.device.management.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload;
 
 public abstract class AbstractSimpleTranslatorResponseKuraKapua<TO_C extends KapuaResponseChannel, TO_P extends KapuaResponsePayload, TO_M extends KapuaResponseMessage<TO_C, TO_P>>
         extends AbstractTranslatorResponseKuraKapua<TO_C, TO_P, TO_M> {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final GenericRequestFactory FACTORY = LOCATOR.getFactory(GenericRequestFactory.class);
 
     private Class<TO_M> messageClazz;
 
@@ -31,7 +37,11 @@ public abstract class AbstractSimpleTranslatorResponseKuraKapua<TO_C extends Kap
     @Override
     protected TO_M createMessage() throws KapuaException {
         try {
-            return this.messageClazz.newInstance();
+            if (messageClazz.equals(GenericResponseMessage.class)) {
+                return (TO_M)FACTORY.newResponseMessage();
+            } else {
+                return this.messageClazz.newInstance();
+            }
         } catch (InstantiationException | IllegalAccessException e) {
             throw KapuaException.internalError(e);
         }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorDataKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorDataKuraKapua.java
@@ -94,7 +94,7 @@ public class TranslatorDataKuraKapua extends Translator<KuraDataMessage, KapuaDa
         KapuaDataPayload kapuaPayload = new KapuaDataPayloadImpl();
 
         if (kuraPayload.getMetrics() != null) {
-            kapuaPayload.setProperties(new HashMap<>(kuraPayload.getMetrics()));
+            kapuaPayload.setMetrics(new HashMap<>(kuraPayload.getMetrics()));
         }
 
         if (kuraPayload.getBody() != null) {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorGenericResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorGenericResponseKuraKapua.java
@@ -48,7 +48,9 @@ public class TranslatorGenericResponseKuraKapua extends AbstractSimpleTranslator
         String[] appIdTokens = kuraChannel.getAppId().split("-");
 
         genericResponseChannel.setAppName(new GenericAppProperties(appIdTokens[0]));
-        genericResponseChannel.setVersion(new GenericAppProperties(appIdTokens[1]));
+        if (appIdTokens.length > 1) {
+            genericResponseChannel.setVersion(new GenericAppProperties(appIdTokens[1]));
+        }
 
         return genericResponseChannel;
     }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorGenericResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorGenericResponseKuraKapua.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kura.kapua;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseChannel;
+import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponsePayload;
+import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSetting;
+import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSettingKeys;
+import org.eclipse.kapua.service.device.management.request.GenericRequestFactory;
+import org.eclipse.kapua.service.device.management.request.internal.GenericAppProperties;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
+import org.eclipse.kapua.translator.exception.TranslatorErrorCodes;
+import org.eclipse.kapua.translator.exception.TranslatorException;
+
+public class TranslatorGenericResponseKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<GenericResponseChannel, GenericResponsePayload, GenericResponseMessage>{
+
+    private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final GenericRequestFactory FACTORY = LOCATOR.getFactory(GenericRequestFactory.class);
+
+    public TranslatorGenericResponseKuraKapua() {
+        super(GenericResponseMessage.class);
+    }
+
+    @Override
+    protected GenericResponseChannel translateChannel(KuraResponseChannel kuraChannel) throws KapuaException {
+        if (!CONTROL_MESSAGE_CLASSIFIER.equals(kuraChannel.getMessageClassification())) {
+            throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_CLASSIFIER,
+                    null,
+                    kuraChannel.getMessageClassification());
+        }
+
+        GenericResponseChannel genericResponseChannel = FACTORY.newResponseChannel();
+        String[] appIdTokens = kuraChannel.getAppId().split("-");
+
+        genericResponseChannel.setAppName(new GenericAppProperties(appIdTokens[0]));
+        genericResponseChannel.setVersion(new GenericAppProperties(appIdTokens[1]));
+
+        return genericResponseChannel;
+    }
+
+    @Override protected GenericResponsePayload translatePayload(KuraResponsePayload kuraPayload) throws KapuaException {
+        GenericResponsePayload genericResponsePayload = FACTORY.newResponsePayload();
+        genericResponsePayload.setBody(kuraPayload.getBody());
+        genericResponsePayload.setMetrics(kuraPayload.getMetrics());
+        genericResponsePayload.setExceptionMessage(kuraPayload.getExceptionMessage());
+        genericResponsePayload.setExceptionStack(kuraPayload.getExceptionStack());
+        return genericResponsePayload;
+    }
+}

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeMissingKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeMissingKuraKapua.java
@@ -80,7 +80,7 @@ public class TranslatorLifeMissingKuraKapua extends Translator<KuraMissingMessag
             throws KapuaException {
         KapuaMissingPayload kapuaMissingPayload = new KapuaMissingPayloadImpl();
         kapuaMissingPayload.setBody(kuraMissingPayload.getBody());
-        kapuaMissingPayload.setProperties(kuraMissingPayload.getMetrics());
+        kapuaMissingPayload.setMetrics(kuraMissingPayload.getMetrics());
         return kapuaMissingPayload;
     }
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeNotifyKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeNotifyKuraKapua.java
@@ -80,7 +80,7 @@ public class TranslatorLifeNotifyKuraKapua extends Translator<KuraNotifyMessage,
             throws KapuaException {
         KapuaNotifyPayload kapuaNotifyPayload = new KapuaNotifyPayloadImpl();
         kapuaNotifyPayload.setBody(kuraNotifyPayload.getBody());
-        kapuaNotifyPayload.setProperties(kuraNotifyPayload.getMetrics());
+        kapuaNotifyPayload.setMetrics(kuraNotifyPayload.getMetrics());
         return kapuaNotifyPayload;
     }
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeUnmatchedKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorLifeUnmatchedKuraKapua.java
@@ -71,7 +71,7 @@ public class TranslatorLifeUnmatchedKuraKapua extends Translator<KuraUnmatchedMe
             throws KapuaException {
         KapuaUnmatchedPayload kapuaUnmatchedPayload = new KapuaUnmatchedPayloadImpl();
         kapuaUnmatchedPayload.setBody(kuraUnmatchedPayload.getBody());
-        kapuaUnmatchedPayload.setProperties(kuraUnmatchedPayload.getMetrics());
+        kapuaUnmatchedPayload.setMetrics(kuraUnmatchedPayload.getMetrics());
         return kapuaUnmatchedPayload;
     }
 

--- a/translator/kapua/kura/src/main/resources/META-INF/services/org.eclipse.kapua.translator.Translator
+++ b/translator/kapua/kura/src/main/resources/META-INF/services/org.eclipse.kapua.translator.Translator
@@ -5,6 +5,7 @@ org.eclipse.kapua.translator.kapua.kura.TranslatorAppCommandKapuaKura
 org.eclipse.kapua.translator.kapua.kura.TranslatorAppConfigurationKapuaKura
 org.eclipse.kapua.translator.kapua.kura.TranslatorAppPackageKapuaKura
 org.eclipse.kapua.translator.kapua.kura.TranslatorAppSnapshotKapuaKura
+org.eclipse.kapua.translator.kapua.kura.TranslatorGenericRequestKapuaKura
 org.eclipse.kapua.translator.kapua.kura.TranslatorDataKapuaKura
 
 #from kura to kapua
@@ -14,6 +15,7 @@ org.eclipse.kapua.translator.kura.kapua.TranslatorAppCommandKuraKapua
 org.eclipse.kapua.translator.kura.kapua.TranslatorAppConfigurationKuraKapua
 org.eclipse.kapua.translator.kura.kapua.TranslatorAppPackageKuraKapua
 org.eclipse.kapua.translator.kura.kapua.TranslatorAppSnapshotKuraKapua
+org.eclipse.kapua.translator.kura.kapua.TranslatorGenericResponseKuraKapua
 org.eclipse.kapua.translator.kura.kapua.TranslatorDataKuraKapua
 org.eclipse.kapua.translator.kura.kapua.TranslatorLifeAppsKuraKapua
 org.eclipse.kapua.translator.kura.kapua.TranslatorLifeBirthKuraKapua

--- a/translator/kura/mqtt/src/main/java/org/eclipse/kapua/translator/kura/mqtt/TranslatorDataKuraMqtt.java
+++ b/translator/kura/mqtt/src/main/java/org/eclipse/kapua/translator/kura/mqtt/TranslatorDataKuraMqtt.java
@@ -11,18 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.translator.kura.mqtt;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
-import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
-import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataChannel;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataPayload;
 import org.eclipse.kapua.translator.Translator;
 import org.eclipse.kapua.transport.message.mqtt.MqttMessage;
 import org.eclipse.kapua.transport.message.mqtt.MqttPayload;
 import org.eclipse.kapua.transport.message.mqtt.MqttTopic;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Messages translator implementation from {@link org.eclipse.kapua.service.device.call.message.kura.KuraMessage} to {@link org.eclipse.kapua.transport.message.mqtt.MqttMessage}
@@ -31,10 +31,10 @@ import org.eclipse.kapua.transport.message.mqtt.MqttTopic;
  *
  */
 @SuppressWarnings("rawtypes")
-public class TranslatorDataKuraMqtt extends Translator<KuraMessage, MqttMessage> {
+public class TranslatorDataKuraMqtt extends Translator<KuraDataMessage, MqttMessage> {
 
     @Override
-    public MqttMessage translate(KuraMessage kuraMessage)
+    public MqttMessage translate(KuraDataMessage kuraMessage)
             throws KapuaException {
         //
         // Mqtt request topic
@@ -51,7 +51,7 @@ public class TranslatorDataKuraMqtt extends Translator<KuraMessage, MqttMessage>
                 mqttPayload);
     }
 
-    private MqttTopic translate(KuraChannel kuraChannel)
+    private MqttTopic translate(KuraDataChannel kuraChannel)
             throws KapuaException {
         List<String> topicTokens = new ArrayList<>();
 
@@ -66,14 +66,14 @@ public class TranslatorDataKuraMqtt extends Translator<KuraMessage, MqttMessage>
         return new MqttTopic(topicTokens.toArray(new String[0]));
     }
 
-    private MqttPayload translate(KuraPayload kuraPayload)
+    private MqttPayload translate(KuraDataPayload kuraPayload)
             throws KapuaException {
         return new MqttPayload(kuraPayload.toByteArray());
     }
 
     @Override
-    public Class<KuraMessage> getClassFrom() {
-        return KuraMessage.class;
+    public Class<KuraDataMessage> getClassFrom() {
+        return KuraDataMessage.class;
     }
 
     @Override

--- a/translator/kura/mqtt/src/main/java/org/eclipse/kapua/translator/mqtt/kura/TranslatorDataMqttKura.java
+++ b/translator/kura/mqtt/src/main/java/org/eclipse/kapua/translator/mqtt/kura/TranslatorDataMqttKura.java
@@ -12,10 +12,9 @@
 package org.eclipse.kapua.translator.mqtt.kura;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseChannel;
-import org.eclipse.kapua.service.device.call.message.kura.KuraChannel;
-import org.eclipse.kapua.service.device.call.message.kura.KuraMessage;
-import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataChannel;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataPayload;
 import org.eclipse.kapua.translator.Translator;
 import org.eclipse.kapua.transport.message.mqtt.MqttMessage;
 import org.eclipse.kapua.transport.message.mqtt.MqttPayload;
@@ -28,42 +27,42 @@ import org.eclipse.kapua.transport.message.mqtt.MqttTopic;
  *
  */
 @SuppressWarnings("rawtypes")
-public class TranslatorDataMqttKura extends Translator<MqttMessage, KuraMessage> {
+public class TranslatorDataMqttKura extends Translator<MqttMessage, KuraDataMessage> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public KuraMessage translate(MqttMessage mqttMessage)
+    public KuraDataMessage translate(MqttMessage mqttMessage)
             throws KapuaException {
         //
         // Kura topic
-        KuraChannel kuraChannel = translate(mqttMessage.getRequestTopic());
+        KuraDataChannel kuraChannel = translate(mqttMessage.getRequestTopic());
 
         //
         // Kura payload
-        KuraPayload kuraPayload = translate(mqttMessage.getPayload());
+        KuraDataPayload kuraPayload = translate(mqttMessage.getPayload());
 
         //
         // Return Kura message
-        return new KuraMessage(kuraChannel,
+        return new KuraDataMessage(kuraChannel,
                 mqttMessage.getTimestamp(),
                 kuraPayload);
     }
 
-    private KuraChannel translate(MqttTopic mqttTopic)
+    private KuraDataChannel translate(MqttTopic mqttTopic)
             throws KapuaException {
         String[] mqttTopicTokens = mqttTopic.getSplittedTopic();
 
         //
         // Return Kura Channel
-        return new KuraResponseChannel(mqttTopicTokens[0],
+        return new KuraDataChannel(mqttTopicTokens[0],
                 mqttTopicTokens[1]);
     }
 
-    private KuraPayload translate(MqttPayload mqttPayload)
+    private KuraDataPayload translate(MqttPayload mqttPayload)
             throws KapuaException {
         byte[] jmsBody = mqttPayload.getBody();
 
-        KuraPayload kuraPayload = new KuraPayload();
+        KuraDataPayload kuraPayload = new KuraDataPayload();
         kuraPayload.readFromByteArray(jmsBody);
 
         //
@@ -77,8 +76,8 @@ public class TranslatorDataMqttKura extends Translator<MqttMessage, KuraMessage>
     }
 
     @Override
-    public Class<KuraMessage> getClassTo() {
-        return KuraMessage.class;
+    public Class<KuraDataMessage> getClassTo() {
+        return KuraDataMessage.class;
     }
 
 }


### PR DESCRIPTION
Hi all,

This PR introduces three new REST APIs:

- Send Request: send a generic request, on a control topic, to a device
- Publish: send a message on a data topic and store it in the datastore
- Store: store a message in the datastore

Also a couple of new backend services are implemented in this PR to support the Send Request and the Publish; proper testing for such services are still to be implemented  (#669) 

Cheers