### PR TITLE
Added data view profile ACL tests

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceBrokerI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceBrokerI9nTest.java
@@ -19,7 +19,9 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = {"classpath:features/broker"
+        features = {"classpath:features/broker/DeviceBrokerI9n.feature",
+                    "classpath:features/broker/DeviceData.feature",
+                    "classpath:features/broker/DeviceLifecycle.feature"
                    },
         glue = {"org.eclipse.kapua.qa.steps",
                 "org.eclipse.kapua.service.user.steps",

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclCreator.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclCreator.java
@@ -250,12 +250,14 @@ public class AclCreator {
 
     void attachDataViewPermissions(Account account, User user) throws Exception {
         List<PermissionData> permissionList = new ArrayList<>();
+        permissionList.add(new PermissionData(new BrokerDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
         permissionList.add(new PermissionData(new DatastoreDomain(), Actions.read, (KapuaEid) user.getScopeId()));
         createPermissions(permissionList, user, account);
     }
 
     void attachDataManagePermissions(Account account, User user) throws Exception {
         List<PermissionData> permissionList = new ArrayList<>();
+        permissionList.add(new PermissionData(new BrokerDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
         permissionList.add(new PermissionData(new DatastoreDomain(), Actions.write, (KapuaEid) user.getScopeId()));
         createPermissions(permissionList, user, account);
     }

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclSteps.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -240,6 +241,15 @@ public class AclSteps {
         aclCreator.attachDevicePermissions(account, user);
     }
 
+    @And("^data view account and user are created$")
+    public void createDataViewAccountAndUser() throws Throwable {
+
+        Account account = aclCreator.createAccount("acme","ACME Corp.", "john@acme.org");
+        User user = aclCreator.createUser(account, "luise");
+        aclCreator.attachUserCredentials(account, user);
+        aclCreator.attachDataViewPermissions(account, user);
+    }
+
     @And("^other broker account and user are created$")
     public void createOtherBrokerAccountAndUser() throws Throwable {
 
@@ -254,6 +264,13 @@ public class AclSteps {
 
         Exception e = (Exception) stepData.get("exception");
         assertNotNull("Exception expected!", e);
+    }
+
+    @Then("^exception is not thrown$")
+    public void exceptionIsNotThrown() throws Throwable {
+
+        Exception e = (Exception) stepData.get("exception");
+        assertNull("Exception not expected!", e);
     }
 
     /**


### PR DESCRIPTION
Gherkin scenarios were added and minor changes to ACL steps were made.
Next and last chunck of ACL tests that is missing is data manage profile.

Specifed feature files for broker integration tests.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>