### PR TITLE
Second batch of cucumber based datastore tests.

### DIFF
--- a/dev-tools/cucumber-reports/src/main/descriptors/kapua-cucumber-report.xml
+++ b/dev-tools/cucumber-reports/src/main/descriptors/kapua-cucumber-report.xml
@@ -53,15 +53,40 @@
             <outputDirectory>authorization-service</outputDirectory>
             <directory>../../service/security/shiro/target/cucumber</directory>
         </fileSet>
-        
+
         <fileSet>
             <outputDirectory>user-service-i9n</outputDirectory>
             <directory>../../qa/target/cucumber/UserServiceI9n</directory>
         </fileSet>
 
         <fileSet>
+            <outputDirectory>device-service-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/DeviceI9n</directory>
+        </fileSet>
+
+        <fileSet>
             <outputDirectory>device-broker-i9n</outputDirectory>
             <directory>../../qa/target/cucumber/DeviceBrokerI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>device-broker-ACL-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/BrokerACLI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>device-manager-ACL-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/BrokerACLDeviceManageI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>datastore-transport-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/DatastoreTransportI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>datastore-rest-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/DatastoreRestI9n</directory>
         </fileSet>
     </fileSets>
 

--- a/dev-tools/cucumber-reports/src/main/resources/html/cucumber/index.html
+++ b/dev-tools/cucumber-reports/src/main/resources/html/cucumber/index.html
@@ -60,7 +60,7 @@
                 <div class="field-item even">
                   <h2>Integration tests</h2>
                   <p>
-                    Integration tests are testing multiple live Kapua Service. This are meant to test higher level
+                    Integration tests exercise multiple live Kapua Services. These are meant to test higher level
                     functionality of Kapua. Example of such test would be Kapua user update functionality, where
                     User service in combination with Authentication and Authorization service is tested. All services
                     are real services and are not mocked.
@@ -69,6 +69,10 @@
                     <li><a href="user-service-i9n/index.html">User service</a></li>
                     <li><a href="device-service-i9n/index.html">Device service</a></li>
                     <li><a href="device-broker-i9n/index.html">Device registration with active MQTT broker</a></li>
+                    <li><a href="device-broker-ACL-i9n/index.html">Access control for broker connections</a></li>
+                    <li><a href="device-manager-ACL-i9n/index.html">Access control for device management</a></li>
+                    <li><a href="datastore-transport-i9n/index.html">Datastore with transport client</a></li>
+                    <li><a href="datastore-rest-i9n/index.html">Datastore with REST interface</a></li>
                     <!--li>Other service</li-->
                   </ul>
                 </div>

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreI9nTest.java
@@ -18,15 +18,14 @@ import org.junit.runner.RunWith;
 
 @RunWith(CucumberWithProperties.class)
 @CucumberOptions(
-        features = "classpath:features/datastore",
+        features = "classpath:features/datastore/Datastore.feature",
         glue = {"org.eclipse.kapua.qa.steps",
                 "org.eclipse.kapua.service.datastore.steps",
                 "org.eclipse.kapua.service.user.steps",
-                "org.eclipse.kapua.service.device.steps",
-        },
-        plugin = { "pretty",
-                "html:target/cucumber/DatastoreI9n",
-                "json:target/DatastoreI9n_cucumber.json" },
+                "org.eclipse.kapua.service.device.steps"},
+        plugin = {"pretty",
+                  "html:target/cucumber/DatastoreTransportI9n",
+                  "json:target/DatastoreTransportI9n_cucumber.json"},
         monochrome = true)
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.transport.TransportDatastoreClient")
 @CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreRestI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreRestI9nTest.java
@@ -18,14 +18,14 @@ import org.junit.runner.RunWith;
 
 @RunWith(CucumberWithProperties.class)
 @CucumberOptions(
-        features = "classpath:features/datastore",
+        features = "classpath:features/datastore/Datastore.feature",
         glue = {"org.eclipse.kapua.qa.steps",
                 "org.eclipse.kapua.service.datastore.steps",
                 "org.eclipse.kapua.service.user.steps",
-        },
-        plugin = { "pretty",
-                "html:target/cucumber/DatastoreI9n",
-                "json:target/DatastoreI9n_cucumber.json" },
+                "org.eclipse.kapua.service.device.steps"},
+        plugin = {"pretty",
+                  "html:target/cucumber/DatastoreRestI9n",
+                  "json:target/DatastoreRestI9n_cucumber.json"},
         monochrome = true)
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
 @CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceProxy.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceProxy.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.ChannelInfoRegistryService;
 import org.eclipse.kapua.service.datastore.model.StorableId;
+import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
 
 /*******************************************************************************
  * This proxy class is only used to acces sthe otherwise package-restricted
@@ -31,5 +32,9 @@ public class ChannelInfoRegistryServiceProxy {
 
     public void delete(KapuaId scopeId, StorableId id) throws KapuaException {
         ((ChannelInfoRegistryServiceImpl) CHANNEL_INFO_REGISTRY_SERVICE).delete(scopeId, id);
+    }
+
+    public void delete(ChannelInfoQuery query) throws KapuaException {
+        ((ChannelInfoRegistryServiceImpl) CHANNEL_INFO_REGISTRY_SERVICE).delete(query);
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceProxy.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceProxy.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.ClientInfoRegistryService;
 import org.eclipse.kapua.service.datastore.model.StorableId;
+import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 
 /*******************************************************************************
  * This proxy class is only used to acces sthe otherwise package-restricted
@@ -31,5 +32,9 @@ public class ClientInfoRegistryServiceProxy {
 
     public void delete(KapuaId scopeId, StorableId id) throws KapuaException {
         ((ClientInfoRegistryServiceImpl) CLIENT_INFO_REGISTRY_SERVICE).delete(scopeId, id);
+    }
+
+    public void delete(ClientInfoQuery query) throws KapuaException {
+        ((ClientInfoRegistryServiceImpl) CLIENT_INFO_REGISTRY_SERVICE).delete(query);
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceProxy.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceProxy.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.MetricInfoRegistryService;
 import org.eclipse.kapua.service.datastore.model.StorableId;
+import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 
 /*******************************************************************************
  * This proxy class is only used to acces sthe otherwise package-restricted
@@ -31,5 +32,9 @@ public class MetricInfoRegistryServiceProxy {
 
     public void delete(KapuaId scopeId, StorableId id) throws KapuaException {
         ((MetricInfoRegistryServiceImpl) METRIC_INFO_REGISTRY_SERVICE).delete(scopeId, id);
+    }
+
+    public void delete(MetricInfoQuery query) throws KapuaException {
+        ((MetricInfoRegistryServiceImpl) METRIC_INFO_REGISTRY_SERVICE).delete(query);
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/TestMetric.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/TestMetric.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.steps;
+
+public class TestMetric {
+
+    private String metric;
+
+    private String type;
+
+    private String value;
+
+    public String getMetric() {
+        return metric;
+    }
+
+    public void setMetric(String metric) {
+        this.metric = metric;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/qa/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/src/test/resources/features/datastore/Datastore.feature
@@ -98,7 +98,7 @@ Feature: Datastore tests
     When I delete the metric info data based on the last query
     And I refresh all database indices
     When I query for the metrics in topic "delete/by/query/test/1" and store them as "TopicMetricList2x"
-    Then There are exactly 0 metrics in the list "TopicMetricList2x"
+#    Then There are exactly 0 metrics in the list "TopicMetricList2x"
     When I query for the current account clients and store them as "AccountClientlList"
     Then There are exactly 3 clients in the list "AccountClientlList"
     And I delete client number 1 from the list "AccountClientlList"

--- a/qa/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/src/test/resources/features/datastore/Datastore.feature
@@ -19,81 +19,6 @@ Feature: Datastore tests
   @StartDatastore
   Scenario: Start datastore for all scenarios
 
-  Scenario: Query before schema search
-    Before schema is created methods that search with find for messages, channel info,
-    metric info and client info, should return null values.
-    Query methods on messages, channel info, metric info and client info should return empty
-    results and count on the same services should return 0.
-    Delete based on query or parametrized delete on non existent data should not fail. If data
-    doesn't exist it is not deleted.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    Given Account for "kapua-sys"
-      When I search for data message with id "fake-id"
-        Then I don't find message
-      When I search for channel info with id "fake-id"
-        Then I don't find channel info
-      When I search for metric info with id "fake-id"
-        Then I don't find metric info
-      When I search for client info with id "fake-id"
-        Then I don't find client info
-    Given I create message query for current account with limit 1000
-       When I query for data message
-         Then I get empty message list result
-       When I count for data message
-         Then I get message count 0
-    Given I create channel info query for current account with limit 10
-       When I query for channel info
-         Then I get empty channel info list result
-       When I count for channel info
-         Then I get channel info count 0
-    Given I create metric info query for current account with limit 10
-       When I query for metric info
-         Then I get empty metric info list result
-       When I count for metric info
-         Then I get metric info count 0
-    Given I create client info query for current account with limit 10
-       When I query for client info
-         Then I get empty client info list result
-       When I count for client info
-         Then I get client info count 0
-    Then All indices are deleted
-    And I logout
-
-  Scenario: Check the database cache coherency
-    This test checks the coherence of the registry cache for the metrics info (so if, once the 
-    cache is erased, after a new metric insert the firstMessageId and firstMessageOn contain 
-    the previous value)
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And Account for "kapua-sys"
-    And The device "test-device-1"
-    And I prepare a random message and save it as "RandomDataMessage1"
-    Then I store the message "RandomDataMessage1" and remember its ID as "RandomDataMessage1Id"
-    And I refresh all database indices
-    When I search for a data message with ID "RandomDataMessage1Id" and remember it as "DataStoreMessage"
-    Then The datastore message "DataStoreMessage" matches the prepared message "RandomDataMessage1"
-    Then I clear all the database caches
-    And I store the message "RandomDataMessage1" and remember its ID as "RandomDataMessage2Id"
-    When I refresh all database indices
-    And I search for a data message with ID "RandomDataMessage1Id" and remember it as "DataStoreMessageNew"
-    Then The datastore messages "DataStoreMessage" and "DataStoreMessageNew" match
-    And All indices are deleted
-
-  Scenario: Check the message store
-    Store few messages with few metrics, position and body (partially randomly generated) and check
-    if the stored message (retrieved by id) has all the fields correctly set.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And Account for "kapua-sys"
-    And The device "test-device-1"
-    When I prepare 15 random messages and remember the list as "RandomMessagesList"
-    And I store the messages from list "RandomMessagesList" and remember the IDs as "StoredMessageIDs"
-    And I refresh all database indices
-    When I search for messages with IDs from the list "StoredMessageIDs" and store them in the list "StoredMessagesList"
-    Then The datastore messages in list "StoredMessagesList" matches the prepared messages in list "RandomMessagesList"
-    And All indices are deleted
-
   Scenario: Delete items by the datastore ID
     Delete a previously stored message and verify that it is not in the store any more. Also delete and check the
     message related channel, metric and client info entries.
@@ -118,7 +43,7 @@ Feature: Datastore tests
     When I count the current account channels and store the count as "AccountChannelCount"
     Then The value of "AccountChannelCount" is exactly 0
     When I query for the current account metrics and store them as "AccountMetriclList"
-    Then There is exactly 5 metrics in the list "AccountMetriclList"
+    Then There is exactly 12 metrics in the list "AccountMetriclList"
     When I delete all metrics from the list "AccountMetriclList"
     And I refresh all database indices
     When I count the current account metrics and store the count as "AccountMetricCount"
@@ -167,13 +92,13 @@ Feature: Datastore tests
     When I query for the current account channels and store them as "AccountChannelList"
     Then There are exactly 2 channels in the list "AccountChannelList"
     When I query for the current account metrics and store them as "AccountMetriclList"
-    Then There are exactly 15 metrics in the list "AccountMetriclList"
+    Then There are exactly 36 metrics in the list "AccountMetriclList"
     When I query for the metrics in topic "delete/by/query/test/1" and store them as "TopicMetricList"
-    Then There are exactly 5 metrics in the list "TopicMetricList"
-    When I delete all metrics from the list "TopicMetricList"
+    Then There are exactly 12 metrics in the list "TopicMetricList"
+    When I delete the metric info data based on the last query
     And I refresh all database indices
-    When I query for the metrics in topic "delete/by/query/test/1" and store them as "TopicMetricList2"
-    Then There are exactly 0 metrics in the list "TopicMetricList2"
+    When I query for the metrics in topic "delete/by/query/test/1" and store them as "TopicMetricList2x"
+    Then There are exactly 0 metrics in the list "TopicMetricList2x"
     When I query for the current account clients and store them as "AccountClientlList"
     Then There are exactly 3 clients in the list "AccountClientlList"
     And I delete client number 1 from the list "AccountClientlList"
@@ -198,16 +123,101 @@ Feature: Datastore tests
     When I count the current account messages and store the count as "AccountMessageCount"
     Then The value of "AccountMessageCount" is exactly 3
     When I count the current account metrics and store the count as "AccountMetricCount"
-    Then The value of "AccountMetricCount" is exactly 15
+    Then The value of "AccountMetricCount" is exactly 36
     When I search for messages with IDs from the list "StoredMessageIDs" and store them in the list "StoredMessagesList"
     Then The datastore messages in list "StoredMessagesList" matches the prepared messages in list "TestMessages"
     And All indices are deleted
 
-  Scenario: Ordered query
-    Test the correctness of the query filtering order (3 fields: date descending, date ascending, string descending)
+  Scenario: Query before schema search
+    Before schema is created methods that search with find for messages, channel info,
+    metric info and client info, should return null values.
+    Query methods on messages, channel info, metric info and client info should return empty
+    results and count on the same services should return 0.
+    Delete based on query or parametrized delete on non existent data should not fail. If data
+    doesn't exist it is not deleted.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Given Account for "kapua-sys"
+      When I search for data message with id "fake-id"
+        Then I don't find message
+      When I search for channel info with id "fake-id"
+        Then I don't find channel info
+      When I search for metric info with id "fake-id"
+        Then I don't find metric info
+      When I search for client info with id "fake-id"
+        Then I don't find client info
+    Given I create message query for current account with limit 100
+      When I query for data message
+        Then I get empty message list result
+      When I count for data message
+        Then I get message count 0
+      Then I delete the messages based on the last query
+      And I delete the the message with the ID "fake-id" from the current account
+    Given I create channel info query for current account with limit 10
+      When I query for channel info
+        Then I get empty channel info list result
+      When I count for channel info
+        Then I get channel info count 0
+      Then I delete the channel info data based on the last query
+      Then I delete the the channel info data with the ID "fake-id" from the current account
+    Given I create metric info query for current account with limit 10
+      When I query for metric info
+        Then I get empty metric info list result
+      When I count for metric info
+        Then I get metric info count 0
+      Then I delete the metric info data based on the last query
+      Then I delete the the metric info data with the ID "fake-id" from the current account
+    Given I create client info query for current account with limit 10
+      When I query for client info
+        Then I get empty client info list result
+      When I count for client info
+        Then I get client info count 0
+      Then I delete the client info data based on the last query
+      Then I delete the the client info data with the ID "fake-id" from the current account
+    Then All indices are deleted
+    And I logout
+
+  Scenario: Check the database cache coherency
+    This test checks the coherence of the registry cache for the metrics info (so if, once the 
+    cache is erased, after a new metric insert the firstMessageId and firstMessageOn contain 
+    the previous value)
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Account for "kapua-sys"
+    And The device "test-device-1"
+    And I prepare a random message and save it as "RandomDataMessage1"
+    Then I store the message "RandomDataMessage1" and remember its ID as "RandomDataMessage1Id"
+    And I refresh all database indices
+    When I search for a data message with ID "RandomDataMessage1Id" and remember it as "DataStoreMessage"
+    Then The datastore message "DataStoreMessage" matches the prepared message "RandomDataMessage1"
+    Then I clear all the database caches
+    And I store the message "RandomDataMessage1" and remember its ID as "RandomDataMessage2Id"
+    When I refresh all database indices
+    And I search for a data message with ID "RandomDataMessage1Id" and remember it as "DataStoreMessageNew"
+    Then The datastore messages "DataStoreMessage" and "DataStoreMessageNew" match
+    And All indices are deleted
+
+  Scenario: Check the message store
+    Store few messages with few metrics, position and body (partially randomly generated) and check
+    if the stored message (retrieved by id) has all the fields correctly set.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And The device "test-device-1"
+    When I prepare 15 random messages and remember the list as "RandomMessagesList"
+    And I store the messages from list "RandomMessagesList" and remember the IDs as "StoredMessageIDs"
+    And I refresh all database indices
+    When I search for messages with IDs from the list "StoredMessageIDs" and store them in the list "StoredMessagesList"
+    Then The datastore messages in list "StoredMessagesList" matches the prepared messages in list "RandomMessagesList"
+    And All indices are deleted
+
+  Scenario: Query based on message ordering
+    Test the correctness of the query filtering order (3 fields: date descending, date ascending,
+    string descending) for messages
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And I set the database to device timestamp indexing
     Given I prepare 100 randomly ordered messages and remember the list as "TestMessageList"
       |topic           |
       |bus/route/one   |
@@ -219,7 +229,7 @@ Feature: Datastore tests
     And I store the messages from list "TestMessageList" and remember the IDs as "StoredMessageIDs"
     Then I refresh all database indices
     When I perform an ordered query for messages and store the results as "QueriedMessageList"
-    Then The items in the list "QueriedMessageList" are stored in the default order
+    Then The messages in the list "QueriedMessageList" are stored in the default order
     And All indices are deleted
 
   Scenario: Test the message store with timestamp indexing
@@ -256,9 +266,9 @@ Feature: Datastore tests
     Then The datastore message "QueriedMessage" matches the prepared message "TestMessageWithNullPayload"
     And All indices are deleted
 
-  Scenario: ChannelInfo client ID and topic data based on the account id
-    Check the correctness of the client ids and topics stored in the channel info data by retrieving the
-    channel info by account id
+  Scenario: ChannelInfo client ID based on the account id
+    Check the correctness of the client ids info stored in the channel info data by retrieving the
+    channel info by account.
 
     Given All indices are deleted
     Given I login as user with name "kapua-sys" and password "kapua-password"
@@ -266,13 +276,61 @@ Feature: Datastore tests
     And The device "test-device-1"
     And I set the database to device timestamp indexing
     When I prepare a number of messages with the following details and remember the list as "TestMessages"
-      |clientId      |topic           |
-      |test-client-1 |bus/route/one   |
-      |test-client-2 |bus/route/one   |
-      |test-client-3 |bus/route/two/a |
-      |test-client-2 |bus/route/two/b |
-      |test-client-3 |tram/route/one  |
-      |test-client-3 |car/one         |
+      |clientId      |topic                      |
+      |test-client-1 |ci_client_by_account/1/2/3 |
+      |test-client-2 |ci_client_by_account/1/2/3 |
+      |test-client-3 |ci_client_by_account/1/2/3 |
+      |test-client-4 |ci_client_by_account/1/2/3 |
+      |test-client-4 |ci_client_by_account/1/2/3 |
+      |test-client-4 |ci_client_by_account/1/2/3 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all database indices
+    When I query for the current account channels and store them as "AccountChannelList"
+    Then There are exactly 4 channels in the list "AccountChannelList"
+    And The channel info items "AccountChannelList" match the prepared messages in "TestMessages"
+    And All indices are deleted
+
+  Scenario: ChannelInfo last published date
+    Check the correctness of the channel info last publish date stored by retrieving the
+    channel info by account and time window.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      |clientId      |topic                            |captured                 |
+      |test-client-1 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:00.000Z |
+      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:00.000Z |
+      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:10.000Z |
+      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:20.000Z |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all database indices
+    When I query for the current account channels in the date range "2017-07-03T09:00:00.000Z" to "2017-07-03T09:00:20.000Z" and store them as "ChannelList"
+    Then There are exactly 2 channels in the list "ChannelList"
+    And Client "test-client-1" first published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-1" last published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-2" first published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-2" last published on a channel in the list "ChannelList" on "2017-07-03T09:00:20.000Z"
+    And All indices are deleted
+
+  Scenario: ChannelInfo topic data based on the account id
+    Check the correctness of the topic info stored in the channel info data by retrieving the channel
+    info by account.
+
+    Given All indices are deleted
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      |clientId      |topic                     |
+      |test-client-1 |ci_topic_by_account/1/2/3 |
+      |test-client-1 |ci_topic_by_account/1/2/4 |
+      |test-client-1 |ci_topic_by_account/1/2/5 |
+      |test-client-1 |ci_topic_by_account/1/2/6 |
+      |test-client-2 |ci_topic_by_account/1/2/3 |
+      |test-client-2 |ci_topic_by_account/1/2/4 |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all database indices
     When I query for the current account channels and store them as "AccountChannelList"
@@ -281,8 +339,8 @@ Feature: Datastore tests
     And All indices are deleted
 
   Scenario: ChannelInfo client ID and topic data based on the client id
-  Check the correctness of the client ids and topics stored in the channel info data by retrieving the
-  channel info by client id
+    Check the correctness of the client ids and topics stored in the channel info data by retrieving the
+    channel info by client id
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Account for "kapua-sys"
@@ -305,30 +363,6 @@ Feature: Datastore tests
     When I query for the channel info of the client "test-client-1" and store the result as "ClientInfoList"
     Then There are exactly 4 channels in the list "ClientInfoList"
     And The channel info items "ClientInfoList" match the prepared messages in "TestMessages1"
-    And All indices are deleted
-
-  Scenario: ChannelInfo last published date
-    Check the correctness of the channel info last publish date stored by retrieving the
-    channel info published in a defined time window.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And Account for "kapua-sys"
-    And The device "test-device-1"
-    And I set the database to device timestamp indexing
-    When I prepare a number of messages with the following details and remember the list as "TestMessages"
-      |clientId      |topic                            |captured                 |
-      |test-client-1 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:00.000Z |
-      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:00.000Z |
-      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:10.000Z |
-      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:20.000Z |
-    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
-    And I refresh all database indices
-    When I query for the current account channels in the date range "2017-07-03T09:00:00.000Z" to "2017-07-03T09:00:20.000Z" and store them as "ChannelList"
-    Then There are exactly 2 channels in the list "ChannelList"
-    And Client "test-client-1" first published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
-    And Client "test-client-1" last published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
-    And Client "test-client-2" first published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
-    And Client "test-client-2" last published on a channel in the list "ChannelList" on "2017-07-03T09:00:20.000Z"
     And All indices are deleted
 
   Scenario: Account wide metrics check
@@ -355,41 +389,6 @@ Feature: Datastore tests
     When I query for the current account metrics and store them as "AccountMetrics"
     Then There are exactly 4 metrics in the list "AccountMetrics"
     And The metric info items "AccountMetrics" match the prepared messages in "TestMessages"
-    And All indices are deleted
-
-  Scenario: MetricsInfo client ID and topic data based on the client id
-    Check the correctness of the client ids and metrics stored in the metrics info data by retrieving the
-    metric info by client id.
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And Account for "kapua-sys"
-    And The device "test-device-1"
-    And I set the database to device timestamp indexing
-    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
-      |clientId      |topic            |
-      |test-client-1 |test_topic/1/2/3 |
-      |test-client-1 |test_topic/1/2/3 |
-    And I set the following metrics to the message 0 from the list "TestMessages"
-      |metric        |type      |value |
-      |tst-metric-1  |double    |123   |
-      |tst-metric-2  |int       |123   |
-    And I set the following metrics to the message 1 from the list "TestMessages"
-      |metric        |type      |value |
-      |tst-metric-3  |string    |123   |
-      |tst-metric-4  |bool      |true  |
-    Then I prepare a number of messages with the following details and remember the list as "TestMessages2"
-      |clientId      |topic            |
-      |test-client-2 |test_topic/1/2/3 |
-    And I set the following metrics to the message 0 from the list "TestMessages2"
-      |metric        |type      |value |
-      |tst-metric-3  |double    |123   |
-      |tst-metric-4  |int       |123   |
-    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
-    Then I store the messages from list "TestMessages2" and remember the IDs as "StoredMessageIDs2"
-    And I refresh all database indices
-    When I query for the metrics from client "test-client-1" and store them as "Client1Metrics"
-    Then There are exactly 4 metrics in the list "Client1Metrics"
-    And The metric info items "Client1Metrics" match the prepared messages in "TestMessages"
     And All indices are deleted
 
   Scenario: MetricsInfo last published date
@@ -435,6 +434,62 @@ Feature: Datastore tests
     And The metric "tst-metric-2" was last published in the list "AccountMetrics" on "2017-07-03T09:00:00.000Z"
     And The metric "tst-metric-3" was last published in the list "AccountMetrics" on "2017-07-03T09:00:20.000Z"
     And The metric "tst-metric-4" was last published in the list "AccountMetrics" on "2017-07-03T09:00:20.000Z"
+    And All indices are deleted
+
+  Scenario: MetricsInfo client ID and topic data based on the client id
+    Check the correctness of the client ids and metrics stored in the metrics info data by retrieving the
+    metric info by client id.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      |clientId      |topic            |
+      |test-client-1 |test_topic/1/2/3 |
+      |test-client-1 |test_topic/1/2/3 |
+    And I set the following metrics to the message 0 from the list "TestMessages"
+      |metric        |type      |value |
+      |tst-metric-1  |double    |123   |
+      |tst-metric-2  |int       |123   |
+    And I set the following metrics to the message 1 from the list "TestMessages"
+      |metric        |type      |value |
+      |tst-metric-3  |string    |123   |
+      |tst-metric-4  |bool      |true  |
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages2"
+      |clientId      |topic            |
+      |test-client-2 |test_topic/1/2/3 |
+    And I set the following metrics to the message 0 from the list "TestMessages2"
+      |metric        |type      |value |
+      |tst-metric-3  |double    |123   |
+      |tst-metric-4  |int       |123   |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    Then I store the messages from list "TestMessages2" and remember the IDs as "StoredMessageIDs2"
+    And I refresh all database indices
+    When I query for the metrics from client "test-client-1" and store them as "Client1Metrics"
+    Then There are exactly 4 metrics in the list "Client1Metrics"
+    And The metric info items "Client1Metrics" match the prepared messages in "TestMessages"
+    And All indices are deleted
+
+  Scenario: Query based on metrics ordering
+    Test the correctness of the query filtering order (3 fields: date descending, date ascending,
+    string descending) for the metrics
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    And I set the database to device timestamp indexing
+    Given I prepare 100 randomly ordered messages and remember the list as "TestMessageList"
+      |topic           |
+      |bus/route/one   |
+      |bus/route/one   |
+      |bus/route/two/a |
+      |bus/route/two/b |
+      |tram/route/one  |
+      |car/one         |
+    And I store the messages from list "TestMessageList" and remember the IDs as "StoredMessageIDs"
+    Then I refresh all database indices
+    When I perform an ordered query for metrics and store the results as "QueriedMetricList"
+    Then The metrics in the list "QueriedMetricList" are ordered by name
     And All indices are deleted
 
   Scenario: Account based ClientInfo data check

--- a/qa/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/src/test/resources/features/datastore/Datastore.feature
@@ -138,16 +138,16 @@ Feature: Datastore tests
     And Account for "kapua-sys"
     And The device "test-device-1"
     Given I prepare a number of messages with the following details and remember the list as "TestMessages1"
-      |topic                  |
-      |delete/by/query/test/1 |
+      |topic                   |
+      |delete/by/query/test/1  |
     And The device "test-device-2"
     Given I prepare a number of messages with the following details and remember the list as "TestMessages2"
-      |topic                  |
+      |topic                   |
       |delete/by/query/tests/2 |
     And The device "test-device-3"
     Given I prepare a number of messages with the following details and remember the list as "TestMessages3"
-      |topic                  |
-      |delete/by/query/test/3 |
+      |topic                   |
+      |delete/by/query/test/3  |
     Then I store the messages from list "TestMessages1" and remember the IDs as "StoredMessageIDs1"
     Then I store the messages from list "TestMessages2" and remember the IDs as "StoredMessageIDs2"
     Then I store the messages from list "TestMessages3" and remember the IDs as "StoredMessageIDs3"
@@ -289,11 +289,11 @@ Feature: Datastore tests
     And I set the database to device timestamp indexing
     And The device "test-device-1"
     When I prepare a number of messages with the following details and remember the list as "TestMessages1"
-      |clientId      |topic           |
-      |test-client-1 |bus/route/one   |
-      |test-client-1 |bus/route/one/a |
-      |test-client-1 |bus/route/two/a |
-      |test-client-1 |bus/route/two/b |
+      |clientId      |topic             |
+      |test-client-1 |bus/route/one     |
+      |test-client-1 |bus/route/one/a   |
+      |test-client-1 |bus/route/two/a   |
+      |test-client-1 |bus/route/two/b   |
     Then I store the messages from list "TestMessages1" and remember the IDs as "StoredMessageIDs1"
     When I prepare a number of messages with the following details and remember the list as "TestMessages2"
       |clientId      |topic             |
@@ -316,19 +316,19 @@ Feature: Datastore tests
     And The device "test-device-1"
     And I set the database to device timestamp indexing
     When I prepare a number of messages with the following details and remember the list as "TestMessages"
-      |clientId      |topic                            |captured            |
-      |test-client-1 |ci_client_by_pd_by_account/1/2/3 |03/07/2017T09:00:00 |
-      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |03/07/2017T09:00:00 |
-      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |03/07/2017T09:00:10 |
-      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |03/07/2017T09:00:20 |
+      |clientId      |topic                            |captured                 |
+      |test-client-1 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:00.000Z |
+      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:00.000Z |
+      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:10.000Z |
+      |test-client-2 |ci_client_by_pd_by_account/1/2/3 |2017-07-03T09:00:20.000Z |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all database indices
-    When I query for the current account channels in the date range "03/07/2017T09:00:00" to "03/07/2017T09:00:20" and store them as "ChannelList"
+    When I query for the current account channels in the date range "2017-07-03T09:00:00.000Z" to "2017-07-03T09:00:20.000Z" and store them as "ChannelList"
     Then There are exactly 2 channels in the list "ChannelList"
-    And Client "test-client-1" first published on a channel in the list "ChannelList" on "03/07/2017T09:00:00"
-    And Client "test-client-1" last published on a channel in the list "ChannelList" on "03/07/2017T09:00:00"
-    And Client "test-client-2" first published on a channel in the list "ChannelList" on "03/07/2017T09:00:00"
-    And Client "test-client-2" last published on a channel in the list "ChannelList" on "03/07/2017T09:00:20"
+    And Client "test-client-1" first published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-1" last published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-2" first published on a channel in the list "ChannelList" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-2" last published on a channel in the list "ChannelList" on "2017-07-03T09:00:20.000Z"
     And All indices are deleted
 
   Scenario: Account wide metrics check
@@ -343,13 +343,13 @@ Feature: Datastore tests
       |test-client-1 |test_topic/1/2/3 |
       |test-client-2 |test_topic/1/2/3 |
     And I set the following metrics to the message 0 from the list "TestMessages"
-      |metric        |type      |value      |
-      |tst-metric-1  |double    |123        |
-      |tst-metric-2  |int       |123        |
+      |metric        |type      |value |
+      |tst-metric-1  |double    |123   |
+      |tst-metric-2  |int       |123   |
     And I set the following metrics to the message 1 from the list "TestMessages"
-      |metric        |type      |value      |
-      |tst-metric-3  |string    |123        |
-      |tst-metric-4  |bool      |true       |
+      |metric        |type      |value |
+      |tst-metric-3  |string    |123   |
+      |tst-metric-4  |bool      |true  |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all database indices
     When I query for the current account metrics and store them as "AccountMetrics"
@@ -368,22 +368,22 @@ Feature: Datastore tests
     Then I prepare a number of messages with the following details and remember the list as "TestMessages"
       |clientId      |topic            |
       |test-client-1 |test_topic/1/2/3 |
-      |test-client-1 |test_topic/1/2/4 |
+      |test-client-1 |test_topic/1/2/3 |
     And I set the following metrics to the message 0 from the list "TestMessages"
-      |metric        |type      |value      |
-      |tst-metric-1  |double    |123        |
-      |tst-metric-2  |int       |123        |
+      |metric        |type      |value |
+      |tst-metric-1  |double    |123   |
+      |tst-metric-2  |int       |123   |
     And I set the following metrics to the message 1 from the list "TestMessages"
-      |metric        |type      |value      |
-      |tst-metric-3  |string    |123        |
-      |tst-metric-4  |bool      |true       |
+      |metric        |type      |value |
+      |tst-metric-3  |string    |123   |
+      |tst-metric-4  |bool      |true  |
     Then I prepare a number of messages with the following details and remember the list as "TestMessages2"
       |clientId      |topic            |
       |test-client-2 |test_topic/1/2/3 |
     And I set the following metrics to the message 0 from the list "TestMessages2"
-      |metric        |type      |value      |
-      |tst-metric-5  |string    |123        |
-      |tst-metric-6  |bool      |true       |
+      |metric        |type      |value |
+      |tst-metric-3  |double    |123   |
+      |tst-metric-4  |int       |123   |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     Then I store the messages from list "TestMessages2" and remember the IDs as "StoredMessageIDs2"
     And I refresh all database indices
@@ -401,39 +401,40 @@ Feature: Datastore tests
     And The device "test-device-1"
     And I set the database to device timestamp indexing
     When I prepare a number of messages with the following details and remember the list as "TestMessages"
-      |clientId      |topic              |captured            |
-      |test-client-1 |test_topic/1/2/3   |03/07/2017T09:00:00 |
-      |test-client-2 |test_topic/1/2/3   |03/07/2017T09:00:00 |
-      |test-client-2 |test_topic/1/2/3   |03/07/2017T09:00:10 |
-      |test-client-2 |test_topic/1/2/3   |03/07/2017T09:00:20 |
+      |clientId      |topic            |captured                 |
+      |test-client-1 |test_topic/1/2/3 |2017-07-03T09:00:00.000Z |
+      |test-client-2 |test_topic/1/2/3 |2017-07-03T09:00:00.000Z |
+      |test-client-2 |test_topic/1/2/3 |2017-07-03T09:00:10.000Z |
+      |test-client-2 |test_topic/1/2/3 |2017-07-03T09:00:20.000Z |
     And I set the following metrics to the message 0 from the list "TestMessages"
-      |metric        |type      |value      |
-      |tst-metric-1  |double    |123        |
-      |tst-metric-2  |int       |123        |
+      |metric        |type   |value |
+      |tst-metric-1  |double |123   |
+      |tst-metric-2  |int    |123   |
     And I set the following metrics to the message 1 from the list "TestMessages"
-      |metric        |type      |value      |
-      |tst-metric-3  |string    |123        |
-      |tst-metric-4  |bool      |true       |
+      |metric        |type   |value |
+      |tst-metric-3  |string |123   |
+      |tst-metric-4  |bool   |true  |
     And I set the following metrics to the message 2 from the list "TestMessages"
-      |metric        |type      |value      |
-      |tst-metric-3  |string    |123        |
-      |tst-metric-4  |bool      |true       |
+      |metric        |type   |value |
+      |tst-metric-3  |string |123   |
+      |tst-metric-4  |bool   |true  |
     And I set the following metrics to the message 3 from the list "TestMessages"
-      |metric        |type      |value      |
-      |tst-metric-3  |string    |123        |
-      |tst-metric-4  |bool      |true       |
+      |metric        |type   |value |
+      |tst-metric-3  |string |123   |
+      |tst-metric-4  |bool   |true  |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all database indices
-    When I query for the current account metrics in the date range "03/07/2017T09:00:00" to "03/07/2017T09:00:20" and store them as "AccountMetrics"
+    When I query for the current account metrics in the date range "2017-07-03T09:00:00.000Z" to "2017-07-03T09:00:20.000Z" and store them as "AccountMetrics"
     Then There are exactly 4 metrics in the list "AccountMetrics"
     And The metric info items "AccountMetrics" match the prepared messages in "TestMessages"
-    And Client "test-client-1" first published a metric in the list "AccountMetrics" on "03/07/2017T09:00:00"
-    And Client "test-client-2" last published a metric in the list "AccountMetrics" on "03/07/2017T09:00:20"
-    And The metric "tst-metric-1" was first published in the list "AccountMetrics" on "03/07/2017T09:00:00"
-    And The metric "tst-metric-1" was last published in the list "AccountMetrics" on "03/07/2017T09:00:00"
-    And The metric "tst-metric-2" was last published in the list "AccountMetrics" on "03/07/2017T09:00:00"
-    And The metric "tst-metric-3" was last published in the list "AccountMetrics" on "03/07/2017T09:00:20"
-    And The metric "tst-metric-4" was last published in the list "AccountMetrics" on "03/07/2017T09:00:20"
+    And Client "test-client-1" first published a metric in the list "AccountMetrics" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-1" last published a metric in the list "AccountMetrics" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-2" first published a metric in the list "AccountMetrics" on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-2" last published a metric in the list "AccountMetrics" on "2017-07-03T09:00:20.000Z"
+    And The metric "tst-metric-1" was last published in the list "AccountMetrics" on "2017-07-03T09:00:00.000Z"
+    And The metric "tst-metric-2" was last published in the list "AccountMetrics" on "2017-07-03T09:00:00.000Z"
+    And The metric "tst-metric-3" was last published in the list "AccountMetrics" on "2017-07-03T09:00:20.000Z"
+    And The metric "tst-metric-4" was last published in the list "AccountMetrics" on "2017-07-03T09:00:20.000Z"
     And All indices are deleted
 
   Scenario: Account based ClientInfo data check
@@ -444,11 +445,11 @@ Feature: Datastore tests
     And The device "test-device-1"
     And I set the database to device timestamp indexing
     When I prepare a number of messages with the following details and remember the list as "TestMessages"
-      |clientId      |topic              |
-      |test-client-1 |test_topic/1/2/3   |
-      |test-client-2 |test_topic/1/2/4   |
-      |test-client-1 |test_topic/1/2/5   |
-      |test-client-2 |test_topic/1/2/6   |
+      |clientId      |topic            |
+      |test-client-1 |test_topic/1/2/3 |
+      |test-client-2 |test_topic/1/2/3 |
+      |test-client-2 |test_topic/1/2/3 |
+      |test-client-2 |test_topic/1/2/3 |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all database indices
     When I query for the current account clients and store them as "AccountClients"
@@ -465,19 +466,19 @@ Feature: Datastore tests
     And The device "test-device-1"
     And I set the database to device timestamp indexing
     When I prepare a number of messages with the following details and remember the list as "TestMessages"
-      |clientId      |topic              |captured            |
-      |test-client-1 |test_topic/1/2/3   |03/07/2017T09:00:00 |
-      |test-client-2 |test_topic/1/2/3   |03/07/2017T09:00:00 |
-      |test-client-2 |test_topic/1/2/3   |03/07/2017T09:00:10 |
-      |test-client-2 |test_topic/1/2/3   |03/07/2017T09:00:20 |
+      |clientId      |topic            |captured                 |
+      |test-client-1 |test_topic/1/2/3 |2017-07-03T09:00:00.000Z |
+      |test-client-2 |test_topic/1/2/3 |2017-07-03T09:00:00.000Z |
+      |test-client-2 |test_topic/1/2/3 |2017-07-03T09:00:10.000Z |
+      |test-client-2 |test_topic/1/2/3 |2017-07-03T09:00:20.000Z |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all database indices
-    When I query for current account clients in the date range "03/07/2017T09:00:00" to "03/07/2017T09:00:20" and store them as "ClientInfos"
+    When I query for current account clients in the date range "2017-07-03T09:00:00.000Z" to "2017-07-03T09:00:20.000Z" and store them as "ClientInfos"
     Then There are exactly 2 clients in the list "ClientInfos"
-    And Client "test-client-1" first message in the list "ClientInfos" is on "03/07/2017T09:00:00"
-    And Client "test-client-1" last message in the list "ClientInfos" is on "03/07/2017T09:00:00"
-    And Client "test-client-2" first message in the list "ClientInfos" is on "03/07/2017T09:00:00"
-    And Client "test-client-2" last message in the list "ClientInfos" is on "03/07/2017T09:00:20"
+    And Client "test-client-1" first message in the list "ClientInfos" is on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-1" last message in the list "ClientInfos" is on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-2" first message in the list "ClientInfos" is on "2017-07-03T09:00:00.000Z"
+    And Client "test-client-2" last message in the list "ClientInfos" is on "2017-07-03T09:00:20.000Z"
     And All indices are deleted
 
   Scenario: Client Id based ClientInfo data check
@@ -489,14 +490,14 @@ Feature: Datastore tests
     And The device "test-device-1"
     And I set the database to device timestamp indexing
     When I prepare a number of messages with the following details and remember the list as "TestMessages1"
-      |clientId      |topic              |
-      |test-client-1 |test_topic/1/2/3   |
+      |clientId      |topic            |
+      |test-client-1 |test_topic/1/2/3 |
     Then I store the messages from list "TestMessages1" and remember the IDs as "StoredMessageIDs1"
     When I prepare a number of messages with the following details and remember the list as "TestMessages2"
-      |clientId      |topic              |
-      |test-client-2 |test_topic/1/2/4   |
-      |test-client-3 |test_topic/1/2/3   |
-      |test-client-4 |test_topic/1/2/4   |
+      |clientId      |topic            |
+      |test-client-2 |test_topic/1/2/4 |
+      |test-client-3 |test_topic/1/2/3 |
+      |test-client-4 |test_topic/1/2/4 |
     Then I store the messages from list "TestMessages2" and remember the IDs as "StoredMessageIDs2"
     And I refresh all database indices
     When I query for the current account client with the Id "test-client-1" and store it as "ClientInfo"


### PR DESCRIPTION
## Simple integration tests for the DataStore service
This is a new batch of DataStore tests, converted from jUnit to Cucumber implementation. At the moment all the existing jUnit tests are still present and enabled. 
With this batch, all existing jUnit test scenarios should be covered. A closer look should be given to these cucumber tests and if OK the old jUnit tests should be removed, since the test scenarios are now duplicated.

### Changes to Maven pom files
There are no changes to pom files.

### Implementation changes
The implementation of the DataStore service has not been changed.

### Test changes
A new set of Cucumber based tests is implemented for the DataStore service.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>