### PR TITLE
Starting implementation of test steps for User Connection Coupling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
  
                         <sourceDirectory>${project.basedir}</sourceDirectory>
                         <includes>**/*.java, **/*.xml</includes>
-                        <excludes>**/target/**/*, **/.settings/**/*, maven/**/*, .maven/**/*</excludes>
+                        <excludes>**/target/**/*, **/.settings/**/*, maven/**/*, .maven/**/*, .idea/**/*</excludes>
                     </configuration>
                 </plugin>
             </plugins>

--- a/qa/src/test/java/org/eclipse/kapua/qa/steps/BasicSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/qa/steps/BasicSteps.java
@@ -11,19 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.qa.steps;
 
-import static java.time.Duration.ofSeconds;
-
+import com.google.inject.Inject;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
 import org.eclipse.kapua.service.StepData;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.Inject;
-
-import cucumber.api.java.Before;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
-import cucumber.runtime.java.guice.ScenarioScoped;
+import static java.time.Duration.ofSeconds;
 
 @ScenarioScoped
 public class BasicSteps extends Assert {
@@ -67,7 +65,10 @@ public class BasicSteps extends Assert {
 
     @Then("^No exception was thrown$")
     public void noExceptionCaught() {
-        assertFalse((boolean) stepData.get("ExceptionCaught"));
+        Object val = stepData.get("ExceptionCaught");
+        if (val != null) {
+            assertFalse((boolean) val);
+        }
     }
 
     @Then("^I get (\\d+)$")

--- a/qa/src/test/java/org/eclipse/kapua/service/connection/steps/ConnectionSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/connection/steps/ConnectionSteps.java
@@ -1,0 +1,404 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.connection.steps;
+
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.steps.DBHelper;
+import org.eclipse.kapua.service.StepData;
+import org.eclipse.kapua.service.TestJAXBContextProvider;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountFactory;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.authentication.AuthenticationService;
+import org.eclipse.kapua.service.authentication.credential.CredentialService;
+import org.eclipse.kapua.service.authorization.access.AccessInfoService;
+import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionListResult;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionStatus;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionListResultImpl;
+import org.eclipse.kapua.service.device.steps.AclCreator;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserFactory;
+import org.eclipse.kapua.service.user.UserService;
+import org.eclipse.kapua.service.user.steps.TestUser;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+@ScenarioScoped
+public class ConnectionSteps {
+
+    /**
+     * Authentication service.
+     */
+    private static AuthenticationService authenticationService;
+
+    /**
+     * Account service.
+     */
+    private static AccountService accountService;
+
+    /**
+     * Account factory.
+     */
+    private static AccountFactory accountFactory;
+
+    /**
+     * User service.
+     */
+    private static UserService userService;
+
+    /**
+     * User factory.
+     */
+    private static UserFactory userFactory;
+
+    /**
+     * Credential service.
+     */
+    private static CredentialService credentialService;
+
+    /**
+     * Accessinfo service.
+     */
+    private static AccessInfoService accessInfoService;
+
+    private static DeviceRegistryService deviceRegistryService;
+    private static DeviceConnectionService deviceConnectionService;
+    private static DeviceConnectionFactory deviceConnectionFactory;
+
+    /**
+     * Helper for creating Accoutn, User and other artifacts needed in tests.
+     */
+    private static AclCreator aclCreator;
+
+    // Scenario scoped Device Registry test data
+    private static StepData stepData;
+
+    // Single point to database access.
+    private static DBHelper dbHelper;
+
+    @Inject
+    public ConnectionSteps(StepData stepData, DBHelper dbHelper) {
+        this.dbHelper = dbHelper;
+        this.stepData = stepData;
+    }
+
+    @Before
+    public void beforeScenario() {
+
+        KapuaLocator locator = KapuaLocator.getInstance();
+        authenticationService = locator.getService(AuthenticationService.class);
+        accountService = locator.getService(AccountService.class);
+        accountFactory = locator.getFactory(AccountFactory.class);
+        userService = locator.getService(UserService.class);
+        userFactory = locator.getFactory(UserFactory.class);
+        credentialService = locator.getService(CredentialService.class);
+        accessInfoService = locator.getService(AccessInfoService.class);
+        deviceRegistryService = locator.getService(DeviceRegistryService.class);
+        deviceConnectionService = locator.getService(DeviceConnectionService.class);
+        deviceConnectionFactory = locator.getFactory(DeviceConnectionFactory.class);
+
+        aclCreator = new AclCreator(accountService, accountFactory, userService, accessInfoService, credentialService);
+
+        // Initialize the database
+        dbHelper.setup();
+
+        XmlUtil.setContextProvider(new TestJAXBContextProvider());
+    }
+
+    @After
+    public void afterScenario() throws Exception {
+
+        // Clean up the database
+        dbHelper.deleteAll();
+        KapuaSecurityUtils.clearSession();
+    }
+
+    @Given("^Such a set of privileged users for account \"(.+)\"$")
+    public void createPrivilegedUsers(String accName, List<TestUser> users) throws Throwable {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            Account account = accountService.findByName(accName);
+
+            for (TestUser tmpTestUsr : users) {
+                User tmpUser = aclCreator.createUser(account, tmpTestUsr.getName());
+                if ((tmpTestUsr.getPassword() != null) && !tmpTestUsr.getPassword().isEmpty()) {
+                    aclCreator.attachUserCredentials(account, tmpUser, tmpTestUsr.getPassword());
+                } else {
+                    aclCreator.attachUserCredentials(account, tmpUser);
+                }
+                aclCreator.attachFullPermissions(account, tmpUser);
+            }
+        });
+    }
+
+    @Given("^A full set of device privileges for account \"(.+)\"$")
+    public void setAccountDevicePrivileges(String name) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            Account account = accountService.findByName(name);
+
+            Map<String, Object> valueMap = new HashMap<>();
+            valueMap.put("infiniteChildEntities", true);
+            valueMap.put("maxNumberChildEntities", 1000);
+
+            deviceRegistryService.setConfigValues(account.getId(), account.getScopeId(), valueMap);
+        });
+    }
+
+    @Given("^The default connection coupling mode for account \"(.+)\" is set to \"(.+)\"$")
+    public void setDeviceConnectionCouplingMode(String name, String mode) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            Account account = accountService.findByName(name);
+
+            Map<String, Object> valueMap = new HashMap<>();
+            //            valueMap.put("infiniteChildEntities", true);
+            //            valueMap.put("maxNumberChildEntities", 1000);
+            valueMap.put("deviceConnectionUserCouplingDefaultMode", mode);
+
+            deviceConnectionService.setConfigValues(account.getId(), account.getScopeId(), valueMap);
+        });
+    }
+
+    @Given("^The following device connections?$")
+    public void createConnectionForDevice(List<CucConnection> connections) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            for (CucConnection tmpConn : connections) {
+                DeviceConnectionCreator tmpCreator = deviceConnectionFactory.newCreator(tmpConn.getScopeId());
+                tmpCreator.setClientId(tmpConn.getClientId());
+                tmpCreator.setUserId(tmpConn.getUserId());
+                tmpCreator.setReservedUserId(tmpConn.getReservedUserId());
+                tmpCreator.setAllowUserChange(tmpConn.getAllowUserChange());
+                tmpCreator.setUserCouplingMode(tmpConn.getUserCouplingMode());
+
+                DeviceConnection tmpDevConn = deviceConnectionService.create(tmpCreator);
+
+                tmpDevConn.setStatus(DeviceConnectionStatus.DISCONNECTED);
+                deviceConnectionService.update(tmpDevConn);
+            }
+        });
+    }
+
+    @Given("^I wait for (\\d+) seconds?$")
+    public void waitForSpecifiedTime(int delay) throws InterruptedException {
+
+        Thread.sleep(delay * 1000);
+    }
+
+    @When("^I search for a connection from the device \"(.+)\" in account \"(.+)\"$")
+    public void searchForConnectionFromDeviceWithClientID(String clientId, String account)
+            throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            Account tmpAcc;
+            DeviceConnection tmpConn;
+            DeviceConnectionListResult tmpConnLst = new DeviceConnectionListResultImpl();
+
+            tmpAcc = accountService.findByName(account);
+            assertNotNull(tmpAcc);
+            assertNotNull(tmpAcc.getId());
+
+            tmpConn = deviceConnectionService.findByClientId(tmpAcc.getId(), clientId);
+            Map<String, Object> props = deviceRegistryService.getConfigValues(tmpAcc.getId());
+            stepData.put("DeviceConnection", tmpConn);
+            if (tmpConn != null) {
+                Vector<DeviceConnection> dcv = new Vector<>();
+                dcv.add(tmpConn);
+                tmpConnLst.addItems(dcv);
+            }
+            stepData.put("DeviceConnectionList", tmpConnLst);
+        });
+    }
+
+    @Then("^I find (\\d+) connections?$")
+    public void countNumberOfConnections(int cnt) {
+
+        DeviceConnectionListResult tmpConnLst = (DeviceConnectionListResult) stepData.get("DeviceConnectionList");
+        assertEquals(cnt, tmpConnLst.getSize());
+    }
+
+    @Then("^The connection status is \"(.+)\"$")
+    public void checkDeviceConnectionStatus(String status) {
+
+        DeviceConnectionStatus tmpStat = parseConnectionStatusString(status);
+        DeviceConnectionListResult tmpConnLst = (DeviceConnectionListResult) stepData.get("DeviceConnectionList");
+
+        assertNotNull(tmpConnLst);
+        assertNotEquals(0, tmpConnLst.getSize());
+
+        DeviceConnection tmpConnection = tmpConnLst.getFirstItem();
+        assertEquals(tmpStat, tmpConnection.getStatus());
+    }
+
+    @Then("^The connection user is \"(.+)\"$")
+    public void checkDeviceConnectionUser(String user) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            DeviceConnectionListResult tmpConnLst = (DeviceConnectionListResult) stepData.get("DeviceConnectionList");
+            User tmpUsr = userService.findByName(user);
+
+            assertNotNull(tmpConnLst);
+            assertNotEquals(0, tmpConnLst.getSize());
+
+            DeviceConnection tmpConnection = tmpConnLst.getFirstItem();
+            assertEquals(tmpUsr.getId(), tmpConnection.getUserId());
+        });
+    }
+
+    @When("^I set the connection status from the device \"(.+)\" in account \"(.+)\" to \"(.+)\"$")
+    public void modifyDeviceConnectionStatus(String device, String account, String status) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            Account tmpAcc = accountService.findByName(account);
+            DeviceConnection tmpConn = deviceConnectionService.findByClientId(tmpAcc.getId(), device);
+            DeviceConnectionStatus tmpStat = parseConnectionStatusString(status);
+
+            assertNotNull(tmpStat);
+            assertNotNull(tmpConn);
+
+            tmpConn.setStatus(tmpStat);
+            deviceConnectionService.update(tmpConn);
+        });
+    }
+
+    @When("^I set the user coupling mode for the connection from device \"(.+)\" in account \"(.+)\" to \"(.+)\"$")
+    public void modifyDeviceConnectionCouplingMode(String device, String account, String mode) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            ConnectionUserCouplingMode tmpMode = parseConnectionCouplingString(mode);
+            assertNotNull(tmpMode);
+
+            Account tmpAcc = accountService.findByName(account);
+            DeviceConnection tmpConn = deviceConnectionService.findByClientId(tmpAcc.getId(), device);
+
+            assertNotNull(tmpConn);
+
+            tmpConn.setUserCouplingMode(tmpMode);
+            deviceConnectionService.update(tmpConn);
+        });
+    }
+
+    @When("^I set the user change flag for the connection from device \"(.+)\" in account \"(.+)\" to \"(.+)\"$")
+    public void modifyDeviceConnectionUserChangeFlag(String device, String account, String flag) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            Account tmpAcc = accountService.findByName(account);
+            DeviceConnection tmpConn = deviceConnectionService.findByClientId(tmpAcc.getId(), device);
+
+            assertNotNull(tmpConn);
+
+            tmpConn.setAllowUserChange(parseBooleanFromString(flag));
+            deviceConnectionService.update(tmpConn);
+        });
+    }
+
+    @When("^I set the reserved user for the connection from device \"(.+)\" in account \"(.+)\" to \"(.*)\"$")
+    public void modifyDeviceConnectionReservedUser(String device, String scope, String resUser) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            Account tmpAcc = accountService.findByName(scope);
+            DeviceConnection tmpConn = deviceConnectionService.findByClientId(tmpAcc.getId(), device);
+            KapuaId userId;
+
+            assertNotNull(tmpConn);
+
+            if (resUser.isEmpty() || resUser.trim().toLowerCase().contains("null")) {
+                userId = null;
+            } else {
+                userId = userService.findByName(resUser).getId();
+            }
+
+            tmpConn.setReservedUserId(userId);
+            stepData.put("ExceptionCaught", false);
+            try {
+                deviceConnectionService.update(tmpConn);
+            } catch (KapuaException ex) {
+                stepData.put("ExceptionCaught", true);
+            }
+        });
+    }
+
+    @Then("^The user for the connection from device \"(.+)\" in scope \"(.+)\" is \"(.+)\"$")
+    public void checkUserForExistingConnection(String device, String scope, String name) throws KapuaException {
+
+        KapuaSecurityUtils.doPrivileged(() -> {
+            Account account = accountService.findByName(scope);
+            DeviceConnection connection = deviceConnectionService.findByClientId(account.getId(), device);
+            User user = userService.findByName(name);
+
+            assertNotNull(connection);
+            assertNotNull(user);
+            assertEquals(user.getId(), connection.getUserId());
+        });
+    }
+
+    // Private helper functions
+
+    DeviceConnectionStatus parseConnectionStatusString(String stat) {
+        switch (stat.trim().toUpperCase()) {
+        case "CONNECTED":
+            return DeviceConnectionStatus.CONNECTED;
+        case "DISCONNECTED":
+            return DeviceConnectionStatus.DISCONNECTED;
+        case "MISSING":
+            return DeviceConnectionStatus.MISSING;
+        }
+        return null;
+    }
+
+    ConnectionUserCouplingMode parseConnectionCouplingString(String mode) {
+        switch (mode.trim().toUpperCase()) {
+        case "INHERITED":
+            return ConnectionUserCouplingMode.INHERITED;
+        case "LOOSE":
+            return ConnectionUserCouplingMode.LOOSE;
+        case "STRICT":
+            return ConnectionUserCouplingMode.STRICT;
+        }
+        return null;
+    }
+
+    boolean parseBooleanFromString(String value) {
+        switch (value.trim().toLowerCase()) {
+        case "true":
+            return true;
+        case "false":
+            return false;
+        }
+        return false;
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/connection/steps/CucConnection.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/connection/steps/CucConnection.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.connection.steps;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionStatus;
+import org.eclipse.kapua.service.user.UserService;
+
+/**
+ * Data object used in Gherkin to input Device Connection parameters.
+ * The data setters intentionally use only cucumber-friendly data types and
+ * generate the resulting Kapua types internally.
+ */
+public class CucConnection {
+
+    String scope;
+    KapuaId scopeId;
+    String status;
+    String clientId;
+    String user;
+    KapuaId userId;
+    String allowUserChange;
+    String userCouplingMode;
+    String reservedUser;
+    KapuaId reservedUserId;
+    String protocol;
+    String clientIp;
+    String serverIp;
+
+    private static UserService userService = KapuaLocator.getInstance().getService(UserService.class);
+    private static AccountService accountService = KapuaLocator.getInstance().getService(AccountService.class);
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public KapuaId getScopeId() throws KapuaException {
+        return KapuaSecurityUtils.doPrivileged(() -> accountService.findByName(scope).getId());
+    }
+
+    public DeviceConnectionStatus getStatus() {
+        DeviceConnectionStatus tmpStatus = null;
+        if (status == null) {
+            return null;
+        }
+        switch (status.trim().toUpperCase()) {
+        case "CONNECTED":
+            tmpStatus = DeviceConnectionStatus.CONNECTED;
+            break;
+        case "DISCONNECTED":
+            tmpStatus = DeviceConnectionStatus.DISCONNECTED;
+            break;
+        case "MISSING":
+            tmpStatus = DeviceConnectionStatus.MISSING;
+            break;
+        }
+        return tmpStatus;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public KapuaId getUserId() throws KapuaException {
+        return KapuaSecurityUtils.doPrivileged(() -> userService.findByName(user).getId());
+    }
+
+    public boolean getAllowUserChange() {
+        boolean allowChng = false;
+        if (allowUserChange == null) {
+            return false;
+        }
+        switch (allowUserChange.trim().toLowerCase()) {
+        case "true":
+            allowChng = true;
+            break;
+        case "false":
+            allowChng = false;
+            break;
+        default:
+            allowChng = false;
+        }
+        return allowChng;
+    }
+
+    public void setAllowUserChange(String allowUserChange) {
+        this.allowUserChange = allowUserChange;
+    }
+
+    public ConnectionUserCouplingMode getUserCouplingMode() {
+        ConnectionUserCouplingMode mode;
+
+        if (userCouplingMode == null) {
+            return ConnectionUserCouplingMode.INHERITED;
+        }
+        switch (userCouplingMode.toUpperCase().trim()) {
+        case "INHERITED":
+            mode = ConnectionUserCouplingMode.INHERITED;
+            break;
+        case "LOOSE":
+            mode = ConnectionUserCouplingMode.LOOSE;
+            break;
+        case "STRICT":
+            mode = ConnectionUserCouplingMode.STRICT;
+            break;
+        default:
+            mode = ConnectionUserCouplingMode.INHERITED;
+        }
+        return mode;
+    }
+
+    public void setUserCouplingMode(String userCouplingMode) {
+        this.userCouplingMode = userCouplingMode;
+    }
+
+    public String getReservedUser() {
+        return reservedUser;
+    }
+
+    public void setReservedUser(String reservedUser) {
+        this.reservedUser = reservedUser;
+    }
+
+    public KapuaId getReservedUserId() throws KapuaException {
+        if ((reservedUser == null) || reservedUser.isEmpty()) {
+            return null;
+        } else {
+            return KapuaSecurityUtils.doPrivileged(() -> userService.findByName(reservedUser).getId());
+        }
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public void setClientIp(String clientIp) {
+        this.clientIp = clientIp;
+    }
+
+    public String getServerIp() {
+        return serverIp;
+    }
+
+    public void setServerIp(String serverIp) {
+        this.serverIp = serverIp;
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclCreator.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclCreator.java
@@ -21,7 +21,6 @@ import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountCreator;
 import org.eclipse.kapua.service.account.AccountFactory;
 import org.eclipse.kapua.service.account.AccountService;
-import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
 import org.eclipse.kapua.service.authentication.credential.CredentialService;
 import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
@@ -37,6 +36,8 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.authorization.permission.shiro.PermissionFactoryImpl;
 import org.eclipse.kapua.service.datastore.DatastoreDomain;
 import org.eclipse.kapua.service.device.management.commons.DeviceManagementDomain;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionDomain;
+import org.eclipse.kapua.service.device.registry.internal.DeviceDomain;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserCreator;
 import org.eclipse.kapua.service.user.UserService;
@@ -108,10 +109,8 @@ public class AclCreator {
     /**
      * Configure user service with reasonable default values.
      *
-     * @param accId
-     *            account id
-     * @param scopeId
-     *            scope id
+     * @param accId   account id
+     * @param scopeId scope id
      */
     private void configureUserService(KapuaId accId, KapuaId scopeId) {
 
@@ -133,10 +132,8 @@ public class AclCreator {
     /**
      * Configure account service with reasonable default values.
      *
-     * @param accId
-     *            account id
-     * @param scopeId
-     *            scope id
+     * @param accId   account id
+     * @param scopeId scope id
      */
     private void configureAccountService(KapuaId accId, KapuaId scopeId) {
 
@@ -154,13 +151,10 @@ public class AclCreator {
     /**
      * Creates permissions for user with specified account. Permissions are created in privileged mode.
      *
-     * @param permissionList
-     *            list of permissions for user, if targetScopeId is not set user scope that is
-     *            specified as account
-     * @param user
-     *            user for whom permissions are set
-     * @param account
-     *            account in which user is defined
+     * @param permissionList list of permissions for user, if targetScopeId is not set user scope that is
+     *                       specified as account
+     * @param user           user for whom permissions are set
+     * @param account        account in which user is defined
      * @throws Exception
      */
     private void createPermissions(List<PermissionData> permissionList, User user, Account account)
@@ -171,7 +165,7 @@ public class AclCreator {
                 accessInfoService.create(accessInfoCreatorCreator(permissionList, user, account));
             } catch (KapuaException ke) {
                 ke.printStackTrace();
-                // skip
+                //skip
             }
 
             return null;
@@ -182,12 +176,9 @@ public class AclCreator {
      * Create accessInfoCreator instance with data about user permissions.
      * If target scope is not defined in permission list use account scope.
      *
-     * @param permissionList
-     *            list of all permissions
-     * @param user
-     *            user for which permissions are set
-     * @param account
-     *            that user belongs to
+     * @param permissionList list of all permissions
+     * @param user           user for which permissions are set
+     * @param account        that user belongs to
      * @return AccessInfoCreator instance for creating user permissions
      */
     private AccessInfoCreator accessInfoCreatorCreator(List<PermissionData> permissionList,
@@ -214,13 +205,12 @@ public class AclCreator {
         return accessInfoCreator;
     }
 
-    void attachUserCredentials(Account account, User user) throws KapuaException {
+    public void attachUserCredentials(Account account, User user) throws KapuaException {
         KapuaSecurityUtils.doPrivileged(() -> {
             CredentialCreator credentialCreator;
             credentialCreator = new CredentialFactoryImpl().newCreator(account.getId(), user.getId(), CredentialType.PASSWORD, "kapua-password", CredentialStatus.ENABLED, null);
             try {
-                @SuppressWarnings("unused")
-                Credential credential = credentialService.create(credentialCreator);
+                credentialService.create(credentialCreator);
             } catch (KapuaException ke) {
                 // skip
             }
@@ -229,7 +219,21 @@ public class AclCreator {
         });
     }
 
-    User createUser(Account account, String name) throws KapuaException {
+    public void attachUserCredentials(Account account, User user, String password) throws KapuaException {
+        KapuaSecurityUtils.doPrivileged(() -> {
+            CredentialCreator credentialCreator;
+            credentialCreator = new CredentialFactoryImpl().newCreator(account.getId(), user.getId(), CredentialType.PASSWORD, password, CredentialStatus.ENABLED, null);
+            try {
+                credentialService.create(credentialCreator);
+            } catch (KapuaException ke) {
+                // skip
+            }
+
+            return null;
+        });
+    }
+
+    public User createUser(Account account, String name) throws KapuaException {
         configureUserService(account.getId(), SYS_ID);
         UserCreator userCreator = new UserFactoryImpl().newCreator(account.getId(), name);
         return userService.create(userCreator);
@@ -251,22 +255,39 @@ public class AclCreator {
 
     void attachDevicePermissions(Account account, User user) throws Exception {
         List<PermissionData> permissionList = new ArrayList<>();
-        permissionList.add(new PermissionData(new BrokerDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
         permissionList.add(new PermissionData(new DeviceManagementDomain(), Actions.write, (KapuaEid) user.getScopeId()));
         createPermissions(permissionList, user, account);
     }
 
     void attachDataViewPermissions(Account account, User user) throws Exception {
         List<PermissionData> permissionList = new ArrayList<>();
-        permissionList.add(new PermissionData(new BrokerDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
         permissionList.add(new PermissionData(new DatastoreDomain(), Actions.read, (KapuaEid) user.getScopeId()));
         createPermissions(permissionList, user, account);
     }
 
     void attachDataManagePermissions(Account account, User user) throws Exception {
         List<PermissionData> permissionList = new ArrayList<>();
-        permissionList.add(new PermissionData(new BrokerDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
         permissionList.add(new PermissionData(new DatastoreDomain(), Actions.write, (KapuaEid) user.getScopeId()));
+        createPermissions(permissionList, user, account);
+    }
+
+    public void attachFullPermissions(Account account, User user) throws Exception {
+        List<PermissionData> permissionList = new ArrayList<>();
+        permissionList.add(new PermissionData(new BrokerDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new BrokerDomain(), Actions.write, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new BrokerDomain(), Actions.read, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new BrokerDomain(), Actions.delete, (KapuaEid) user.getScopeId()));
+
+        permissionList.add(new PermissionData(new DeviceConnectionDomain(), Actions.read, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new DeviceConnectionDomain(), Actions.write, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new DeviceConnectionDomain(), Actions.delete, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new DeviceConnectionDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
+
+        permissionList.add(new PermissionData(new DeviceDomain(), Actions.read, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new DeviceDomain(), Actions.write, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new DeviceDomain(), Actions.delete, (KapuaEid) user.getScopeId()));
+        permissionList.add(new PermissionData(new DeviceDomain(), Actions.connect, (KapuaEid) user.getScopeId()));
+
         createPermissions(permissionList, user, account);
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
@@ -341,19 +341,21 @@ public class DeviceServiceSteps extends KapuaTest {
         }
     }
 
-    @Given("^A device such as$")
-    public void createADeviceAsSpecified(List<CucDevice> devLst)
+    @Given("^(?:A d|D)evices? such as$")
+    public void createADevicesAsSpecified(List<CucDevice> devLst)
             throws KapuaException {
 
-        assertNotNull(devLst);
-        assertEquals(1, devLst.size());
+        KapuaSecurityUtils.doPrivileged(() -> {
+            assertNotNull(devLst);
 
-        CucDevice tmpCDev = devLst.get(0);
-        tmpCDev.parse();
-        DeviceCreator devCr = prepareDeviceCreatorFromCucDevice(tmpCDev);
-        Device tmpDevice = deviceRegistryService.create(devCr);
-
-        stepData.put("LastDevice", tmpDevice);
+            Device tmpDevice = null;
+            for (CucDevice tmpCDev : devLst) {
+                tmpCDev.parse();
+                DeviceCreator devCr = prepareDeviceCreatorFromCucDevice(tmpCDev);
+                tmpDevice = deviceRegistryService.create(devCr);
+            }
+            stepData.put("LastDevice", tmpDevice);
+        });
     }
 
     @When("^I search for the device \"(.+)\" in account \"(.+)\"$")
@@ -370,7 +372,7 @@ public class DeviceServiceSteps extends KapuaTest {
 
         tmpDev = deviceRegistryService.findByClientId(tmpAcc.getId(), clientId);
         if (tmpDev != null) {
-            Vector<Device> dv = new Vector<Device>();
+            Vector<Device> dv = new Vector<>();
             dv.add(tmpDev);
             tmpList.addItems(dv);
             stepData.put("Device", tmpDev);
@@ -437,7 +439,7 @@ public class DeviceServiceSteps extends KapuaTest {
         tmpQuery = new DeviceEventQueryImpl(tmpAcc.getId());
         tmpQuery.setPredicate(attributeIsEqualTo("deviceId", tmpDev.getId()));
         tmpQuery.setSortCriteria(new FieldSortCriteria("receivedOn", FieldSortCriteria.SortOrder.ASCENDING));
-        tmpList = (DeviceEventListResult) deviceEventsService.query(tmpQuery);
+        tmpList = deviceEventsService.query(tmpQuery);
 
         assertNotNull(tmpList);
         stepData.put("DeviceEventList", tmpList);

--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/TestUser.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/TestUser.java
@@ -41,6 +41,8 @@ public class TestUser {
 
     private BigInteger scopeId;
 
+    private String password;
+
     private String expirationDate;
 
     public String getName() {
@@ -49,6 +51,14 @@ public class TestUser {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     public String getDisplayName() {

--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -57,6 +57,7 @@ import org.eclipse.kapua.service.authorization.permission.shiro.PermissionFactor
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserCreator;
 import org.eclipse.kapua.service.user.UserService;
+import org.eclipse.kapua.service.user.internal.UserCreatorImpl;
 import org.eclipse.kapua.service.user.internal.UserDomain;
 import org.eclipse.kapua.service.user.internal.UserFactoryImpl;
 import org.eclipse.kapua.service.user.internal.UsersJAXBContextProvider;
@@ -202,6 +203,25 @@ public class UserServiceSteps extends AbstractKapuaSteps {
             tmpUser = userIterator.next();
         }
         stepData.put("LastUser", tmpUser);
+    }
+
+    @Given("^The following users? with full permissions$")
+    public void createFullPermissionUsers(List<TestUser> userList) throws Exception {
+
+        Account account = (Account)stepData.get("LastAccount");
+        createUsersInList(userList, account);
+
+        for (TestUser tmpUsr : userList) {
+            String tmpName = tmpUsr.getName();
+            String tmpPwd = tmpUsr.getPassword();
+
+            assertNotNull(tmpName);
+            assertNotNull(tmpPwd);
+
+            UserCreator usrCr = new UserCreatorImpl(account.getId(), tmpName);
+            //User tmpUsr = userService.create(usrCr);
+            // TODO: Finish this implementation!
+        }
     }
 
     @When("^I login as user with name \"(.*)\" and password \"(.*)\"$")

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -13,7 +13,7 @@ package org.eclipse.kapua.service.device.registry.connection.internal;
 
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableService;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -27,10 +27,8 @@ import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionListResult;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionPredicates;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionQuery;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
 import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFactory;
 
@@ -42,8 +40,9 @@ import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFac
  */
 @KapuaProvider
 public class DeviceConnectionServiceImpl extends
-        AbstractKapuaConfigurableResourceLimitedService<DeviceConnection, DeviceConnectionCreator, DeviceConnectionService, DeviceConnectionListResult, DeviceConnectionQuery, DeviceConnectionFactory>
-implements DeviceConnectionService {
+        //        AbstractKapuaConfigurableResourceLimitedService<DeviceConnection, DeviceConnectionCreator, DeviceConnectionService, DeviceConnectionListResult, DeviceConnectionQuery, DeviceConnectionFactory>
+        AbstractKapuaConfigurableService
+        implements DeviceConnectionService {
 
     private static final Domain DEVICE_CONNECTION_DOMAIN = new DeviceConnectionDomain();
 
@@ -52,7 +51,8 @@ implements DeviceConnectionService {
     }
 
     public DeviceConnectionServiceImpl(DeviceEntityManagerFactory deviceEntityManagerFactory) {
-        super(DeviceConnectionService.class.getName(), DEVICE_CONNECTION_DOMAIN, deviceEntityManagerFactory, DeviceConnectionService.class, DeviceConnectionFactory.class);
+        //        super(DeviceConnectionService.class.getName(), DEVICE_CONNECTION_DOMAIN, deviceEntityManagerFactory, DeviceConnectionService.class, DeviceConnectionFactory.class);
+        super(DeviceConnectionService.class.getName(), DEVICE_CONNECTION_DOMAIN, deviceEntityManagerFactory);
     }
 
     @Override


### PR DESCRIPTION
## User Connection Coupling tests

This is the starting implementation of the test steps for the user coupling feature for device connections. As such it still has some rough edges and may require some refactoring. 

### Changes to Maven pom files
The main pom.xml file was changed to exclude the .idea folder from style checks.

### Implementation changes
The DeviceConnectionServiceImpl was temporarily modified to extend AbstractKapuaConfigurableService instead of AbstractKapuaConfigurableResourceLimitedService due to missing property items in the service metatype definition xml. This will be reverted once the appropriate properties and default seeded values are added.

### Test changes
A new set of Cucumber test steps was implemented for the Device Connection User Coupling feature.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>