### PR TITLE
Tag Service unit and integration tests

### DIFF
--- a/dev-tools/src/main/database/all_delete.sql
+++ b/dev-tools/src/main/database/all_delete.sql
@@ -26,7 +26,7 @@ DELETE FROM dvc_device;
 
 DELETE FROM dvc_device_event;
 
-DELETE FROM sys_configuration WHERE NOT (scope_id = 1 AND id IN (1,2,3,4,5));
+DELETE FROM sys_configuration WHERE NOT (scope_id = 1 AND id IN (1,2,3,4,5,6));
 
 DELETE FROM usr_user WHERE NOT (scope_id = 1 AND id IN (1,2));
 

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
@@ -17,16 +17,20 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.Vector;
 
 import javax.inject.Inject;
 
+import cucumber.api.java.en.And;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.query.FieldSortCriteria;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -57,6 +61,8 @@ import org.eclipse.kapua.message.internal.device.lifecycle.KapuaMissingChannelIm
 import org.eclipse.kapua.message.internal.device.lifecycle.KapuaMissingMessageImpl;
 import org.eclipse.kapua.message.internal.device.lifecycle.KapuaMissingPayloadImpl;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate;
 import org.eclipse.kapua.qa.steps.DBHelper;
 import org.eclipse.kapua.service.StepData;
 import org.eclipse.kapua.service.TestJAXBContextProvider;
@@ -67,6 +73,7 @@ import org.eclipse.kapua.service.device.registry.DeviceCreator;
 import org.eclipse.kapua.service.device.registry.DeviceCredentialsMode;
 import org.eclipse.kapua.service.device.registry.DeviceFactory;
 import org.eclipse.kapua.service.device.registry.DeviceListResult;
+import org.eclipse.kapua.service.device.registry.DevicePredicates;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 import org.eclipse.kapua.service.device.registry.DeviceStatus;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
@@ -75,7 +82,14 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventListResultImpl;
 import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventQueryImpl;
 import org.eclipse.kapua.service.device.registry.internal.DeviceListResultImpl;
+import org.eclipse.kapua.service.device.registry.internal.DeviceQueryImpl;
 import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService;
+import org.eclipse.kapua.service.tag.Tag;
+import org.eclipse.kapua.service.tag.TagCreator;
+import org.eclipse.kapua.service.tag.TagListResult;
+import org.eclipse.kapua.service.tag.TagService;
+import org.eclipse.kapua.service.tag.internal.TagFactoryImpl;
+import org.eclipse.kapua.service.tag.internal.TagPredicates;
 import org.eclipse.kapua.service.user.steps.TestConfig;
 import org.eclipse.kapua.test.KapuaTest;
 
@@ -91,10 +105,13 @@ import cucumber.runtime.java.guice.ScenarioScoped;
 @ScenarioScoped
 public class DeviceServiceSteps extends KapuaTest {
 
+    private static final KapuaEid DEFAULT_SCOPE_ID = new KapuaEid(BigInteger.valueOf(1L));
+
     // Device registry services
     private DeviceRegistryService deviceRegistryService;
     private DeviceEventService deviceEventsService;
     private DeviceLifeCycleService deviceLifeCycleService;
+    private TagService tagService;
 
     // Scenario scoped Device Registry test data
     StepData stepData;
@@ -117,6 +134,7 @@ public class DeviceServiceSteps extends KapuaTest {
         deviceRegistryService = locator.getService(DeviceRegistryService.class);
         deviceEventsService = locator.getService(DeviceEventService.class);
         deviceLifeCycleService = locator.getService(DeviceLifeCycleService.class);
+        tagService = locator.getService(TagService.class);
 
         // Initialize the database
         dbHelper.setup();
@@ -306,6 +324,24 @@ public class DeviceServiceSteps extends KapuaTest {
         }
     }
 
+    @When("^I configure the tag service$")
+    public void setTagServiceConfig(List<TestConfig> testConfigs)
+            throws KapuaException {
+
+        Account tmpAccount = (Account) stepData.get("LastAccount");
+        Map<String, Object> valueMap = new HashMap<>();
+
+        for (TestConfig config : testConfigs) {
+            config.addConfigToMap(valueMap);
+        }
+        try {
+            stepData.put("ExceptionCaught", false);
+            tagService.setConfigValues(tmpAccount.getId(), tmpAccount.getScopeId(), valueMap);
+        } catch (KapuaException ex) {
+            stepData.put("ExceptionCaught", true);
+        }
+    }
+
     @Given("^A device such as$")
     public void createADeviceAsSpecified(List<CucDevice> devLst)
             throws KapuaException {
@@ -340,6 +376,45 @@ public class DeviceServiceSteps extends KapuaTest {
             stepData.put("Device", tmpDev);
             stepData.put("DeviceList", tmpList);
         }
+    }
+
+    @And("^I tag device with \"([^\"]*)\" tag$")
+    public void iTagDeviceWithTag(String deviceTagName) throws Throwable {
+
+        Device device = (Device) stepData.get("Device");
+        TagCreator tagCreator = new TagFactoryImpl().newCreator(DEFAULT_SCOPE_ID);
+        tagCreator.setName(deviceTagName);
+        Tag tag = tagService.create(tagCreator);
+        Set<KapuaId> tags = new HashSet<>();
+        tags.add(tag.getId());
+        device.setTagIds(tags);
+        deviceRegistryService.update(device);
+    }
+
+
+    @When("^I search for device with tag \"([^\"]*)\"$")
+    public void iSearchForDeviceWithTag(String deviceTagName) throws Throwable {
+
+        Account lastAcc = (Account) stepData.get("LastAccount");
+        DeviceQueryImpl deviceQuery = new DeviceQueryImpl(lastAcc.getId());
+
+        KapuaQuery<Tag> tagQuery = new TagFactoryImpl().newQuery(DEFAULT_SCOPE_ID);
+        tagQuery.setPredicate(new AttributePredicate<String>(TagPredicates.NAME, deviceTagName, KapuaAttributePredicate.Operator.EQUAL));
+        TagListResult tagQueryResult = tagService.query(tagQuery);
+        Tag tag = tagQueryResult.getFirstItem();
+        deviceQuery.setPredicate(attributeIsEqualTo(DevicePredicates.TAG_IDS, tag.getId()));
+        DeviceListResult deviceList = (DeviceListResult) deviceRegistryService.query(deviceQuery);
+
+        stepData.put("DeviceList", deviceList);
+    }
+
+    @Then("^I find device \"([^\"]*)\"$")
+    public void iFindDeviceWithTag(String deviceName) throws Throwable {
+
+        DeviceListResult deviceList = (DeviceListResult) stepData.get("DeviceList");
+        Device device = deviceList.getFirstItem();
+
+        assertEquals(deviceName, device.getClientId());
     }
 
     @When("^I search for events from device \"(.+)\" in account \"(.+)\"$")

--- a/qa/src/test/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.tag.steps;
+
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate;
+import org.eclipse.kapua.service.StepData;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.tag.Tag;
+import org.eclipse.kapua.service.tag.TagCreator;
+import org.eclipse.kapua.service.tag.TagListResult;
+import org.eclipse.kapua.service.tag.TagService;
+import org.eclipse.kapua.service.tag.internal.TagFactoryImpl;
+import org.eclipse.kapua.service.tag.internal.TagPredicates;
+import org.eclipse.kapua.service.user.steps.TestConfig;
+
+import javax.inject.Inject;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Implementation of Gherkin steps used in TagService.feature scenarios.
+ */
+@ScenarioScoped
+public class TagServiceSteps {
+
+    private static final KapuaEid DEFAULT_SCOPE_ID = new KapuaEid(BigInteger.valueOf(1L));
+
+    /**
+     * Tag service.
+     */
+    private static TagService tagService;
+
+    /**
+     * Inter step data scratchpad.
+     */
+    private StepData stepData;
+
+    @Inject
+    public TagServiceSteps(StepData stepData) {
+
+        this.stepData = stepData;
+    }
+
+    @Before
+    public void tagStepsBefore() {
+
+        KapuaLocator locator = KapuaLocator.getInstance();
+        tagService = locator.getService(TagService.class);
+        stepData.put("LastAccount", null);
+    }
+
+    @Given("^Tag Service configuration$")
+    public void setConfigurationValue(List<TestConfig> testConfigs)
+            throws KapuaException {
+
+        Account lastAcc = (Account) stepData.get("LastAccount");
+        KapuaId scopeId = DEFAULT_SCOPE_ID;
+        KapuaId parentId = DEFAULT_SCOPE_ID;
+        if (lastAcc != null) {
+            scopeId = lastAcc.getId();
+            parentId = lastAcc.getScopeId();
+        }
+        Map<String, Object> valueMap = new HashMap<>();
+
+        for (TestConfig config : testConfigs) {
+            config.addConfigToMap(valueMap);
+        }
+        try {
+            stepData.put("isException", false);
+            tagService.setConfigValues(scopeId, parentId, valueMap);
+        } catch (KapuaException ke) {
+            stepData.put("isException", true);
+            stepData.put("exception", ke);
+        }
+    }
+
+    @Given("^Tag with name \"([^\"]*)\"$")
+    public void tagWithName(String tagName) throws Throwable {
+
+        TagCreator tagCreator = tagCreatorCreator(tagName);
+        tagService.create(tagCreator);
+    }
+
+    @When("^Tag with name \"([^\"]*)\" is searched$")
+    public void tagWithNameIfSearched(String tagName) throws Throwable {
+
+        KapuaQuery<Tag> query = new TagFactoryImpl().newQuery(DEFAULT_SCOPE_ID);
+        query.setPredicate(new AttributePredicate<String>(TagPredicates.NAME, tagName, KapuaAttributePredicate.Operator.EQUAL));
+        TagListResult queryResult = tagService.query(query);
+        Tag foundTag = queryResult.getFirstItem();
+        stepData.put("tag", foundTag);
+    }
+
+    @Then("^Tag with name \"([^\"]*)\" is found$")
+    public void tagWithNameIsFound(String tagName) throws Throwable {
+
+        Tag foundTag = (Tag) stepData.get("tag");
+        assertEquals(tagName, foundTag.getName());
+    }
+
+    /**
+     * Create TagCreator for creating tag with specified name.
+     *
+     * @param tagName name of tag
+     * @return tag creator for tag with specified name
+     */
+    private TagCreator tagCreatorCreator(String tagName) {
+
+        TagCreator tagCreator = new TagFactoryImpl().newCreator(DEFAULT_SCOPE_ID);
+        tagCreator.setName(tagName);
+
+        return tagCreator;
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/tag/unit/RunTagServiceTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/tag/unit/RunTagServiceTest.java
@@ -9,26 +9,23 @@
  * Contributors:
  *     Eurotech
  *******************************************************************************/
-package org.eclipse.kapua.service.device.integration;
-
-import org.junit.runner.RunWith;
+package org.eclipse.kapua.service.tag.unit;
 
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = {"classpath:features/device"
-                   },
+        features = "classpath:features/tag/TagService.feature",
         glue = {"org.eclipse.kapua.qa.steps",
                 "org.eclipse.kapua.service.user.steps",
-                "org.eclipse.kapua.service.device.steps",
                 "org.eclipse.kapua.service.tag.steps"
-               },
-        plugin = {"pretty", 
-                  "html:target/cucumber/DeviceI9n",
-                  "json:target/DeviceI9n_cucumber.json"
-                 },
-        monochrome = true )
-
-public class RunDeviceI9nTest {}
+        },
+        plugin = { "pretty",
+                "html:target/cucumber/TagService",
+                "json:target/TagService_cucumber.json"
+        },
+        monochrome = true)
+public class RunTagServiceTest {
+}

--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -227,3 +227,33 @@ Scenario: Birth and applications event handling
     Then I find 2 events
     And The type of the last event is "APPLICATION"
     And I logout
+
+Scenario: Creating new device and tagging it with specific Tag
+  Procedure of registering a device is executed and device BIRTH message is sent.
+  After that device is tagged with Tag KuraDevice and searched by this same tag.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account
+      | name      | scopeId |
+      | AccountA  | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    Given User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | UserA   | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I configure the device service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    And I configure the tag service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 10     |
+    And A birth message from device "device_1"
+    And I search for the device "device_1" in account "AccountA"
+    And I tag device with "KuraDevice" tag
+    When I search for device with tag "KuraDevice"
+    Then I find device "device_1"
+    And I logout

--- a/qa/src/test/resources/features/tag/TagService.feature
+++ b/qa/src/test/resources/features/tag/TagService.feature
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech
+###############################################################################
+Feature: Tag Service
+  Tag Service is responsible for CRUD operations on Tags. This service is currently
+  used to attach tags to Devices, but could be used to tag eny kapua entity, like
+  User for example.
+
+  Background:
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+      And Tag Service configuration
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+
+  Scenario: Creating tag
+    Create a tag entry, with specified name. Name is only tag specific attribute.
+    Once created search for it and is should been created.
+
+    Given Tag with name "tagName"
+    When Tag with name "tagName" is searched
+    Then Tag with name "tagName" is found
+      And I logout


### PR DESCRIPTION
First setup of basic Tag service tests, where tag is created and searched for.

Device registry integration scenarios are extended with tagging capability.
Device is tagged and searched by this tag.

all_delete sql updated with tag service specifics.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>