### PR TITLE
Update kapua-template.yml

### DIFF
--- a/dev-tools/src/main/openshift/kapua-template.yml
+++ b/dev-tools/src/main/openshift/kapua-template.yml
@@ -391,6 +391,8 @@ objects:
             value: "-Xms${ELASTIC_SEARCH_MEMORY} -Xmx${ELASTIC_SEARCH_MEMORY}"
           image: elasticsearch:5.4
           command:
+            - 'gosu'
+            - 'elasticsearch'
             - 'elasticsearch'
             - '-Etransport.host=_site_'
             - '-Ecluster.name=kapua-datastore'


### PR DESCRIPTION
Actually the possibility to run as root has been removed since Elasticsearch 5.0.
Elasticsearch should be run as 'elasticsearch' user.
see https://stackoverflow.com/questions/42807114/how-to-run-elasticsearch-5-2-1-as-root-user-in-linux-machine