### PR TITLE
fix datastore es rest client timeout handling

### DIFF
--- a/assembly/broker/src/main/resources/conf/broker/camel.xml
+++ b/assembly/broker/src/main/resources/conf/broker/camel.xml
@@ -88,17 +88,9 @@
                       type="DeadLetterChannel"
                       deadLetterUri="bean:errorMessageListener?method=processMessage"
                       useOriginalMessage="true">
-            <redeliveryPolicy maximumRedeliveries="1"/>
+            <redeliveryPolicy maximumRedeliveries="3" redeliveryDelay="2000"/>
         </errorHandler>
 
-        <!-- Executor thread pool
-        Please check the KapuaExecutorThreadPoolFactory comments before modify the threadName attributes
-        -->
-        <threadPool id="serviceThreads"
-                    threadName="kapuaExecutorPoolServiceProcessor"
-                    poolSize="3"
-                    maxPoolSize="5"
-                    maxQueueSize="2"/>
         <!--
         For the transaction/acknowledge mode please follow http://stackoverflow.com/questions/13498652/camel-jms-client-acknowledge-mode
 
@@ -115,7 +107,7 @@
         transacted=false
         -->
         <route errorHandlerRef="mainRouteMessageErrorHandler">
-            <from uri="activemq:queue:Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.>?asyncConsumer=false&amp;acknowledgementModeName=CLIENT_ACKNOWLEDGE&amp;transacted=false&amp;concurrentConsumers=10&amp;maxConcurrentConsumers=10"/>
+            <from uri="activemq:queue:Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.>?asyncConsumer=false&amp;acknowledgementModeName=CLIENT_ACKNOWLEDGE&amp;transacted=false&amp;concurrentConsumers=20&amp;maxConcurrentConsumers=50"/>
             <pipeline>
                 <bean ref="kapuaCamelFilter" method="bindSession"/>
                 <choice id="choice">

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettingsKey.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettingsKey.java
@@ -38,6 +38,14 @@ public enum ClientSettingsKey implements SettingKey {
      */
     ELASTICSEARCH_CLUSTER("datastore.elasticsearch.cluster"),
     /**
+     * Elasticsearch max retry attempt (when a timeout occurred in the rest call)
+     */
+    ELASTICSEARCH_REST_TIMEOUT_MAX_RETRY("datastore.elasticsearch.rest.max_retry_attempt"),
+    /**
+     * Elasticsearch max wait time between retry attempt (in milliseconds)
+     */
+    ELASTICSEARCH_REST_TIMEOUT_MAX_WAIT("datastore.elasticsearch.rest.max_wait_time"),
+    /**
      * Query timeout
      */
     QUERY_TIMEOUT("datastore.query.timeout"),

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/RestDatastoreClient.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/RestDatastoreClient.java
@@ -679,7 +679,7 @@ public class RestDatastoreClient implements org.eclipse.kapua.service.datastore.
                         }
                         // try again
                         try {
-                            Thread.sleep((long) (RANDOM.nextFloat() * MAX_RETRY_WAIT_TIME));
+                            Thread.sleep((long) (MAX_RETRY_WAIT_TIME * (0.5 + RANDOM.nextFloat() / 2)));
                         } catch (InterruptedException e1) {
                             // DO NOTHING
                         }

--- a/service/datastore/client-rest/src/main/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/client-rest/src/main/resources/kapua-datastore-rest-client-setting.properties
@@ -18,6 +18,9 @@
 datastore.query.timeout=15000
 datastore.scroll.timeout=60000
 
+datastore.elasticsearch.rest.max_retry_attempt=3
+datastore.elasticsearch.rest.max_wait_time=2500
+
 datastore.elasticsearch.cluster=kapua-datastore
 #Elasticsearch node IP/port - current ip/port values are to use the external develop vagrant machine
 datastore.elasticsearch.node=192.168.33.10

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -15,6 +15,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.UUID;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.cache.LocalCache;
@@ -514,6 +515,10 @@ public final class MessageStoreFacade {
         datastoreMessage.setReceivedOn(message.getReceivedOn());
         datastoreMessage.setScopeId(message.getScopeId());
         datastoreMessage.setSentOn(message.getSentOn());
+
+        // generate uuid
+        String id = UUID.randomUUID().toString();
+        datastoreMessage.setDatastoreId(new StorableIdImpl(id));
         return datastoreMessage;
     }
 


### PR DESCRIPTION
Handling the rest call timeout by repeating (up to a maximum attempts) the rest call.


Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>