### PR TITLE
Exclude console when releasing

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -34,9 +34,21 @@
         <module>jetty-base</module>
         <module>sql</module>
         <module>broker</module>
-        <module>console</module>
         <module>api</module>
     </modules>
+    
+    <profiles>
+        <!-- Profile used to exclude console module on release process -->
+        <profile>
+            <id>console</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>console</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
                     <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <releaseProfiles>javadoc,deploy,release,docker-push</releaseProfiles>
+                        <releaseProfiles>javadoc,deploy,release,docker-push,-console</releaseProfiles>
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>
@@ -1003,7 +1003,6 @@
         <module>sso</module>
 
         <!-- Applications -->
-        <module>console</module>
         <module>rest-api</module>
 
         <!-- Simulator framework -->
@@ -1016,6 +1015,17 @@
     </modules>
 
     <profiles>
+        <!-- Profile used to exclude console module on release process -->
+        <profile>
+            <id>console</id>
+             <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>console</module>
+            </modules>
+        </profile>
+    
         <!-- Profile used only during release process. -->
         <profile>
             <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
                     <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <releaseProfiles>javadoc,deploy,release,docker-push,-console</releaseProfiles>
+                        <releaseProfiles>javadoc,deploy,release,-console</releaseProfiles>
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>

--- a/travis.sh
+++ b/travis.sh
@@ -29,7 +29,7 @@ HEARTBEAT_PROCESS_PID=$!
 ### Build itself
 
 "$M2_HOME"/bin/mvn -v
-"$M2_HOME"/bin/mvn -B -Dorg.eclipse.kapua.qa.waitMultiplier=2.0 -Dgwt.compiler.localWorkers=2 -Pjavadoc >> $OUTPUT 2>&1
+"$M2_HOME"/bin/mvn -B -Dorg.eclipse.kapua.qa.waitMultiplier=2.0 -Dgwt.compiler.localWorkers=2 -Pjavadoc,console >> $OUTPUT 2>&1
 tail_log
 
 ### Cleaning up heartbeat process


### PR DESCRIPTION
Hi all, 

This PR disable `console` and `assembly-assembly` module when using `maven-release-plugin` avoiding any action on console module when releasing.

Regards,

_Alberto_