### PR TITLE
Removed static initialization of Factories in translator

### DIFF
--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractSimpleTranslatorResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/AbstractSimpleTranslatorResponseKuraKapua.java
@@ -25,9 +25,6 @@ import org.eclipse.kapua.service.device.management.response.KapuaResponsePayload
 public abstract class AbstractSimpleTranslatorResponseKuraKapua<TO_C extends KapuaResponseChannel, TO_P extends KapuaResponsePayload, TO_M extends KapuaResponseMessage<TO_C, TO_P>>
         extends AbstractTranslatorResponseKuraKapua<TO_C, TO_P, TO_M> {
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
-    private static final GenericRequestFactory FACTORY = LOCATOR.getFactory(GenericRequestFactory.class);
-
     private final Class<TO_M> messageClazz;
 
     public AbstractSimpleTranslatorResponseKuraKapua(final Class<TO_M> messageClazz) {
@@ -36,9 +33,12 @@ public abstract class AbstractSimpleTranslatorResponseKuraKapua<TO_C extends Kap
 
     @Override
     protected TO_M createMessage() throws KapuaException {
+
         try {
             if (this.messageClazz.equals(GenericResponseMessage.class)) {
-                return this.messageClazz.cast(FACTORY.newResponseMessage());
+                KapuaLocator locator = KapuaLocator.getInstance();
+                GenericRequestFactory genericRequestFactory = locator.getFactory(GenericRequestFactory.class);
+                return this.messageClazz.cast(genericRequestFactory.newResponseMessage());
             } else {
                 return this.messageClazz.newInstance();
             }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppAssetKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppAssetKuraKapua.java
@@ -33,9 +33,9 @@ import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraRespo
 import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponsePayload;
 import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSetting;
 import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSettingKeys;
-import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannelMode;
 import org.eclipse.kapua.service.device.management.asset.DeviceAsset;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannel;
+import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannelMode;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
 import org.eclipse.kapua.service.device.management.asset.internal.DeviceAssetAppProperties;
@@ -55,8 +55,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  */
 public class TranslatorAppAssetKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<AssetResponseChannel, AssetResponsePayload, AssetResponseMessage> {
-
-    private static final DeviceAssetFactory DEVICE_ASSET_FACTORY = KapuaLocator.getInstance().getFactory(DeviceAssetFactory.class);
 
     private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
     private static final Map<AssetMetrics, DeviceAssetAppProperties> METRICS_DICTIONARY;
@@ -116,14 +114,16 @@ public class TranslatorAppAssetKuraKapua extends AbstractSimpleTranslatorRespons
 
                 JsonNode jsonNode = mapper.readTree(kuraPayload.getBody());
 
-                DeviceAssets deviceAssets = DEVICE_ASSET_FACTORY.newAssetListResult();
+                KapuaLocator locator = KapuaLocator.getInstance();
+                DeviceAssetFactory deviceAssetFactory = locator.getFactory(DeviceAssetFactory.class);
+                DeviceAssets deviceAssets = deviceAssetFactory.newAssetListResult();
                 KuraAssets kuraAssets = KuraAssets.readJsonNode(jsonNode);
                 for (KuraAsset kuraAsset : kuraAssets.getAssets()) {
-                    DeviceAsset deviceAsset = DEVICE_ASSET_FACTORY.newDeviceAsset();
+                    DeviceAsset deviceAsset = deviceAssetFactory.newDeviceAsset();
                     deviceAsset.setName(kuraAsset.getName());
 
                     for (KuraAssetChannel kuraAssetChannel : kuraAsset.getChannels()) {
-                        DeviceAssetChannel deviceAssetChannel = DEVICE_ASSET_FACTORY.newDeviceAssetChannel();
+                        DeviceAssetChannel deviceAssetChannel = deviceAssetFactory.newDeviceAssetChannel();
 
                         deviceAssetChannel.setName(kuraAssetChannel.getName());
                         KuraAssetChannelMode kuraChannelMode = kuraAssetChannel.getMode();

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorGenericResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorGenericResponseKuraKapua.java
@@ -29,9 +29,6 @@ public class TranslatorGenericResponseKuraKapua extends AbstractSimpleTranslator
 
     private static final String CONTROL_MESSAGE_CLASSIFIER = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_MESSAGE_CLASSIFIER);
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
-    private static final GenericRequestFactory FACTORY = LOCATOR.getFactory(GenericRequestFactory.class);
-
     public TranslatorGenericResponseKuraKapua() {
         super(GenericResponseMessage.class);
     }
@@ -44,7 +41,9 @@ public class TranslatorGenericResponseKuraKapua extends AbstractSimpleTranslator
                     kuraChannel.getMessageClassification());
         }
 
-        GenericResponseChannel genericResponseChannel = FACTORY.newResponseChannel();
+        KapuaLocator locator = KapuaLocator.getInstance();
+        GenericRequestFactory genericRequestFactory = locator.getFactory(GenericRequestFactory.class);
+        GenericResponseChannel genericResponseChannel = genericRequestFactory.newResponseChannel();
         String[] appIdTokens = kuraChannel.getAppId().split("-");
 
         genericResponseChannel.setAppName(new GenericAppProperties(appIdTokens[0]));
@@ -57,7 +56,10 @@ public class TranslatorGenericResponseKuraKapua extends AbstractSimpleTranslator
 
     @Override
     protected GenericResponsePayload translatePayload(KuraResponsePayload kuraPayload) throws KapuaException {
-        GenericResponsePayload genericResponsePayload = FACTORY.newResponsePayload();
+        KapuaLocator locator = KapuaLocator.getInstance();
+        GenericRequestFactory genericRequestFactory = locator.getFactory(GenericRequestFactory.class);
+
+        GenericResponsePayload genericResponsePayload = genericRequestFactory.newResponsePayload();
         genericResponsePayload.setBody(kuraPayload.getBody());
         genericResponsePayload.setMetrics(kuraPayload.getMetrics());
         genericResponsePayload.setExceptionMessage(kuraPayload.getExceptionMessage());


### PR DESCRIPTION
Hi all,

this PR fixes exceptions on broker when retrieving Translators. 

Having static referenced KapuaServices/KapuaFactories means that they need to be configured into the `locator.xml` of the broker. But the broker does require few translators, and does not have to map all resources required by all the translators available. So this PR moves the initialization of the KapuaSerivces/KapuaFactories to the translate methods, require proper configuration only when used.

Regards, 

_Alberto_
