### PR TITLE
Use CentOS 7 as vagrant basebox

### DIFF
--- a/dev-tools/src/main/vagrant/README.md
+++ b/dev-tools/src/main/vagrant/README.md
@@ -18,7 +18,7 @@ The machines assigned IP is:
 
 The ports exposed are documented per service within the Vagrant files.
 
-**Note:** Before proceeding, check that Vagrant is installed in your PC, otherwise install it. In order to run Vagrant machines, VirtualBox or other virtualization software supported by Vagrant needs also to be installed.
+**Note:** Before proceeding, check that Vagrant is installed in your PC, otherwise install it. In order to run Vagrant machines, VirtualBox or other virtualization software supported by Vagrant needs also to be installed. When using VirtualBox vagrant vagrant-vbguest plugin should also be installed.
 
 ## Demo machine quick start
 It is possible to create the **demo machine in only one step** (so create the base box, the demo vagrant machine, compile the Kapua project and start the services inside the vagrant demo machine) just using this script
@@ -36,14 +36,14 @@ $ cd $KAPUA_GITHUB_HOME_DIR/dev-tools/src/main/vagrant
 $ ./start.sh base-box
 ```
 
-After a while a new box, called ***trusty64/kapua-dev-box-0.x***, will be created on the system. To check it please refer to the command showed in the ***Helpful Vagrant commands*** section
+After a while a new box, called ***kapua-dev-box/0.x***, will be created on the system. To check it please refer to the command showed in the ***Helpful Vagrant commands*** section
 
-**Note 1:** this step may take few minutes due to the components to be downloaded.   
+**Note 1:** this step may take few minutes due to the components to be downloaded.
 **Note 2:** the script will delete a previous created kapua-box, so due to Note 1, be careful before run this step.
 
 ## Creating the Kapua dev-box
 
-Once the base-box is created, from the same directory, it's possible to invoke the same script with a different value (as the first parameter) to create and start the development Vagrant machine.   
+Once the base-box is created, from the same directory, it's possible to invoke the same script with a different value (as the first parameter) to create and start the development Vagrant machine.
 
 ```
 $ cd $KAPUA_GITHUB_HOME_DIR
@@ -51,7 +51,7 @@ $ cd dev-tools/src/main/vagrant
 $ ./start.sh develop
 ```
 
-The machine can be recreated every time you need (running the same commands) or, alternatively, it's possible to freeze it and start it again later (see ***Helpful Vagrant commands*** section).   
+The machine can be recreated every time you need (running the same commands) or, alternatively, it's possible to freeze it and start it again later (see ***Helpful Vagrant commands*** section).
 If you choose to start it again instead of recreating, you should enter the Vagrant machine and start manually the H2 service (please replace ${H2DB_VERSION} with the correct value):
 ```
 $ cd $KAPUA_GITHUB_HOME_DIR
@@ -83,7 +83,7 @@ There is script to start the broker
 ```
 $ ./start-broker.sh
 ```
-The script recreates the link between all the libraries and Kapua jars (inside Kapua workspace) needed by the broker at runtime, recreate configuration links and then start the broker.   
+The script recreates the link between all the libraries and Kapua jars (inside Kapua workspace) needed by the broker at runtime, recreate configuration links and then start the broker.
 To stop the broker type:
 ```
 bin/activemq stop
@@ -136,7 +136,7 @@ Password: kapua-password
 ```
 
 ## Creating the Kapua demo-box
-As for the development machine, once the base-box is created, from the same directory, it's possible to invoke the same script with a different value (as the first parameter) to create and start the demo Vagrant machine.   
+As for the development machine, once the base-box is created, from the same directory, it's possible to invoke the same script with a different value (as the first parameter) to create and start the demo Vagrant machine.
 
 ```
 $ cd $KAPUA_GITHUB_HOME_DIR
@@ -144,7 +144,7 @@ $ cd dev-tools/src/main/vagrant
 $ ./start.sh demo
 ```
 
-The machine can be recreated every time you need (running the same commands) or, alternatively, it's possible to freeze it and start it again later (see ***Helpful Vagrant commands*** section).   
+The machine can be recreated every time you need (running the same commands) or, alternatively, it's possible to freeze it and start it again later (see ***Helpful Vagrant commands*** section).
 If you choose to start it again instead of recreating, you should enter the Vagrant machine and start manually the H2 service (please replace ${H2DB_VERSION} with the correct value):
 ```
 $ cd $KAPUA_GITHUB_HOME_DIR
@@ -161,7 +161,7 @@ As for the development machine, once the demo machine has been created (or start
 $ vagrant ssh
 ```
 
-The fresh machine has both the ActiveMQ and Tomcat installed, but please don't use them, it's just due to the reuse of the base-box.   
+The fresh machine has both the ActiveMQ and Tomcat installed, but please don't use them, it's just due to the reuse of the base-box.
 To start ***using properly the demo machine*** run a full Kapua build as follow:
 
 ```

--- a/dev-tools/src/main/vagrant/baseBox/baseBox-Vagrantfile
+++ b/dev-tools/src/main/vagrant/baseBox/baseBox-Vagrantfile
@@ -12,7 +12,7 @@
 #*******************************************************************************
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "centos/7"
 
   config.vm.box_check_update = false
 
@@ -23,16 +23,10 @@ Vagrant.configure(2) do |config|
 	 export H2DB_VERSION="1.4.192"
 	 export ACTIVE_MQ_VERSION="5.14.5"
 	 export TOMCAT_VERSION="8.0.41"
-	 
-     # update
-     sudo apt-get update -y
 
 	 ### install oracle jdk 8 ###
-     sudo add-apt-repository -y ppa:webupd8team/java
-     sudo apt-get update
-     echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
-     echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-     sudo apt-get -y install -qq oracle-java8-installer
+	sudo yum clean all
+	sudo yum install -y java-1.8.0-openjdk-devel
 
      ### install activemq ###
 	 sudo mkdir -p /usr/local/activemq
@@ -140,10 +134,10 @@ Vagrant.configure(2) do |config|
 	 ############################
 	 sudo bash -c 'echo "* soft nofile 65536" > /etc/security/limits.d/kapua.conf'
 	 sudo bash -c 'echo "* hard nofile 65536" >> /etc/security/limits.d/kapua.conf'
-	 
+
 	 sudo bash -c "echo 'vm.max_map_count=262144' > /etc/sysctl.d/98-kapua.conf"
 	 sudo sysctl --system
-	
+
      cat /dev/null > ~/.bash_history && history -c
 
   SHELL

--- a/dev-tools/src/main/vagrant/baseBox/create-base-box.sh
+++ b/dev-tools/src/main/vagrant/baseBox/create-base-box.sh
@@ -14,8 +14,8 @@
 
 CURRDIR=$(pwd)
 BASEDIR=$(dirname "$0")
-KAPUA_BOX_VERSION=0.4
-KAPUA_BOX_NAME=trusty64/kapua-dev-box-$KAPUA_BOX_VERSION
+KAPUA_BOX_VERSION=0.5
+KAPUA_BOX_NAME=kapua-dev-box/$KAPUA_BOX_VERSION
 KAPUA_BOX_TMP_DIR=$BASEDIR/kapua-box-tmp
 
 KAPUA_BOX_EXISTS=$(vagrant box list | grep $KAPUA_BOX_NAME)
@@ -33,7 +33,7 @@ then
    echo 'access to the internet. Depending on your internet connection'
    echo 'this operation may take some time.'
    echo
-   
+
    read -p "Proceed with replacement [y/N] ? " -r
 
    echo
@@ -45,13 +45,13 @@ then
       echo 'Removing base kapua box named: ' $KAPUA_BOX_NAME ' ...'
 
       vagrant box remove $KAPUA_BOX_NAME
-      
+
    fi
 
 fi
 
-# If the box has been removed or it wasn't there before, then proceed 
-# with the creation. Otherwise the user hasn't confirmed the removal 
+# If the box has been removed or it wasn't there before, then proceed
+# with the creation. Otherwise the user hasn't confirmed the removal
 # so skip.
 
 KAPUA_BOX_EXISTS=$(vagrant box list | grep $KAPUA_BOX_NAME)
@@ -61,7 +61,7 @@ if [[ -z "$KAPUA_BOX_EXISTS" ]]
 then
 
    echo 'Creating base kapua box named ' $KAPUA_BOX_NAME ' ...'
-   
+
    mkdir -p $KAPUA_BOX_TMP_DIR
 
    cp $BASEDIR/baseBox-Vagrantfile $KAPUA_BOX_TMP_DIR/Vagrantfile
@@ -69,19 +69,19 @@ then
    cd $KAPUA_BOX_TMP_DIR
 
    echo '========================'
-      
+
    pwd
-      
+
    vagrant up
 
-   vagrant package --output trusty64-kapua-dev-$KAPUA_BOX_VERSION.box
+   vagrant package --output kapua-dev-$KAPUA_BOX_VERSION.box
 
-   vagrant box add $KAPUA_BOX_NAME trusty64-kapua-dev-$KAPUA_BOX_VERSION.box
+   vagrant box add $KAPUA_BOX_NAME kapua-dev-$KAPUA_BOX_VERSION.box
 
-   vagrant destroy --force 
+   vagrant destroy --force
 
    # go up one level to allow the removal of the tmp dir
-    
+
    cd ../..
 
    rm -rf $KAPUA_BOX_TMP_DIR

--- a/dev-tools/src/main/vagrant/demo/demo-Vagrantfile
+++ b/dev-tools/src/main/vagrant/demo/demo-Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
      group: "vagrant",
      mount_options: ["dmode=775,fmode=664"]
 
-  config.vm.box = "trusty64/kapua-dev-box-0.4"
+  config.vm.box = "kapua-dev-box/0.5"
 
   config.vm.box_check_update = false
 
@@ -80,7 +80,10 @@ Vagrant.configure("2") do |config|
      sudo bash -c "echo 'http.host: 192.168.33.10' >> /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml"
      sudo bash -c "echo 'http.port: 9200' >> /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml"
      sudo bash -c "echo 'transport.ping_schedule: -1' >> /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml"
-	
+
+    ### needed when using OpenJDK ###
+    sudo bash -c "echo '-XX:-AssumeMP' >> /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/config/jvm.options"
+
      # Run the datastore engine
      sudo chown -R vagrant /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}
      su --login -c "/usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch -d" vagrant
@@ -95,6 +98,6 @@ Vagrant.configure("2") do |config|
 	 sudo rm -rf /usr/local/tomcat
 	 sudo rm -rf /usr/local/activemq
 	 sudo chown -R vagrant:vagrant /usr/local/kapua
-	 
+
   SHELL
 end

--- a/dev-tools/src/main/vagrant/develop/develop-Vagrantfile
+++ b/dev-tools/src/main/vagrant/develop/develop-Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
      group: "vagrant",
      mount_options: ["dmode=775,fmode=664"]
 
-  config.vm.box = "trusty64/kapua-dev-box-0.4"
+  config.vm.box = "kapua-dev-box/0.5"
 
   config.vm.box_check_update = false
 
@@ -57,7 +57,7 @@ Vagrant.configure("2") do |config|
 	 export ACTIVEMQ_VERSION="5.14.5"
 	 export TOMCAT_VERSION="8.0.41"
 	 export KAPUA_VERSION="0.2.0-SNAPSHOT"
-	 
+
 	 #########################
      ### H2 database setup ###
 	 #########################
@@ -68,7 +68,7 @@ Vagrant.configure("2") do |config|
 	 java -cp /usr/local/h2database/h2database-${H2DB_VERSION}/h2*.jar org.h2.tools.Shell -url jdbc:h2:tcp://localhost:3306/kapuadb -user "root" -password "password" -sql "CREATE SCHEMA IF NOT EXISTS kapuadb; \
 		CREATE USER IF NOT EXISTS kapua PASSWORD 'kapua'; \
 		GRANT ALL ON SCHEMA kapuadb TO kapua;"
-		
+
 	 pkill -f h2database
 
 	 ############################
@@ -82,7 +82,10 @@ Vagrant.configure("2") do |config|
      sudo bash -c "echo 'http.host: 192.168.33.10' >> /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml"
      sudo bash -c "echo 'http.port: 9200' >> /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml"
      sudo bash -c "echo 'transport.ping_schedule: -1' >> /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/config/elasticsearch.yml"
-	 
+
+    ### needed when using OpenJDK ###
+    sudo bash -c "echo '-XX:-AssumeMP' >> /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/config/jvm.options"
+
      # Run the datastore engine
      sudo chown -R vagrant /usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}
 
@@ -137,7 +140,7 @@ Vagrant.configure("2") do |config|
   SHELL
 
   config.vm.provision "shell", run: "always", inline: <<-SHELL
-  	  export DEBIAN_FRONTEND=noninteractive
+    export DEBIAN_FRONTEND=noninteractive
 	  export ELASTICSEARCH_VERSION="5.4.0"
 	  export H2DB_VERSION="1.4.192"
 	  setsid su --login -c "/usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch -d" vagrant

--- a/dev-tools/src/main/vagrant/integrationTestScript/startup.sh
+++ b/dev-tools/src/main/vagrant/integrationTestScript/startup.sh
@@ -11,6 +11,6 @@
 #
 #*******************************************************************************
 echo 'VARGRANT UP......'
-vagrant box list | grep -q trusty64/kapua-dev-box-0.1 || ../start.sh base-box
+vagrant box list | grep -q kapua-dev-box/0.5 || ../start.sh base-box
 vagrant up
 echo 'VARGRANT UP...... DONE'


### PR DESCRIPTION
This PR applies the following changes:
- use CentOS7 as basebox
- use OpenJDK instead of Oracle JDK
- change dev-box image naming schema

Closes #151.