### PR TITLE
Split up travis build in build and test phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ jdk:
 
 sudo: false
 
+# The cache is stored per-branch
+
+cache:
+  directories:
+  - $HOME/.m2
+
 install:
   - echo ==== Setting up toolchain.xml ====
   - ls /usr/lib/jvm
@@ -18,13 +24,22 @@ install:
 
 before_script:
   - export M2_HOME=$PWD/maven
-  - export PATH=$PWD/maven/bin:${PATH}
+  - export PATH=${M2_HOME}/bin:${PATH}
   - hash -r
 
-script: ./travis.sh
-
-after_script:
-  - bash <(curl -s https://codecov.io/bash)
+jobs:
+  include:
+    - stage: build
+      script:
+        - $M2_HOME/bin/mvn -v
+        - $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -DskipTests install
+    - stage: test
+      script:
+        - $M2_HOME/bin/mvn -B javadoc:jar
+    - stage: test
+      script:
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Pdev test
+        - bash <(curl -s https://codecov.io/bash)
 
 # The following upgrades Java during the build in
 # order to work around an older Java 8 compiler issue
@@ -34,4 +49,4 @@ after_script:
 addons:
   apt:
     packages:
-      - oracle-java8-installer 
+      - oracle-java8-installer

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,12 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
@@ -392,7 +398,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
                 <configuration>
                     <!-- Travis has an overall 3GB limit -->
                     <argLine>@{argLine} -Xmx1024m</argLine>

--- a/travis.sh
+++ b/travis.sh
@@ -26,10 +26,9 @@ trap 'on_error' ERR
 bash -c "while true; do echo Building Kapua...; sleep 30; done" &
 HEARTBEAT_PROCESS_PID=$!
 
-### Build itself
+### Run
 
-"$M2_HOME"/bin/mvn -v
-"$M2_HOME"/bin/mvn -B -Dorg.eclipse.kapua.qa.waitMultiplier=2.0 -Dgwt.compiler.localWorkers=2 -Pjavadoc,console >> $OUTPUT 2>&1
+"$@" >> $OUTPUT 2>&1
 tail_log
 
 ### Cleaning up heartbeat process


### PR DESCRIPTION
This change will split up the build into different build stages on Travis.

The first step does a plain build without tests and without javadoc. Then javadoc and tests will be executed in parallel.