### PR TITLE
Fixed checkstyle configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
  
                         <sourceDirectory>${project.basedir}</sourceDirectory>
                         <includes>**/*.java, **/*.xml</includes>
-                        <excludes>**/target/**/*, **/.settings/**/*, maven/**/*</excludes>
+                        <excludes>**/target/**/*, **/.settings/**/*, maven/**/*, .maven/**/*</excludes>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Hi all, 

This PR fixes checkstyle configuration to exclude `.maven/` directory created in Hudson.

This folder was causing check-style errors because it contains third party xml files.
