### PR TITLE
Added profiles to QA integration tests

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -286,4 +286,52 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>tests_unit</id>
+            <activation>
+                <property>
+                    <name>tests</name>
+                    <value>unit</value>
+                </property>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <cucumber.options>--tags @unit</cucumber.options>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>tests_integration</id>
+            <activation>
+                <property>
+                    <name>tests</name>
+                    <value>integration</value>
+                </property>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <cucumber.options>--tags @integration</cucumber.options>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@integration
 Feature: Device Broker Integration
   Device Service integration scenarios with running broker service.
   Each Scenario starts with BIRTH of device and then the communication over MQTT

--- a/qa/src/test/resources/features/broker/DeviceData.feature
+++ b/qa/src/test/resources/features/broker/DeviceData.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@integration
 Feature: Device data scenarios
 
 Scenario: Connect to the system and publish some data

--- a/qa/src/test/resources/features/broker/DeviceLifecycle.feature
+++ b/qa/src/test/resources/features/broker/DeviceLifecycle.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@integration
 Feature: Device lifecycle scenarios
 
 Scenario: Starting and stopping the simulator should create a device entry and properly set its status

--- a/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@integration
 Feature: Broker ACL tests
   These tests are validating correct access control rights of broker security.
   User with one or more profile connects to the broker and tries to issue actions such as

--- a/qa/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/src/test/resources/features/datastore/Datastore.feature
@@ -10,7 +10,7 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-
+@integration
 Feature: Datastore tests
 
   Scenario: Query before schema search

--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@integration
 Feature: Device Registry Integration
     Device Registy integration test scenarios. These scenarios test higher level device service functionality
     with all services live.

--- a/qa/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/src/test/resources/features/user/UserServiceI9n.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@integration
 Feature: User Service Integration
   User Service integration scenarios
 


### PR DESCRIPTION
Cucumber integration tests are annotated with @integration.
This tests are not run during normal build, normal build only runs
unit tests.

This profile is for now provided only in qa module.

Integration tests can be run with:
mvn test -Dtests=integration

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>