### PR TITLE
Refactored Datastore service and its tests from locator to injection

### DIFF
--- a/service/datastore/api/pom.xml
+++ b/service/datastore/api/pom.xml
@@ -33,5 +33,10 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-datastore-client-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoXmlRegistry.java
@@ -11,9 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
+import javax.inject.Inject;
 import javax.xml.bind.annotation.XmlRegistry;
 
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
 
@@ -25,8 +25,8 @@ import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
 @XmlRegistry
 public class ChannelInfoXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DatastoreObjectFactory factory = locator.getFactory(DatastoreObjectFactory.class);
+    @Inject
+    private DatastoreObjectFactory factory;
 
     /**
      * Creates a {@link ChannelInfoListResult} instance

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoXmlRegistry.java
@@ -11,9 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
+import javax.inject.Inject;
 import javax.xml.bind.annotation.XmlRegistry;
 
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.model.ClientInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 
@@ -25,8 +25,8 @@ import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 @XmlRegistry
 public class ClientInfoXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DatastoreObjectFactory factory = locator.getFactory(DatastoreObjectFactory.class);
+    @Inject
+    private DatastoreObjectFactory factory;
 
     /**
      * Creates a {@link ClientInfoListResult} instance

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreMessageXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreMessageXmlRegistry.java
@@ -11,9 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
+import javax.inject.Inject;
 import javax.xml.bind.annotation.XmlRegistry;
 
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 
@@ -25,8 +25,8 @@ import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 @XmlRegistry
 public class DatastoreMessageXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DatastoreObjectFactory factory = locator.getFactory(DatastoreObjectFactory.class);
+    @Inject
+    private DatastoreObjectFactory factory;
 
     /**
      * Creates a {@link MessageListResult} instance

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoXmlRegistry.java
@@ -11,9 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
+import javax.inject.Inject;
 import javax.xml.bind.annotation.XmlRegistry;
 
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.model.MetricInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 
@@ -25,8 +25,8 @@ import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 @XmlRegistry
 public class MetricInfoXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DatastoreObjectFactory factory = locator.getFactory(DatastoreObjectFactory.class);
+    @Inject
+    private DatastoreObjectFactory factory;
 
     /**
      * Creates a {@link MetricInfoListResult} instance

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdAdapter.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdAdapter.java
@@ -11,9 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
+import javax.inject.Inject;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
-
-import org.eclipse.kapua.locator.KapuaLocator;
 
 /**
  * Kapua identifier adapter. It marshal and unmarshal the Kapua identifier in a proper way.
@@ -24,14 +23,10 @@ import org.eclipse.kapua.locator.KapuaLocator;
 public class StorableIdAdapter extends XmlAdapter<String, StorableId> {
 
     /**
-     * Locator instance
-     */
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-
-    /**
      * Meta type factory instance
      */
-    private final StorableIdFactory storableIdFactory = locator.getFactory(StorableIdFactory.class);
+    @Inject
+    private StorableIdFactory storableIdFactory;
 
     @Override
     public String marshal(StorableId v) throws Exception {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.AccountService;
@@ -57,6 +56,8 @@ import org.eclipse.kapua.service.datastore.model.query.TermPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+
 /**
  * Channel info registry implementation
  * 
@@ -69,29 +70,28 @@ public class ChannelInfoRegistryServiceImpl extends AbstractKapuaConfigurableSer
 
     private static final Logger logger = LoggerFactory.getLogger(ChannelInfoRegistryServiceImpl.class);
 
-    private final AccountService accountService;
-    private final AuthorizationService authorizationService;
-    private final PermissionFactory permissionFactory;
+    @Inject
+    private AccountService accountService;
+    @Inject
+    private AuthorizationService authorizationService;
+    @Inject
+    private PermissionFactory permissionFactory;
+    @Inject
+    private MessageStoreService messageStoreService;
+    @Inject
+    private StorablePredicateFactory storablePredicateFactory;
+
     private final ChannelInfoRegistryFacade channelInfoRegistryFacade;
-    private final MessageStoreService messageStoreService;
-    private final StorablePredicateFactory storablePredicateFactory;
 
     /**
      * Default constructor
      * 
      * @throws ClientUnavailableException
      */
-    public ChannelInfoRegistryServiceImpl() throws ClientUnavailableException {
+    @Inject
+    public ChannelInfoRegistryServiceImpl(MessageStoreService messageStoreService, AccountService accountService) throws ClientUnavailableException {
         super(ChannelInfoRegistryService.class.getName(), DATASTORE_DOMAIN, DatastoreEntityManagerFactory.getInstance());
 
-        KapuaLocator locator = KapuaLocator.getInstance();
-        accountService = locator.getService(AccountService.class);
-        authorizationService = locator.getService(AuthorizationService.class);
-        permissionFactory = locator.getFactory(PermissionFactory.class);
-        messageStoreService = locator.getService(MessageStoreService.class);
-        storablePredicateFactory = KapuaLocator.getInstance().getFactory(StorablePredicateFactory.class);
-
-        MessageStoreService messageStoreService = KapuaLocator.getInstance().getService(MessageStoreService.class);
         ConfigurationProviderImpl configurationProvider = new ConfigurationProviderImpl(messageStoreService, accountService);
         channelInfoRegistryFacade = new ChannelInfoRegistryFacade(configurationProvider, DatastoreMediator.getInstance());
         DatastoreMediator.getInstance().setChannelInfoStoreFacade(channelInfoRegistryFacade);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.AccountService;
@@ -57,6 +56,8 @@ import org.eclipse.kapua.service.datastore.model.query.TermPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+
 /**
  * Client information registry implementation.
  * 
@@ -69,29 +70,28 @@ public class ClientInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
 
     private static final Logger logger = LoggerFactory.getLogger(ClientInfoRegistryServiceImpl.class);
 
-    private final AccountService accountService;
-    private final AuthorizationService authorizationService;
-    private final PermissionFactory permissionFactory;
+    @Inject
+    private AccountService accountService;
+    @Inject
+    private AuthorizationService authorizationService;
+    @Inject
+    private PermissionFactory permissionFactory;
+    @Inject
+    private MessageStoreService messageStoreService;
+    @Inject
+    private StorablePredicateFactory storablePredicateFactory;
+
     private final ClientInfoRegistryFacade clientInfoRegistryFacade;
-    private final MessageStoreService messageStoreService;
-    private final StorablePredicateFactory storablePredicateFactory;
 
     /**
      * Default constructor
      * 
      * @throws ClientUnavailableException
      */
-    public ClientInfoRegistryServiceImpl() throws ClientUnavailableException {
+    @Inject
+    public ClientInfoRegistryServiceImpl(MessageStoreService messageStoreService, AccountService accountService) throws ClientUnavailableException {
         super(ClientInfoRegistryService.class.getName(), DATASTORE_DOMAIN, DatastoreEntityManagerFactory.getInstance());
 
-        KapuaLocator locator = KapuaLocator.getInstance();
-        accountService = locator.getService(AccountService.class);
-        authorizationService = locator.getService(AuthorizationService.class);
-        permissionFactory = locator.getFactory(PermissionFactory.class);
-        messageStoreService = locator.getService(MessageStoreService.class);
-        storablePredicateFactory = KapuaLocator.getInstance().getFactory(StorablePredicateFactory.class);
-
-        MessageStoreService messageStoreService = KapuaLocator.getInstance().getService(MessageStoreService.class);
         ConfigurationProviderImpl configurationProvider = new ConfigurationProviderImpl(messageStoreService, accountService);
         clientInfoRegistryFacade = new ClientInfoRegistryFacade(configurationProvider, DatastoreMediator.getInstance());
         DatastoreMediator.getInstance().setClientInfoStoreFacade(clientInfoRegistryFacade);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableService;
 import org.eclipse.kapua.commons.metric.MetricServiceFactory;
 import org.eclipse.kapua.commons.metric.MetricsService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -51,6 +50,8 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Timer.Context;
 
+import javax.inject.Inject;
+
 /**
  * Message store service implementation.
  * 
@@ -62,7 +63,6 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
     private static final Domain DATASTORE_DOMAIN = new DatastoreDomain();
     private static final String METRIC_COMPONENT_NAME = "datastore";
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
     // metrics
     private final Counter metricMessageCount;
     private final Counter metricCommunicationErrorCount;
@@ -76,9 +76,13 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
     private final Counter metricQueueConfigurationErrorCount;
     private final Counter metricQueueGenericErrorCount;
 
-    private final AccountService accountService = LOCATOR.getService(AccountService.class);
-    private final AuthorizationService authorizationService = LOCATOR.getService(AuthorizationService.class);
-    private final PermissionFactory permissionFactory = LOCATOR.getFactory(PermissionFactory.class);
+    @Inject
+    private AccountService accountService;
+    @Inject
+    private AuthorizationService authorizationService;
+    @Inject
+    private PermissionFactory permissionFactory;
+
     private final static Integer MAX_ENTRIES_ON_DELETE = DatastoreSettings.getInstance().get(Integer.class, DatastoreSettingKey.CONFIG_MAX_ENTRIES_ON_DELETE);
 
     private final MessageStoreFacade messageStoreFacade;
@@ -88,7 +92,8 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
      * 
      * @throws ClientUnavailableException
      */
-    public MessageStoreServiceImpl() throws ClientUnavailableException {
+    @Inject
+    public MessageStoreServiceImpl(AccountService accountService) throws ClientUnavailableException {
         super(MessageStoreService.class.getName(), DATASTORE_DOMAIN, DatastoreEntityManagerFactory.getInstance());
         ConfigurationProviderImpl configurationProvider = new ConfigurationProviderImpl(this, accountService);
         messageStoreFacade = new MessageStoreFacade(configurationProvider, DatastoreMediator.getInstance());

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.AccountService;
@@ -59,6 +58,8 @@ import org.eclipse.kapua.service.datastore.model.query.TermPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
+
 /**
  * Metric information registry implementation.
  * 
@@ -71,29 +72,28 @@ public class MetricInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
 
     private static final Logger logger = LoggerFactory.getLogger(MetricInfoRegistryServiceImpl.class);
 
-    private final AccountService accountService;
-    private final AuthorizationService authorizationService;
-    private final PermissionFactory permissionFactory;
-    private final MetricInfoRegistryFacade metricInfoRegistryFacade;
-    private final MessageStoreService messageStoreService;
-    private final StorablePredicateFactory storablePredicateFactory;
+    @Inject
+    private AccountService accountService;
+    @Inject
+    private AuthorizationService authorizationService;
+    @Inject
+    private PermissionFactory permissionFactory;
+    @Inject
+    private MessageStoreService messageStoreService;
+    @Inject
+    private StorablePredicateFactory storablePredicateFactory;
+
+    private MetricInfoRegistryFacade metricInfoRegistryFacade;
 
     /**
      * Default constructor
-     * 
+     *
      * @throws ClientUnavailableException
      */
-    public MetricInfoRegistryServiceImpl() throws ClientUnavailableException {
+    @Inject
+    public MetricInfoRegistryServiceImpl(MessageStoreService messageStoreService, AccountService accountService) throws ClientUnavailableException {
         super(MetricInfoRegistryService.class.getName(), DATASTORE_DOMAIN, DatastoreEntityManagerFactory.getInstance());
 
-        KapuaLocator locator = KapuaLocator.getInstance();
-        accountService = locator.getService(AccountService.class);
-        authorizationService = locator.getService(AuthorizationService.class);
-        permissionFactory = locator.getFactory(PermissionFactory.class);
-        messageStoreService = locator.getService(MessageStoreService.class);
-        storablePredicateFactory = KapuaLocator.getInstance().getFactory(StorablePredicateFactory.class);
-
-        MessageStoreService messageStoreService = KapuaLocator.getInstance().getService(MessageStoreService.class);
         ConfigurationProviderImpl configurationProvider = new ConfigurationProviderImpl(messageStoreService, accountService);
         metricInfoRegistryFacade = new MetricInfoRegistryFacade(configurationProvider, DatastoreMediator.getInstance());
         DatastoreMediator.getInstance().setMetricInfoStoreFacade(metricInfoRegistryFacade);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
@@ -15,12 +15,8 @@ package org.eclipse.kapua.service.datastore.internal.mediator;
 import java.util.Map;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.datastore.ChannelInfoRegistryService;
-import org.eclipse.kapua.service.datastore.ClientInfoRegistryService;
-import org.eclipse.kapua.service.datastore.MetricInfoRegistryService;
 import org.eclipse.kapua.service.datastore.client.ClientException;
 import org.eclipse.kapua.service.datastore.client.QueryMappingException;
 import org.eclipse.kapua.service.datastore.internal.ChannelInfoRegistryFacade;
@@ -60,11 +56,6 @@ public class DatastoreMediator implements MessageStoreMediator,
 
     static {
         INSTANCE = new DatastoreMediator();
-
-        // Be sure the data registry services are instantiated
-        KapuaLocator.getInstance().getService(ClientInfoRegistryService.class);
-        KapuaLocator.getInstance().getService(ChannelInfoRegistryService.class);
-        KapuaLocator.getInstance().getService(MetricInfoRegistryService.class);
     }
 
     private DatastoreMediator() {


### PR DESCRIPTION
Datastore service and its unit tests were refactored to injection.
Services that datastore service and its supporting classes are using are
injected.

This refactoring needs careful review, regardless that all the tests are
passing.

Unit tests are still using Locator for services used in unit tests.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>