### PR TITLE
Added tests for SystemUtils

### DIFF
--- a/commons/src/test/java/org/eclipse/kapua/commons/util/SystemUtilsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/SystemUtilsTest.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.util;
+
+import java.lang.reflect.Constructor;
+import java.net.URISyntaxException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SystemUtilsTest extends Assert {
+
+    @Test
+    public void testConstructor() throws Exception {
+        Constructor<SystemUtils> systemUtils = SystemUtils.class.getDeclaredConstructor();
+        systemUtils.setAccessible(true);
+        SystemUtils systemUtilsTest = systemUtils.newInstance();
+    }
+    
+    @Test
+    public void getBrokerURITest()
+            throws URISyntaxException {
+        Assert.assertNotNull(SystemUtils.getBrokerURI());
+    }
+}


### PR DESCRIPTION
Added two simple tests to check SystemUtils of ArgumentValidator.
One test checks constructor, other one tests getBrokerURI().

Signed-off-by: Leonardo Gaube <leonardo.gaube@comtrade.com>