### PR TITLE
GWT Console Custom CSS

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SkinServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SkinServlet.java
@@ -9,10 +9,10 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.console.servlet;
+package org.eclipse.kapua.app.console.core.servlet;
 
-import org.eclipse.kapua.app.console.setting.ConsoleSetting;
-import org.eclipse.kapua.app.console.setting.ConsoleSettingKeys;
+import org.eclipse.kapua.app.console.module.api.setting.ConsoleSetting;
+import org.eclipse.kapua.app.console.module.api.setting.ConsoleSettingKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +32,7 @@ public class SkinServlet extends HttpServlet {
     private static final long serialVersionUID = -5374075152873372059L;
     private static final Logger LOGGER = LoggerFactory.getLogger(SkinServlet.class);
 
+    @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         FileReader fr = null;
@@ -51,7 +52,7 @@ public class SkinServlet extends HttpServlet {
                 }
 
                 List<String> resourceFragments = Arrays.asList(resourceName.split("\\\\|/"));
-                if(resourceFragments.contains("..")) {
+                if (resourceFragments.contains("..")) {
                     LOGGER.warn("No directory traversing allowed; requested path is {}", resourceFragments);
                     return;
                 }

--- a/console/src/main/java/org/eclipse/kapua/app/console/servlet/SkinServlet.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/servlet/SkinServlet.java
@@ -11,22 +11,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.servlet;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.PrintWriter;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.kapua.app.console.setting.ConsoleSetting;
 import org.eclipse.kapua.app.console.setting.ConsoleSettingKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+
 public class SkinServlet extends HttpServlet {
+
     private static final long serialVersionUID = -5374075152873372059L;
     private static final Logger LOGGER = LoggerFactory.getLogger(SkinServlet.class);
 
@@ -48,6 +50,11 @@ public class SkinServlet extends HttpServlet {
                     return;
                 }
 
+                List<String> resourceFragments = Arrays.asList(resourceName.split("\\\\|/"));
+                if(resourceFragments.contains("..")) {
+                    LOGGER.warn("No directory traversing allowed; requested path is {}", resourceFragments);
+                    return;
+                }
                 File fResourceFile = new File(fResourceDir, resourceName);
                 if (!fResourceFile.exists()) {
                     LOGGER.warn("Resource File {} does not exist", fResourceFile.getAbsolutePath());

--- a/console/src/main/java/org/eclipse/kapua/app/console/servlet/SkinServlet.java
+++ b/console/src/main/java/org/eclipse/kapua/app/console/servlet/SkinServlet.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.servlet;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.kapua.app.console.setting.ConsoleSetting;
+import org.eclipse.kapua.app.console.setting.ConsoleSettingKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SkinServlet extends HttpServlet {
+    private static final long serialVersionUID = -5374075152873372059L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkinServlet.class);
+
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        FileReader fr = null;
+        PrintWriter w = response.getWriter();
+        String resourceName = request.getPathInfo();
+        try {
+
+            // check to see if we have an external resource directory configured
+            ConsoleSetting consoleSetting = ConsoleSetting.getInstance();
+            String resourceDir = consoleSetting.getString(ConsoleSettingKeys.SKIN_RESOURCE_DIR);
+            if (resourceDir != null && resourceDir.trim().length() != 0) {
+
+                File fResourceDir = new File(resourceDir);
+                if (!fResourceDir.exists()) {
+                    LOGGER.warn("Resource Directory {} does not exist", fResourceDir.getAbsolutePath());
+                    return;
+                }
+
+                File fResourceFile = new File(fResourceDir, resourceName);
+                if (!fResourceFile.exists()) {
+                    LOGGER.warn("Resource File {} does not exist", fResourceFile.getAbsolutePath());
+                    return;
+                }
+
+                // write the requested resource
+                fr = new FileReader(fResourceFile);
+                char[] buffer = new char[1024];
+                int iRead = fr.read(buffer);
+                while (iRead != -1) {
+                    w.write(buffer, 0, iRead);
+                    iRead = fr.read(buffer);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error loading skin resource", e);
+        } finally {
+            if (fr != null) {
+                fr.close();
+            }
+            if (w != null) {
+                w.close();
+            }
+        }
+    }
+}

--- a/console/web/src/main/resources/console-setting.properties
+++ b/console/web/src/main/resources/console-setting.properties
@@ -33,3 +33,5 @@ console.sso.openid.server.endpoint.auth=http://localhost:9090/auth/realms/master
 console.sso.openid.server.endpoint.token=http://localhost:9090/auth/realms/master/protocol/openid-connect/token
 console.sso.openid.client.id=console
 console.sso.openid.redirect.uri=http://localhost:8889/sso/callback
+
+console.skin.resource.dir=

--- a/console/web/src/main/webapp/WEB-INF/web.xml
+++ b/console/web/src/main/webapp/WEB-INF/web.xml
@@ -339,6 +339,15 @@
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>skinServlet</servlet-name>
+        <servlet-class>org.eclipse.kapua.app.console.servlet.SkinServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>skinServlet</servlet-name>
+        <url-pattern>/skin/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>ssoCallbackServlet</servlet-name>
         <servlet-class>org.eclipse.kapua.app.console.core.servlet.SsoCallbackServlet</servlet-class>
     </servlet>

--- a/console/web/src/main/webapp/WEB-INF/web.xml
+++ b/console/web/src/main/webapp/WEB-INF/web.xml
@@ -11,7 +11,7 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<web-app version="3.0" 
+<web-app version="3.0"
          xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
@@ -134,7 +134,7 @@
         <servlet-name>deviceExporterServlet</servlet-name>
         <url-pattern>/exporter_device/*</url-pattern>
     </servlet-mapping>
-    
+
     <servlet>
         <servlet-name>deviceEventExporterServlet</servlet-name>
         <servlet-class>org.eclipse.kapua.app.console.module.device.servlet.DeviceEventExporterServlet</servlet-class>
@@ -326,7 +326,7 @@
     </servlet-mapping>
 
     <listener>
-      <listener-class>org.apache.commons.fileupload.servlet.FileCleanerCleanup</listener-class>
+        <listener-class>org.apache.commons.fileupload.servlet.FileCleanerCleanup</listener-class>
     </listener>
 
     <servlet>
@@ -340,7 +340,7 @@
 
     <servlet>
         <servlet-name>skinServlet</servlet-name>
-        <servlet-class>org.eclipse.kapua.app.console.servlet.SkinServlet</servlet-class>
+        <servlet-class>org.eclipse.kapua.app.console.core.servlet.SkinServlet</servlet-class>
     </servlet>
     <servlet-mapping>
         <servlet-name>skinServlet</servlet-name>

--- a/console/web/src/main/webapp/js/kapuaconsole/console.js
+++ b/console/web/src/main/webapp/js/kapuaconsole/console.js
@@ -45,7 +45,7 @@ function downloadCss(elementSrc, elementId) {
 //
 // Adds console sking script
 function downloadJsConsoleSkin() {
-	downloadJs("console/skin/skin.js?v=1", "consoleSkinScript");
+	downloadJs("/skin/skin.js?v=1", "consoleSkinScript");
 }
 
 //
@@ -57,7 +57,7 @@ function downloadCssConsole() {
 //
 // Adds console skin css
 function downloadCssConsoleSkin() {
-	downloadCss("console/skin/skin.css?v=1", "consoleSkinCss")
+	downloadCss("/skin/skin.css?v=1", "consoleSkinCss")
 }
 
 //

--- a/console/web/src/main/webapp/js/kapuaconsole/console.js
+++ b/console/web/src/main/webapp/js/kapuaconsole/console.js
@@ -43,9 +43,21 @@ function downloadCss(elementSrc, elementId) {
 }
 
 //
+// Adds console sking script
+function downloadJsConsoleSkin() {
+	downloadJs("console/skin/skin.js?v=1", "consoleSkinScript");
+}
+
+//
 // Adds console css
 function downloadCssConsole() {
 	downloadCss("css/console.css", "consoleCss")
+}
+
+//
+// Adds console skin css
+function downloadCssConsoleSkin() {
+	downloadCss("console/skin/skin.css?v=1", "consoleSkinCss")
 }
 
 //
@@ -54,6 +66,10 @@ function deferResourcesDownload() {
 
 	// Custom Kapua CSS
 	downloadCssConsole();
+
+	// Skin resources
+	downloadJsConsoleSkin();
+	downloadCssConsoleSkin();
 }
 
 if (window.addEventListener)


### PR DESCRIPTION
Hi all,

With this PR is now possible to specify custom CSS and JS files when loading the GWT console. Such files must be named `skin.css` and `skin.js`, and must be placed in the path that can be specified via the `console.skin.resource.dir` property in `console/src/main/resources/console-setting.properties`.

Resolves #514 