### PR TITLE
Lockout and Expiration tests on user and credentials

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/TestCredentials.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/TestCredentials.java
@@ -11,6 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.steps;
 
+import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
 /**
  * Data object used in Gherkin to transfer Credentials data.
  */
@@ -19,6 +28,10 @@ public class TestCredentials {
     private String name;
 
     private String password;
+
+    private boolean enabled;
+
+    private String expirationDate;
 
     public String getName() {
         return name;
@@ -34,5 +47,55 @@ public class TestCredentials {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public CredentialStatus getStatus() {
+        if (isEnabled()) {
+            return CredentialStatus.ENABLED;
+        } else {
+            return CredentialStatus.DISABLED;
+        }
+    }
+
+    public Date getExpirationDate() {
+        DateFormat df = new SimpleDateFormat("dd/mm/yyyy");
+        Date expDate = null;
+        LocalDateTime now = LocalDateTime.now();
+
+        if (expirationDate == null) {
+            return null;
+        }
+        // Special keywords for date
+        switch (expirationDate) {
+            case "yesterday":
+                expDate = Date.from(now.minusDays(1).atZone(ZoneId.systemDefault()).toInstant());
+                break;
+            case "today":
+                expDate = Date.from(now.atZone(ZoneId.systemDefault()).toInstant());
+                break;
+            case "tomorrow":
+                expDate = Date.from(now.plusDays(1).atZone(ZoneId.systemDefault()).toInstant());
+                break;
+        }
+        // Just parse date
+        try {
+            expDate = df.parse(expirationDate);
+        } catch (ParseException | NullPointerException e) {
+            // skip, leave date null
+        }
+
+        return expDate;
+    }
+
+    public void setExpirationDate(String expirationDate) {
+        this.expirationDate = expirationDate;
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/TestUser.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/TestUser.java
@@ -12,6 +12,12 @@
 package org.eclipse.kapua.service.user.steps;
 
 import java.math.BigInteger;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 
 import org.eclipse.kapua.service.user.UserStatus;
 import org.eclipse.kapua.service.user.UserType;
@@ -34,6 +40,8 @@ public class TestUser {
     private UserType userType;
 
     private BigInteger scopeId;
+
+    private String expirationDate;
 
     public String getName() {
         return name;
@@ -89,5 +97,39 @@ public class TestUser {
 
     public void setScopeId(BigInteger scopeId) {
         this.scopeId = scopeId;
+    }
+
+    public Date getExpirationDate() {
+        DateFormat df = new SimpleDateFormat("dd/mm/yyyy");
+        Date expDate = null;
+        LocalDateTime now = LocalDateTime.now();
+
+        if (expirationDate == null) {
+            return null;
+        }
+        // Special keywords for date
+        switch (expirationDate) {
+            case "yesterday":
+                expDate = Date.from(now.minusDays(1).atZone(ZoneId.systemDefault()).toInstant());
+                break;
+            case "today":
+                expDate = Date.from(now.atZone(ZoneId.systemDefault()).toInstant());
+                break;
+            case "tomorrow":
+                expDate = Date.from(now.plusDays(1).atZone(ZoneId.systemDefault()).toInstant());
+                break;
+        }
+        // Just parse date
+        try {
+            expDate = df.parse(expirationDate);
+        } catch (ParseException | NullPointerException e) {
+            // skip, leave date null
+        }
+
+        return expDate;
+    }
+
+    public void setExpirationDate(String expirationDate) {
+        this.expirationDate = expirationDate;
     }
 }

--- a/qa/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -1,0 +1,324 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+Feature: User and Credential expiration abd lockout features
+  User Service has expiration value after which user is disabled.
+  There is also expiration and status on user's credentials which are also tested.
+  Additionally login failures and lockout and lockout resets are tested.
+
+  Scenario: If user credential is in state enabled, user can login
+    User is set up with credentials that have state enabled. If credentials state is
+    enabled, user can login into system. All other expiration settings are set for
+    successful login. Only state is tested.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: If user credential is in state disabled, user can not login
+    User is set up with credentials that have state disabled. If credentials state is
+    disabled, user can not login into system. All other expiration settings are set for
+    successful login. Only state is tested.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | false   |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: If user credential expiration date is before today, user can not login
+    Expiration date on credentials is set one day in the past and is in state enabled.
+    This prevents user from logging in.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled | expirationDate |
+      | kapua-a | ToManySecrets123# | true    | yesterday      |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: If user credential expiration date is today, user can not login it is day inclusive
+    Expiration date on credentials is set to today and is in state enabled.
+    This prevents user from logging in, because expiration is today and is day inclusive.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled | expirationDate |
+      | kapua-a | ToManySecrets123# | true    | today          |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: If user credential expiration date is tomorrow, user can login
+    Expiration date on credentials is set to tomorrow and is in state enabled.
+    This allows user to login, because expiration is not yet reached.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled | expirationDate |
+      | kapua-a | ToManySecrets123# | true    | tomorrow       |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: If user expiration date is before today, user can not login
+    Expiration date on user is set to yesterday and is in state enabled.
+    Expiration on Credentials is not set and is in state enabled.
+    This doesn't allow user to login, because expiration was reached.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType | expirationDate |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL | yesterday      |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: If user expiration date is today, user can not login because expiration date was reached
+    Expiration date on user is set today and is in state enabled.
+    Expiration on Credentials is not set and is in state enabled.
+    This doesn't allow user to login, because expiration is reached.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType | expirationDate |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL | today          |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: If user expiration date is tomorrow, user can login
+    Expiration date on user is set tomorrow and is in state enabled.
+    Expiration on Credentials is not set and is in state enabled.
+    This allows user to login, because expiration is not yet reached.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType | expirationDate |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL | tomorrow       |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then No exception was thrown
+    And I logout

--- a/qa/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/src/test/resources/features/user/UserServiceI9n.feature
@@ -44,8 +44,8 @@ Feature: User Service Integration
       | name    | displayName  | email             | phoneNumber     | status  | userType |
       | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
     And Credentials
-      | name    | password          |
-      | kapua-a | ToManySecrets123# |
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
     And Permissions
       | domain | action |
       | user   | read   |
@@ -116,8 +116,8 @@ Feature: User Service Integration
       | name    | displayName  | email             | phoneNumber     | status  | userType |
      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
     And Credentials
-      | name    | password          |
-      | kapua-a | ToManySecrets123# |
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
     And Permissions
      | domain | action |
       | user   | read   |


### PR DESCRIPTION
Added Expiration date and state for gherkin scenarios on User
and Credentials.
New feature file that tests Lockout and Expiration.

Two simple tests that test for status attribute on Credentials.

Updated existing credentials steps with status value.

Tests that check expiration date on Credentials and on User.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>