### PR TITLE
Added ACL tests for device manage profile

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclCreator.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclCreator.java
@@ -243,6 +243,7 @@ public class AclCreator {
 
     void attachDevicePermissions(Account account, User user) throws Exception {
         List<PermissionData> permissionList = new ArrayList<>();
+        permissionList.add(new PermissionData(new BrokerDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
         permissionList.add(new PermissionData(new DeviceManagementDomain(), Actions.write, (KapuaEid) user.getScopeId()));
         createPermissions(permissionList, user, account);
     }

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclSteps.java
@@ -231,6 +231,15 @@ public class AclSteps {
         aclCreator.attachBrokerPermissions(account, user);
     }
 
+    @And("^device account and user are created$")
+    public void createDeviceAccountAndUser() throws Throwable {
+
+        Account account = aclCreator.createAccount("acme","ACME Corp.", "john@acme.org");
+        User user = aclCreator.createUser(account, "luise");
+        aclCreator.attachUserCredentials(account, user);
+        aclCreator.attachDevicePermissions(account, user);
+    }
+
     @And("^other broker account and user are created$")
     public void createOtherBrokerAccountAndUser() throws Throwable {
 

--- a/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -225,3 +225,156 @@ Feature: Broker ACL tests
     Then exception is thrown
       And clients are disconnected
       And Mqtt Device is stoped
+#
+# Device / manage
+#
+  Scenario: D1 Device publish to CTRL_ACC_REPLY
+    Normal user with device manage profile publishes to topic $EDC.{0}.*.*.REPLY.>
+    and this is allowed as it is part of publishing data.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic ""
+      And string "Hello broker" is published to topic "$EDC/acme/client-1/CONF-V1/REPLY" with client "client-1"
+      And 1 second passed for message to arrive
+    Then Broker receives string "Hello broker" on topic "$EDC/acme/client-1/CONF-V1/REPLY"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D2 Device create sub-topic on CTRL_ACC_REPLY
+    Normal user with device manage profile publishes to topic $EDC.{0}.*.*.REPLY.foo
+    This means that foo topic is created and this is allowed as device has admin rights
+    on REPLY.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic ""
+      And string "Hello broker" is published to topic "$EDC/acme/client-1/CONF-V1/REPLY/foo" with client "client-1"
+      And 1 second passed for message to arrive
+    Then Broker receives string "Hello broker" on topic "$EDC/acme/client-1/CONF-V1/REPLY/foo"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D3 Device subscribe on personal CTRL_ACC_REPLY
+    Normal user with device manage profile subscribes to $EDC.{0}.*.*.REPLY
+    Subscribe is not allowed, but it is on client's own topic. Is that OK?
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme/client-1/CONF-V1/REPLY"
+      And string "Hello broker" is published to topic "$EDC/acme/client-1/CONF-V1/REPLY" with client "client-1"
+      And 1 second passed for message to arrive
+    Then client "client-1" receives string "Hello broker" on topic "$EDC/acme/client-1/CONF-V1/REPLY"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D4 Device subscribe on CTRL_ACC_REPLY of another account
+    Normal user with device manage profile subscribes to $EDC.{0}.*.*.REPLY of other account
+    Subscribe is not allowed on other account.
+    Given Mqtt Device is started
+      And device account and user are created
+      And other broker account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/domino/client-1/CONF-V1/REPLY"
+    Then exception is thrown
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D5 Device subscribe - publish - admin on CTRL_ACC
+    Normal user with device manage profile subscribes to $EDC.{0}.> and at the same time
+    publishes to subtopic foo. All this operations are allowed.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme/foo"
+      And string "Hello broker" is published to topic "$EDC/acme/foo" with client "client-1"
+      And 1 second passed for message to arrive
+    Then client "client-1" receives string "Hello broker" on topic "$EDC/acme/foo"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D6 Device subscribe - publish - admin on CTRL_ACC_CLI
+    Normal user with device manage profile subscribes to $EDC.{0}.{1}.> and at the same time
+    publishes to subtopic foo. All this operations are allowed.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme/client-1/foo"
+      And string "Hello broker" is published to topic "$EDC/acme/client-1/foo" with client "client-1"
+      And 1 second passed for message to arrive
+    Then client "client-1" receives string "Hello broker" on topic "$EDC/acme/client-1/foo"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D7 Device publish to ACL_DATA_ACC is not allowed
+    Normal user with device manage profile publishes to topic {0}.>
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic ""
+      And string "Hello broker" is published to topic "acme" with client "client-1"
+      And 1 second passed for message to arrive
+    Then Broker doesn't receive string "Hello broker" on topic "acme"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D8 Device create sub-topic on ACL_DATA_ACC is not allowed
+    Normal user with device manage profile publishes to topic {0}.foo
+    This means that foo topic is not created as device has no admin rights on this topic.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic ""
+      And string "Hello broker" is published to topic "acme/foo" with client "client-1"
+      And 1 second passed for message to arrive
+    Then Broker doesn't receive string "Hello broker" on topic "acme/foo"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D9 Device subscribe on ACL_DATA_ACC is not allowed
+    Normal user with device manage profile subscribes to {0}.>
+    Subscribe is not allowed.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "acme"
+    Then exception is thrown
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D10 Device subscribe - publish - admin on ACL_DATA_ACC_CLI
+    Normal user with device manage profile subscribes to {0}.{1}.> and at the same time
+    publishes to subtopic foo. All this operations are allowed.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "acme/client-1/foo"
+      And string "Hello broker" is published to topic "acme/client-1/foo" with client "client-1"
+      And 1 second passed for message to arrive
+    Then client "client-1" receives string "Hello broker" on topic "acme/client-1/foo"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+  Scenario: D11 Device publish to ACL_CTRL_ACC_NOTIFY is allowed
+    Normal user with device manage profile publishes to topic $EDC.{0}.*.*.NOTIFY.{1}.>
+    Publish is allowed, but not subscribe and admin.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic ""
+      And string "Hello broker" is published to topic "$EDC/acme/foo/bar/NOTIFY/client-1" with client "client-1"
+      And 1 second passed for message to arrive
+    Then Broker receives string "Hello broker" on topic "$EDC/acme/foo/bar/NOTIFY/client-1"
+      And clients are disconnected
+      And Mqtt Device is stoped
+
+#  Scenario: D12 Device create sub-topic on ACL_CTRL_ACC_NOTIFY is not allowed
+#    Normal user with device manage profile publishes to topic $EDC.{0}.*.*.NOTIFY.{1}.foo
+#    This means that foo topic is not created as broker has no admin rights on this topic.
+#    Given Mqtt Device is started
+#      And device account and user are created
+#    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic ""
+#      And string "Hello broker" is published to topic "$EDC/acme/foo/bar/NOTIFY/client-1/foo" with client "client-1"
+#      And 1 second passed for message to arrive
+#    Then Broker doesn't receive string "Hello broker" on topic "$EDC/acme/foo/bar/NOTIFY/client-1/foo"
+#      And clients are disconnected
+#      And Mqtt Device is stoped
+
+  Scenario: D13 Device subscribe on ACL_CTRL_ACC_NOTIFY is not allowed
+    Normal user with device manage profile subscribes to $EDC.{0}.*.*.NOTIFY.{1}.>
+    Subscribe is not allowed.
+    Given Mqtt Device is started
+      And device account and user are created
+    When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme/foo/bar/NOTIFY/client-1"
+    Then exception is thrown
+      And clients are disconnected
+      And Mqtt Device is stoped


### PR DESCRIPTION
Full set of scenarios for device manage scenarios.
Still to add data view and manage scenarios.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>