### PR TITLE
Swagger improvements

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -313,7 +313,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
             loginPreCheckTimeContext.stop();
 
             Context loginShiroLoginTimeContext = metricLoginShiroLoginTime.time();
-            LoginCredentials credentials = credentialsFactory.newUsernamePasswordCredentials(username, password != null ? password.toCharArray() : null);
+            LoginCredentials credentials = credentialsFactory.newUsernamePasswordCredentials(username, password);
             AccessToken accessToken = authenticationService.login(credentials);
 
             KapuaId scopeId = accessToken.getScopeId();

--- a/console/src/main/java/org/eclipse/kapua/app/console/server/GwtAuthorizationServiceImpl.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/server/GwtAuthorizationServiceImpl.java
@@ -95,7 +95,7 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
             KapuaLocator locator = KapuaLocator.getInstance();
             AuthenticationService authenticationService = locator.getService(AuthenticationService.class);
             CredentialsFactory credentialsFactory = locator.getFactory(CredentialsFactory.class);
-            LoginCredentials credentials = credentialsFactory.newUsernamePasswordCredentials(gwtLoginCredentials.getUsername(), gwtLoginCredentials.getPassword().toCharArray());
+            LoginCredentials credentials = credentialsFactory.newUsernamePasswordCredentials(gwtLoginCredentials.getUsername(), gwtLoginCredentials.getPassword());
 
             // Login
             authenticationService.login(credentials);

--- a/console/src/main/java/org/eclipse/kapua/app/console/server/GwtCredentialServiceImpl.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/server/GwtCredentialServiceImpl.java
@@ -245,7 +245,7 @@ public class GwtCredentialServiceImpl extends KapuaConfigurableRemoteServiceServ
 
             User user = userService.find(scopeId, userId);
             final String username = user.getName();
-            LoginCredentials loginCredentials = credentialsFactory.newUsernamePasswordCredentials(username, oldPassword.toCharArray());
+            LoginCredentials loginCredentials = credentialsFactory.newUsernamePasswordCredentials(username, oldPassword);
 
             boolean validPassword = authenticationService.verifyCredentials(loginCredentials);
 

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessage.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.message.xml.MessageXmlRegistry;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -73,6 +74,7 @@ public interface KapuaMessage<C extends KapuaChannel, P extends KapuaPayload> ex
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getScopeId();
 
     /**
@@ -104,6 +106,7 @@ public interface KapuaMessage<C extends KapuaChannel, P extends KapuaPayload> ex
      */
     @XmlElement(name = "deviceId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getDeviceId();
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <slf4j.version>1.7.24</slf4j.version>
         <logback.version>1.1.8</logback.version>
         <snakeyaml.version>1.15</snakeyaml.version>
+        <swagger.version>1.5.12</swagger.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <cucumber.version>1.2.4</cucumber.version>
         <elasticsearch.version>5.3.0</elasticsearch.version>

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclSteps.java
@@ -147,7 +147,7 @@ public class AclSteps {
         // Wait for broker to start
         waitInMillis(BROKER_START_WAIT_MILLIS);
         // Login with system user
-        char[] passwd = SYS_PASSWORD.toCharArray();
+        String passwd = SYS_PASSWORD;
         LoginCredentials credentials = new UsernamePasswordCredentialsImpl(SYS_USERNAME, passwd);
         authenticationService.login(credentials);
     }

--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -207,7 +207,7 @@ public class UserServiceSteps extends AbstractKapuaSteps {
     @When("^I login as user with name \"(.*)\" and password \"(.*)\"$")
     public void loginUser(String userName, String password) throws KapuaException {
 
-        char[] passwd = password.toCharArray();
+        String passwd = password;
         LoginCredentials credentials = new UsernamePasswordCredentialsImpl(userName, passwd);
         authenticationService.logout();
         stepData.put("ExceptionCaught", false);

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -1,185 +1,184 @@
 <?xml version="1.0"?>
-<!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+<!-- 
+	Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+	All rights reserved. This program and the accompanying materials
+	are made available under the terms of the Eclipse Public License v1.0
+	which accompanies this distribution, and is available at
+	http://www.eclipse.org/legal/epl-v10.html
 
-    Contributors:
-        Eurotech - initial API and implementation
-        Red Hat Inc
+	Contributors: 
+		Eurotech - initial API and implementation
+		Red Hat Inc
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.eclipse.kapua</groupId>
-        <artifactId>kapua</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>org.eclipse.kapua</groupId>
+		<artifactId>kapua</artifactId>
+		<version>0.3.0-SNAPSHOT</version>
+	</parent>
 
-    <artifactId>kapua-rest-api</artifactId>
-    <packaging>war</packaging>
+	<artifactId>kapua-rest-api</artifactId>
+	<packaging>war</packaging>
 
-    <properties>
-        <jersey.version>2.23.2</jersey.version>
-        <swagger.version>1.5.12</swagger.version>
-        <swagger-ui.version>2.1.4</swagger-ui.version>
-    </properties>
+	<properties>
+		<jersey.version>2.23.2</jersey.version>
+		<swagger-ui.version>2.1.4</swagger-ui.version>
+	</properties>
 
-    <dependencies>
+	<dependencies>
 
-        <!-- Jersey -->
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet-core</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
+		<!-- Jersey -->
+		<dependency>
+			<groupId>org.glassfish.jersey.containers</groupId>
+			<artifactId>jersey-container-servlet-core</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
 
-        <!-- Swagger for apidoc -->
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-jersey2-jaxrs</artifactId>
-            <version>${swagger.version}</version>
-        </dependency>
+		<!-- Swagger for apidoc -->
+		<dependency>
+			<groupId>io.swagger</groupId>
+			<artifactId>swagger-jersey2-jaxrs</artifactId>
+			<version>${swagger.version}</version>
+		</dependency>
 
-        <!-- Moxy for object marshalling unmarshalling -->
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-moxy</artifactId>
-            <version>2.23.2</version>
-        </dependency>
+		<!-- Moxy for object marshalling unmarshalling -->
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-moxy</artifactId>
+			<version>2.23.2</version>
+		</dependency>
 
-        <!-- Apache shiro security framework -->
-        <dependency>
-            <groupId>org.apache.shiro</groupId>
-            <artifactId>shiro-core</artifactId>
-            <version>${shiro.version}</version>
-        </dependency>
+		<!-- Apache shiro security framework -->
+		<dependency>
+			<groupId>org.apache.shiro</groupId>
+			<artifactId>shiro-core</artifactId>
+			<version>${shiro.version}</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.shiro</groupId>
-            <artifactId>shiro-web</artifactId>
-            <version>${shiro.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.shiro</groupId>
+			<artifactId>shiro-web</artifactId>
+			<version>${shiro.version}</version>
+		</dependency>
 
-        <!-- Same version of the Servlet APIs supported in Apache Tomcat 8.0.x -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
-        </dependency>
+		<!-- Same version of the Servlet APIs supported in Apache Tomcat 8.0.x -->
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
+			<scope>provided</scope>
+		</dependency>
 
-        <!-- Internal dependencies -->
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-commons</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-account-internal</artifactId>
-        </dependency>
+		<!-- Internal dependencies -->
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-commons</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-guice</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-account-internal</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-datastore-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-datastore-internal</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-datastore-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-datastore-internal</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-datastore-client-transport</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-datastore-client-transport</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-datastore-client-rest</artifactId>
         </dependency>
-        <dependency>
+		<dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-message-internal</artifactId>
         </dependency>
-        
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-security-shiro</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-registry-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-asset-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-translator-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-translator-kapua-kura</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-translator-kura-jms</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-translator-kura-mqtt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-jms</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-mqtt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-test</artifactId>
-        </dependency>
+		
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-security-shiro</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-registry-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-asset-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-translator-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-translator-kapua-kura</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-translator-kura-jms</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-translator-kura-mqtt</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-transport-jms</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-transport-mqtt</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-transport-test</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-asset-internal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-bundle-internal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-command-internal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-configuration-internal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-packages-internal</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-asset-internal</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-bundle-internal</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-command-internal</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-configuration-internal</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-packages-internal</artifactId>
+		</dependency>
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-user-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-user-internal</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-user-internal</artifactId>
+		</dependency>
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
@@ -190,167 +189,167 @@
             <artifactId>kapua-tag-internal</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        
-        <!-- use logback only for testing -->
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+		</dependency>
+		
+		<!-- use logback only for testing -->
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- re-declare as provided as our web container will provide this -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-    
-        <!-- Elasticsearch Dependencies -->
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>transport</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty3-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty4-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>reindex-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>lang-mustache-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>percolator-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
-        </dependency>
-        <!-- log4j2 for ES -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
-        </dependency>
+		<!-- re-declare as provided as our web container will provide this -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	
+		<!-- Elasticsearch Dependencies -->
+		<dependency>
+			<groupId>org.elasticsearch</groupId>
+			<artifactId>elasticsearch</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>transport</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.plugin</groupId>
+			<artifactId>transport-netty3-client</artifactId>
+			<version>${elasticsearch-client-transport.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.plugin</groupId>
+			<artifactId>transport-netty4-client</artifactId>
+			<version>${elasticsearch-client-transport.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.plugin</groupId>
+			<artifactId>reindex-client</artifactId>
+			<version>${elasticsearch-client-transport.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.plugin</groupId>
+			<artifactId>lang-mustache-client</artifactId>
+			<version>${elasticsearch-client-transport.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.plugin</groupId>
+			<artifactId>percolator-client</artifactId>
+			<version>${elasticsearch-client-transport.version}</version>
+		</dependency>
+		<!-- log4j2 for ES -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-to-slf4j</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-request-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-request-internal</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-device-request-internal</artifactId>
+		</dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-stream-api</artifactId>
         </dependency><dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-stream-internal</artifactId>
-        </dependency>
+			<groupId>org.eclipse.kapua</groupId>
+			<artifactId>kapua-stream-internal</artifactId>
+		</dependency>
     </dependencies>
-    <build>
-        <finalName>api</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-swagger-ui</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.eclipse.kapua.external</groupId>
-                                    <artifactId>swagger-ui</artifactId>
-                                    <version>${swagger-ui.version}-CQ-10792</version>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/tmp/swagger-ui</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.eclipse.kapua.external</groupId>
-                                    <artifactId>swagger-ui-lib</artifactId>
-                                    <version>${swagger-ui.version}</version>
-                                    <outputDirectory>${project.build.directory}/tmp/swagger-ui-lib</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+	<build>
+		<finalName>api</finalName>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>unpack-swagger-ui</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>unpack</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.eclipse.kapua.external</groupId>
+									<artifactId>swagger-ui</artifactId>
+									<version>${swagger-ui.version}-CQ-10792</version>
+									<overWrite>true</overWrite>
+									<outputDirectory>${project.build.directory}/tmp/swagger-ui</outputDirectory>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.eclipse.kapua.external</groupId>
+									<artifactId>swagger-ui-lib</artifactId>
+									<version>${swagger-ui.version}</version>
+									<outputDirectory>${project.build.directory}/tmp/swagger-ui-lib</outputDirectory>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>package swagger ui</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <echo>Swagger-ui: create doc dir</echo>
-                                <copy todir="${project.build.directory}/${project.build.finalName}/doc">
-                                    <fileset dir="${project.build.directory}/tmp/swagger-ui/" />
-                                </copy>
-                                <echo>Swagger-ui-lib: create lib dir for swagger-ui</echo>
-                                <copy todir="${project.build.directory}/${project.build.finalName}/doc/lib">
-                                    <fileset dir="${project.build.directory}/tmp/swagger-ui-lib/" />
-                                </copy>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-                
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>package swagger ui</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<echo>Swagger-ui: create doc dir</echo>
+								<copy todir="${project.build.directory}/${project.build.finalName}/doc">
+									<fileset dir="${project.build.directory}/tmp/swagger-ui/" />
+								</copy>
+								<echo>Swagger-ui-lib: create lib dir for swagger-ui</echo>
+								<copy todir="${project.build.directory}/${project.build.finalName}/doc/lib">
+									<fileset dir="${project.build.directory}/tmp/swagger-ui-lib/" />
+								</copy>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+				
+			</plugin>
 
-            <!-- To help IntelliJ IDEA correctly recognize the source path when using Maven Auto Import -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <configuration>
-                    <webResources>
-                        <resource>
-                            <directory>${basedir}</directory>
-                            <includes>
-                                <include>about.html</include>
-                                <include>epl-v10.html</include>
-                                <include>notice.html</include>
-                            </includes>
-                        </resource>
-                    </webResources>
-                    <!-- exclude slf4j-api and logback as the web container has to provide this -->
-                    <packagingExcludes>
-                        WEB-INF/lib/slf4j-api-*.jar,
-                        WEB-INF/lib/logback*.jar
-                    </packagingExcludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+			<!-- To help IntelliJ IDEA correctly recognize the source path when using Maven Auto Import -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<configuration>
+					<webResources>
+						<resource>
+							<directory>${basedir}</directory>
+							<includes>
+								<include>about.html</include>
+								<include>epl-v10.html</include>
+								<include>notice.html</include>
+							</includes>
+						</resource>
+					</webResources>
+					<!-- exclude slf4j-api and logback as the web container has to provide this -->
+					<packagingExcludes>
+						WEB-INF/lib/slf4j-api-*.jar,
+						WEB-INF/lib/logback*.jar
+					</packagingExcludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -1,184 +1,185 @@
 <?xml version="1.0"?>
-<!-- 
-	Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+<!--
+    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 
-	All rights reserved. This program and the accompanying materials
-	are made available under the terms of the Eclipse Public License v1.0
-	which accompanies this distribution, and is available at
-	http://www.eclipse.org/legal/epl-v10.html
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
 
-	Contributors: 
-		Eurotech - initial API and implementation
-		Red Hat Inc
+    Contributors:
+        Eurotech - initial API and implementation
+        Red Hat Inc
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.eclipse.kapua</groupId>
-		<artifactId>kapua</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>kapua-rest-api</artifactId>
-	<packaging>war</packaging>
+    <artifactId>kapua-rest-api</artifactId>
+    <packaging>war</packaging>
 
-	<properties>
-		<jersey.version>2.23.2</jersey.version>
-		<swagger-ui.version>2.1.4</swagger-ui.version>
-	</properties>
+    <properties>
+        <jersey.version>2.23.2</jersey.version>
+        <swagger.version>1.5.12</swagger.version>
+        <swagger-ui.version>2.1.4</swagger-ui.version>
+    </properties>
 
-	<dependencies>
+    <dependencies>
 
-		<!-- Jersey -->
-		<dependency>
-			<groupId>org.glassfish.jersey.containers</groupId>
-			<artifactId>jersey-container-servlet-core</artifactId>
-			<version>${jersey.version}</version>
-		</dependency>
+        <!-- Jersey -->
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet-core</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
 
-		<!-- Swagger for apidoc -->
-		<dependency>
-			<groupId>io.swagger</groupId>
-			<artifactId>swagger-jersey2-jaxrs</artifactId>
-			<version>${swagger.version}</version>
-		</dependency>
+        <!-- Swagger for apidoc -->
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jersey2-jaxrs</artifactId>
+            <version>${swagger.version}</version>
+        </dependency>
 
-		<!-- Moxy for object marshalling unmarshalling -->
-		<dependency>
-			<groupId>org.glassfish.jersey.media</groupId>
-			<artifactId>jersey-media-moxy</artifactId>
-			<version>2.23.2</version>
-		</dependency>
+        <!-- Moxy for object marshalling unmarshalling -->
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-moxy</artifactId>
+            <version>2.23.2</version>
+        </dependency>
 
-		<!-- Apache shiro security framework -->
-		<dependency>
-			<groupId>org.apache.shiro</groupId>
-			<artifactId>shiro-core</artifactId>
-			<version>${shiro.version}</version>
-		</dependency>
+        <!-- Apache shiro security framework -->
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-core</artifactId>
+            <version>${shiro.version}</version>
+        </dependency>
 
-		<dependency>
-			<groupId>org.apache.shiro</groupId>
-			<artifactId>shiro-web</artifactId>
-			<version>${shiro.version}</version>
-		</dependency>
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-web</artifactId>
+            <version>${shiro.version}</version>
+        </dependency>
 
-		<!-- Same version of the Servlet APIs supported in Apache Tomcat 8.0.x -->
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>3.1.0</version>
-			<scope>provided</scope>
-		</dependency>
+        <!-- Same version of the Servlet APIs supported in Apache Tomcat 8.0.x -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<!-- Internal dependencies -->
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-commons</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-guice</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-account-internal</artifactId>
-		</dependency>
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-internal</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-datastore-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-datastore-internal</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-datastore-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-datastore-internal</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-datastore-client-transport</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-datastore-client-transport</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-datastore-client-rest</artifactId>
         </dependency>
-		<dependency>
+        <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-message-internal</artifactId>
         </dependency>
-		
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-security-shiro</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-device-registry-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-device-asset-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-translator-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-translator-kapua-kura</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-translator-kura-jms</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-translator-kura-mqtt</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-transport-jms</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-transport-mqtt</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-transport-test</artifactId>
-		</dependency>
+        
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-shiro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-asset-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-kapua-kura</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-kura-jms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-kura-mqtt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-transport-jms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-transport-mqtt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-transport-test</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-device-asset-internal</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-device-bundle-internal</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-device-command-internal</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-device-configuration-internal</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-device-packages-internal</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-asset-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-bundle-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-command-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-configuration-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-packages-internal</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-user-api</artifactId>
         </dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-user-internal</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-user-internal</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
@@ -189,167 +190,167 @@
             <artifactId>kapua-tag-internal</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-		</dependency>
-		
-		<!-- use logback only for testing -->
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        
+        <!-- use logback only for testing -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-		<!-- re-declare as provided as our web container will provide this -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-	
-		<!-- Elasticsearch Dependencies -->
-		<dependency>
-			<groupId>org.elasticsearch</groupId>
-			<artifactId>elasticsearch</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.elasticsearch.client</groupId>
-			<artifactId>transport</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.elasticsearch.plugin</groupId>
-			<artifactId>transport-netty3-client</artifactId>
-			<version>${elasticsearch-client-transport.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.elasticsearch.plugin</groupId>
-			<artifactId>transport-netty4-client</artifactId>
-			<version>${elasticsearch-client-transport.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.elasticsearch.plugin</groupId>
-			<artifactId>reindex-client</artifactId>
-			<version>${elasticsearch-client-transport.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.elasticsearch.plugin</groupId>
-			<artifactId>lang-mustache-client</artifactId>
-			<version>${elasticsearch-client-transport.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.elasticsearch.plugin</groupId>
-			<artifactId>percolator-client</artifactId>
-			<version>${elasticsearch-client-transport.version}</version>
-		</dependency>
-		<!-- log4j2 for ES -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-to-slf4j</artifactId>
-		</dependency>
+        <!-- re-declare as provided as our web container will provide this -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    
+        <!-- Elasticsearch Dependencies -->
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty3-client</artifactId>
+            <version>${elasticsearch-client-transport.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
+            <version>${elasticsearch-client-transport.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>reindex-client</artifactId>
+            <version>${elasticsearch-client-transport.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>lang-mustache-client</artifactId>
+            <version>${elasticsearch-client-transport.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>percolator-client</artifactId>
+            <version>${elasticsearch-client-transport.version}</version>
+        </dependency>
+        <!-- log4j2 for ES -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-request-api</artifactId>
         </dependency>
-		<dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-device-request-internal</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-request-internal</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-stream-api</artifactId>
         </dependency><dependency>
-			<groupId>org.eclipse.kapua</groupId>
-			<artifactId>kapua-stream-internal</artifactId>
-		</dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-stream-internal</artifactId>
+        </dependency>
     </dependencies>
-	<build>
-		<finalName>api</finalName>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>unpack-swagger-ui</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>unpack</goal>
-						</goals>
-						<configuration>
-							<artifactItems>
-								<artifactItem>
-									<groupId>org.eclipse.kapua.external</groupId>
-									<artifactId>swagger-ui</artifactId>
-									<version>${swagger-ui.version}-CQ-10792</version>
-									<overWrite>true</overWrite>
-									<outputDirectory>${project.build.directory}/tmp/swagger-ui</outputDirectory>
-								</artifactItem>
-								<artifactItem>
-									<groupId>org.eclipse.kapua.external</groupId>
-									<artifactId>swagger-ui-lib</artifactId>
-									<version>${swagger-ui.version}</version>
-									<outputDirectory>${project.build.directory}/tmp/swagger-ui-lib</outputDirectory>
-								</artifactItem>
-							</artifactItems>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+    <build>
+        <finalName>api</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-swagger-ui</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kapua.external</groupId>
+                                    <artifactId>swagger-ui</artifactId>
+                                    <version>${swagger-ui.version}-CQ-10792</version>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/tmp/swagger-ui</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kapua.external</groupId>
+                                    <artifactId>swagger-ui-lib</artifactId>
+                                    <version>${swagger-ui.version}</version>
+                                    <outputDirectory>${project.build.directory}/tmp/swagger-ui-lib</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>package swagger ui</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target>
-								<echo>Swagger-ui: create doc dir</echo>
-								<copy todir="${project.build.directory}/${project.build.finalName}/doc">
-									<fileset dir="${project.build.directory}/tmp/swagger-ui/" />
-								</copy>
-								<echo>Swagger-ui-lib: create lib dir for swagger-ui</echo>
-								<copy todir="${project.build.directory}/${project.build.finalName}/doc/lib">
-									<fileset dir="${project.build.directory}/tmp/swagger-ui-lib/" />
-								</copy>
-							</target>
-						</configuration>
-					</execution>
-				</executions>
-				
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package swagger ui</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <echo>Swagger-ui: create doc dir</echo>
+                                <copy todir="${project.build.directory}/${project.build.finalName}/doc">
+                                    <fileset dir="${project.build.directory}/tmp/swagger-ui/" />
+                                </copy>
+                                <echo>Swagger-ui-lib: create lib dir for swagger-ui</echo>
+                                <copy todir="${project.build.directory}/${project.build.finalName}/doc/lib">
+                                    <fileset dir="${project.build.directory}/tmp/swagger-ui-lib/" />
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+                
+            </plugin>
 
-			<!-- To help IntelliJ IDEA correctly recognize the source path when using Maven Auto Import -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-war-plugin</artifactId>
-				<configuration>
-					<webResources>
-						<resource>
-							<directory>${basedir}</directory>
-							<includes>
-								<include>about.html</include>
-								<include>epl-v10.html</include>
-								<include>notice.html</include>
-							</includes>
-						</resource>
-					</webResources>
-					<!-- exclude slf4j-api and logback as the web container has to provide this -->
-					<packagingExcludes>
-						WEB-INF/lib/slf4j-api-*.jar,
-						WEB-INF/lib/logback*.jar
-					</packagingExcludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+            <!-- To help IntelliJ IDEA correctly recognize the source path when using Maven Auto Import -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <webResources>
+                        <resource>
+                            <directory>${basedir}</directory>
+                            <includes>
+                                <include>about.html</include>
+                                <include>epl-v10.html</include>
+                                <include>notice.html</include>
+                            </includes>
+                        </resource>
+                    </webResources>
+                    <!-- exclude slf4j-api and logback as the web container has to provide this -->
+                    <packagingExcludes>
+                        WEB-INF/lib/slf4j-api-*.jar,
+                        WEB-INF/lib/logback*.jar
+                    </packagingExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
@@ -12,6 +12,8 @@
 package org.eclipse.kapua.app.api;
 
 import java.security.acl.Permission;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -166,6 +168,7 @@ import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserQuery;
 import org.eclipse.kapua.service.user.UserXmlRegistry;
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.eclipse.persistence.jaxb.MarshallerProperties;
 
 /**
  * Provide a customized JAXBContext that makes the concrete implementations
@@ -181,6 +184,9 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
 
     public JaxbContextResolver() {
         try {
+            Map<String, Object> properties = new HashMap<String, Object>(1);
+            properties.put(MarshallerProperties.JSON_WRAPPER_AS_ARRAY_NAME, true);
+
             jaxbContext = JAXBContextFactory.createContext(new Class[] {
                     // REST API utility models
                     CountResult.class,
@@ -389,7 +395,7 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     UserQuery.class,
                     UserXmlRegistry.class
 
-            }, null);
+            }, properties);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/MoxyJsonConfigContextResolver.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/MoxyJsonConfigContextResolver.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api;
+
+import org.eclipse.persistence.jaxb.JAXBContextProperties;
+import org.glassfish.jersey.moxy.json.MoxyJsonConfig;
+
+import javax.ws.rs.ext.ContextResolver;
+
+public class MoxyJsonConfigContextResolver implements ContextResolver<MoxyJsonConfig> {
+
+    MoxyJsonConfig config;
+
+    public MoxyJsonConfigContextResolver() {
+        config = new MoxyJsonConfig().property(JAXBContextProperties.JSON_WRAPPER_AS_ARRAY_NAME, true);
+    }
+
+    @Override
+    public MoxyJsonConfig getContext(Class<?> type) {
+        return config;
+    }
+}

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/RestApisApplication.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/RestApisApplication.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import javax.ws.rs.core.MediaType;
 import javax.xml.bind.JAXBException;
 
+
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -45,6 +46,8 @@ public class RestApisApplication extends ResourceConfig {
         register(KapuaSerializableBodyWriter.class);
         register(ListBodyWriter.class);
         register(CORSResponseFilter.class);
+        register(SwaggerDefinition.class);
+        register(MoxyJsonConfigContextResolver.class);
 
         register(new ContainerLifecycleListener() {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/SwaggerDefinition.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/SwaggerDefinition.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api;
+
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.ApiKeyAuthDefinition.ApiKeyLocation;
+import io.swagger.annotations.SecurityDefinition;
+
+@io.swagger.annotations.SwaggerDefinition(
+        securityDefinition = @SecurityDefinition(
+                apiKeyAuthDefinitions = {
+                        @ApiKeyAuthDefinition(in = ApiKeyLocation.HEADER, name = "Authorization", key = "kapuaAccessToken")
+                }
+        )
+)
+public interface SwaggerDefinition { }

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/exception/model/EntityNotFoundExceptionInfo.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/exception/model/EntityNotFoundExceptionInfo.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -31,6 +32,7 @@ public class EntityNotFoundExceptionInfo extends AbstractInfo {
 
     @XmlElement(name = "entityId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     private KapuaId entityId;
 
     protected EntityNotFoundExceptionInfo() {

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/AccessInfos.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/AccessInfos.java
@@ -23,6 +23,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -49,7 +50,7 @@ import io.swagger.annotations.ApiParam;
  *
  * @since 1.0.0
  */
-@Api("Access Info")
+@Api(value = "Access Info", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/accessinfos")
 public class AccessInfos extends AbstractKapuaResource {
 
@@ -77,8 +78,7 @@ public class AccessInfos extends AbstractKapuaResource {
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     @ApiOperation(value = "Gets the AccessInfo list in the scope.", //
             notes = "Gets the AccessInfo list in the scope. The query parameter userId is optional and can be used to filter results", //
-            response = AccessInfo.class, //
-            responseContainer = "AccessInfoListResult")
+            response = AccessInfoListResult.class)
     public AccessInfoListResult simpleQuery(//
             @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId, //
             @ApiParam(value = "The optional User id to filter results") @QueryParam("userId") EntityId userId, //
@@ -117,8 +117,7 @@ public class AccessInfos extends AbstractKapuaResource {
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Queries the AccessInfos", //
             notes = "Queries the AccessInfos with the given AccessInfoQuery parameter returning all matching AccessInfos",  //
-            response = AccessInfo.class, //
-            responseContainer = "AccessInfoListResult")  //
+            response = AccessInfoListResult.class)  //
     public AccessInfoListResult query( //
             @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId, //
             @ApiParam(value = "The AccessInfoQuery to use to filter results", required = true) AccessInfoQuery query) throws Exception {

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/AccessPermissions.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/AccessPermissions.java
@@ -23,6 +23,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -49,7 +50,7 @@ import io.swagger.annotations.ApiParam;
  *
  * @since 1.0.0
  */
-@Api("Access Info")
+@Api(value = "Access Info", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/accessinfos/{accessInfoId}/permissions")
 public class AccessPermissions extends AbstractKapuaResource {
 
@@ -73,7 +74,7 @@ public class AccessPermissions extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the AccessPermission list in the scope", notes = "Gets the AccessPermission list in the scope. The query parameter accessInfoId is optional and can be used to filter results", response = AccessPermission.class, responseContainer = "AccessPermissionListResult")
+    @ApiOperation(value = "Gets the AccessPermission list in the scope", notes = "Gets the AccessPermission list in the scope. The query parameter accessInfoId is optional and can be used to filter results", response = AccessPermissionListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public AccessPermissionListResult simpleQuery(
@@ -105,7 +106,7 @@ public class AccessPermissions extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the AccessPermissions", notes = "Queries the AccessPermissions with the given AccessPermissionQuery parameter returning all matching AccessPermissions", response = AccessPermission.class, responseContainer = "AccessPermissionListResult")
+    @ApiOperation(value = "Queries the AccessPermissions", notes = "Queries the AccessPermissions with the given AccessPermissionQuery parameter returning all matching AccessPermissions", response = AccessPermissionListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/AccessRoles.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/AccessRoles.java
@@ -23,6 +23,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -43,7 +44,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Access Info")
+@Api(value = "Access Info", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/accessinfos/{accessInfoId}/roles")
 public class AccessRoles extends AbstractKapuaResource {
 
@@ -65,7 +66,7 @@ public class AccessRoles extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the AccessRole list in the scope", notes = "Returns the list of all the accessRoles associated to the current selected scope.", response = AccessRole.class, responseContainer = "AccessRoleListResult")
+    @ApiOperation(value = "Gets the AccessRole list in the scope", notes = "Returns the list of all the accessRoles associated to the current selected scope.", response = AccessRoleListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public AccessRoleListResult simpleQuery(
@@ -95,7 +96,7 @@ public class AccessRoles extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the AccessRoles", notes = "Queries the AccessRoles with the given AccessRoleQuery parameter returning all matching AccessRoles", response = AccessRole.class, responseContainer = "AccessRoleListResult")
+    @ApiOperation(value = "Queries the AccessRoles", notes = "Queries the AccessRoles with the given AccessRoleQuery parameter returning all matching AccessRoles", response = AccessRoleListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Accounts.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Accounts.java
@@ -24,6 +24,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -46,7 +47,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Accounts")
+@Api(value = "Accounts", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/accounts")
 public class Accounts extends AbstractKapuaResource {
 
@@ -72,8 +73,7 @@ public class Accounts extends AbstractKapuaResource {
      */
     @ApiOperation(value = "Gets the Account list in the scope", //
             notes = "Returns the list of all the accounts associated to the current selected scope.", //
-            response = Account.class, //
-            responseContainer = "AccountListResult") //
+            response = AccountListResult.class) //
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public AccountListResult simpleQuery( //
@@ -109,8 +109,7 @@ public class Accounts extends AbstractKapuaResource {
      */
     @ApiOperation(value = "Queries the Accounts", //
             notes = "Queries the Accounts with the given AccountQuery parameter returning all matching Accounts", //
-            response = Account.class, //
-            responseContainer = "AccountListResult") //
+            response = AccountListResult.class) //
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Credentials.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Credentials.java
@@ -24,6 +24,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -44,7 +45,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Credentials")
+@Api(value = "Credentials", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/credentials")
 public class Credentials extends AbstractKapuaResource {
 
@@ -66,7 +67,7 @@ public class Credentials extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the Credential list in the scope", notes = "Returns the list of all the credentials associated to the current selected scope.", response = Credential.class, responseContainer = "CredentialListResult")
+    @ApiOperation(value = "Gets the Credential list in the scope", notes = "Returns the list of all the credentials associated to the current selected scope.", response = CredentialListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public CredentialListResult simpleQuery(
@@ -100,7 +101,7 @@ public class Credentials extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the Credentials", notes = "Queries the Credentials with the given CredentialQuery parameter returning all matching Credentials", response = Credential.class, responseContainer = "CredentialListResult")
+    @ApiOperation(value = "Queries the Credentials", notes = "Queries the Credentials with the given CredentialQuery parameter returning all matching Credentials", response = CredentialListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataChannels.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataChannels.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.app.api.v1.resources.model.StorableEntityId;
@@ -45,7 +46,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Data Channels")
+@Api(value = "Data Channels", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/data/channels")
 public class DataChannels extends AbstractKapuaResource {
 
@@ -74,8 +75,7 @@ public class DataChannels extends AbstractKapuaResource {
      */
     @ApiOperation(value = "Gets the ChannelInfo list in the scope", //
             notes = "Returns the list of all the channelInfos associated to the current selected scope.", //
-            response = ChannelInfo.class, //
-            responseContainer = "ChannelInfoListResult")
+            response = ChannelInfoListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public ChannelInfoListResult simpleQuery( //
@@ -121,8 +121,7 @@ public class DataChannels extends AbstractKapuaResource {
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Queries the ChannelInfos", //
             notes = "Queries the ChannelInfos with the given ChannelInfoQuery parameter returning all matching ChannelInfos",  //
-            response = ChannelInfo.class, //
-            responseContainer = "ChannelInfoListResult")  //
+            response = ChannelInfoListResult.class)  //
     public ChannelInfoListResult query( //
             @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId, //
             @ApiParam(value = "The ChannelInfoQuery to use to filter results", required = true) ChannelInfoQuery query) throws Exception {

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataClients.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataClients.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.app.api.v1.resources.model.StorableEntityId;
@@ -42,7 +43,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Data Clients")
+@Api(value = "Data Clients", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/data/clients")
 public class DataClients extends AbstractKapuaResource {
 
@@ -69,8 +70,7 @@ public class DataClients extends AbstractKapuaResource {
      */
     @ApiOperation(value = "Gets the ClientInfo list in the scope", //
             notes = "Returns the list of all the clientInfos associated to the current selected scope.", //
-            response = ClientInfo.class, //
-            responseContainer = "ClientInfoListResult")
+            response = ClientInfoListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public ClientInfoListResult simpleQuery( //
@@ -112,8 +112,7 @@ public class DataClients extends AbstractKapuaResource {
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Queries the ClientInfos", //
             notes = "Queries the ClientInfos with the given ClientInfoQuery parameter returning all matching ClientInfos",  //
-            response = ClientInfo.class, //
-            responseContainer = "ClientInfoListResult")  //
+            response = ClientInfoListResult.class)  //
     public ClientInfoListResult query( //
             @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId, //
             @ApiParam(value = "The ClientInfoQuery to use to filter results", required = true) ClientInfoQuery query) throws Exception {

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
@@ -23,6 +23,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.DateParam;
 import org.eclipse.kapua.app.api.v1.resources.model.MetricType;
@@ -54,7 +55,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Data Messages")
+@Api(value = "Data Messages", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/data/messages")
 public class DataMessages extends AbstractKapuaResource {
 
@@ -90,8 +91,7 @@ public class DataMessages extends AbstractKapuaResource {
     @SuppressWarnings("unchecked")
     @ApiOperation(value = "Gets the DatastoreMessage list in the scope", //
             notes = "Returns the list of all the datastoreMessages associated to the current selected scope.", //
-            response = DatastoreMessage.class, //
-            responseContainer = "DatastoreMessageListResult")
+            response = MessageListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public <V extends Comparable<V>> MessageListResult simpleQuery(  //
@@ -190,8 +190,7 @@ public class DataMessages extends AbstractKapuaResource {
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Queries the DatastoreMessages", //
             notes = "Queries the DatastoreMessages with the given DatastoreMessageQuery parameter returning all matching DatastoreMessages",  //
-            response = DatastoreMessage.class, //
-            responseContainer = "DatastoreMessageListResult")
+            response = MessageListResult.class)
     public MessageListResult query( //
             @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId, //
             @ApiParam(value = "The DatastoreMessageQuery to use to filter results", required = true) MessageQuery query) throws Exception {

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMetrics.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMetrics.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.app.api.v1.resources.model.StorableEntityId;
@@ -43,7 +44,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Data Metrics")
+@Api(value = "Data Metrics", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/data/metrics")
 public class DataMetrics extends AbstractKapuaResource {
 
@@ -72,8 +73,7 @@ public class DataMetrics extends AbstractKapuaResource {
      */
     @ApiOperation(value = "Gets the MetricInfo list in the scope", //
             notes = "Returns the list of all the metricInfos associated to the current selected scope.", //
-            response = MetricInfo.class, //
-            responseContainer = "MetricInfoListResult")
+            response = MetricInfoListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public MetricInfoListResult simpleQuery( //
@@ -123,8 +123,7 @@ public class DataMetrics extends AbstractKapuaResource {
     @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Queries the MetricInfos", //
             notes = "Queries the MetricInfos with the given MetricInfoQuery parameter returning all matching MetricInfos",  //
-            response = MetricInfo.class, //
-            responseContainer = "MetricInfoListResult")
+            response = MetricInfoListResult.class)
     public MetricInfoListResult query( //
             @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId, //
             @ApiParam(value = "The MetricInfoQuery to use to filter results", required = true) MetricInfoQuery query) throws Exception {

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceConnections.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceConnections.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -44,7 +45,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Device Connections")
+@Api(value = "Device Connections", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/deviceconnections")
 public class DeviceConnections extends AbstractKapuaResource {
 
@@ -70,7 +71,7 @@ public class DeviceConnections extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the DeviceConnection list in the scope", notes = "Returns the list of all the deviceConnections associated to the current selected scope.", response = DeviceConnection.class, responseContainer = "DeviceConnectionListResult")
+    @ApiOperation(value = "Gets the DeviceConnection list in the scope", notes = "Returns the list of all the deviceConnections associated to the current selected scope.", response = DeviceConnectionListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public DeviceConnectionListResult simpleQuery(
@@ -108,7 +109,7 @@ public class DeviceConnections extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the DeviceConnections", notes = "Queries the DeviceConnections with the given DeviceConnections parameter returning all matching DeviceConnections", response = DeviceConnection.class, responseContainer = "DeviceConnectionListResult")
+    @ApiOperation(value = "Queries the DeviceConnections", notes = "Queries the DeviceConnections with the given DeviceConnections parameter returning all matching DeviceConnections", response = DeviceConnectionListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceEvents.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceEvents.java
@@ -26,6 +26,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -48,7 +49,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/events")
 public class DeviceEvents extends AbstractKapuaResource {
 
@@ -74,7 +75,7 @@ public class DeviceEvents extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the DeviceEvent list in the scope", notes = "Returns the list of all the deviceEvents associated to the current selected scope.", response = DeviceEvent.class, responseContainer = "DeviceEventListResult")
+    @ApiOperation(value = "Gets the DeviceEvent list in the scope", notes = "Returns the list of all the deviceEvents associated to the current selected scope.", response = DeviceEventListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public DeviceEventListResult simpleQuery(
@@ -112,7 +113,7 @@ public class DeviceEvents extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the DeviceEvents", notes = "Queries the DeviceEvents with the given DeviceEvents parameter returning all matching DeviceEvents", response = DeviceEvent.class, responseContainer = "DeviceEventListResult")
+    @ApiOperation(value = "Queries the DeviceEvents", notes = "Queries the DeviceEvents with the given DeviceEvents parameter returning all matching DeviceEvents", response = DeviceEventListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementAssets.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementAssets.java
@@ -19,6 +19,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -33,7 +34,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/assets")
 public class DeviceManagementAssets extends AbstractKapuaResource {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementBundles.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementBundles.java
@@ -20,6 +20,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -32,7 +33,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/bundles")
 public class DeviceManagementBundles extends AbstractKapuaResource {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementCommands.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementCommands.java
@@ -19,6 +19,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -32,7 +33,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/commands")
 public class DeviceManagementCommands extends AbstractKapuaResource {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementConfigurations.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementConfigurations.java
@@ -21,6 +21,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -34,7 +35,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/configurations")
 public class DeviceManagementConfigurations extends AbstractKapuaResource {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementPackages.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementPackages.java
@@ -20,6 +20,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -35,7 +36,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/packages")
 public class DeviceManagementPackages extends AbstractKapuaResource {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementRequests.java
@@ -15,6 +15,7 @@ package org.eclipse.kapua.app.api.v1.resources;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -33,7 +34,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/requests")
 public class DeviceManagementRequests extends AbstractKapuaResource {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementSnapshots.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DeviceManagementSnapshots.java
@@ -20,6 +20,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -32,7 +33,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/snapshots")
 public class DeviceManagementSnapshots extends AbstractKapuaResource {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Devices.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Devices.java
@@ -26,6 +26,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -50,7 +51,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Devices")
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices")
 public class Devices extends AbstractKapuaResource {
 
@@ -79,7 +80,7 @@ public class Devices extends AbstractKapuaResource {
      * @since 1.0.0
      * 
      */
-    @ApiOperation(value = "Gets the Device list in the scope", notes = "Returns the list of all the devices associated to the current selected scope.", response = DeviceListResult.class, responseContainer = "DeviceListResult")
+    @ApiOperation(value = "Gets the Device list in the scope", notes = "Returns the list of all the devices associated to the current selected scope.", response = DeviceListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public DeviceListResult simpleQuery(
@@ -122,7 +123,7 @@ public class Devices extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the Devices", notes = "Queries the Devices with the given Devices parameter returning all matching Devices", response = DeviceListResult.class, responseContainer = "DeviceListResult")
+    @ApiOperation(value = "Queries the Devices", notes = "Queries the Devices with the given Devices parameter returning all matching Devices", response = DeviceListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Domains.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Domains.java
@@ -21,6 +21,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -42,7 +43,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Domains")
+@Api(value = "Domains", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/domains")
 public class Domains extends AbstractKapuaResource {
 
@@ -66,7 +67,7 @@ public class Domains extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the Domain list in the scope", notes = "Returns the list of all the domains associated to the current selected scope.", response = Domain.class, responseContainer = "DomainListResult")
+    @ApiOperation(value = "Gets the Domain list in the scope", notes = "Returns the list of all the domains associated to the current selected scope.", response = DomainListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public DomainListResult simpleQuery(
@@ -100,7 +101,7 @@ public class Domains extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the Domains", notes = "Queries the Domains with the given DomainQuery parameter returning all matching Domains", response = Domain.class, responseContainer = "DomainListResult")
+    @ApiOperation(value = "Queries the Domains", notes = "Queries the Domains with the given DomainQuery parameter returning all matching Domains", response = DomainListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Groups.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Groups.java
@@ -24,6 +24,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -46,7 +47,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Groups")
+@Api(value = "Groups", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/groups")
 public class Groups extends AbstractKapuaResource {
 
@@ -70,7 +71,7 @@ public class Groups extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the Group list in the scope", notes = "Returns the list of all the groups associated to the current selected scope.", response = Group.class, responseContainer = "GroupListResult")
+    @ApiOperation(value = "Gets the Group list in the scope", notes = "Returns the list of all the groups associated to the current selected scope.", response = GroupListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public GroupListResult simpleQuery(
@@ -104,7 +105,7 @@ public class Groups extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the Groups", notes = "Queries the Groups with the given GroupQuery parameter returning all matching Groups", response = Group.class, responseContainer = "GroupListResult")
+    @ApiOperation(value = "Queries the Groups", notes = "Queries the Groups with the given GroupQuery parameter returning all matching Groups", response = GroupListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Roles.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Roles.java
@@ -24,6 +24,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -46,7 +47,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Roles")
+@Api(value = "Roles", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/roles")
 public class Roles extends AbstractKapuaResource {
 
@@ -70,7 +71,7 @@ public class Roles extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the Role list in the scope", notes = "Returns the list of all the roles associated to the current selected scope.", response = Role.class, responseContainer = "RoleListResult")
+    @ApiOperation(value = "Gets the Role list in the scope", notes = "Returns the list of all the roles associated to the current selected scope.", response = RoleListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public RoleListResult simpleQuery(
@@ -104,7 +105,7 @@ public class Roles extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the Roles", notes = "Queries the Roles with the given RoleQuery parameter returning all matching Roles", response = Role.class, responseContainer = "RoleListResult")
+    @ApiOperation(value = "Queries the Roles", notes = "Queries the Roles with the given RoleQuery parameter returning all matching Roles", response = RoleListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/RolesPermissions.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/RolesPermissions.java
@@ -23,6 +23,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -47,7 +48,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Roles")
+@Api(value = "Roles", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/roles/{roleId}/permissions")
 public class RolesPermissions extends AbstractKapuaResource {
 
@@ -75,7 +76,7 @@ public class RolesPermissions extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the RolePermission list in the scope", notes = "Returns the list of all the rolePermissions associated to the current selected scope.", response = RolePermission.class, responseContainer = "RolePermissionListResult")
+    @ApiOperation(value = "Gets the RolePermission list in the scope", notes = "Returns the list of all the rolePermissions associated to the current selected scope.", response = RolePermissionListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public RolePermissionListResult simpleQuery(
@@ -117,7 +118,7 @@ public class RolesPermissions extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the RolePermissions", notes = "Queries the RolePermissions with the given RolePermissionQuery parameter returning all matching RolePermissions", response = RolePermission.class, responseContainer = "RolePermissionListResult")
+    @ApiOperation(value = "Queries the RolePermissions", notes = "Queries the RolePermissions with the given RolePermissionQuery parameter returning all matching RolePermissions", response = RolePermissionListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Streams.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Streams.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.app.api.v1.resources;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.app.api.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
@@ -28,7 +29,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Api("Streams")
+@Api(value = "Streams", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/streams")
 public class Streams extends AbstractKapuaResource {
 

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Tags.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Tags.java
@@ -24,6 +24,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -47,7 +48,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Tags")
+@Api(value = "Tags", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/tags")
 public class Tags extends AbstractKapuaResource {
 
@@ -73,8 +74,7 @@ public class Tags extends AbstractKapuaResource {
      */
     @ApiOperation(value = "Gets the Tag list in the scope", //
             notes = "Returns the list of all the tags associated to the current selected scope.", //
-            response = Tag.class, //
-            responseContainer = "TagListResult")
+            response = TagListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public TagListResult simpleQuery(
@@ -110,8 +110,7 @@ public class Tags extends AbstractKapuaResource {
      */
     @ApiOperation(value = "Queries the Tags", //
             notes = "Queries the Tags with the given TagQuery parameter returning all matching Tags", //
-            response = Tag.class, //
-            responseContainer = "TagListResult")
+            response = TagListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Users.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/Users.java
@@ -24,6 +24,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.swagger.annotations.Authorization;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.v1.resources.model.EntityId;
@@ -46,7 +47,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
-@Api("Users")
+@Api(value = "Users", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/users")
 public class Users extends AbstractKapuaResource {
 
@@ -70,7 +71,7 @@ public class Users extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Gets the User list in the scope", notes = "Returns the list of all the users associated to the current selected scope.", response = User.class, responseContainer = "UserListResult")
+    @ApiOperation(value = "Gets the User list in the scope", notes = "Returns the list of all the users associated to the current selected scope.", response = UserListResult.class)
     @GET
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public UserListResult simpleQuery(
@@ -104,7 +105,7 @@ public class Users extends AbstractKapuaResource {
      *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
-    @ApiOperation(value = "Queries the Users", notes = "Queries the Users with the given UserQuery parameter returning all matching Users", response = User.class, responseContainer = "UserListResult")
+    @ApiOperation(value = "Queries the Users", notes = "Queries the Users with the given UserQuery parameter returning all matching Users", response = UserListResult.class)
     @POST
     @Path("_query")
     @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })

--- a/rest-api/src/main/webapp/WEB-INF/web.xml
+++ b/rest-api/src/main/webapp/WEB-INF/web.xml
@@ -50,9 +50,9 @@
         <init-param>
             <param-name>jersey.config.server.provider.packages</param-name>
             <param-value>
-                io.swagger.jaxrs.listing<!-- ,
-                {your.application.packages}-->
-            </param-value>
+	            io.swagger.jaxrs.listing,
+                org.eclipse.kapua.app.api
+	        </param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>

--- a/rest-api/src/main/webapp/WEB-INF/web.xml
+++ b/rest-api/src/main/webapp/WEB-INF/web.xml
@@ -50,9 +50,9 @@
         <init-param>
             <param-name>jersey.config.server.provider.packages</param-name>
             <param-value>
-	            io.swagger.jaxrs.listing,
+                io.swagger.jaxrs.listing,
                 org.eclipse.kapua.app.api
-	        </param-value>
+            </param-value>
         </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>

--- a/rest-api/src/main/webapp/doc/index.html
+++ b/rest-api/src/main/webapp/doc/index.html
@@ -100,7 +100,7 @@
 			if (key && key.trim() != "") {
 				var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization(
 						"Authorization", "Bearer " + key, "header");
-				window.swaggerUi.api.clientAuthorizations.add("api_key",
+				window.swaggerUi.api.clientAuthorizations.add("kapuaAccessToken",
 						apiKeyAuth);
 				log("added key " + key);
 			}

--- a/service/api/pom.xml
+++ b/service/api/pom.xml
@@ -23,6 +23,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.KapuaSerializable;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -47,6 +48,7 @@ public interface KapuaEntity extends KapuaSerializable {
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getId();
 
     /**
@@ -65,6 +67,7 @@ public interface KapuaEntity extends KapuaSerializable {
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getScopeId();
 
     /**
@@ -94,5 +97,6 @@ public interface KapuaEntity extends KapuaSerializable {
      */
     @XmlElement(name = "createdBy")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getCreatedBy();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityCreator.java
@@ -15,6 +15,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
@@ -38,6 +39,7 @@ public interface KapuaEntityCreator<E extends KapuaEntity> {
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getScopeId();
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
@@ -19,6 +19,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -53,6 +54,7 @@ public interface KapuaUpdatableEntity extends KapuaEntity {
      */
     @XmlElement(name = "modifiedBy")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getModifiedBy();
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -69,6 +70,7 @@ public interface KapuaQuery<E extends KapuaEntity> {
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getScopeId();
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
@@ -20,6 +20,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
@@ -74,6 +75,7 @@ public interface ChannelInfo extends Storable {
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getScopeId();
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
@@ -20,6 +20,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
@@ -73,6 +74,7 @@ public interface ClientInfo extends Storable {
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getScopeId();
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
@@ -21,6 +21,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.message.KapuaChannel;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
@@ -103,6 +104,7 @@ public interface DatastoreMessage extends Storable {
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getScopeId();
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
@@ -20,6 +20,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
@@ -76,6 +77,7 @@ public interface MetricInfo extends Storable {
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getScopeId();
 
     /**

--- a/service/device/command/test/src/test/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementServiceTest.java
+++ b/service/device/command/test/src/test/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementServiceTest.java
@@ -92,7 +92,7 @@ public class DeviceCommandManagementServiceTest extends Assert {
 
             AuthenticationService authenticationService = locator.getService(AuthenticationService.class);
             CredentialsFactory credentialsFactory = locator.getFactory(CredentialsFactory.class);
-            authenticationService.login(credentialsFactory.newUsernamePasswordCredentials(username, password.toCharArray()));
+            authenticationService.login(credentialsFactory.newUsernamePasswordCredentials(username, password));
 
             //
             // Get current user Id

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
@@ -21,6 +21,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -108,6 +109,7 @@ public interface Device extends KapuaUpdatableEntity {
     @XmlElementWrapper(name = "tagIds")
     @XmlElement(name = "tagId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public Set<KapuaId> getTagIds();
 
     /**
@@ -117,6 +119,7 @@ public interface Device extends KapuaUpdatableEntity {
      */
     @XmlElement(name = "groupId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getGroupId();
 
     /**
@@ -148,6 +151,7 @@ public interface Device extends KapuaUpdatableEntity {
      */
     @XmlElement(name = "connectionId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getConnectionId();
 
     /**
@@ -202,6 +206,7 @@ public interface Device extends KapuaUpdatableEntity {
      */
     @XmlElement(name = "lastEventId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getLastEventId();
 
     /**
@@ -540,6 +545,7 @@ public interface Device extends KapuaUpdatableEntity {
      */
     @XmlElement(name = "preferredUserId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getPreferredUserId();
 
     /**

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -75,6 +76,7 @@ public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
      */
     @XmlElement(name = "groupId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getGroupId();
 
     /**
@@ -121,6 +123,7 @@ public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
      */
     @XmlElement(name = "connectionId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getConnectionId();
 
     /**
@@ -137,6 +140,7 @@ public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
      */
     @XmlElement(name = "lastEventId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getLastEventId();
 
     /**
@@ -482,6 +486,7 @@ public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
      */
     @XmlElement(name = "preferredUserId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getPreferredUserId();
 
     /**

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -82,6 +83,7 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getUserId();
 
     /**

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
@@ -20,6 +20,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -63,6 +64,7 @@ public interface DeviceEvent extends KapuaEntity {
      */
     @XmlElement(name = "deviceId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getDeviceId();
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
@@ -28,20 +28,7 @@ public interface CredentialsFactory extends KapuaObjectFactory {
      *            the password of the user
      * @return the new credentials
      */
-    public UsernamePasswordCredentials newUsernamePasswordCredentials(String username, char[] password);
-
-    /**
-     * Creates a new {@link UsernamePasswordCredentials} instance based on provided username and password
-     * 
-     * @param username
-     *            the name of the user
-     * @param password
-     *            the password of the user
-     * @return the new credentials
-     */
-    public default UsernamePasswordCredentials newUsernamePasswordCredentials(final String username, final String password) {
-        return newUsernamePasswordCredentials(username, password != null ? password.toCharArray() : null);
-    }
+    public UsernamePasswordCredentials newUsernamePasswordCredentials(String username, String password);
 
     /**
      * Creates a new {@link UsernamePasswordCredentials} instance based on username and password with no preset values
@@ -49,7 +36,7 @@ public interface CredentialsFactory extends KapuaObjectFactory {
      * @return the new, empty credentials instance
      */
     public default UsernamePasswordCredentials newUsernamePasswordCredentials() {
-        return newUsernamePasswordCredentials((String) null, (String) null);
+        return newUsernamePasswordCredentials(null, null);
     }
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -15,7 +15,6 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * Username and password {@link LoginCredentials} definition.
@@ -47,13 +46,12 @@ public interface UsernamePasswordCredentials extends LoginCredentials {
      * 
      * @return
      */
-    @XmlJavaTypeAdapter(StringToCharArrayAdapter.class)
-    public char[] getPassword();
+    public String getPassword();
 
     /**
      * Set the password
      * 
      * @param password
      */
-    public void setPassword(char[] password);
+    public void setPassword(String password);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -60,6 +61,7 @@ public interface Credential extends KapuaUpdatableEntity {
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getUserId();
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -47,6 +48,7 @@ public interface CredentialCreator extends KapuaEntityCreator<Credential> {
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getUserId();
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
@@ -21,6 +21,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -79,6 +80,7 @@ public interface AccessToken extends KapuaUpdatableEntity, Serializable {
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getUserId();
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -61,5 +62,6 @@ public interface AccessInfo extends KapuaUpdatableEntity {
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getUserId();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -61,6 +62,7 @@ public interface AccessInfoCreator extends KapuaEntityCreator<AccessInfo> {
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getUserId();
 
     /**
@@ -83,6 +85,7 @@ public interface AccessInfoCreator extends KapuaEntityCreator<AccessInfo> {
     @XmlElementWrapper(name = "roleIds")
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public Set<KapuaId> getRoleIds();
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -64,6 +65,7 @@ public interface AccessPermission extends KapuaEntity {
      */
     @XmlElement(name = "accessInfoId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getAccessInfoId();
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -53,6 +54,7 @@ public interface AccessPermissionCreator extends KapuaEntityCreator<AccessPermis
      */
     @XmlElement(name = "accessInfoId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getAccessInfoId();
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -68,6 +69,7 @@ public interface AccessRole extends KapuaEntity {
      */
     @XmlElement(name = "accessInfoId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getAccessInfoId();
 
     /**
@@ -87,5 +89,6 @@ public interface AccessRole extends KapuaEntity {
      */
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getRoleId();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -53,6 +54,7 @@ public interface AccessRoleCreator extends KapuaEntityCreator<AccessRole> {
      */
     @XmlElement(name = "accessInfoId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getAccessInfoId();
 
     /**
@@ -73,5 +75,6 @@ public interface AccessRoleCreator extends KapuaEntityCreator<AccessRole> {
      */
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getRoleId();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Groupable.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Groupable.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.authorization.group;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
@@ -40,6 +41,7 @@ public interface Groupable {
      */
     @XmlElement(name = "groupId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getGroupId();
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
@@ -19,6 +19,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
@@ -101,6 +102,7 @@ public interface Permission {
      */
     @XmlElement(name = "targetScopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getTargetScopeId();
 
     /**
@@ -120,6 +122,7 @@ public interface Permission {
      */
     @XmlElement(name = "groupId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getGroupId();
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
@@ -19,6 +19,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -66,6 +67,7 @@ public interface RolePermission extends KapuaEntity {
      */
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getRoleId();
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
@@ -18,6 +18,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
@@ -53,6 +54,7 @@ public interface RolePermissionCreator extends KapuaEntityCreator<RolePermission
      */
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public KapuaId getRoleId();
 
     /**

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
@@ -29,7 +29,7 @@ import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 public class CredentialsFactoryImpl implements CredentialsFactory {
 
     @Override
-    public UsernamePasswordCredentials newUsernamePasswordCredentials(String username, char[] password) {
+    public UsernamePasswordCredentials newUsernamePasswordCredentials(String username, String password) {
         return new UsernamePasswordCredentialsImpl(username, password);
     }
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
@@ -12,7 +12,6 @@
 package org.eclipse.kapua.service.authentication.shiro;
 
 import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.UsernamePasswordToken;
 import org.eclipse.kapua.service.authentication.AuthenticationCredentials;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 
@@ -22,20 +21,19 @@ import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
  * @since 1.0
  * 
  */
-public class UsernamePasswordCredentialsImpl extends UsernamePasswordToken implements UsernamePasswordCredentials, AuthenticationToken {
+public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredentials, AuthenticationToken {
 
     private static final long serialVersionUID = -7549848672967689716L;
 
     private String username;
-    private char[] password;
+    private String password;
 
     /**
      * Constructor
-     * 
-     * @param username
+     *  @param username
      * @param password
      */
-    public UsernamePasswordCredentialsImpl(String username, char[] password) {
+    public UsernamePasswordCredentialsImpl(String username, String password) {
         this.username = username;
         this.password = password;
     }
@@ -51,12 +49,22 @@ public class UsernamePasswordCredentialsImpl extends UsernamePasswordToken imple
     }
 
     @Override
-    public char[] getPassword() {
+    public String getPassword() {
         return password;
     }
 
     @Override
-    public void setPassword(char[] password) {
+    public void setPassword(String password) {
         this.password = password;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return username;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return password;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
@@ -13,9 +13,9 @@ package org.eclipse.kapua.service.authentication.shiro.realm;
 
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.UsernamePasswordToken;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
+import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
 import org.eclipse.kapua.service.user.User;
@@ -34,9 +34,9 @@ public class UserPassCredentialsMatcher implements CredentialsMatcher {
 
         //
         // Token data
-        UsernamePasswordToken token = (UsernamePasswordToken) authenticationToken;
+        UsernamePasswordCredentials token = (UsernamePasswordCredentials) authenticationToken;
         String tokenUsername = token.getUsername();
-        String tokenPassword = String.valueOf(token.getPassword());
+        String tokenPassword = token.getPassword();
 
         //
         // Info data

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Taggable.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Taggable.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
@@ -43,6 +44,7 @@ public interface Taggable {
      */
     @XmlElement(name = "tagId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public <I extends KapuaId> Set<I> getTagIds();
 
 }

--- a/test/src/main/java/org/eclipse/kapua/test/KapuaTest.java
+++ b/test/src/main/java/org/eclipse/kapua/test/KapuaTest.java
@@ -63,7 +63,7 @@ public class KapuaTest extends Assert {
 
             AuthenticationService authenticationService = locator.getService(AuthenticationService.class);
             CredentialsFactory credentialsFactory = locator.getFactory(CredentialsFactory.class);
-            authenticationService.login(credentialsFactory.newUsernamePasswordCredentials(username, password.toCharArray()));
+            authenticationService.login(credentialsFactory.newUsernamePasswordCredentials(username, password));
 
             //
             // Get current user Id

--- a/test/src/main/java/org/eclipse/kapua/test/authentication/CredentialsFactoryMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/authentication/CredentialsFactoryMock.java
@@ -25,7 +25,7 @@ import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 public class CredentialsFactoryMock implements CredentialsFactory {
 
     @Override
-    public UsernamePasswordCredentials newUsernamePasswordCredentials(String username, char[] password) {
+    public UsernamePasswordCredentials newUsernamePasswordCredentials(String username, String password) {
         return new UsernamePasswordCredentialsMock(username, password);
     }
 

--- a/test/src/main/java/org/eclipse/kapua/test/authentication/UsernamePasswordCredentialsMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/authentication/UsernamePasswordCredentialsMock.java
@@ -16,9 +16,9 @@ import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 public class UsernamePasswordCredentialsMock implements UsernamePasswordCredentials {
 
     private String username;
-    private char[] password;
+    private String password;
 
-    public UsernamePasswordCredentialsMock(String username, char[] password) {
+    public UsernamePasswordCredentialsMock(String username, String password) {
         this.username = username;
         this.password = password;
     }
@@ -34,12 +34,12 @@ public class UsernamePasswordCredentialsMock implements UsernamePasswordCredenti
     }
 
     @Override
-    public char[] getPassword() {
+    public String getPassword() {
         return this.password;
     }
 
     @Override
-    public void setPassword(char[] password) {
+    public void setPassword(String password) {
         this.password = password;
     }
 


### PR DESCRIPTION
Hi all,

This PR improves Swagger and REST APIs interaction in a few ways:

- It adds a proper Swagger Security Definition for the `Authorization` HTTP header and its content, to reflect what we're actually using, and adds such Security Definition to all the resources except `Authentication`;
- It fixes JSON serialization of lists inside objects: instead of generating `{ items: { item: [<item 1>, <item 2>, <etc.> ] }` it just generates `{ items: [<item 1>, <item 2>, <etc.> ] }`, as one would expect and also Swagger Codegen expects;
- It forces KapuaId entities to be treated as strings in JSON;
- It changes the `password` property of `UsernamePasswordCredentials` from string[] to string.

Cheers