### PR TITLE
Fix datastore message

### DIFF
--- a/assembly/broker/src/main/resources/conf/broker/camel.xml
+++ b/assembly/broker/src/main/resources/conf/broker/camel.xml
@@ -84,13 +84,18 @@
         CamelExceptionCaught
         (others useful fields CamelMulticastIndex - CamelMessageHistory - CamelCreatedTimestamp)
         -->
-        <errorHandler id="mainRouteMessageErrorHandler"
+        <errorHandler id="mainRouteMessageErrorHandler" redeliveryPolicyRef="kapuaRedeliveryPolicy"
                       type="DeadLetterChannel"
                       deadLetterUri="bean:errorMessageListener?method=processMessage"
                       useOriginalMessage="true">
-            <redeliveryPolicy maximumRedeliveries="3" redeliveryDelay="2000"/>
         </errorHandler>
-
+        <errorHandler id="messageErrorHandler" redeliveryPolicyRef="kapuaErrorRedeliveryPolicy"
+                      type="DeadLetterChannel"
+                      deadLetterUri="activemq:queue:notProcessableMessage"
+                      useOriginalMessage="true">
+        </errorHandler>
+        <redeliveryPolicyProfile id="kapuaRedeliveryPolicy" maximumRedeliveries="0" redeliveryDelay="0" retryAttemptedLogLevel="WARN" logRetryAttempted="true" />
+        <redeliveryPolicyProfile id="kapuaErrorRedeliveryPolicy" maximumRedeliveries="0" redeliveryDelay="0" retryAttemptedLogLevel="WARN" logRetryAttempted="true" />
         <!--
         For the transaction/acknowledge mode please follow http://stackoverflow.com/questions/13498652/camel-jms-client-acknowledge-mode
 
@@ -106,8 +111,42 @@
         acknowledgementModeName=CLIENT_ACKNOWLEDGE
         transacted=false
         -->
-        <route errorHandlerRef="mainRouteMessageErrorHandler">
+        <route errorHandlerRef="mainRouteMessageErrorHandler" id="mainKapuaRoute">
             <from uri="activemq:queue:Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.>?asyncConsumer=false&amp;acknowledgementModeName=CLIENT_ACKNOWLEDGE&amp;transacted=false&amp;concurrentConsumers=20&amp;maxConcurrentConsumers=50"/>
+            <!--  handling timeout and communication exceptions in a retry queue -->
+            <onException>
+                <exception>org.eclipse.kapua.service.datastore.internal.mediator.DatastoreCommunicationException</exception>
+                <redeliveryPolicy maximumRedeliveries="0" logRetryAttempted="true" retryAttemptedLogLevel="WARN"/>
+                <handled>
+                    <constant>true</constant>
+                </handled>
+                <to uri="activemq:queue:storeCommunicationException"/>
+            </onException>
+            <!-- handling configuration error -->
+            <onException>
+                <exception>org.eclipse.kapua.service.datastore.internal.mediator.ConfigurationException</exception>
+                <redeliveryPolicy maximumRedeliveries="0" logRetryAttempted="true" retryAttemptedLogLevel="WARN"/>
+                <handled>
+                    <constant>true</constant>
+                </handled>
+                <to uri="activemq:queue:storeConfigurationException"/>
+            </onException>
+            <onException>
+                <exception>org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException</exception>
+                <redeliveryPolicy maximumRedeliveries="0" logRetryAttempted="true" retryAttemptedLogLevel="WARN"/>
+                <handled>
+                    <constant>true</constant>
+                </handled>
+                <to uri="activemq:queue:storeGenericException"/>
+            </onException>
+            <onException>
+                <exception>org.eclipse.kapua.KapuaException</exception>
+                <redeliveryPolicy maximumRedeliveries="0" logRetryAttempted="true" retryAttemptedLogLevel="WARN"/>
+                <handled>
+                    <constant>true</constant>
+                </handled>
+                <to uri="activemq:queue:notProcessableMessage"/>
+            </onException>
             <pipeline>
                 <bean ref="kapuaCamelFilter" method="bindSession"/>
                 <choice id="choice">
@@ -151,6 +190,50 @@
                         <to uri="bean:dataStorageMessageProcessor?method=processMessage"/>
                     </otherwise>
                 </choice>
+                <bean ref="kapuaCamelFilter" method="unbindSession"/>
+            </pipeline>
+        </route>
+        <route errorHandlerRef="messageErrorHandler" id="dataMessageCommunicationErrorRoute">
+            <from uri="activemq:queue:storeCommunicationException?asyncConsumer=false&amp;acknowledgementModeName=CLIENT_ACKNOWLEDGE&amp;transacted=false&amp;concurrentConsumers=2&amp;maxConcurrentConsumers=5"/>
+            <pipeline>
+                <delay>
+                    <constant>1000</constant>
+                </delay>
+                <bean ref="kapuaCamelFilter" method="bindSession"/>
+                <bean ref="kapuaDataConverter" method="convertToDataOnException"/>
+                <to uri="bean:dataStorageMessageProcessor?method=processCommunicationErrorMessage"/>
+                <bean ref="kapuaCamelFilter" method="unbindSession"/>
+            </pipeline>
+        </route>
+        <route errorHandlerRef="messageErrorHandler" id="dataMessageConfigurationErrorRoute">
+            <from uri="activemq:queue:storeConfigurationException?asyncConsumer=false&amp;acknowledgementModeName=CLIENT_ACKNOWLEDGE&amp;transacted=false&amp;concurrentConsumers=2&amp;maxConcurrentConsumers=5"/>
+            <pipeline>
+                <delay>
+                    <constant>1000</constant>
+                </delay>
+                <bean ref="kapuaCamelFilter" method="bindSession"/>
+                <bean ref="kapuaDataConverter" method="convertToDataOnException"/>
+                <to uri="bean:dataStorageMessageProcessor?method=processConfigurationErrorMessage"/>
+                <bean ref="kapuaCamelFilter" method="unbindSession"/>
+            </pipeline>
+        </route>
+        <route errorHandlerRef="messageErrorHandler" id="dataMessageGenericErrorRoute">
+            <from uri="activemq:queue:storeGenericException?asyncConsumer=false&amp;acknowledgementModeName=CLIENT_ACKNOWLEDGE&amp;transacted=false&amp;concurrentConsumers=2&amp;maxConcurrentConsumers=5"/>
+            <pipeline>
+                <delay>
+                    <constant>1000</constant>
+                </delay>
+                <bean ref="kapuaCamelFilter" method="bindSession"/>
+                <bean ref="kapuaDataConverter" method="convertToDataOnException"/>
+                <to uri="bean:dataStorageMessageProcessor?method=processGenericErrorMessage"/>
+                <bean ref="kapuaCamelFilter" method="unbindSession"/>
+            </pipeline>
+        </route>
+        <route id="dataMessageNotProcessableErrorRoute" >
+            <from uri="activemq:queue:notProcessableMessage?asyncConsumer=false&amp;acknowledgementModeName=CLIENT_ACKNOWLEDGE&amp;transacted=false&amp;concurrentConsumers=2&amp;maxConcurrentConsumers=5"/>
+            <pipeline>
+                <bean ref="kapuaCamelFilter" method="bindSession"/>
+                <to uri="bean:dataStorageMessageProcessor?method=notProcessableMessage"/>
                 <bean ref="kapuaCamelFilter" method="unbindSession"/>
             </pipeline>
         </route>

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.converter;
 
+import java.util.Base64;
 import java.util.Date;
 
 import javax.jms.BytesMessage;
@@ -82,10 +83,10 @@ public abstract class AbstractKapuaConverter {
             try {
                 // FIX #164
                 Date queuedOn = new Date(message.getHeader(CamelConstants.JMS_HEADER_TIMESTAMP, Long.class));
-                KapuaId connectionId = (KapuaId) SerializationUtils.deserialize(message.getHeader(MessageConstants.HEADER_KAPUA_CONNECTION_ID, byte[].class));
+                KapuaId connectionId = (KapuaId) SerializationUtils.deserialize(Base64.getDecoder().decode(exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_CONNECTION_ID, String.class)));
                 String clientId = message.getHeader(MessageConstants.HEADER_KAPUA_CLIENT_ID, String.class);
                 ConnectorDescriptor connectorDescriptor = (ConnectorDescriptor) SerializationUtils
-                        .deserialize(message.getHeader(MessageConstants.HEADER_KAPUA_CONNECTOR_DEVICE_PROTOCOL, byte[].class));
+                        .deserialize(Base64.getDecoder().decode(exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_CONNECTOR_DEVICE_PROTOCOL, String.class)));
                 return JmsUtil.convertToCamelKapuaMessage(connectorDescriptor, messageType, (byte[]) value, CamelUtil.getTopic(message), queuedOn, connectionId, clientId);
             } catch (JMSException e) {
                 metricConverterErrorMessage.inc();

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaCamelFilter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaCamelFilter.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.converter;
 
+import java.util.Base64;
+
 import org.apache.camel.Exchange;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.shiro.util.ThreadContext;
@@ -40,7 +42,7 @@ public class KapuaCamelFilter extends AbstractListener {
     public void bindSession(Exchange exchange, Object value) throws KapuaException {
         ThreadContext.unbindSubject();
         // FIX #164
-        byte[] kapuaSession = exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_SESSION, byte[].class);
+        byte[] kapuaSession = Base64.getDecoder().decode(exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_SESSION, String.class));
         KapuaSecurityUtils.setSession((KapuaSession) SerializationUtils.deserialize(kapuaSession));
     }
 

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessage.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessage.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.message;
 
+import java.io.Serializable;
+
 import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -23,10 +25,13 @@ import org.eclipse.kapua.model.id.KapuaId;
  * @param <M> Contained message type
  * @since 1.0
  */
-public class CamelKapuaMessage<M extends KapuaMessage<?, ?>> {
+public class CamelKapuaMessage<M extends KapuaMessage<?, ?>> implements Serializable {
+
+    private static final long serialVersionUID = 6299705913639768816L;
 
     private M message;
     private KapuaId connectionId;
+    private String datastoreId;
     private ConnectorDescriptor connectorDescriptor;
 
     /**
@@ -64,6 +69,14 @@ public class CamelKapuaMessage<M extends KapuaMessage<?, ?>> {
 
     public void setConnectorDescriptor(ConnectorDescriptor connectorDescriptor) {
         this.connectorDescriptor = connectorDescriptor;
+    }
+
+    public String getDatastoreId() {
+        return datastoreId;
+    }
+
+    public void setDatastoreId(String datastoreId) {
+        this.datastoreId = datastoreId;
     }
 
 }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.broker.core.plugin;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -622,10 +623,11 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
                 }
             }
             // FIX #164
-            messageSend.setProperty(MessageConstants.HEADER_KAPUA_CONNECTION_ID, SerializationUtils.serialize(kapuaSecurityContext.getConnectionId()));
+            messageSend.setProperty(MessageConstants.HEADER_KAPUA_CONNECTION_ID, Base64.getEncoder().encodeToString(SerializationUtils.serialize(kapuaSecurityContext.getConnectionId())));
             messageSend.setProperty(MessageConstants.HEADER_KAPUA_CLIENT_ID, ((KapuaPrincipal) kapuaSecurityContext.getMainPrincipal()).getClientId());
-            messageSend.setProperty(MessageConstants.HEADER_KAPUA_CONNECTOR_DEVICE_PROTOCOL, SerializationUtils.serialize(kapuaSecurityContext.getConnectorDescriptor()));
-            messageSend.setProperty(MessageConstants.HEADER_KAPUA_SESSION, SerializationUtils.serialize(kapuaSecurityContext.getKapuaSession()));
+            messageSend.setProperty(MessageConstants.HEADER_KAPUA_CONNECTOR_DEVICE_PROTOCOL,
+                    Base64.getEncoder().encodeToString(SerializationUtils.serialize(kapuaSecurityContext.getConnectorDescriptor())));
+            messageSend.setProperty(MessageConstants.HEADER_KAPUA_SESSION, Base64.getEncoder().encodeToString(SerializationUtils.serialize(kapuaSecurityContext.getKapuaSession())));
         }
         if (messageSend.getContent() != null) {
             metricPublishMessageSizeAllowed.update(messageSend.getContent().length);

--- a/dev-tools/src/main/vagrant/develop/broker/start-broker.sh
+++ b/dev-tools/src/main/vagrant/develop/broker/start-broker.sh
@@ -12,4 +12,5 @@
 #*******************************************************************************
 # Kapua jars and activemq.xml need to be added before starting the activemq instance...
 ./update-kapua-jars-cfg.sh
+export ACTIVEMQ_OPTS="-Dorg.apache.activemq.SERIALIZABLE_PACKAGES=*"
 bin/activemq start xbean:conf/activemq.xml

--- a/message/api/src/main/java/org/eclipse/kapua/message/Channel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Channel.java
@@ -13,6 +13,8 @@ package org.eclipse.kapua.message;
 
 import org.eclipse.kapua.message.xml.MessageXmlRegistry;
 
+import java.io.Serializable;
+
 import javax.xml.bind.annotation.XmlType;
 
 /**
@@ -21,6 +23,6 @@ import javax.xml.bind.annotation.XmlType;
  * @since 1.0
  */
 @XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaChannel") //
-public interface Channel {
+public interface Channel extends Serializable {
 
 }

--- a/message/api/src/main/java/org/eclipse/kapua/message/Payload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Payload.java
@@ -13,6 +13,8 @@ package org.eclipse.kapua.message;
 
 import org.eclipse.kapua.message.xml.MessageXmlRegistry;
 
+import java.io.Serializable;
+
 import javax.xml.bind.annotation.XmlType;
 
 /**
@@ -21,6 +23,6 @@ import javax.xml.bind.annotation.XmlType;
  * @since 1.0
  */
 @XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newPayload") //
-public interface Payload {
+public interface Payload extends Serializable {
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
@@ -43,6 +43,17 @@ public interface MessageStoreService extends KapuaService, KapuaConfigurableServ
             throws KapuaException;
 
     /**
+     * Store the message setting the provided datastoreId
+     * 
+     * @param message
+     * @param datastoreId
+     * @return
+     * @throws KapuaException
+     */
+    InsertResponse store(KapuaMessage<?, ?> message, String datastoreId)
+            throws KapuaException;
+
+    /**
      * Find message by identifier
      * 
      * @param scopeId

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientCommunicationException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientCommunicationException.java
@@ -9,28 +9,25 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.service.datastore.client.model;
+package org.eclipse.kapua.service.datastore.client;
 
 /**
- * Insert request
- * 
- * @since 1.0
+ * Client communication exception (timeout, no node available ...)
  *
+ * @since 1.0
  */
-public class InsertRequest extends Request {
+public class ClientCommunicationException extends ClientException {
+
+    private static final long serialVersionUID = 1599649533697887868L;
 
     /**
-     * Defualt constructor
-     * 
-     * @param id
-     *            object identifier
-     * @param typeDescriptor
-     *            index/type descriptor
-     * @param storable
-     *            object to insert
+     * Construct the exception with the provided throwable
+     *
+     * @param message
+     * @param t
      */
-    public InsertRequest(String id, TypeDescriptor typeDescriptor, Object storable) {
-        super(id, typeDescriptor, storable);
+    public ClientCommunicationException(String message, Throwable t) {
+        super(ClientErrorCodes.COMMUNICATION_ERROR, t);
     }
 
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorCodes.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorCodes.java
@@ -43,6 +43,9 @@ public enum ClientErrorCodes implements KapuaErrorCode {
     /**
      * Error on performed action
      */
-    ACTION_ERROR
-
+    ACTION_ERROR,
+    /**
+     * Error on communication with the underlying datastore layer (timeout, no node available ...)
+     */
+    COMMUNICATION_ERROR
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientException.java
@@ -53,4 +53,14 @@ public class ClientException extends KapuaException {
         super(code, t, message);
     }
 
+    /**
+     * Construct the exception with the provided code, throwable and message
+     * 
+     * @param code
+     * @param t
+     */
+    public ClientException(KapuaErrorCode code, Throwable t) {
+        super(code, t);
+    }
+
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/Request.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/Request.java
@@ -19,11 +19,15 @@ package org.eclipse.kapua.service.datastore.client.model;
 public abstract class Request {
 
     /**
+     * Object identifier
+     */
+    private String id;
+    /**
      * index/type descriptor
      */
     private TypeDescriptor typeDescriptor;
     /**
-     * Storable object
+     * Object to be stored
      */
     private Object storable;
 
@@ -34,9 +38,28 @@ public abstract class Request {
      *            index/type descriptor
      * @param storable
      */
-    protected Request(TypeDescriptor typeDescriptor, Object storable) {
+    protected Request(String id, TypeDescriptor typeDescriptor, Object storable) {
+        this.id = id;
         this.typeDescriptor = typeDescriptor;
         this.storable = storable;
+    }
+
+    /**
+     * Get the object id
+     * 
+     * @return
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set the object id
+     * 
+     * @param id
+     */
+    public void setId(String id) {
+        this.id = id;
     }
 
     /**

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/UpdateRequest.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/UpdateRequest.java
@@ -18,36 +18,19 @@ package org.eclipse.kapua.service.datastore.client.model;
  */
 public class UpdateRequest extends Request {
 
-    private String id;
 
     /**
-     * Construct the update request with the provided parameters
+     * Defualt constructor
      * 
+     * @param id
+     *            object identifier
      * @param typeDescriptor
-     * @param id
+     *            index/type descriptor
      * @param storable
+     *            object to insert
      */
-    public UpdateRequest(TypeDescriptor typeDescriptor, String id, Object storable) {
-        super(typeDescriptor, storable);
-        this.id = id;
-    }
-
-    /**
-     * Get the object id
-     * 
-     * @return
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Set the object id
-     * 
-     * @param id
-     */
-    public void setId(String id) {
-        this.id = id;
+    public UpdateRequest(String id, TypeDescriptor typeDescriptor, Object storable) {
+        super(id, typeDescriptor, storable);
     }
 
 }

--- a/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/TransportDatastoreClient.java
+++ b/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/TransportDatastoreClient.java
@@ -61,6 +61,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.search.SearchHit;
@@ -193,6 +194,9 @@ public class TransportDatastoreClient implements org.eclipse.kapua.service.datas
         Map<String, Object> storableMap = modelContext.marshal(insertRequest.getStorable());
         logger.debug("Insert - converted object: '{}'", storableMap);
         IndexRequest idxRequest = new IndexRequest(insertRequest.getTypeDescriptor().getIndex(), insertRequest.getTypeDescriptor().getType()).source(storableMap);
+        if (insertRequest.getId() != null) {
+            idxRequest.id(insertRequest.getId()).version(1).versionType(VersionType.EXTERNAL);
+        }
         IndexResponse response = esClientProvider.getClient().index(idxRequest).actionGet(getQueryTimeout());
         return new InsertResponse(response.getId(), insertRequest.getTypeDescriptor());
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -107,7 +107,7 @@ public class ChannelInfoRegistryFacade {
                         Metadata metadata = mediator.getMetadata(channelInfo.getScopeId(), channelInfo.getFirstMessageOn().getTime());
                         String registryIndexName = metadata.getRegistryIndexName();
 
-                        UpdateRequest request = new UpdateRequest(new TypeDescriptor(metadata.getRegistryIndexName(), ChannelInfoSchema.CHANNEL_TYPE_NAME), channelInfo.getId().toString(),
+                        UpdateRequest request = new UpdateRequest(channelInfo.getId().toString(), new TypeDescriptor(metadata.getRegistryIndexName(), ChannelInfoSchema.CHANNEL_TYPE_NAME),
                                 channelInfo);
                         response = client.upsert(request);
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
@@ -108,7 +108,7 @@ public class ClientInfoRegistryFacade {
                         Metadata metadata = mediator.getMetadata(clientInfo.getScopeId(), clientInfo.getFirstMessageOn().getTime());
                         String kapuaIndexName = metadata.getRegistryIndexName();
 
-                        UpdateRequest request = new UpdateRequest(new TypeDescriptor(kapuaIndexName, ClientInfoSchema.CLIENT_TYPE_NAME), clientInfo.getId().toString(), clientInfo);
+                        UpdateRequest request = new UpdateRequest(clientInfo.getId().toString(), new TypeDescriptor(kapuaIndexName, ClientInfoSchema.CLIENT_TYPE_NAME), clientInfo);
                         response = client.upsert(request);
 
                         if (!clientInfoId.equals(response.getId())) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -11,8 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
+import java.util.UUID;
+
+import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableService;
+import org.eclipse.kapua.commons.metric.MetricServiceFactory;
+import org.eclipse.kapua.commons.metric.MetricsService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
@@ -26,8 +32,12 @@ import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.datastore.DatastoreDomain;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.client.ClientCommunicationException;
 import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
 import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
+import org.eclipse.kapua.service.datastore.internal.mediator.ConfigurationException;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreCommunicationException;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettingKey;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettings;
@@ -36,6 +46,10 @@ import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.StorableId;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.Timer.Context;
 
 /**
  * Message store service implementation.
@@ -46,8 +60,21 @@ import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
 public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService implements MessageStoreService {
 
     private static final Domain DATASTORE_DOMAIN = new DatastoreDomain();
+    private static final String METRIC_COMPONENT_NAME = "datastore";
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    // metrics
+    private final Counter metricMessageCount;
+    private final Counter metricCommunicationErrorCount;
+    private final Counter metricConfigurationErrorCount;
+    private final Counter metricGenericErrorCount;
+    private final Counter metricValidationErrorCount;
+    // store timers
+    private final Timer metricDataSaveTime;
+    // queues counters
+    private final Counter metricQueueCommunicationErrorCount;
+    private final Counter metricQueueConfigurationErrorCount;
+    private final Counter metricQueueGenericErrorCount;
 
     private final AccountService accountService = LOCATOR.getService(AccountService.class);
     private final AuthorizationService authorizationService = LOCATOR.getService(AuthorizationService.class);
@@ -63,51 +90,103 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
      */
     public MessageStoreServiceImpl() throws ClientUnavailableException {
         super(MessageStoreService.class.getName(), DATASTORE_DOMAIN, DatastoreEntityManagerFactory.getInstance());
-
         ConfigurationProviderImpl configurationProvider = new ConfigurationProviderImpl(this, accountService);
         messageStoreFacade = new MessageStoreFacade(configurationProvider, DatastoreMediator.getInstance());
         DatastoreMediator.getInstance().setMessageStoreFacade(messageStoreFacade);
+        // data message
+        MetricsService metricService = MetricServiceFactory.getInstance();
+        metricMessageCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "count");
+        metricCommunicationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "communication", "error", "count");
+        metricConfigurationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "configuration", "error", "count");
+        metricGenericErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "generic", "error", "count");
+        metricValidationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "validation", "error", "count");
+        // error messages queues size
+        metricQueueCommunicationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "queue", "communication", "error", "count");
+        metricQueueConfigurationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "queue", "configuration", "error", "count");
+        metricQueueGenericErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "queue", "generic", "error", "count");
+        // store timers
+        metricDataSaveTime = metricService.getTimer(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "time", "s");
     }
 
     @Override
     public InsertResponse store(KapuaMessage<?, ?> message)
             throws KapuaException {
-        ArgumentValidator.notNull(message.getScopeId(), "message.scopeId");
-
-        checkDataAccess(message.getScopeId(), Actions.write);
+        String datastoreId = UUID.randomUUID().toString();
+        Context metricDataSaveTimeContext = metricDataSaveTime.time();
         try {
-            return messageStoreFacade.store(message);
+            checkDataAccess(message.getScopeId(), Actions.write);
+            metricMessageCount.inc();
+            return messageStoreFacade.store(message, datastoreId, true);
+        } catch (ConfigurationException e) {
+            metricConfigurationErrorCount.inc();
+            metricQueueConfigurationErrorCount.inc();
+            throw e;
+        } catch (KapuaIllegalArgumentException e) {
+            metricValidationErrorCount.inc();
+            metricQueueGenericErrorCount.inc();
+            throw e;
+        } catch (ClientCommunicationException e) {
+            metricCommunicationErrorCount.inc();
+            metricQueueCommunicationErrorCount.inc();
+            throw new DatastoreCommunicationException(datastoreId, e);
         } catch (Exception e) {
-            throw KapuaException.internalError(e);
+            metricGenericErrorCount.inc();
+            metricQueueGenericErrorCount.inc();
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+        } finally {
+            metricDataSaveTimeContext.stop();
+        }
+    }
+
+    @Override
+    public InsertResponse store(KapuaMessage<?, ?> message, String datastoreId)
+            throws KapuaException {
+        ArgumentValidator.notEmptyOrNull(datastoreId, "datastoreId");
+        Context metricDataSaveTimeContext = metricDataSaveTime.time();
+        try {
+            checkDataAccess(message.getScopeId(), Actions.write);
+            metricMessageCount.inc();
+            return messageStoreFacade.store(message, datastoreId, false);
+        } catch (ConfigurationException e) {
+            metricConfigurationErrorCount.inc();
+            metricQueueConfigurationErrorCount.inc();
+            throw e;
+        } catch (KapuaIllegalArgumentException e) {
+            metricValidationErrorCount.inc();
+            metricQueueGenericErrorCount.inc();
+            throw e;
+        } catch (ClientCommunicationException e) {
+            metricCommunicationErrorCount.inc();
+            metricQueueCommunicationErrorCount.inc();
+            throw new DatastoreCommunicationException(datastoreId, e);
+        } catch (Exception e) {
+            metricGenericErrorCount.inc();
+            metricQueueGenericErrorCount.inc();
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+        } finally {
+            metricDataSaveTimeContext.stop();
         }
     }
 
     @Override
     public void delete(KapuaId scopeId, StorableId id)
             throws KapuaException {
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(id, "id");
-
         checkDataAccess(scopeId, Actions.delete);
         try {
             messageStoreFacade.delete(scopeId, id);
         } catch (Exception e) {
-            throw KapuaException.internalError(e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
         }
     }
 
     @Override
     public DatastoreMessage find(KapuaId scopeId, StorableId id, StorableFetchStyle fetchStyle)
             throws KapuaException {
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(id, "id");
-        ArgumentValidator.notNull(fetchStyle, "fetchStyle");
-
         checkDataAccess(scopeId, Actions.read);
         try {
             return messageStoreFacade.find(scopeId, id, fetchStyle);
         } catch (Exception e) {
-            throw KapuaException.internalError(e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
         }
     }
 
@@ -118,36 +197,31 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         try {
             return messageStoreFacade.query(query);
         } catch (Exception e) {
-            throw KapuaException.internalError(e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
         }
     }
 
     @Override
     public long count(MessageQuery query)
             throws KapuaException {
-        ArgumentValidator.notNull(query, "query");
-        ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
-
         checkDataAccess(query.getScopeId(), Actions.read);
         try {
             return messageStoreFacade.count(query);
         } catch (Exception e) {
-            throw KapuaException.internalError(e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
         }
     }
 
     @Override
     public void delete(MessageQuery query)
             throws KapuaException {
-        ArgumentValidator.notNull(query, "query");
-        ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
         ArgumentValidator.numRange(query.getLimit(), 0, MAX_ENTRIES_ON_DELETE, "limit");
 
         checkDataAccess(query.getScopeId(), Actions.delete);
         try {
             messageStoreFacade.delete(query);
         } catch (Exception e) {
-            throw KapuaException.internalError(e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
         }
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
@@ -102,7 +102,7 @@ public class MetricInfoRegistryFacade {
                 Metadata metadata = mediator.getMetadata(metricInfo.getScopeId(), metricInfo.getFirstMessageOn().getTime());
                 String kapuaIndexName = metadata.getRegistryIndexName();
 
-                UpdateRequest request = new UpdateRequest(new TypeDescriptor(metadata.getRegistryIndexName(), MetricInfoSchema.METRIC_TYPE_NAME), metricInfo.getId().toString(), metricInfo);
+                UpdateRequest request = new UpdateRequest(metricInfo.getId().toString(), new TypeDescriptor(metadata.getRegistryIndexName(), MetricInfoSchema.METRIC_TYPE_NAME), metricInfo);
                 response = client.upsert(request);
 
                 if (!metricInfoId.equals(response.getId())) {
@@ -149,7 +149,7 @@ public class MetricInfoRegistryFacade {
                 performUpdate = true;
                 Metadata metadata = mediator.getMetadata(metricInfo.getScopeId(), metricInfo.getFirstMessageOn().getTime());
                 bulkRequest.add(
-                        new UpdateRequest(new TypeDescriptor(metadata.getRegistryIndexName(), MetricInfoSchema.METRIC_TYPE_NAME), metricInfo.getId().toString(), metricInfo));
+                        new UpdateRequest(metricInfo.getId().toString(), new TypeDescriptor(metadata.getRegistryIndexName(), MetricInfoSchema.METRIC_TYPE_NAME), metricInfo));
             }
         }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/ModelContextImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/ModelContextImpl.java
@@ -18,6 +18,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
@@ -124,6 +125,10 @@ public class ModelContextImpl implements ModelContext {
         DatastoreMessageImpl message = new DatastoreMessageImpl();
         String id = (String) messageMap.get(ModelContext.DATASTORE_ID_KEY);
         message.setDatastoreId(new StorableIdImpl(id));
+        String messageId = (String) messageMap.get(MessageSchema.MESSAGE_ID);
+        if (messageId != null) {
+            message.setId(UUID.fromString(messageId));
+        }
 
         KapuaId scopeId = new KapuaEid(new BigInteger((String) messageMap.get(MessageSchema.MESSAGE_SCOPE_ID)));
         message.setScopeId(scopeId);
@@ -291,6 +296,9 @@ public class ModelContextImpl implements ModelContext {
         Map<String, Object> unmarshalledMessage = new HashMap<>();
         String scopeId = message.getScopeId().toStringId();
         String deviceIdStr = message.getDeviceId() == null ? null : message.getDeviceId().toStringId();
+        if (message.getId() != null) {
+            unmarshalledMessage.put(MessageSchema.MESSAGE_ID, message.getId().toString());
+        }
         unmarshalledMessage.put(MessageSchema.MESSAGE_TIMESTAMP, KapuaDateUtils.formatDate(message.getTimestamp()));
         unmarshalledMessage.put(MessageSchema.MESSAGE_RECEIVED_ON, KapuaDateUtils.formatDate(message.getReceivedOn()));
         unmarshalledMessage.put(MessageSchema.MESSAGE_IP_ADDRESS, "127.0.0.1");// TODO

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreCommunicationException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreCommunicationException.java
@@ -18,27 +18,27 @@ package org.eclipse.kapua.service.datastore.internal.mediator;
  * @since 1.0
  *
  */
-public class ConfigurationException extends DatastoreException {
+public class DatastoreCommunicationException extends DatastoreException {
 
     private static final long serialVersionUID = 5211237236391747299L;
 
-    /**
-     * Construct the exception with the provided message
-     * 
-     * @param message
-     */
-    public ConfigurationException(String message) {
-        super(DatastoreErrorCodes.CONFIGURATION_ERROR, message);
-    }
+    private String uuid;
 
     /**
-     * Construct the exception with the provided message and throwable
+     * Construct the exception with the provided uuid and throwable
      * 
-     * @param message
+     * @param uuid
+     *            the kapua message identifier
      * @param t
+     *            cause exception
      */
-    public ConfigurationException(String message, Throwable t) {
-        super(DatastoreErrorCodes.CONFIGURATION_ERROR, t, message);
+    public DatastoreCommunicationException(String uuid, Throwable t) {
+        super(DatastoreErrorCodes.COMMUNICATION_ERROR, t);
+        this.uuid = uuid;
+    }
+
+    public String getUuid() {
+        return uuid;
     }
 
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreErrorCodes.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreErrorCodes.java
@@ -27,6 +27,9 @@ public enum DatastoreErrorCodes implements KapuaErrorCode {
     /**
      * Invalid channel format
      */
-    INVALID_CHANNEL
-
+    INVALID_CHANNEL,
+    /**
+     * Error on communication with the underlying datastore layer (timeout, no node available ...)
+     */
+    COMMUNICATION_ERROR
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreException.java
@@ -47,7 +47,18 @@ public class DatastoreException extends KapuaException {
      * 
      * @param code
      * @param t
+     */
+    public DatastoreException(KapuaErrorCode code, Throwable t) {
+        super(code, t);
+    }
+
+    /**
+     * Construct the exception with the provided error code, throwable and message
+     * 
+     * @param code
+     * @param t
      * @param message
+     *            message
      */
     public DatastoreException(KapuaErrorCode code, Throwable t, String message) {
         super(code, t, message);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageField.java
@@ -21,6 +21,10 @@ import org.eclipse.kapua.service.datastore.model.query.StorableField;
  */
 public enum MessageField implements StorableField {
     /**
+     * Message identifier
+     */
+    MESSAGE_ID(MessageSchema.MESSAGE_ID),
+    /**
      * Account identifier
      */
     SCOPE_ID(MessageSchema.MESSAGE_SCOPE_ID),

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MessageQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MessageQueryImpl.java
@@ -75,6 +75,7 @@ public class MessageQueryImpl extends AbstractStorableQuery<DatastoreMessage> im
     @Override
     public String[] getFields() {
         return new String[] {
+                MessageField.MESSAGE_ID.field(),
                 MessageField.SCOPE_ID.field(),
                 MessageField.DEVICE_ID.field(),
                 MessageField.CLIENT_ID.field(),

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -56,6 +56,10 @@ public class MessageSchema {
      */
     public final static String MESSAGE_TYPE_NAME = "message";
     /**
+     * Message id
+     */
+    public static final String MESSAGE_ID = "message_id";
+    /**
      * Message timestamp
      */
     public final static String MESSAGE_TIMESTAMP = "timestamp";
@@ -201,6 +205,9 @@ public class MessageSchema {
         messageNode.set(KEY_ALL, allMessage);
 
         ObjectNode propertiesNode = SchemaUtil.getObjectNode();
+        ObjectNode messageId = SchemaUtil.getField(
+                new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_KEYWORD), new KeyValueEntry(KEY_INDEX, VALUE_TRUE) });
+        propertiesNode.set(MESSAGE_ID, messageId);
         ObjectNode messageTimestamp = SchemaUtil.getField(
                 new KeyValueEntry[] { new KeyValueEntry(KEY_TYPE, TYPE_DATE), new KeyValueEntry(KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
         propertiesNode.set(MESSAGE_TIMESTAMP, messageTimestamp);

--- a/translator/kura/jms/src/main/java/org/eclipse/kapua/translator/jms/kura/TranslatorDataJmsKura.java
+++ b/translator/kura/jms/src/main/java/org/eclipse/kapua/translator/jms/kura/TranslatorDataJmsKura.java
@@ -12,6 +12,8 @@
 package org.eclipse.kapua.translator.jms.kura;
 
 import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataChannel;
@@ -45,7 +47,12 @@ public class TranslatorDataJmsKura extends Translator<JmsMessage, KuraDataMessag
         KuraDataChannel kuraDataChannel = new KuraDataChannel();
         kuraDataChannel.setScope(mqttTopicTokens[0]);
         kuraDataChannel.setClientId(mqttTopicTokens[1]);
-        kuraDataChannel.setSemanticChannelParts(Arrays.asList(mqttTopicTokens).subList(2, mqttTopicTokens.length));
+        List<String> channelPartsList = new LinkedList<String>(Arrays.asList(mqttTopicTokens));
+        // remove the first 2 items (do no use sublist since the returned object is not serializable then Camel will throws exception on error handling
+        // channelPartsList.subList(2,mqttTopicTokens.length))
+        channelPartsList.remove(0);
+        channelPartsList.remove(0);
+        kuraDataChannel.setSemanticChannelParts(channelPartsList);
         return kuraDataChannel;
     }
 


### PR DESCRIPTION
To avoid duplication on message inserting (especially using the ES rest client) the datastore id should be generated and set before processing the message store call.
This PR generates and handles the id (via camel routes) the message inserting retry if some error occurred.