### PR TITLE
First batch of DataStore jUnit tests converted to cucumber

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/StepData.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/StepData.java
@@ -46,4 +46,8 @@ public class StepData {
     public Object get(String key) {
         return stepDataMap.get(key);
     }
+
+    public void remove(String key) {
+        stepDataMap.remove(key);
+    }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreI9nTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
         glue = {"org.eclipse.kapua.qa.steps",
                 "org.eclipse.kapua.service.datastore.steps",
                 "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps",
         },
         plugin = { "pretty",
                 "html:target/cucumber/DatastoreI9n",

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceProxy.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceProxy.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.datastore.ChannelInfoRegistryService;
+import org.eclipse.kapua.service.datastore.model.StorableId;
+
+/*******************************************************************************
+ * This proxy class is only used to acces sthe otherwise package-restricted
+ * methods of the Channel Info Registry service.
+ *
+ * At the moment the only method that is required is delete().
+ *
+ *******************************************************************************/
+
+public class ChannelInfoRegistryServiceProxy {
+    private static final ChannelInfoRegistryService CHANNEL_INFO_REGISTRY_SERVICE =
+            KapuaLocator.getInstance().getService(ChannelInfoRegistryService.class);
+
+    public void delete(KapuaId scopeId, StorableId id) throws KapuaException {
+        ((ChannelInfoRegistryServiceImpl) CHANNEL_INFO_REGISTRY_SERVICE).delete(scopeId, id);
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceProxy.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceProxy.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.datastore.ClientInfoRegistryService;
+import org.eclipse.kapua.service.datastore.model.StorableId;
+
+/*******************************************************************************
+ * This proxy class is only used to acces sthe otherwise package-restricted
+ * methods of the Client Info Registry service.
+ *
+ * At the moment the only method that is required is delete().
+ *
+ *******************************************************************************/
+
+public class ClientInfoRegistryServiceProxy {
+    private static final ClientInfoRegistryService CLIENT_INFO_REGISTRY_SERVICE =
+            KapuaLocator.getInstance().getService(ClientInfoRegistryService.class);
+
+    public void delete(KapuaId scopeId, StorableId id) throws KapuaException {
+        ((ClientInfoRegistryServiceImpl) CLIENT_INFO_REGISTRY_SERVICE).delete(scopeId, id);
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceProxy.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceProxy.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.datastore.MetricInfoRegistryService;
+import org.eclipse.kapua.service.datastore.model.StorableId;
+
+/*******************************************************************************
+ * This proxy class is only used to acces sthe otherwise package-restricted
+ * methods of the Metric Info Registry service.
+ *
+ * At the moment the only method that is required is delete().
+ *
+ *******************************************************************************/
+
+public class MetricInfoRegistryServiceProxy {
+    private static final MetricInfoRegistryService METRIC_INFO_REGISTRY_SERVICE =
+            KapuaLocator.getInstance().getService(MetricInfoRegistryService.class);
+
+    public void delete(KapuaId scopeId, StorableId id) throws KapuaException {
+        ((MetricInfoRegistryServiceImpl) METRIC_INFO_REGISTRY_SERVICE).delete(scopeId, id);
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -656,7 +656,7 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
         tmpMetrics.put("double", random.nextDouble() * 100);
         tmpMetrics.put("long", random.nextLong());
         tmpMetrics.put("string_value", Integer.toString(random.nextInt()));
-        tmpTestPayload.setProperties(tmpMetrics);
+        tmpTestPayload.setMetrics(tmpMetrics);
 
         return tmpTestPayload;
     }
@@ -831,7 +831,7 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
 
         assertTrue(areSemanticPartsEqual(origMsg.getChannel().getSemanticParts(), foundMsg.getChannel().getSemanticParts()));
         assertArrayEquals(origMsg.getPayload().getBody(), foundMsg.getPayload().getBody());
-        assertTrue(areMetricsEqual(origMsg.getPayload().getProperties(), foundMsg.getPayload().getProperties()));
+        assertTrue(areMetricsEqual(origMsg.getPayload().getMetrics(), foundMsg.getPayload().getMetrics()));
         assertTrue(arePositionsEqual(origMsg.getPosition(), foundMsg.getPosition()));
         assertEquals(origMsg.getCapturedOn(), foundMsg.getCapturedOn());
         assertEquals(origMsg.getSentOn(), foundMsg.getSentOn());
@@ -846,7 +846,7 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
         assertEquals(firstMsg.getDatastoreId().toString(), secondMsg.getDatastoreId().toString());
         assertTrue(areSemanticPartsEqual(firstMsg.getChannel().getSemanticParts(), secondMsg.getChannel().getSemanticParts()));
         assertArrayEquals(firstMsg.getPayload().getBody(), secondMsg.getPayload().getBody());
-        assertTrue(areMetricsEqual(firstMsg.getPayload().getProperties(), secondMsg.getPayload().getProperties()));
+        assertTrue(areMetricsEqual(firstMsg.getPayload().getMetrics(), secondMsg.getPayload().getMetrics()));
         assertTrue(arePositionsEqual(firstMsg.getPosition(), secondMsg.getPosition()));
         assertEquals(firstMsg.getCapturedOn(), secondMsg.getCapturedOn());
         assertEquals(firstMsg.getSentOn(), secondMsg.getSentOn());

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -18,11 +18,20 @@ import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.shiro.SecurityUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
+import org.eclipse.kapua.message.internal.KapuaPositionImpl;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataChannelImpl;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataMessageImpl;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataPayloadImpl;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.qa.steps.DBHelper;
 import org.eclipse.kapua.service.StepData;
 import org.eclipse.kapua.service.account.Account;
@@ -33,8 +42,18 @@ import org.eclipse.kapua.service.datastore.DatastoreJAXBContextProvider;
 import org.eclipse.kapua.service.datastore.DatastoreObjectFactory;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.MetricInfoRegistryService;
+import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
+import org.eclipse.kapua.service.datastore.internal.ChannelInfoRegistryServiceProxy;
+import org.eclipse.kapua.service.datastore.internal.ClientInfoRegistryServiceProxy;
+import org.eclipse.kapua.service.datastore.internal.DatastoreCacheManager;
+import org.eclipse.kapua.service.datastore.internal.MetricInfoRegistryServiceProxy;
+import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
+import org.eclipse.kapua.service.datastore.internal.mediator.ClientInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
+import org.eclipse.kapua.service.datastore.internal.mediator.MetricInfoField;
 import org.eclipse.kapua.service.datastore.internal.model.StorableIdImpl;
+import org.eclipse.kapua.service.datastore.internal.model.query.AndPredicateImpl;
+import org.eclipse.kapua.service.datastore.internal.model.query.TermPredicateImpl;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
@@ -43,12 +62,16 @@ import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
 import org.eclipse.kapua.service.datastore.model.MetricInfoListResult;
+import org.eclipse.kapua.service.datastore.model.StorableId;
+import org.eclipse.kapua.service.datastore.model.query.AndPredicate;
 import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
 import org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceCreator;
 import org.eclipse.kapua.service.device.registry.DeviceFactory;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
@@ -56,6 +79,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Steps used in Datastore scenarios.
@@ -78,10 +108,13 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     private StorablePredicateFactory storablePredicateFactory;
 
     private ChannelInfoRegistryService channelInfoRegistryService;
+    private ChannelInfoRegistryServiceProxy channelInfoRegistryServiceProxy;
 
     private MetricInfoRegistryService metricInfoRegistryService;
+    private MetricInfoRegistryServiceProxy metricInfoRegistryServiceProxy;
 
     private ClientInfoRegistryService clientInfoRegistryService;
+    private ClientInfoRegistryServiceProxy clientInfoRegistryServiceProxy;
 
     private StepData stepData;
 
@@ -103,8 +136,11 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
         datastoreObjectFactory = locator.getFactory(DatastoreObjectFactory.class);
         storablePredicateFactory = locator.getFactory(StorablePredicateFactory.class);
         channelInfoRegistryService = locator.getService(ChannelInfoRegistryService.class);
+        channelInfoRegistryServiceProxy = new ChannelInfoRegistryServiceProxy();
         metricInfoRegistryService = locator.getService(MetricInfoRegistryService.class);
+        metricInfoRegistryServiceProxy = new MetricInfoRegistryServiceProxy();
         clientInfoRegistryService = locator.getService(ClientInfoRegistryService.class);
+        clientInfoRegistryServiceProxy = new ClientInfoRegistryServiceProxy();
 
         // JAXB Context
         XmlUtil.setContextProvider(new DatastoreJAXBContextProvider());
@@ -129,15 +165,225 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     public void getAccountForName(String accountName) throws KapuaException {
 
         Account account = accountService.findByName(accountName);
-        stepData.put("account", account);
+        stepData.put("LastAccount", account);
+    }
+
+    @Given("^The device \"(.*)\"$")
+    public void createDeviceWithName(String clientId) throws KapuaException {
+
+        Account tmpAcc = (Account) stepData.get("LastAccount");
+        DeviceCreator tmpDevCr = deviceFactory.newCreator(tmpAcc.getId(), clientId);
+        Device tmpDev = deviceRegistryService.create(tmpDevCr);
+        stepData.put("LastDevice", tmpDev);
+    }
+
+    @Given("^I prepare a random message and save it as \"(.*)\"$")
+    public void prepareAndRememberARandomMessage(String msgKey) throws KapuaException {
+
+        KapuaDataMessage tmpMessage = createTestMessage(((Account) stepData.get("LastAccount")).getId(),
+                ((Device) stepData.get("LastDevice")).getId(),
+                ((Device) stepData.get("LastDevice")).getClientId());
+        stepData.put(msgKey, tmpMessage);
+    }
+
+    @Given("^I prepare (\\d+) random messages and remember the list as \"(.*)\"$")
+    public void prepareAndRememberANumberOfRandomMessages(int number, String lstKey) {
+
+        KapuaDataMessage tmpMsg;
+        List<KapuaDataMessage> msgList = new ArrayList<>();
+
+        for (int i = 0; i < number; i++) {
+            tmpMsg = createTestMessage(((Account) stepData.get("LastAccount")).getId(),
+                    ((Device) stepData.get("LastDevice")).getId(),
+                    ((Device) stepData.get("LastDevice")).getClientId());
+            msgList.add(tmpMsg);
+        }
+
+        stepData.put(lstKey, msgList);
+    }
+
+    @Given("^I store the message \"(.*)\" and remember its ID as \"(.*)\"$")
+    public void insertRandomMessageIntoDatastore(String msgKey, String idKey) throws KapuaException {
+
+        KapuaDataMessage tmpMessage = (KapuaDataMessage) stepData.get(msgKey);
+        StorableId storeId = insertMessageInStore(tmpMessage);
+        stepData.put(idKey, storeId);
+        // Wait for the database to index the newly inserted records
+        waitABit(5000);
+    }
+
+    @Given("^I store the messages from list \"(.*)\" and remember the IDs as \"(.*)\"$")
+    public void insertRandomMessagesIntoDatastore(String msgListKey, String idListKey) throws KapuaException {
+
+        List<KapuaDataMessage> tmpMsgList = (List<KapuaDataMessage>) stepData.get(msgListKey);
+        List<StorableId> tmpIdList = insertMessagesInStore(tmpMsgList);
+        stepData.put(idListKey, tmpIdList);
+        // Wait for the database to index the newly inserted records
+        waitABit(5000);
+    }
+
+    @When("^I clear all the database caches$")
+    public void clearDatabaseCaches() {
+
+        clearAllCaches();
+    }
+
+    @When("^I refresh all database indices$")
+    public void refreshDatabaseIndices() throws Exception {
+
+        refreshAllIndices();
+    }
+
+    @When("^I delete the datastore message with ID \"(.*)\"$")
+    public void deleteDatastoreMessage(String idKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        StorableId msgId = (StorableId) stepData.get(idKey);
+        messageStoreService.delete(account.getId(), msgId);
+    }
+
+    @When("^I search for a data message with ID \"(.*)\" and remember it as \"(.*)\"")
+    public void searchForMessageInDatastore(String idKey, String msgKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        StorableId tmpId = (StorableId) stepData.get(idKey);
+        DatastoreMessage tmpMsg = messageStoreService.find(account.getId(), tmpId, StorableFetchStyle.SOURCE_FULL);
+        stepData.put(msgKey, tmpMsg);
+    }
+
+    @When("^I search for messages with IDs from the list \"(.*)\" and store them in the list \"(.*)\"$")
+    public void searchForMessagesInTheDatastore(String idListKey, String msgListKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        List<StorableId> msgIdLst = (List<StorableId>) stepData.get(idListKey);
+        List<DatastoreMessage> tmpMsgLst = new ArrayList<DatastoreMessage>();
+        DatastoreMessage tmpMsg;
+
+        for (StorableId tmpId : msgIdLst) {
+            tmpMsg = messageStoreService.find(account.getId(), tmpId, StorableFetchStyle.SOURCE_FULL);
+            tmpMsgLst.add(tmpMsg);
+        }
+
+        stepData.put(msgListKey, tmpMsgLst);
+    }
+
+    @When("^I query for the current account channel(?:|s) (?:|again )and store (?:it|them) as \"(.*)\"$")
+    public void queryForAccountChannels(String chnKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        ChannelInfoQuery tmpQuery = DatastoreQueryFactory.createBaseChannelInfoQuery(account.getId(), 100);
+
+        ChannelInfoListResult tmpList = channelInfoRegistryService.query(tmpQuery);
+        stepData.put(chnKey, tmpList);
+    }
+
+    @When("^I count the current account channels and store the count as \"(.*)\"$")
+    public void countAccountChannels(String countKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        ChannelInfoQuery tmpQuery = DatastoreQueryFactory.createBaseChannelInfoQuery(account.getId(), 100);
+
+        long channelCount = channelInfoRegistryService.count(tmpQuery);
+        stepData.put(countKey, channelCount);
+    }
+
+    @Then("^There (?:is|are) exactly (\\d+) channel(?:|s) in the list \"(.*)\"$")
+    public void checkNumberOfQueriedChannels(int cnt, String lstKey) {
+
+        assertEquals(cnt, ((ChannelInfoListResult) stepData.get(lstKey)).getSize());
+    }
+
+    @When("^I delete all channels from the list \"(.*)\"$")
+    public void deleteAllChannelsFromList(String lstKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        ChannelInfoListResult tmpList = (ChannelInfoListResult) stepData.get(lstKey);
+
+        for (ChannelInfo tmpItem : tmpList.getItems()) {
+            channelInfoRegistryServiceProxy.delete(account.getId(), tmpItem.getId());
+        }
+    }
+
+    @When("^I query for the current account metrics (?:|again )and store (?:it|them) as \"(.*)\"$")
+    public void queryForAccountMetrics(String metricKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        MetricInfoQuery tmpQuery = DatastoreQueryFactory.createBaseMetricInfoQuery(account.getId(), 100);
+
+        MetricInfoListResult tmpList = metricInfoRegistryService.query(tmpQuery);
+        stepData.put(metricKey, tmpList);
+    }
+
+    @When("^I count the current account metrics and store the count as \"(.*)\"$")
+    public void countAccountMetrics(String countKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        MetricInfoQuery tmpQuery = DatastoreQueryFactory.createBaseMetricInfoQuery(account.getId(), 100);
+
+        long metricCount = metricInfoRegistryService.count(tmpQuery);
+        stepData.put(countKey, metricCount);
+    }
+
+    @Then("^There (?:is|are) exactly (\\d+) metric(?:|s) in the list \"(.*)\"$")
+    public void checkNumberOfQueriedMetrics(int cnt, String lstKey) {
+
+        assertEquals(cnt, ((MetricInfoListResult) stepData.get(lstKey)).getSize());
+    }
+
+    @When("^I delete all metrics from the list \"(.*)\"$")
+    public void deleteAllMetricsFromList(String lstKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        MetricInfoListResult tmpList = (MetricInfoListResult) stepData.get(lstKey);
+
+        for (MetricInfo tmpItem : tmpList.getItems()) {
+            metricInfoRegistryServiceProxy.delete(account.getId(), tmpItem.getId());
+        }
+    }
+
+    @When("^I query for the current account client(?:|s) (?:|again )and store (?:it|them) as \"(.*)\"$")
+    public void queryForAccountClientInfo(String clientKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        ClientInfoQuery tmpQuery = DatastoreQueryFactory.createBaseClientInfoQuery(account.getId(), 100);
+
+        ClientInfoListResult tmpList = clientInfoRegistryService.query(tmpQuery);
+        stepData.put(clientKey, tmpList);
+    }
+
+    @When("^I count the current account clients and store the count as \"(.*)\"$")
+    public void countAccountClients(String countKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        ClientInfoQuery tmpQuery = DatastoreQueryFactory.createBaseClientInfoQuery(account.getId(), 100);
+
+        long clientCount = clientInfoRegistryService.count(tmpQuery);
+        stepData.put(countKey, clientCount);
+    }
+
+    @Then("^There (?:is|are) exactly (\\d+) client(?:|s) in the list \"(.*)\"$")
+    public void checkNumberOfQueriedClients(int cnt, String lstKey) {
+
+        assertEquals(cnt, ((ClientInfoListResult) stepData.get(lstKey)).getSize());
+    }
+
+    @When("^I delete all clients from the list \"(.*)\"$")
+    public void deleteAllClientsFromList(String lstKey) throws KapuaException {
+
+        Account account = (Account) stepData.get("LastAccount");
+        ClientInfoListResult tmpList = (ClientInfoListResult) stepData.get(lstKey);
+
+        for (ClientInfo tmpItem : tmpList.getItems()) {
+            clientInfoRegistryServiceProxy.delete(account.getId(), tmpItem.getId());
+        }
     }
 
     @When("^I search for data message with id \"(.*)\"")
-    public void messageStoreFind(String storableId) throws KapuaException {
+    public void messageStoreFind(String storeId) throws KapuaException {
 
-        Account account = (Account) stepData.get("account");
-        DatastoreMessage message = messageStoreService.find(account.getId(), new StorableIdImpl(storableId), StorableFetchStyle.SOURCE_FULL);
-        stepData.put("message", message);
+        Account account = (Account) stepData.get("LastAccount");
+        DatastoreMessage tmpMsg = messageStoreService.find(account.getId(), new StorableIdImpl(storeId), StorableFetchStyle.SOURCE_FULL);
+        stepData.put("message", tmpMsg);
     }
 
     @Then("^I don't find message$")
@@ -147,10 +393,53 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
         assertNull(message);
     }
 
+    @Then("^Message \"(.*)\" is null$")
+    public void checkThatTheMessageIsActuallyNull(String msgKey) {
+
+        assertNull(stepData.get(msgKey));
+    }
+
+    @Then("^The datastore message \"(.*)\" matches the prepared message \"(.*)\"$")
+    public void checkThatTheStoredMessageMatchesTheOriginal(String datastoreMsgKey, String originalMsgKey) throws KapuaException {
+
+        KapuaDataMessage origMsg = (KapuaDataMessage) stepData.get(originalMsgKey);
+        DatastoreMessage foundMsg = (DatastoreMessage) stepData.get(datastoreMsgKey);
+
+        checkThatTheInsertedMessageMatchesTheOriginal(origMsg, foundMsg);
+
+        isChannelForFirstMessageInStoreOK(foundMsg.getDatastoreId(), foundMsg.getTimestamp());
+        isClientForFirstMessageInStoreOK(foundMsg.getDatastoreId(), foundMsg.getTimestamp());
+        isMetricForFirstMessageInStoreOK(foundMsg.getDatastoreId(), foundMsg.getTimestamp());
+    }
+
+    @Then("^The datastore messages in list \"(.*)\" matches the prepared messages in list \"(.*)\"$")
+    public void checkThatTheStoredMessagesMatchTheOriginals(String datastoreMsgLstKey, String originalMsgLstKey) throws KapuaException {
+
+        List<KapuaDataMessage> origMsgs = (List<KapuaDataMessage>) stepData.get(originalMsgLstKey);
+        List<DatastoreMessage> dataMsg = (List<DatastoreMessage>) stepData.get(datastoreMsgLstKey);
+
+        for (int i = 0; i < origMsgs.size(); i++) {
+            checkThatTheInsertedMessageMatchesTheOriginal(origMsgs.get(i), dataMsg.get(i));
+        }
+    }
+
+    @Then("^The datastore messages \"(.*)\" and \"(.*)\" match$")
+    public void checkSavedMessages(String firstMsg, String secondMsg) throws KapuaException {
+
+        DatastoreMessage origMsg = (DatastoreMessage) stepData.get(firstMsg);
+        DatastoreMessage foundMsg = (DatastoreMessage) stepData.get(secondMsg);
+
+        checkThatDatastoreMessagesMatch(origMsg, foundMsg);
+
+        isChannelForFirstMessageInStoreOK(foundMsg.getDatastoreId(), foundMsg.getTimestamp());
+        isClientForFirstMessageInStoreOK(foundMsg.getDatastoreId(), foundMsg.getTimestamp());
+        isMetricForFirstMessageInStoreOK(foundMsg.getDatastoreId(), foundMsg.getTimestamp());
+    }
+
     @When("^I search for channel info with id \"(.*)\"")
     public void channelInfoFind(String storableId) throws KapuaException {
 
-        Account account = (Account) stepData.get("account");
+        Account account = (Account) stepData.get("LastAccount");
         ChannelInfo channelInfo = channelInfoRegistryService.find(account.getId(), new StorableIdImpl(storableId));
         stepData.put("channelInfo", channelInfo);
     }
@@ -165,9 +454,9 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     @When("^I search for metric info with id \"(.*)\"")
     public void metricInfoFind(String storableId) throws KapuaException {
 
-        Account account = (Account) stepData.get("account");
-        MetricInfo metricInfo = metricInfoRegistryService.find(account.getId(), new StorableIdImpl(storableId));
-        stepData.put("metricInfo", metricInfo);
+        Account account = (Account) stepData.get("LastAccount");
+        MetricInfo tmpInfo = metricInfoRegistryService.find(account.getId(), new StorableIdImpl(storableId));
+        stepData.put("metricInfo", tmpInfo);
     }
 
     @Then("^I don't find metric info$")
@@ -180,9 +469,9 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     @When("^I search for client info with id \"(.*)\"")
     public void clientInfoFind(String storableId) throws KapuaException {
 
-        Account account = (Account) stepData.get("account");
-        ClientInfo clientInfo = clientInfoRegistryService.find(account.getId(), new StorableIdImpl(storableId));
-        stepData.put("clientInfo", clientInfo);
+        Account account = (Account) stepData.get("LastAccount");
+        ClientInfo tmpInfo = clientInfoRegistryService.find(account.getId(), new StorableIdImpl(storableId));
+        stepData.put("clientInfo", tmpInfo);
     }
 
     @Then("^I don't find client info$")
@@ -195,7 +484,7 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     @Given("^I create message query for current account with limit (\\d+)$")
     public void createMessageQueryForAccount(int limit) {
 
-        Account account = (Account) stepData.get("account");
+        Account account = (Account) stepData.get("LastAccount");
         MessageQuery messageQuery = DatastoreQueryFactory.createBaseMessageQuery(account.getId(), limit);
         stepData.put("messageQuery", messageQuery);
     }
@@ -233,7 +522,7 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     @Given("^I create channel info query for current account with limit (\\d+)$")
     public void createChannelInofQueryForAccount(int limit) {
 
-        Account account = (Account) stepData.get("account");
+        Account account = (Account) stepData.get("LastAccount");
         ChannelInfoQuery channelInfoQuery = DatastoreQueryFactory.createBaseChannelInfoQuery(account.getId(), limit);
         stepData.put("channelInfoQuery", channelInfoQuery);
     }
@@ -271,7 +560,7 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     @Given("^I create metric info query for current account with limit (\\d+)$")
     public void createMetricInfoQueryForAccount(int limit) {
 
-        Account account = (Account) stepData.get("account");
+        Account account = (Account) stepData.get("LastAccount");
         MetricInfoQuery metricInfoQuery = DatastoreQueryFactory.createBaseMetricInfoQuery(account.getId(), limit);
         stepData.put("metricInfoQuery", metricInfoQuery);
     }
@@ -309,7 +598,7 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     @Given("^I create client info query for current account with limit (\\d+)$")
     public void createClientInfoQueryForAccount(int limit) {
 
-        Account account = (Account) stepData.get("account");
+        Account account = (Account) stepData.get("LastAccount");
         ClientInfoQuery clientInfoQuery = DatastoreQueryFactory.createBaseClientInfoQuery(account.getId(), limit);
         stepData.put("clientInfoQuery", clientInfoQuery);
     }
@@ -344,6 +633,228 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
         assertEquals(desiredCount, count);
     }
 
+    @Then("^The value of \"(.*)\" is exactly (\\d+)$")
+    public void checkValueOfIntegerItem(String valKey, long value) {
+        assertEquals(value, (long) stepData.get(valKey));
+    }
+
+    // Private helper functions
+
+    private KapuaDataPayload createRandomTestPayload() {
+
+        KapuaDataPayloadImpl tmpTestPayload = new KapuaDataPayloadImpl();
+
+        byte[] randomPayload = new byte[128];
+        random.nextBytes(randomPayload);
+        String stringPayload = "Hello first message on!";
+        byte[] tmpByteArrayPayload = ArrayUtils.addAll(randomPayload, stringPayload.getBytes());
+        tmpTestPayload.setBody(tmpByteArrayPayload);
+
+        Map<String, Object> tmpMetrics = new HashMap<String, Object>();
+        tmpMetrics.put("float", random.nextFloat() * 100);
+        tmpMetrics.put("integer", random.nextInt());
+        tmpMetrics.put("double", random.nextDouble() * 100);
+        tmpMetrics.put("long", random.nextLong());
+        tmpMetrics.put("string_value", Integer.toString(random.nextInt()));
+        tmpTestPayload.setProperties(tmpMetrics);
+
+        return tmpTestPayload;
+    }
+
+    private KapuaPosition createRandomTestPosition(Date timeStamp) {
+
+        KapuaPositionImpl tmpPosition = new KapuaPositionImpl();
+        tmpPosition.setAltitude(20000.0 * random.nextDouble()); // 0 .. 20000
+        tmpPosition.setHeading(360.0 * random.nextDouble()); // 0 .. 360
+        tmpPosition.setLatitude(180.0 * (random.nextDouble() - 0.5)); // -90 .. 90
+        tmpPosition.setLongitude(360.0 * (random.nextDouble() - 0.5)); // -180 .. 180
+        tmpPosition.setPrecision(100.0 * random.nextDouble()); // 0 .. 100
+        tmpPosition.setSatellites(random.nextInt(30)); // 0 .. 30
+        tmpPosition.setSpeed(500.0 * random.nextDouble()); // 0 .. 500
+        tmpPosition.setStatus(random.nextInt(10)); // 0 .. 10
+        tmpPosition.setTimestamp(timeStamp);
+
+        return tmpPosition;
+    }
+
+    private KapuaDataMessage createTestMessage(KapuaId scopeId, KapuaId deviceId, String clientId) {
+
+        final String tmpSemanticTopic = "registry/cache/check";
+        KapuaDataMessage tmpMessage = createTestMessageWithTopic(scopeId, deviceId, clientId, tmpSemanticTopic);
+
+        return tmpMessage;
+    }
+
+    private KapuaDataMessage createTestMessageWithTopic(KapuaId scopeId, KapuaId deviceId, String clientId, String topic) {
+
+        KapuaDataMessageImpl tmpMessage = new KapuaDataMessageImpl();
+
+        Date tmpRecDate = new Date();
+        Calendar tmpCal = Calendar.getInstance();
+        tmpCal.add(Calendar.MINUTE, -10);
+        Date tmpSentDate = tmpCal.getTime();
+
+        tmpMessage.setReceivedOn(tmpRecDate);
+        tmpMessage.setCapturedOn(tmpRecDate);
+        tmpMessage.setSentOn(tmpSentDate);
+        tmpMessage.setClientId(clientId);
+        tmpMessage.setDeviceId(deviceId);
+        tmpMessage.setScopeId(scopeId);
+
+        final KapuaDataChannelImpl tmpChannel = new KapuaDataChannelImpl();
+        tmpChannel.setSemanticParts(new ArrayList<>(Arrays.asList(topic.split("/"))));
+        tmpMessage.setChannel(tmpChannel);
+
+        tmpMessage.setPayload(createRandomTestPayload());
+        tmpMessage.setPosition(createRandomTestPosition(tmpSentDate));
+
+        return tmpMessage;
+    }
+
+    private StorableId insertMessageInStore(KapuaDataMessage message) throws KapuaException {
+
+        InsertResponse tmpResponse = messageStoreService.store(message);
+        StorableId tmpId = new StorableIdImpl(tmpResponse.getId());
+        return tmpId;
+    }
+
+    private List<StorableId> insertMessagesInStore(List<KapuaDataMessage> messages) throws KapuaException {
+
+        StorableId tmpId = null;
+        List<StorableId> tmpList = new ArrayList<StorableId>();
+
+        for (KapuaDataMessage tmpMsg : messages) {
+            tmpId = insertMessageInStore(tmpMsg);
+            tmpList.add(tmpId);
+        }
+
+        return tmpList;
+    }
+
+    private boolean areSemanticPartsEqual(List<String> parts1, List<String> parts2) {
+
+        if ((parts1 == null) && (parts2 == null)) {
+            return true;
+        }
+        if ((parts1 != null) && (parts2 != null)) {
+            assertEquals(parts1.size(), parts2.size());
+            for (int i = 0; i < parts1.size(); i++) {
+                assertEquals(parts1.get(i), parts2.get(i));
+            }
+        }
+        return true;
+    }
+
+    private boolean areMetricsEqual(Map<String, Object> properties1, Map<String, Object> properties2) {
+
+        assertEquals(properties1.size(), properties2.size());
+
+        if (properties1.size() > 0) {
+            for (String key : properties1.keySet()) {
+                assertTrue(properties2.containsKey(key));
+                assertEquals(properties1.get(key), properties2.get(key));
+            }
+        }
+        return true;
+    }
+
+    private void isChannelForFirstMessageInStoreOK(StorableId msgId, Date storedOn) throws KapuaException {
+
+        KapuaId tmpAccId = ((Account) stepData.get("LastAccount")).getId();
+        String tmpClId = ((Device) stepData.get("LastDevice")).getClientId();
+        AndPredicate andPredicate = new AndPredicateImpl();
+        andPredicate.getPredicates().add(new TermPredicateImpl(ChannelInfoField.CLIENT_ID, tmpClId));
+        ChannelInfoQuery channelInfoQuery = DatastoreQueryFactory.createBaseChannelInfoQuery(tmpAccId, 100);
+        channelInfoQuery.setPredicate(andPredicate);
+
+        ChannelInfoListResult channelInfoList = channelInfoRegistryService.query(channelInfoQuery);
+
+        assertNotNull("Cannot find the channel info registry!", channelInfoList);
+        assertNotEquals("Cannot find the channel info registry!", channelInfoList.getSize(), 0);
+        assertNotNull("Cannot find the channel info registry!", channelInfoList.getFirstItem());
+        assertEquals("Wrong channel info message id!", channelInfoList.getFirstItem().getFirstMessageId(), msgId);
+        assertEquals("Wrong channel info message on!", channelInfoList.getFirstItem().getFirstMessageOn(), storedOn);
+    }
+
+    private void isClientForFirstMessageInStoreOK(StorableId msgId, Date storedOn) throws KapuaException {
+
+        KapuaId tmpAccId = ((Account) stepData.get("LastAccount")).getId();
+        String tmpClId = ((Device) stepData.get("LastDevice")).getClientId();
+        AndPredicate andPredicate = new AndPredicateImpl();
+        andPredicate.getPredicates().add(new TermPredicateImpl(ClientInfoField.CLIENT_ID, tmpClId));
+        ClientInfoQuery clientInfoQuery = DatastoreQueryFactory.createBaseClientInfoQuery(tmpAccId, 100);
+        clientInfoQuery.setPredicate(andPredicate);
+
+        ClientInfoListResult clientInfoList = clientInfoRegistryService.query(clientInfoQuery);
+
+        assertNotNull("Cannot find the client info registry!", clientInfoList);
+        assertNotEquals("Cannot find the client info registry!", clientInfoList.getSize(), 0);
+        assertNotNull("Cannot find the client info registry!", clientInfoList.getFirstItem());
+        assertEquals("Wrong client info message id!", clientInfoList.getFirstItem().getFirstMessageId(), msgId);
+        assertEquals("Wrong client info message on!", clientInfoList.getFirstItem().getFirstMessageOn(), storedOn);
+    }
+
+    private void isMetricForFirstMessageInStoreOK(StorableId msgId, Date storedOn) throws KapuaException {
+
+        KapuaId tmpAccId = ((Account) stepData.get("LastAccount")).getId();
+        String tmpClId = ((Device) stepData.get("LastDevice")).getClientId();
+        AndPredicate andPredicate = new AndPredicateImpl();
+        andPredicate.getPredicates().add(new TermPredicateImpl(MetricInfoField.CLIENT_ID, tmpClId));
+        MetricInfoQuery metricInfoQuery = DatastoreQueryFactory.createBaseMetricInfoQuery(tmpAccId, 100);
+        metricInfoQuery.setPredicate(andPredicate);
+
+        MetricInfoListResult metricInfoList = metricInfoRegistryService.query(metricInfoQuery);
+
+        assertNotNull("Cannot find the metric info registry!", metricInfoList);
+        assertNotEquals("Cannot find the client info registry!", metricInfoList.getSize(), 0);
+        assertNotNull("Cannot find the metric info registry!", metricInfoList.getFirstItem());
+        assertEquals("Wrong metric info message id!", metricInfoList.getFirstItem().getFirstMessageId(), msgId);
+        assertEquals("Wrong metric info message on!", metricInfoList.getFirstItem().getFirstMessageOn(), storedOn);
+    }
+
+    private boolean arePositionsEqual(KapuaPosition position1, KapuaPosition position2) {
+
+        assertEquals(position1.getAltitude(), position2.getAltitude());
+        assertEquals(position1.getHeading(), position2.getHeading());
+        assertEquals(position1.getLatitude(), position2.getLatitude());
+        assertEquals(position1.getLongitude(), position2.getLongitude());
+        assertEquals(position1.getPrecision(), position2.getPrecision());
+        assertEquals(position1.getSatellites(), position2.getSatellites());
+        assertEquals(position1.getSpeed(), position2.getSpeed());
+        assertEquals(position1.getStatus(), position2.getStatus());
+        assertEquals(position1.getTimestamp(), position2.getTimestamp());
+        return true;
+    }
+
+    // Check whether the message that was inserted into the message store matches the originally prepared message
+    private boolean checkThatTheInsertedMessageMatchesTheOriginal(KapuaDataMessage origMsg, DatastoreMessage foundMsg) throws KapuaException {
+
+        assertTrue(areSemanticPartsEqual(origMsg.getChannel().getSemanticParts(), foundMsg.getChannel().getSemanticParts()));
+        assertArrayEquals(origMsg.getPayload().getBody(), foundMsg.getPayload().getBody());
+        assertTrue(areMetricsEqual(origMsg.getPayload().getProperties(), foundMsg.getPayload().getProperties()));
+        assertTrue(arePositionsEqual(origMsg.getPosition(), foundMsg.getPosition()));
+        assertEquals(origMsg.getCapturedOn(), foundMsg.getCapturedOn());
+        assertEquals(origMsg.getSentOn(), foundMsg.getSentOn());
+        assertEquals(origMsg.getReceivedOn(), foundMsg.getReceivedOn());
+
+        return true;
+    }
+
+    // Check that two datastore messages match
+    private boolean checkThatDatastoreMessagesMatch(DatastoreMessage firstMsg, DatastoreMessage secondMsg) throws KapuaException {
+
+        assertEquals(firstMsg.getDatastoreId().toString(), secondMsg.getDatastoreId().toString());
+        assertTrue(areSemanticPartsEqual(firstMsg.getChannel().getSemanticParts(), secondMsg.getChannel().getSemanticParts()));
+        assertArrayEquals(firstMsg.getPayload().getBody(), secondMsg.getPayload().getBody());
+        assertTrue(areMetricsEqual(firstMsg.getPayload().getProperties(), secondMsg.getPayload().getProperties()));
+        assertTrue(arePositionsEqual(firstMsg.getPosition(), secondMsg.getPosition()));
+        assertEquals(firstMsg.getCapturedOn(), secondMsg.getCapturedOn());
+        assertEquals(firstMsg.getSentOn(), secondMsg.getSentOn());
+        assertEquals(firstMsg.getReceivedOn(), secondMsg.getReceivedOn());
+
+        return true;
+    }
+
     /**
      * Clean-up of indices between scenarios.
      *
@@ -352,5 +863,26 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     private void deleteAllIndices() throws Exception {
 
         DatastoreMediator.getInstance().deleteAllIndexes();
+    }
+
+    private void refreshAllIndices() throws Exception {
+
+        DatastoreMediator.getInstance().refreshAllIndexes();
+    }
+
+    private void clearAllCaches() {
+
+        DatastoreCacheManager.getInstance().getChannelsCache().invalidateAll();
+        DatastoreCacheManager.getInstance().getClientsCache().invalidateAll();
+        DatastoreCacheManager.getInstance().getMetricsCache().invalidateAll();
+        DatastoreCacheManager.getInstance().getMetadataCache().invalidateAll();
+    }
+
+    private void waitABit(int millis) {
+
+        try {
+            Thread.sleep(millis);
+        } catch (Exception ex) {
+        }
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DatastoreQueryFactory.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DatastoreQueryFactory.java
@@ -66,6 +66,26 @@ public class DatastoreQueryFactory {
     }
 
     /**
+     * Creating query for data messages with reasonable defaults and user specified ordering.
+     *
+     * @param scopeId scope
+     * @param limit limit results
+     * @param order the required result ordering
+     * @return query
+     */
+    public static MessageQuery createBaseMessageQuery(KapuaId scopeId, int limit, List<SortField> order) {
+
+        MessageQuery query = new MessageQueryImpl(scopeId);
+        query.setAskTotalCount(true);
+        query.setFetchStyle(StorableFetchStyle.SOURCE_FULL);
+        query.setLimit(limit);
+        query.setOffset(0);
+        query.setSortFields(order);
+
+        return query;
+    }
+
+    /**
      * Creating query for channel info with reasonable defaults.
      *
      * @param scopeId

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/TestTopic.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/TestTopic.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.steps;
+
+public class TestTopic {
+
+    private String topic;
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
@@ -316,8 +316,9 @@ public class DeviceServiceSteps extends KapuaTest {
         CucDevice tmpCDev = devLst.get(0);
         tmpCDev.parse();
         DeviceCreator devCr = prepareDeviceCreatorFromCucDevice(tmpCDev);
+        Device tmpDevice = deviceRegistryService.create(devCr);
 
-        stepData.put("LastDevice", deviceRegistryService.create(devCr));
+        stepData.put("LastDevice", tmpDevice);
     }
 
     @When("^I search for the device \"(.+)\" in account \"(.+)\"$")

--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -219,6 +219,17 @@ public class UserServiceSteps extends AbstractKapuaSteps {
         }
     }
 
+    @When("^I select account \"(.*)\"$")
+    public void selectAccount(String accountName) throws KapuaException{
+        Account tmpAccount;
+        tmpAccount = accountService.findByName(accountName);
+        if (tmpAccount != null) {
+            stepData.put("LastAccount", tmpAccount);
+        } else {
+            stepData.remove("LastAccount");
+        }
+    }
+
     @Then("^I try to delete user \"(.*)\"$")
     public void thenDeleteUser(String userName) throws KapuaException {
         try {

--- a/qa/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/src/test/resources/features/datastore/Datastore.feature
@@ -21,7 +21,6 @@ Feature: Datastore tests
     Delete based on query or parametrized delete on non existent data should not fail. If data
     doesn't exist it is not deleted.
 
-
     Given I login as user with name "kapua-sys" and password "kapua-password"
     Given Account for "kapua-sys"
       When I search for data message with id "fake-id"
@@ -54,3 +53,67 @@ Feature: Datastore tests
          Then I get client info count 0
     And I logout
 
+  Scenario: Check the database cache coherency
+    This test checks the coherence of the registry cache for the metrics info (so if, once the 
+    cache is erased, after a new metric insert the firstMessageId and firstMessageOn contain 
+    the previous value)
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And The device "test-device-1"
+    And I prepare a random message and save it as "RandomDataMessage1"
+    Then I store the message "RandomDataMessage1" and remember its ID as "RandomDataMessage1Id"
+    When I search for a data message with ID "RandomDataMessage1Id" and remember it as "DataStoreMessage"
+    Then The datastore message "DataStoreMessage" matches the prepared message "RandomDataMessage1"
+    Then I clear all the database caches
+    And I store the message "RandomDataMessage1" and remember its ID as "RandomDataMessage2Id"
+    When I refresh all database indices
+    And I search for a data message with ID "RandomDataMessage1Id" and remember it as "DataStoreMessageNew"
+    Then The datastore messages "DataStoreMessage" and "DataStoreMessageNew" match
+
+  Scenario: Check the message store
+    Store few messages with few metrics, position and body (partially randomly generated) and check 
+    if the stored message (retrieved by id) has all the fields correctly set.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And The device "test-device-1"
+    When I prepare 15 random messages and remember the list as "RandomMessagesList"
+    And I store the messages from list "RandomMessagesList" and remember the IDs as "StoredMessageIDs"
+    When I search for messages with IDs from the list "StoredMessageIDs" and store them in the list "StoredMessagesList"
+    Then The datastore messages in list "StoredMessagesList" matches the prepared messages in list "RandomMessagesList"
+
+  Scenario: Delete items by the datastore ID
+    Delete a previously stored message and verify that it is not in the store any more. Also delete and check the
+    message related channel, metric and client info entries.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And The device "test-device-1"
+    And I prepare a random message and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When I search for a data message with ID "RandomDataMessageId" and remember it as "DataStoreMessage"
+    Then The datastore message "DataStoreMessage" matches the prepared message "RandomDataMessage"
+    When I delete the datastore message with ID "RandomDataMessageId"
+    And I refresh all database indices
+    When I search for a data message with ID "RandomDataMessageId" and remember it as "ShouldBeNull"
+    Then Message "ShouldBeNull" is null
+    When I query for the current account channels and store them as "AccountChannelList"
+    Then There is exactly 1 channel in the list "AccountChannelList"
+    When I delete all channels from the list "AccountChannelList"
+    And I refresh all database indices
+    When I count the current account channels and store the count as "AccountChannelCount"
+    Then The value of "AccountChannelCount" is exactly 0
+    When I query for the current account metrics and store them as "AccountMetriclList"
+    Then There is exactly 5 metrics in the list "AccountMetriclList"
+    When I delete all metrics from the list "AccountMetriclList"
+    And I refresh all database indices
+    When I count the current account metrics and store the count as "AccountMetricCount"
+    Then The value of "AccountMetricCount" is exactly 0
+    When I query for the current account clients and store them as "AccountClientlList"
+    Then There is exactly 1 client in the list "AccountClientlList"
+    When I delete all clients from the list "AccountClientlList"
+    And I refresh all database indices
+    When I count the current account clients and store the count as "AccountClientCount"
+    Then The value of "AccountClientCount" is exactly 0


### PR DESCRIPTION
## Simple integration tests for the DataStore service
This first batch of DataStore tests, converted from jUnit to Cucumber implementation. At the moment all the existing jUnit tests are still present and enabled. Eventually all jUnit tests will be reimplemented by suitable cucumber based tests and the original jUnit tests will be removed.

### Changes to Maven pom files
There are no changes to pom files.

### Implementation changes
The implementation of the DataStore service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented for the DataStore service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>