### PR TITLE
Fix on failing QA tests - wait for embedded servers

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/qa/steps/EmbeddedBroker.java
+++ b/qa/src/test/java/org/eclipse/kapua/qa/steps/EmbeddedBroker.java
@@ -52,7 +52,7 @@ public class EmbeddedBroker {
 
     private Map<String, List<AutoCloseable>> closables = new HashMap<>();
 
-    private BrokerService broker;
+    private static BrokerService broker;
 
     private DBHelper database;
 
@@ -61,10 +61,10 @@ public class EmbeddedBroker {
         this.database = database;
     }
 
-    @Before
+    @Before(value = "@StartBroker")
     public void start() {
 
-        this.database.setup();
+        database.setup();
 
         logger.info("Starting new instance");
 
@@ -99,7 +99,7 @@ public class EmbeddedBroker {
         }
     }
 
-    @After
+    @After(value = "@StopBroker")
     public void stop() {
         logger.info("Stopping instance ...");
 

--- a/qa/src/test/java/org/eclipse/kapua/qa/steps/EmbeddedDatastore.java
+++ b/qa/src/test/java/org/eclipse/kapua/qa/steps/EmbeddedDatastore.java
@@ -21,6 +21,8 @@ import cucumber.api.java.After;
 import cucumber.api.java.Before;
 import cucumber.runtime.java.guice.ScenarioScoped;
 
+import static java.time.Duration.ofSeconds;
+
 /**
  * Singleton for managing datastore creation and deletion inside Gherkin scenarios.
  */
@@ -29,18 +31,34 @@ public class EmbeddedDatastore {
 
     private static final Logger logger = LoggerFactory.getLogger(EmbeddedDatastore.class);
 
+    private static final int EXTRA_STARTUP_DELAY = Integer.getInteger("org.eclipse.kapua.qa.datastore.extraStartupDelay", 0);
+
     private EsEmbeddedEngine esEmbeddedEngine;
 
     @Before(order = HookPriorities.DATASTORE)
     public void setup() {
         logger.info("starting embedded datastore");
         esEmbeddedEngine = new EsEmbeddedEngine();
+        if (EXTRA_STARTUP_DELAY > 0) {
+            try {
+                Thread.sleep(ofSeconds(EXTRA_STARTUP_DELAY).toMillis());
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
         logger.info("starting embedded datastore DONE");
     }
 
     @After(order = HookPriorities.DATASTORE)
     public void closeNode() throws IOException {
         logger.info("closing embedded datastore");
+        if (EXTRA_STARTUP_DELAY > 0) {
+            try {
+                Thread.sleep(ofSeconds(EXTRA_STARTUP_DELAY).toMillis());
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
         esEmbeddedEngine.close();
         logger.info("closing embedded datastore DONE");
     }

--- a/qa/src/test/java/org/eclipse/kapua/qa/steps/EmbeddedDatastore.java
+++ b/qa/src/test/java/org/eclipse/kapua/qa/steps/EmbeddedDatastore.java
@@ -13,12 +13,13 @@
 package org.eclipse.kapua.qa.steps;
 
 import java.io.IOException;
+
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
 import org.eclipse.kapua.service.datastore.client.embedded.EsEmbeddedEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
 import cucumber.runtime.java.guice.ScenarioScoped;
 
 import static java.time.Duration.ofSeconds;
@@ -33,9 +34,9 @@ public class EmbeddedDatastore {
 
     private static final int EXTRA_STARTUP_DELAY = Integer.getInteger("org.eclipse.kapua.qa.datastore.extraStartupDelay", 0);
 
-    private EsEmbeddedEngine esEmbeddedEngine;
+    private static EsEmbeddedEngine esEmbeddedEngine;
 
-    @Before(order = HookPriorities.DATASTORE)
+    @Before(order = HookPriorities.DATASTORE, value = "@StartDatastore")
     public void setup() {
         logger.info("starting embedded datastore");
         esEmbeddedEngine = new EsEmbeddedEngine();
@@ -49,7 +50,7 @@ public class EmbeddedDatastore {
         logger.info("starting embedded datastore DONE");
     }
 
-    @After(order = HookPriorities.DATASTORE)
+    @After(order = HookPriorities.DATASTORE, value = "@StopDatastore")
     public void closeNode() throws IOException {
         logger.info("closing embedded datastore");
         if (EXTRA_STARTUP_DELAY > 0) {
@@ -59,7 +60,9 @@ public class EmbeddedDatastore {
                 e.printStackTrace();
             }
         }
-        esEmbeddedEngine.close();
+        if (esEmbeddedEngine != null) {
+            esEmbeddedEngine.close();
+        }
         logger.info("closing embedded datastore DONE");
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreI9nTest.java
@@ -29,5 +29,6 @@ import org.junit.runner.RunWith;
                 "json:target/DatastoreI9n_cucumber.json" },
         monochrome = true)
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.transport.TransportDatastoreClient")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
 public class RunDatastoreI9nTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreRestI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreRestI9nTest.java
@@ -28,5 +28,6 @@ import org.junit.runner.RunWith;
                 "json:target/DatastoreI9n_cucumber.json" },
         monochrome = true)
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
 public class RunDatastoreRestI9nTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -163,9 +163,6 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
 
         // JAXB Context
         XmlUtil.setContextProvider(new DatastoreJAXBContextProvider());
-
-        // Precautions if index exists form previous tests.
-        deleteAllIndices();
     }
 
     @After
@@ -178,6 +175,12 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
         } catch (Exception e) {
             logger.error("Failed to log out in @After", e);
         }
+    }
+
+    @Given("^All indices are deleted$")
+    public void deleteIndices() throws Exception {
+
+        deleteAllIndices();
     }
 
     @Given("^Account for \"(.*)\"$")

--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunBrokerACLDeviceManageI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunBrokerACLDeviceManageI9nTest.java
@@ -12,10 +12,11 @@
 package org.eclipse.kapua.service.device.integration;
 
 import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
-@RunWith(Cucumber.class)
+@RunWith(CucumberWithProperties.class)
 @CucumberOptions(
         features = {"classpath:features/broker/acl/BrokerACLDeviceManageI9n.feature"
         },
@@ -28,6 +29,6 @@ import org.junit.runner.RunWith;
                 "json:target/BrokerACLDeviceManageI9n_cucumber.json"
         },
         monochrome = true )
-
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="3")
 public class RunBrokerACLDeviceManageI9nTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunBrokerACLI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunBrokerACLI9nTest.java
@@ -12,10 +12,11 @@
 package org.eclipse.kapua.service.device.integration;
 
 import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
-@RunWith(Cucumber.class)
+@RunWith(CucumberWithProperties.class)
 @CucumberOptions(
         features = {"classpath:features/broker/acl/BrokerACLI9n.feature"
                    },
@@ -28,6 +29,6 @@ import org.junit.runner.RunWith;
                   "json:target/BrokerACLI9n_cucumber.json"
                  },
         monochrome = true )
-
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="3")
 public class RunBrokerACLI9nTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceBrokerI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceBrokerI9nTest.java
@@ -19,10 +19,7 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = {"classpath:features/broker/DeviceBrokerI9n.feature",
-                    "classpath:features/broker/DeviceData.feature",
-                    "classpath:features/broker/DeviceLifecycle.feature"
-                   },
+        features = {"classpath:features/broker/DeviceBrokerI9n.feature"},
         glue = {"org.eclipse.kapua.qa.steps",
                 "org.eclipse.kapua.service.user.steps",
                 "org.eclipse.kapua.service.device.steps"

--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceDataI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceDataI9nTest.java
@@ -7,26 +7,26 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Eurotech - initial API and implementation
+ *     Eurotech
  *     Red Hat Inc
  *******************************************************************************/
-package org.eclipse.kapua.service.user.integration;
-
-import org.junit.runner.RunWith;
+package org.eclipse.kapua.service.device.integration;
 
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = "classpath:features/user/UserServiceI9n.feature",
+        features = {"classpath:features/broker/DeviceData.feature"},
         glue = {"org.eclipse.kapua.qa.steps",
-                "org.eclipse.kapua.service.user.steps"
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps"
                },
         plugin = {"pretty", 
-                  "html:target/cucumber/UserServiceI9n",
-                  "json:target/UserServiceI9n_cucumber.json"
+                  "html:target/cucumber/DeviceDataI9n",
+                  "json:target/DeviceDataI9n_cucumber.json"
                  },
-        monochrome=true)
+        monochrome = true )
 
-public class RunUserServiceI9nTest {}
+public class RunDeviceDataI9nTest {}

--- a/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceLifecycleI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/integration/RunDeviceLifecycleI9nTest.java
@@ -7,26 +7,26 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Eurotech - initial API and implementation
+ *     Eurotech
  *     Red Hat Inc
  *******************************************************************************/
-package org.eclipse.kapua.service.user.integration;
-
-import org.junit.runner.RunWith;
+package org.eclipse.kapua.service.device.integration;
 
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = "classpath:features/user/UserServiceI9n.feature",
+        features = {"classpath:features/broker/DeviceLifecycle.feature"},
         glue = {"org.eclipse.kapua.qa.steps",
-                "org.eclipse.kapua.service.user.steps"
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps"
                },
         plugin = {"pretty", 
-                  "html:target/cucumber/UserServiceI9n",
-                  "json:target/UserServiceI9n_cucumber.json"
+                  "html:target/cucumber/DeviceLifecycleI9n",
+                  "json:target/DeviceLifecycleI9n_cucumber.json"
                  },
-        monochrome=true)
+        monochrome = true )
 
-public class RunUserServiceI9nTest {}
+public class RunDeviceLifecycleI9nTest {}

--- a/qa/src/test/java/org/eclipse/kapua/service/user/integration/RunLockoutExpirationI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/integration/RunLockoutExpirationI9nTest.java
@@ -12,21 +12,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.integration;
 
-import org.junit.runner.RunWith;
-
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
+import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = "classpath:features/user/UserServiceI9n.feature",
+        features = "classpath:features/user/LockoutExpirationI9n.feature",
         glue = {"org.eclipse.kapua.qa.steps",
                 "org.eclipse.kapua.service.user.steps"
                },
         plugin = {"pretty", 
-                  "html:target/cucumber/UserServiceI9n",
-                  "json:target/UserServiceI9n_cucumber.json"
+                  "html:target/cucumber/LockoutExpirationI9n",
+                  "json:target/LockoutExpirationI9n_cucumber.json"
                  },
         monochrome=true)
 
-public class RunUserServiceI9nTest {}
+public class RunLockoutExpirationI9nTest {}

--- a/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -111,14 +111,19 @@ public class UserServiceSteps extends AbstractKapuaSteps {
      */
     private StepData stepData;
 
+    private DBHelper database;
+
     @Inject
-    public UserServiceSteps(StepData stepData, /*dependency*/ DBHelper dbHelper) {
+    public UserServiceSteps(StepData stepData, DBHelper dbHelper) {
 
         this.stepData = stepData;
+        this.database = dbHelper;
     }
 
     @Before
     public void beforeScenario(Scenario scenario) throws KapuaException {
+
+        this.database.setup();
 
         // Services by default Locator
         KapuaLocator locator = KapuaLocator.getInstance();

--- a/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -14,7 +14,16 @@ Feature: Device Broker Integration
   Each Scenario starts with BIRTH of device and then the communication over MQTT
   between device and Kapua.
 
-  Scenario: Send BIRTH message and then DC message. Effectively this is connect and disconnect of Kura device.
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
+  Scenario: Send BIRTH message and then DC message
+    Effectively this is connect and disconnect of Kura device.
+    Basic birth - death scenario.
+
     When I start the Kura Mock
     And Device birth message is sent
     And I wait 5 seconds for system to receive and process that message
@@ -29,3 +38,10 @@ Feature: Device Broker Integration
     Then Exit code 0 is received
     And I logout
     And Device death message is sent
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios
+

--- a/qa/src/test/resources/features/broker/DeviceData.feature
+++ b/qa/src/test/resources/features/broker/DeviceData.feature
@@ -11,6 +11,12 @@
 ###############################################################################
 Feature: Device data scenarios
 
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
 Scenario: Connect to the system and publish some data
 
   Given The account name is kapua-sys and the client ID is sim-1
@@ -54,3 +60,9 @@ Scenario: Connect to the system and publish some data
   
   When I stop the simulator
   Then Device sim-1 for account kapua-sys is not registered after 5 seconds
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios

--- a/qa/src/test/resources/features/broker/DeviceLifecycle.feature
+++ b/qa/src/test/resources/features/broker/DeviceLifecycle.feature
@@ -11,6 +11,12 @@
 ###############################################################################
 Feature: Device lifecycle scenarios
 
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
 Scenario: Starting and stopping the simulator should create a device entry and properly set its status
   This starts and stops a simulator instance and checks if the connection state
   is recorded properly.
@@ -60,4 +66,10 @@ Scenario: Installing a package
   
   When I fetch the package states
   Then Package "foo.bar" with version 1.2.3 is installed and has 10 mock bundles
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios
 

--- a/qa/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
@@ -39,6 +39,13 @@ Feature: Broker ACL tests
   ACL_DATA_ACC = {0}.>
   ACL_DATA_ACC_CLI = {0}.{1}.>
   ACL_CTRL_ACC_NOTIFY = $EDC.{0}.*.*.NOTIFY.{1}.>
+
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
 #
 # Data manage
 #
@@ -192,3 +199,9 @@ Feature: Broker ACL tests
     Then exception is thrown
     And clients are disconnected
     And Mqtt Device is stoped
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios

--- a/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -38,6 +38,13 @@ Feature: Broker ACL tests
   ACL_DATA_ACC = {0}.>
   ACL_DATA_ACC_CLI = {0}.{1}.>
   ACL_CTRL_ACC_NOTIFY = $EDC.{0}.*.*.NOTIFY.{1}.>
+
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
 #
 #  Admin
 #
@@ -580,3 +587,9 @@ Feature: Broker ACL tests
     Then exception is thrown
       And clients are disconnected
       And Mqtt Device is stoped
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios

--- a/qa/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/src/test/resources/features/datastore/Datastore.feature
@@ -13,6 +13,12 @@
 
 Feature: Datastore tests
 
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
   Scenario: Query before schema search
     Before schema is created methods that search with find for messages, channel info,
     metric info and client info, should return null values.
@@ -324,3 +330,9 @@ Feature: Datastore tests
     And Client "test-client-2" first published on a channel in the list "ChannelList" on "03/07/2017T09:00:00"
     And Client "test-client-2" last published on a channel in the list "ChannelList" on "03/07/2017T09:00:20"
     And All indices are deleted
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios

--- a/qa/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/src/test/resources/features/datastore/Datastore.feature
@@ -51,6 +51,7 @@ Feature: Datastore tests
          Then I get empty client info list result
        When I count for client info
          Then I get client info count 0
+    Then All indices are deleted
     And I logout
 
   Scenario: Check the database cache coherency
@@ -71,9 +72,10 @@ Feature: Datastore tests
     When I refresh all database indices
     And I search for a data message with ID "RandomDataMessage1Id" and remember it as "DataStoreMessageNew"
     Then The datastore messages "DataStoreMessage" and "DataStoreMessageNew" match
+    And All indices are deleted
 
   Scenario: Check the message store
-    Store few messages with few metrics, position and body (partially randomly generated) and check 
+    Store few messages with few metrics, position and body (partially randomly generated) and check
     if the stored message (retrieved by id) has all the fields correctly set.
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
@@ -84,11 +86,13 @@ Feature: Datastore tests
     And I refresh all database indices
     When I search for messages with IDs from the list "StoredMessageIDs" and store them in the list "StoredMessagesList"
     Then The datastore messages in list "StoredMessagesList" matches the prepared messages in list "RandomMessagesList"
+    And All indices are deleted
 
   Scenario: Delete items by the datastore ID
     Delete a previously stored message and verify that it is not in the store any more. Also delete and check the
     message related channel, metric and client info entries.
 
+    Given All indices are deleted
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Account for "kapua-sys"
     And The device "test-device-1"
@@ -119,9 +123,11 @@ Feature: Datastore tests
     And I refresh all database indices
     When I count the current account clients and store the count as "AccountClientCount"
     Then The value of "AccountClientCount" is exactly 0
+    And All indices are deleted
 
   Scenario: Delete items based on query results
 
+    Given All indices are deleted
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Account for "kapua-sys"
     And The device "test-device-1"
@@ -168,9 +174,11 @@ Feature: Datastore tests
     And I refresh all database indices
     When I query for the current account clients and store them as "AccountClientlList2"
     Then There are exactly 2 clients in the list "AccountClientlList2"
+    And All indices are deleted
 
   Scenario: Check the mapping for message semantic topics
 
+    Given All indices are deleted
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Account for "kapua-sys"
     And The device "test-device-1"
@@ -187,6 +195,7 @@ Feature: Datastore tests
     Then The value of "AccountMetricCount" is exactly 15
     When I search for messages with IDs from the list "StoredMessageIDs" and store them in the list "StoredMessagesList"
     Then The datastore messages in list "StoredMessagesList" matches the prepared messages in list "TestMessages"
+    And All indices are deleted
 
   Scenario: Ordered query
     Test the correctness of the query filtering order (3 fields: date descending, date ascending, string descending)
@@ -205,11 +214,13 @@ Feature: Datastore tests
     Then I refresh all database indices
     When I perform an ordered query for messages and store the results as "QueriedMessageList"
     Then The items in the list "QueriedMessageList" are stored in the default order
+    And All indices are deleted
 
   Scenario: Test the message store with timestamp indexing
     Test the correctness of the storage process with a basic message (no metrics, payload and position)
     indexing message date by device timestamp (as default).
 
+    And All indices are deleted
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Account for "kapua-sys"
     And The device "test-device-1"
@@ -220,11 +231,13 @@ Feature: Datastore tests
     When I perform a default query for the account messages and store the results as "AccountMessages"
     And I pick message number 0 from the list "AccountMessages" and remember it as "QueriedMessage"
     Then The datastore message "QueriedMessage" matches the prepared message "TestMessageWithNullPayload"
+    And All indices are deleted
 
   Scenario: Test the message store with server timestamp indexing
     Test the correctness of the storage process with a basic message (no metrics, payload and position)
     indexing message date by server timestamp (as default).
 
+    Given All indices are deleted
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Account for "kapua-sys"
     And The device "test-device-1"
@@ -235,11 +248,13 @@ Feature: Datastore tests
     When I perform a default query for the account messages and store the results as "AccountMessages"
     And I pick message number 0 from the list "AccountMessages" and remember it as "QueriedMessage"
     Then The datastore message "QueriedMessage" matches the prepared message "TestMessageWithNullPayload"
+    And All indices are deleted
 
   Scenario: ChannelInfo client ID and topic data based on the account id
     Check the correctness of the client ids and topics stored in the channel info data by retrieving the
     channel info by account id
 
+    Given All indices are deleted
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Account for "kapua-sys"
     And The device "test-device-1"
@@ -257,6 +272,7 @@ Feature: Datastore tests
     When I query for the current account channels and store them as "AccountChannelList"
     Then There are exactly 6 channels in the list "AccountChannelList"
     And The channel info items "AccountChannelList" match the prepared messages in "TestMessages"
+    And All indices are deleted
 
   Scenario: ChannelInfo client ID and topic data based on the client id
   Check the correctness of the client ids and topics stored in the channel info data by retrieving the
@@ -283,6 +299,7 @@ Feature: Datastore tests
     When I query for the channel info of the client "test-client-1" and store the result as "ClientInfoList"
     Then There are exactly 4 channels in the list "ClientInfoList"
     And The channel info items "ClientInfoList" match the prepared messages in "TestMessages1"
+    And All indices are deleted
 
   Scenario: ChannelInfo last published date
     Check the correctness of the channel info last publish date stored by retrieving the
@@ -306,3 +323,4 @@ Feature: Datastore tests
     And Client "test-client-1" last published on a channel in the list "ChannelList" on "03/07/2017T09:00:00"
     And Client "test-client-2" first published on a channel in the list "ChannelList" on "03/07/2017T09:00:00"
     And Client "test-client-2" last published on a channel in the list "ChannelList" on "03/07/2017T09:00:20"
+    And All indices are deleted

--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -13,6 +13,12 @@ Feature: Device Registry Integration
     Device Registy integration test scenarios. These scenarios test higher level device service functionality
     with all services live.
 
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
 Scenario: Birth message handling from a new device
     A birth message is received. The referenced device does not yet exist and is created on-the-fly. After the
     message is processed a new device must be created and a BIRTH event inserted in the database.
@@ -257,3 +263,9 @@ Scenario: Creating new device and tagging it with specific Tag
     When I search for device with tag "KuraDevice"
     Then I find device "device_1"
     And I logout
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios

--- a/qa/src/test/resources/features/tag/TagService.feature
+++ b/qa/src/test/resources/features/tag/TagService.feature
@@ -21,6 +21,9 @@ Feature: Tag Service
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
 
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
   Scenario: Creating tag
     Create a tag entry, with specified name. Name is only tag specific attribute.
     Once created search for it and is should been created.
@@ -29,3 +32,6 @@ Feature: Tag Service
     When Tag with name "tagName" is searched
     Then Tag with name "tagName" is found
       And I logout
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios


### PR DESCRIPTION
QA tests were failing because datastore - ES or broker was not started
as part of Before hooks in cucumber scenarios.
For that purpose delays were introduced while starting embedded servers.
This solved problem and is configurable from system properties which can
also be set in cucumber tests runners.

Datastore test were changed by deleting indices as part of scenario steps
and not in before and after hooks. This was done because startup issues,
datastore is not yet started when hook is executed.

I know that this is not perfect solution to a problem and it also increases
the execution time of QA tests. Suggestions?

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>