### PR TITLE
Configuration of datastore client in tests

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreRestI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreRestI9nTest.java
@@ -27,6 +27,6 @@ import org.junit.runner.RunWith;
                 "html:target/cucumber/DatastoreI9n",
                 "json:target/DatastoreI9n_cucumber.json" },
         monochrome = true)
-@CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.transport.TransportDatastoreClient")
-public class RunDatastoreI9nTest {
+@CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+public class RunDatastoreRestI9nTest {
 }


### PR DESCRIPTION
Datastore client: rest or transport is configured by property on
cucumber test runner.

Two separate test runners are implemented, one with rest client
and other with transport client.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>