### PR TITLE
Fix jacoco XML code coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>de.dentrassi.maven</groupId>
+                <artifactId>jacoco-extras</artifactId>
+                <version>0.1.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>xml</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>


### PR DESCRIPTION
This PR converts jacoco execution data to XML in a different way as jacoco omits classes which are outside a specific maven module. However several of our project (like `kapua-qa`) provide code coverage for classes outside of the maven module the tests are run in. This creates false coverage reports when using the jacoco reporter plugin instead of the raw jacoco execution data.