### PR TITLE
remove datastore-client objects from datatstore return objects

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -58,7 +58,6 @@ import org.eclipse.kapua.service.datastore.ClientInfoRegistryService;
 import org.eclipse.kapua.service.datastore.DatastoreJAXBContextProvider;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.MetricInfoRegistryService;
-import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.internal.ChannelInfoRegistryServiceProxy;
 import org.eclipse.kapua.service.datastore.internal.ClientInfoRegistryServiceProxy;
 import org.eclipse.kapua.service.datastore.internal.DatastoreCacheManager;
@@ -1439,10 +1438,7 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
     }
 
     private StorableId insertMessageInStore(KapuaDataMessage message) throws KapuaException {
-
-        InsertResponse tmpResponse = messageStoreService.store(message);
-        StorableId tmpId = new StorableIdImpl(tmpResponse.getId());
-        return tmpId;
+        return messageStoreService.store(message);
     }
 
     private List<StorableId> insertMessagesInStore(List<KapuaDataMessage> messages) throws KapuaException {

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/JaxbContextResolver.java
@@ -26,6 +26,7 @@ import org.eclipse.kapua.app.api.exception.model.IllegalArgumentExceptionInfo;
 import org.eclipse.kapua.app.api.exception.model.IllegalNullArgumentExceptionInfo;
 import org.eclipse.kapua.app.api.exception.model.ThrowableInfo;
 import org.eclipse.kapua.app.api.v1.resources.model.CountResult;
+import org.eclipse.kapua.app.api.v1.resources.model.StorableEntityId;
 import org.eclipse.kapua.message.device.data.KapuaDataChannel;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.message.device.data.KapuaDataPayload;
@@ -100,6 +101,7 @@ import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
 import org.eclipse.kapua.service.datastore.model.MetricInfoListResult;
+import org.eclipse.kapua.service.datastore.model.StorableId;
 import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
@@ -239,6 +241,8 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     KapuaDataMessage.class,
                     InsertResponse.class,
                     MessageXmlRegistry.class,
+                    StorableEntityId.class,
+                    StorableId.class,
 
                     // Device
                     Device.class,

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/DataMessages.java
@@ -40,6 +40,7 @@ import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
+import org.eclipse.kapua.service.datastore.model.StorableId;
 import org.eclipse.kapua.service.datastore.model.query.AndPredicate;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.MetricPredicate;
@@ -166,12 +167,12 @@ public class DataMessages extends AbstractKapuaResource {
     @ApiOperation(nickname = "dataMessageStore",
             value = "Stores a new KapuaDataMessage", //
             notes = "Stores a new KapuaDataMessage under the account of the currently connected user. In this case, the provided message will only be stored in the back-end database and it will not be forwarded to the message broker.", //
-            response = InsertResponse.class)
-    public InsertResponse storeMessage(
+            response = StorableId.class)
+    public StorableEntityId storeMessage(
             @ApiParam(value = "The ScopeId in which to store the message", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,//
             @ApiParam(value = "The KapuaDataMessage to be stored") KapuaDataMessage message) throws Exception {
         message.setScopeId(scopeId);
-        return MESSAGE_STORE_SERVICE.store(message);
+        return new StorableEntityId(MESSAGE_STORE_SERVICE.store(message).toString());
     }
 
     /**

--- a/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/model/StorableEntityId.java
+++ b/rest-api/src/main/java/org/eclipse/kapua/app/api/v1/resources/model/StorableEntityId.java
@@ -35,12 +35,18 @@ public class StorableEntityId implements StorableId {
         setId(id);
     }
 
+    public StorableEntityId() { }
+
     @Override
     public String toString() {
         return id;
     }
 
-    private void setId(String storableId) {
+    public void setId(String storableId) {
         this.id = storableId;
+    }
+
+    public String getId() {
+        return id;
     }
 }

--- a/service/datastore/api/pom.xml
+++ b/service/datastore/api/pom.xml
@@ -26,12 +26,21 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-datastore-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-message-api</artifactId>
         </dependency>
 
+    <!--  external dependencies -->
         <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-datastore-client-api</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.config.KapuaConfigurableService;
-import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.StorableId;
@@ -39,7 +38,7 @@ public interface MessageStoreService extends KapuaService, KapuaConfigurableServ
      * 
      * @since 1.0.0
      */
-    InsertResponse store(KapuaMessage<?, ?> message)
+    StorableId store(KapuaMessage<?, ?> message)
             throws KapuaException;
 
     /**
@@ -50,7 +49,7 @@ public interface MessageStoreService extends KapuaService, KapuaConfigurableServ
      * @return
      * @throws KapuaException
      */
-    InsertResponse store(KapuaMessage<?, ?> message, String datastoreId)
+    StorableId store(KapuaMessage<?, ?> message, String datastoreId)
             throws KapuaException;
 
     /**

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -114,7 +114,7 @@ public final class MessageStoreFacade {
      * @throws ConfigurationException
      * @throws ClientException
      */
-    public InsertResponse store(KapuaMessage<?, ?> message, String messageId, boolean newInsert)
+    public StorableId store(KapuaMessage<?, ?> message, String messageId, boolean newInsert)
             throws KapuaIllegalArgumentException,
             ConfigurationException,
             ClientException {
@@ -160,7 +160,7 @@ public final class MessageStoreFacade {
             if (datastoreMessage != null) {
                 logger.debug("Message with datatstore id '{}' already found", messageId);
                 metricMessagesAlreadyInTheDatastoreCount.inc();
-                return new InsertResponse(messageId, typeDescriptor);
+                return new StorableIdImpl(messageId);
             }
         }
 
@@ -190,7 +190,7 @@ public final class MessageStoreFacade {
         messageToStore.setDatastoreId(new StorableIdImpl(insertResponse.getId()));
 
         mediator.onAfterMessageStore(messageInfo, messageToStore);
-        return insertResponse;
+        return new StorableIdImpl(insertResponse.getId());
     }
 
     /**

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -34,7 +34,6 @@ import org.eclipse.kapua.service.datastore.DatastoreDomain;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.client.ClientCommunicationException;
 import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
-import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.internal.mediator.ConfigurationException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreCommunicationException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
@@ -109,7 +108,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
     }
 
     @Override
-    public InsertResponse store(KapuaMessage<?, ?> message)
+    public StorableId store(KapuaMessage<?, ?> message)
             throws KapuaException {
         String datastoreId = UUID.randomUUID().toString();
         Context metricDataSaveTimeContext = metricDataSaveTime.time();
@@ -139,7 +138,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
     }
 
     @Override
-    public InsertResponse store(KapuaMessage<?, ?> message, String datastoreId)
+    public StorableId store(KapuaMessage<?, ?> message, String datastoreId)
             throws KapuaException {
         ArgumentValidator.notEmptyOrNull(datastoreId, "datastoreId");
         Context metricDataSaveTimeContext = metricDataSaveTime.time();

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdImpl.java
@@ -34,7 +34,7 @@ public class StorableIdImpl implements StorableId {
 
     @Override
     public String toString() {
-        return sid.toString();
+        return sid;
     }
 
     @Override

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
@@ -59,7 +59,6 @@ import org.eclipse.kapua.service.datastore.DatastoreObjectFactory;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.MetricInfoRegistryService;
 import org.eclipse.kapua.service.datastore.client.embedded.EsEmbeddedEngine;
-import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.ClientInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreChannel;
@@ -1524,8 +1523,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         List<StorableId> storableIds = new ArrayList<>(messages.length);
         for (KapuaDataMessage message : messages) {
             try {
-                InsertResponse response = MESSAGE_STORE_SERVICE.store(message);
-                storableIds.add(new StorableIdImpl(response.getId()));
+                storableIds.add(MESSAGE_STORE_SERVICE.store(message));
             } catch (Exception e) {
                 logger.error("Message insert exception!", e);
                 fail("Store messages should have succeded");
@@ -2576,9 +2574,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         message.setPayload(messagePayload);
         message.setClientId(clientId);
 
-        InsertResponse response = MESSAGE_STORE_SERVICE.store(message);
-
-        StorableId messageId = new StorableIdImpl(response.getId());
+        StorableId messageId = MESSAGE_STORE_SERVICE.store(message);
         //
         // A non empty message id must be returned
         assertNotNull(messageId);


### PR DESCRIPTION
The datastore-api wrongly exposed datastore-client-api objects.
This pr changes the datastore-api service to expose only datastore-api objects.



Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>