### PR TITLE
Cleanup PermissionFactory API

### DIFF
--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,8 +8,13 @@
  *
  * Contributors:
  *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.permission;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 import org.eclipse.kapua.model.KapuaObjectFactory;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -18,8 +23,6 @@ import org.eclipse.kapua.service.authorization.group.Group;
 
 /**
  * {@link Permission} object factory.
- * 
- * @since 1.0.0
  */
 public interface PermissionFactory extends KapuaObjectFactory {
 
@@ -33,9 +36,10 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param targetScopeId
      *            The target scope id of the new {@link Permission}.
      * @return A instance of the implementing class of {@link Permission}.
-     * @since 1.0.0
      */
-    public Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId);
+    public default Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId) {
+        return newPermission(domain, action, targetScopeId, null);
+    }
 
     /**
      * Instantiate a new {@link Permission} implementing object with the provided parameters.
@@ -49,9 +53,10 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param groupId
      *            The {@link Group} id that this {@link Permission} gives access.
      * @return A instance of the implementing class of {@link Permission}.
-     * @since 1.0.0
      */
-    public Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId);
+    public default Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId) {
+        return newPermission(domain, action, targetScopeId, groupId, false);
+    }
 
     /**
      * Instantiate a new {@link Permission} implementing object with the provided parameters.
@@ -67,7 +72,59 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param forwardable
      *            If the {@link Permission} is forward-able to children scopeIds
      * @return A instance of the implementing class of {@link Permission}.
-     * @since 1.0.0
      */
     public Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId, boolean forwardable);
+
+    /**
+     * Instantiate new {@link Permission}s implementing object with the provided parameters.
+     * 
+     * @param domain
+     *            The {@link Domain} of the new {@link Permission}.
+     * @param targetScopeId
+     *            The target scope id of the new {@link Permission}.
+     * @param actions
+     *            The {@link Action}s of the new {@link Permission}s.
+     * @return A collection of instances of the implementing class of {@link Permission}.
+     */
+    public default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, Actions... actions) {
+        return newPermissions(domain, targetScopeId, null, actions);
+    }
+
+    /**
+     * Instantiate new {@link Permission}s implementing object with the provided parameters.
+     * 
+     * @param domain
+     *            The {@link Domain} of the new {@link Permission}.
+     * @param targetScopeId
+     *            The target scope id of the new {@link Permission}.
+     * @param groupId
+     *            The {@link Group} id that this {@link Permission} gives access.
+     * @param actions
+     *            The {@link Action}s of the new {@link Permission}s.
+     * @return A collection of instances of the implementing class of {@link Permission}.
+     */
+    public default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, KapuaId groupId, Actions... actions) {
+        return newPermissions(domain, targetScopeId, groupId, false, actions);
+    }
+
+    /**
+     * Instantiate new {@link Permission}s implementing object with the provided parameters.
+     * 
+     * @param domain
+     *            The {@link Domain} of the new {@link Permission}.
+     * @param targetScopeId
+     *            The target scope id of the new {@link Permission}.
+     * @param groupId
+     *            The {@link Group} id that this {@link Permission} gives access.
+     * @param forwardable
+     *            If the {@link Permission} is forward-able to children scopeIds
+     * @param actions
+     *            The {@link Action}s of the new {@link Permission}s.
+     * @return A collection of instances of the implementing class of {@link Permission}.
+     */
+    public default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, KapuaId groupId, boolean forwardable, Actions... actions) {
+        return Arrays.stream(actions)
+                .map(action -> newPermission(domain, action, targetScopeId, groupId, forwardable))
+                .collect(Collectors.toList());
+    }
 }

--- a/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/SimpleRegistrationProcessor.java
+++ b/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/SimpleRegistrationProcessor.java
@@ -12,6 +12,10 @@
 package org.eclipse.kapua.security.registration.simple;
 
 import static java.util.Optional.empty;
+import static org.eclipse.kapua.service.authorization.permission.Actions.delete;
+import static org.eclipse.kapua.service.authorization.permission.Actions.execute;
+import static org.eclipse.kapua.service.authorization.permission.Actions.read;
+import static org.eclipse.kapua.service.authorization.permission.Actions.write;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -273,32 +277,16 @@ public class SimpleRegistrationProcessor implements RegistrationProcessor {
         final Set<Permission> permissions = new HashSet<>();
         permissions.add(permissionFactory.newPermission(new AccessInfoDomain(), Actions.read, user.getScopeId()));
 
-        permissions.add(permissionFactory.newPermission(new AccountDomain(), Actions.read, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(new CredentialDomain(), Actions.delete, user.getScopeId()));
-        permissions.add(permissionFactory.newPermission(new CredentialDomain(), Actions.read, user.getScopeId()));
-        permissions.add(permissionFactory.newPermission(new CredentialDomain(), Actions.write, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(new DatastoreDomain(), Actions.read, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(DeviceDomain.INSTANCE, Actions.read, user.getScopeId()));
-        permissions.add(permissionFactory.newPermission(DeviceDomain.INSTANCE, Actions.write, user.getScopeId()));
-        permissions.add(permissionFactory.newPermission(DeviceDomain.INSTANCE, Actions.delete, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(new DeviceConnectionDomain(), Actions.read, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(new DeviceEventDomain(), Actions.read, user.getScopeId()));
-        permissions.add(permissionFactory.newPermission(new DeviceEventDomain(), Actions.write, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(new DeviceManagementDomain(), Actions.read, user.getScopeId()));
-        permissions.add(permissionFactory.newPermission(new DeviceManagementDomain(), Actions.write, user.getScopeId()));
-        permissions.add(permissionFactory.newPermission(new DeviceManagementDomain(), Actions.execute, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(new GroupDomain(), Actions.read, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(new RoleDomain(), Actions.read, user.getScopeId()));
-
-        permissions.add(permissionFactory.newPermission(new UserDomain(), Actions.read, user.getScopeId()));
+        permissions.addAll(permissionFactory.newPermissions(new AccountDomain(), user.getScopeId(), read));
+        permissions.addAll(permissionFactory.newPermissions(new CredentialDomain(), user.getScopeId(), read, write, delete));
+        permissions.addAll(permissionFactory.newPermissions(new DatastoreDomain(), user.getScopeId(), read));
+        permissions.addAll(permissionFactory.newPermissions(DeviceDomain.INSTANCE, user.getScopeId(), read, write, delete));
+        permissions.addAll(permissionFactory.newPermissions(new DeviceConnectionDomain(), user.getScopeId(), read));
+        permissions.addAll(permissionFactory.newPermissions(new DeviceEventDomain(), user.getScopeId(), read, write));
+        permissions.addAll(permissionFactory.newPermissions(new DeviceManagementDomain(), user.getScopeId(), read, write, execute));
+        permissions.addAll(permissionFactory.newPermissions(new GroupDomain(), user.getScopeId(), read));
+        permissions.addAll(permissionFactory.newPermissions(new RoleDomain(), user.getScopeId(), read));
+        permissions.addAll(permissionFactory.newPermissions(new UserDomain(), user.getScopeId(), read));
 
         accessInfoCreator.setPermissions(permissions);
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionFactoryImpl.java
@@ -20,25 +20,12 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 
 /**
  * {@link PermissionFactory} implementation.
- * 
- * @since 1.0.0
  */
 @KapuaProvider
 public class PermissionFactoryImpl implements PermissionFactory {
 
     @Override
-    public Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId) {
-        return newPermission(domain, action, targetScopeId, null);
-    }
-
-    @Override
-    public Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId) {
-        return newPermission(domain, action, targetScopeId, groupId, false);
-    }
-
-    @Override
     public Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId, boolean forwardable) {
         return new PermissionImpl(domain != null ? domain.getName() : null, action, targetScopeId, groupId, forwardable);
     }
-
 }


### PR DESCRIPTION
This change cleans up the API to use default interface methods and to make use of var-arg arrays for the Action parameter. Allowing to create multiple permission objects in a single call, re-using the code which is already there.