### PR TITLE
Refactoring of exception handling in Shiro unit tests

### DIFF
--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTestSteps.java
@@ -80,6 +80,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
 
     // Test data scratchpads
     private CommonTestData commonData;
+    private CommonTestSteps commonSteps;
     private AccessInfoServiceTestData accessData;
 
     // Various Access service related service references
@@ -98,7 +99,6 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
     private RoleFactory roleFactory;
 
     // Currently executing scenario.
-    @SuppressWarnings("unused")
     private Scenario scenario;
 
     @Inject
@@ -136,6 +136,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         // Clean up the test data scratchpads
         accessData.clearData();
         commonData.clearData();
+        commonData.scenario = this.scenario;
     }
 
     // *************************************
@@ -228,7 +229,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
 
     @Given("^The role \"(.*)\"$")
     public void provideRoleForDomain(String name)
-            throws KapuaException {
+            throws Exception {
 
         assertNotNull(commonData.scopeId);
         assertNotNull(accessData.permissions);
@@ -244,13 +245,13 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         accessData.roleCreator.setPermissions(accessData.permissions);
 
         try {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
             KapuaSecurityUtils.doPrivileged(() -> {
                 accessData.role = roleService.create(accessData.roleCreator);
                 return null;
             });
         } catch (KapuaException e) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(e);
             return;
         }
         assertNotNull(accessData.role);
@@ -277,7 +278,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
 
     @When("^I create the access role$")
     public void createAccessRole()
-            throws KapuaException {
+            throws Exception {
 
         assertNotNull(commonData.scopeId);
         assertNotNull(accessData.accessInfo);
@@ -292,18 +293,19 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         tmpCreator.setRoleId(accessData.role.getId());
 
         try {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
             KapuaSecurityUtils.doPrivileged(() -> {
                 accessData.accessRole = accessRoleService.create(tmpCreator);
                 return null;
             });
         } catch (KapuaException e) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(e);
         }
     }
 
     @When("^I create the access info entity$")
-    public void createAccessInfoEntity() {
+    public void createAccessInfoEntity()
+            throws Exception {
 
         assertNotNull(commonData.scopeId);
         assertNotNull(accessData.user);
@@ -326,13 +328,13 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         }
 
         try {
+            commonData.primeException();
             KapuaSecurityUtils.doPrivileged(() -> {
-                commonData.exceptionCaught = false;
                 accessData.accessInfo = accessInfoService.create(accessData.accessInfoCreator);
                 return null;
             });
         } catch (KapuaException ex) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(ex);
         }
     }
 
@@ -419,37 +421,37 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
 
     @When("^I delete the last created access role entry$")
     public void deleteLastCreatedAccessRoleEntry()
-            throws KapuaException {
+            throws Exception {
         assertNotNull(commonData.scopeId);
         assertNotNull(accessData.accessRole);
         assertNotNull(accessData.accessRole.getId());
 
         try {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
             KapuaSecurityUtils.doPrivileged(() -> {
                 accessRoleService.delete(commonData.scopeId, accessData.accessRole.getId());
                 return null;
             });
         } catch (KapuaException e) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(e);
         }
     }
 
     @When("^I delete the existing access info entity$")
     public void deleteLastCreatedAccessInfoEntity()
-            throws KapuaException {
+            throws Exception {
         assertNotNull(commonData.scopeId);
         assertNotNull(accessData.accessInfo);
         assertNotNull(accessData.accessInfo.getId());
 
         try {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
             KapuaSecurityUtils.doPrivileged(() -> {
                 accessInfoService.delete(commonData.scopeId, accessData.accessInfo.getId());
                 return null;
             });
         } catch (KapuaException ex) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(ex);
         }
     }
 
@@ -489,7 +491,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
 
     @When("^I create the permission(?:|s)$")
     public void createPermissionEntries()
-            throws KapuaException {
+            throws Exception {
         assertNotNull(commonData.scopeId);
         assertNotNull(accessData.accessInfo);
         assertNotNull(accessData.accessInfo.getId());
@@ -500,7 +502,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
         accessData.accessPermissionCreator.setAccessInfoId(accessData.accessInfo.getId());
 
         try {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
             for (Permission tmpPerm : accessData.permissions) {
                 accessData.accessPermissionCreator.setPermission(tmpPerm);
                 KapuaSecurityUtils.doPrivileged(() -> {
@@ -509,7 +511,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
                 });
             }
         } catch (KapuaException ex) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(ex);
         }
     }
 
@@ -525,19 +527,19 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
 
     @When("^I delete the last created access permission$")
     public void deleteLastCreatedPermission()
-            throws KapuaException {
+            throws Exception {
 
         assertNotNull(commonData.scopeId);
         assertNotNull(accessData.accessPermission);
 
         try {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
             KapuaSecurityUtils.doPrivileged(() -> {
                 accessPermissionService.delete(commonData.scopeId, accessData.accessPermission.getId());
                 return null;
             });
         } catch (KapuaException ex) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(ex);
         }
     }
 
@@ -556,9 +558,11 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
     }
 
     @When("^I check the sanity of the access info factory$")
-    public void accessInfoServiceSanityCheck() {
+    public void accessInfoServiceSanityCheck()
+            throws Exception {
+
         try {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
 
             assertNotNull(accessInfoFactory.newCreator(generateId()));
             assertNotNull(accessInfoFactory.newEntity(null));
@@ -583,7 +587,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
             tmpAccInfo2.setUserId(null);
             assertNull(tmpAccInfo2.getUserId());
         } catch (KapuaException ex) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(ex);
         }
     }
 
@@ -621,9 +625,12 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
     }
 
     @When("^I check the sanity of the access role factory$")
-    public void accessRoleFactorySanityCheck() {
+    public void accessRoleFactorySanityCheck()
+            throws Exception {
+
         try {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
+
             assertNotNull(accessRoleFactory.newCreator(generateId()));
             assertNotNull(accessRoleFactory.newEntity(generateId()));
             assertNotNull(accessRoleFactory.newQuery(generateId()));
@@ -650,7 +657,7 @@ public class AccessInfoServiceTestSteps extends AbstractAuthorizationServiceTest
             tmpRole.setRoleId(null);
             assertNull(tmpRole.getRoleId());
         } catch (KapuaException ex) {
-            commonData.exceptionCaught = true;
+            commonData.verifyException(ex);
         }
     }
 

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestData.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestData.java
@@ -13,25 +13,53 @@ package org.eclipse.kapua.service.authorization.shiro;
 
 import javax.inject.Singleton;
 
+import cucumber.api.Scenario;
 import org.eclipse.kapua.model.id.KapuaId;
 
 @Singleton
 public class CommonTestData {
 
-    /**
-     * A flag to mark that an exception was thrown in the preceding steps.
-     */
+    public Scenario scenario;
+
+    // Scratchpad data related to exception checking
+    public boolean exceptionExpected;
+    public String exceptionName;
+    public String exceptionMessage;
     public boolean exceptionCaught;
+
     public long count;
     public int intValue;
     public String stringValue;
     public KapuaId scopeId;
 
     public void clearData() {
+        exceptionExpected = false;
+        exceptionName = "";
+        exceptionMessage = "";
         exceptionCaught = false;
         count = 0;
         intValue = 0;
         stringValue = "";
         scopeId = null;
+    }
+
+    public void primeException() {
+        exceptionCaught = false;
+    }
+
+    // Check the exception that was caught. In case the exception was expected the type and message is shown in the cucumber logs.
+    // Otherwise the exception is rethrown failing the test and dumping the stack trace to help resolving problems.
+    public void verifyException(Exception ex)
+            throws Exception {
+
+        if (!exceptionExpected ||
+                (!exceptionName.isEmpty() && !ex.getClass().toGenericString().contains(exceptionName)) ||
+                (!exceptionMessage.isEmpty() && !exceptionMessage.trim().contentEquals("*") && !ex.getMessage().contains(exceptionMessage))) {
+            scenario.write("An unexpected exception was raised!");
+            throw(ex);
+        }
+
+        scenario.write("Exception raised as expected: " + ex.getClass().getCanonicalName() + ", " + ex.getMessage());
+        exceptionCaught = true;
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/CommonTestSteps.java
@@ -39,11 +39,21 @@ public class CommonTestSteps extends AbstractKapuaSteps {
 
     // Database setup and tear-down steps
     @Before
-    public void beforeScenario(Scenario scenario) throws KapuaException {
+    public void beforeScenario(Scenario scenario)
+            throws KapuaException {
         commonData.clearData();
+        commonData.scenario = scenario;
     }
 
     // Cucumber test steps
+
+    @Given("^I expect the exception \"(.+)\" with the text \"(.+)\"$")
+    public void setExpectedExceptionDetails(String name, String text) {
+        commonData.exceptionExpected = true;
+        commonData.exceptionName = name;
+        commonData.exceptionMessage = text;
+    }
+
     @Given("^A scope with ID (\\d+)$")
     public void setScopeId(Integer scope) {
         commonData.scopeId = new KapuaEid(BigInteger.valueOf(scope));

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainServiceTestSteps.java
@@ -89,6 +89,7 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
 
         // Clean up the test data scratchpads
         commonData.clearData();
+        commonData.scenario = this.scenario;
         domainData.clearData();
     }
 
@@ -98,9 +99,9 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @Given("^I create the domain(?:|s)$")
     public void createAListOfDomains(List<CucDomain> domains)
-            throws KapuaException {
+            throws Exception {
         for (CucDomain tmpDom : domains) {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
             tmpDom.doParse();
             domainData.domainCreator = domainFactory.newCreator(tmpDom.getName(), tmpDom.getServiceName());
             if (tmpDom.getActionSet() != null) {
@@ -110,7 +111,7 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
                 try {
                     domainData.domain = domainService.create(domainData.domainCreator);
                 } catch (KapuaException ex) {
-                    commonData.exceptionCaught = true;
+                    commonData.verifyException(ex);
                     return null;
                 }
                 assertNotNull(domainData.domain);
@@ -144,13 +145,13 @@ public class DomainServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @When("^I try to delete domain with a random ID$")
     public void deleteRandomDomainId()
-            throws KapuaException {
+            throws Exception {
         KapuaSecurityUtils.doPrivileged(() -> {
             try {
-                commonData.exceptionCaught = false;
+                commonData.primeException();
                 domainService.delete(null, generateId());
             } catch (KapuaException ex) {
-                commonData.exceptionCaught = true;
+                commonData.verifyException(ex);
             }
             return null;
         });

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTestSteps.java
@@ -68,7 +68,6 @@ public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
     public void beforeScenario(Scenario scenario)
             throws Exception {
         this.scenario = scenario;
-        commonData.exceptionCaught = false;
 
         // Instantiate all the services and factories that are required by the tests
         groupService = new GroupServiceImpl();
@@ -81,6 +80,7 @@ public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
 
         // Clean up the test data scratchpads
         commonData.clearData();
+        commonData.scenario = this.scenario;
         groupData.clearData();
 
         // All operations on database are performed using system user.
@@ -96,7 +96,7 @@ public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
     // *************************************
     @When("^I configure$")
     public void setConfigurationValue(List<TestConfig> testConfigs)
-            throws KapuaException {
+            throws Exception {
 
         KapuaSecurityUtils.doPrivileged(() -> {
             Map<String, Object> valueMap = new HashMap<>();
@@ -109,10 +109,10 @@ public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
                 parentScopeId = new KapuaEid(BigInteger.valueOf(Long.valueOf(config.getParentScopeId())));
             }
             try {
-                commonData.exceptionCaught = false;
+                commonData.primeException();
                 groupService.setConfigValues(scopeId, parentScopeId, valueMap);
             } catch (KapuaException ex) {
-                commonData.exceptionCaught = true;
+                commonData.verifyException(ex);
             }
 
             return null;
@@ -130,9 +130,9 @@ public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @Given("^I create the group(?:|s)$")
     public void createAListOfDomains(List<CucGroup> groups)
-            throws KapuaException {
+            throws Exception {
         for (CucGroup tmpGrp : groups) {
-            commonData.exceptionCaught = false;
+            commonData.primeException();
             tmpGrp.doParse();
             groupData.groupCreator = groupFactory.newCreator(tmpGrp.getScopeId(), tmpGrp.getName());
 
@@ -140,7 +140,7 @@ public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
                 try {
                     groupData.group = groupService.create(groupData.groupCreator);
                 } catch (KapuaException ex) {
-                    commonData.exceptionCaught = true;
+                    commonData.verifyException(ex);
                     return null;
                 }
                 assertNotNull(groupData.group);
@@ -171,16 +171,16 @@ public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @When("^I update the group with an incorrect ID$")
     public void updateGroupWithFalseId()
-            throws KapuaException {
+            throws Exception {
 
         groupData.group.setId(generateId());
+        commonData.primeException();
 
         KapuaSecurityUtils.doPrivileged(() -> {
             try {
-                commonData.exceptionCaught = false;
                 groupService.update(groupData.group);
             } catch (KapuaException ex) {
-                commonData.exceptionCaught = true;
+                commonData.verifyException(ex);
             }
             return null;
         });
@@ -197,13 +197,14 @@ public class GroupServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @When("^I try to delete a random group id$")
     public void deleteGroupWithRandomId()
-            throws KapuaException {
+            throws Exception {
+
+        commonData.primeException();
         KapuaSecurityUtils.doPrivileged(() -> {
             try {
                 groupService.delete(ROOT_SCOPE_ID, generateId());
-                commonData.exceptionCaught = false;
             } catch (KapuaException ex) {
-                commonData.exceptionCaught = true;
+                commonData.verifyException(ex);
             }
             return null;
         });

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTestSteps.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTestSteps.java
@@ -90,7 +90,6 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
     public void beforeScenario(Scenario scenario)
             throws Exception {
         this.scenario = scenario;
-        commonData.exceptionCaught = false;
 
         // Instantiate all the services and factories that are required by the tests
         roleService = new RoleServiceImpl();
@@ -106,6 +105,7 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
 
         // Clean up the test data scratchpads
         commonData.clearData();
+        commonData.scenario = this.scenario;
         roleData.clearData();
     }
 
@@ -114,7 +114,7 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
     // *************************************
     @When("^I configure role$")
     public void setConfigurationValue(List<TestConfig> testConfigs)
-            throws KapuaException {
+            throws Exception {
 
         KapuaSecurityUtils.doPrivileged(() -> {
             Map<String, Object> valueMap = new HashMap<>();
@@ -127,10 +127,10 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
                 parentScopeId = new KapuaEid(BigInteger.valueOf(Long.valueOf(config.getParentScopeId())));
             }
             try {
-                commonData.exceptionCaught = false;
+                commonData.primeException();
                 roleService.setConfigValues(scopeId, parentScopeId, valueMap);
             } catch (KapuaException ex) {
-                commonData.exceptionCaught = true;
+                commonData.verifyException(ex);
             }
 
             return null;
@@ -139,9 +139,10 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @Given("^I create the following role(?:|s)$")
     public void createAListOfRoles(List<CucRole> roles)
-            throws KapuaException {
+            throws Exception {
+
+        commonData.primeException();
         for (CucRole tmpRole : roles) {
-            commonData.exceptionCaught = false;
             tmpRole.doParse();
             roleData.permissions = new HashSet<>();
             if ((tmpRole.getActions() != null) && (tmpRole.getActions().size() > 0)) {
@@ -156,7 +157,7 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
                 try {
                     roleData.role = roleService.create(roleCreator);
                 } catch (KapuaException ex) {
-                    commonData.exceptionCaught = true;
+                    commonData.verifyException(ex);
                 }
                 return null;
             });
@@ -169,7 +170,7 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @Given("^I create the following role permission(?:|s)$")
     public void createAListOfRolePermissions(List<CucRolePermission> perms)
-            throws KapuaException {
+            throws Exception {
 
         assertNotNull(roleData.role);
         assertNotNull(roleData.role.getId());
@@ -179,6 +180,7 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
         TestDomain tmpDom = new TestDomain();
         tmpDom.setName("test_domain");
 
+        commonData.primeException();
         for (CucRolePermission tmpCPerm : perms) {
             tmpCPerm.doParse();
             assertNotNull(tmpCPerm.getScopeId());
@@ -192,10 +194,9 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
 
             KapuaSecurityUtils.doPrivileged(() -> {
                 try {
-                    commonData.exceptionCaught = false;
                     roleData.rolePermission = rolePermissionService.create(rolePermissionCreator);
                 } catch (KapuaException ex) {
-                    commonData.exceptionCaught = true;
+                    commonData.verifyException(ex);
                     return null;
                 }
                 return null;
@@ -210,10 +211,10 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
         Thread.sleep(100);
         KapuaSecurityUtils.doPrivileged(() -> {
             try {
-                commonData.exceptionCaught = false;
+                commonData.primeException();
                 roleService.update(roleData.role);
             } catch (KapuaException ex) {
-                commonData.exceptionCaught = true;
+                commonData.verifyException(ex);
             }
             return null;
         });
@@ -261,13 +262,13 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @When("^I delete the last created role$")
     public void deleteLastCreatedRole()
-            throws KapuaException {
+            throws Exception {
         KapuaSecurityUtils.doPrivileged(() -> {
             try {
-                commonData.exceptionCaught = false;
+                commonData.primeException();
                 roleService.delete(roleData.role.getScopeId(), roleData.role.getId());
             } catch (KapuaException ex) {
-                commonData.exceptionCaught = true;
+                commonData.verifyException(ex);
             }
             return null;
         });
@@ -275,14 +276,14 @@ public class RoleServiceTestSteps extends AbstractAuthorizationServiceTest {
 
     @When("^I delete the last created role permission$")
     public void deleteLastCreatedRolePermission()
-            throws KapuaException {
+            throws Exception {
         KapuaSecurityUtils.doPrivileged(() -> {
             try {
-                commonData.exceptionCaught = false;
+                commonData.primeException();
                 rolePermissionService.delete(
                         roleData.rolePermission.getScopeId(), roleData.rolePermission.getId());
             } catch (KapuaException ex) {
-                commonData.exceptionCaught = true;
+                commonData.verifyException(ex);
             }
             return null;
         });

--- a/service/security/shiro/src/test/resources/features/AccessInfoService.feature
+++ b/service/security/shiro/src/test/resources/features/AccessInfoService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,7 @@
 Feature: Access Info Service CRUD tests
 
 Scenario: Simple create
-    Create a simple access info entry. Only a user is supplied. The entry must 
+    Create a simple access info entry. Only a user is supplied. The entry must
     match the creator parameters.
 
     Given A scope with ID 1
@@ -25,7 +25,7 @@ Scenario: Simple create
     And The entity matches the creator
 
 Scenario: Create with permissions
-    Create an access info entry. In addition to a user a list of permissions is 
+    Create an access info entry. In addition to a user a list of permissions is
     supplied too. The entry must match the creator parameters.
 
     Given A scope with ID 1
@@ -62,20 +62,21 @@ Scenario: Create with permissions and a role
 Scenario: Try to create an access into entity with an invalid role id
     It must not be possible to create an access info entity if the given role is invalid.
     Such an attempt must result in an exception.
-    
+
     Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
     And The permissions "read, write, execute"
     And An invalid role ID
+    Given I expect the exception "KapuaAuthorizationException" with the text "Error: Role not found in the scope"
     When I create the access info entity
     Then An exception was thrown
 
 Scenario: Find an access info entity
-    It must be possible to find an existing access info entity in the database 
+    It must be possible to find an existing access info entity in the database
     based on its ID.
-    
+
     Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
@@ -87,8 +88,8 @@ Scenario: Find an access info entity
     Then I find an accessinfo entity
 
 Scenario: Find an access info entity by user ID
-    It must be possible to find an existing access info entity in the database 
-    based on the entity user ID. 
+    It must be possible to find an existing access info entity in the database
+    based on the entity user ID.
 
     Given A scope with ID 1
     And A user such as
@@ -100,7 +101,7 @@ Scenario: Find an access info entity by user ID
     Then I find an accessinfo entity
 
 Scenario: Search for an access info entity by an incorrect user ID
-    If the user ID supplied for a search is invalid, only a null result 
+    If the user ID supplied for a search is invalid, only a null result
     must be returned. No exception must be thrown.
 
     Given A scope with ID 1
@@ -144,7 +145,7 @@ Scenario: Delete a access info entity with permissions and roles
     Then I find no access info entity
 
 Scenario: Delete an access info entity twice
-    An attempt to delete the same entity multiple times should result 
+    An attempt to delete the same entity multiple times should result
     in an exception.
 
     Given A scope with ID 1
@@ -152,12 +153,13 @@ Scenario: Delete an access info entity twice
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
     And I create the access info entity
+    Then I delete the existing access info entity
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type accessPermission"
     When I delete the existing access info entity
-    And I delete the existing access info entity
     Then An exception was thrown
 
 Scenario: Delete an access info entity using the wrong scope ID
-    An attempt to delete an entity using the wrong scope ID must result 
+    An attempt to delete an entity using the wrong scope ID must result
     in an exception.
 
     Given A scope with ID 1
@@ -170,7 +172,7 @@ Scenario: Delete an access info entity using the wrong scope ID
     Then No exception was thrown
 
 Scenario: Count access info entities in a specific scope
-    It must be possible to count the existing access info entities in various 
+    It must be possible to count the existing access info entities in various
     scopes.
 
     Given A scope with ID 10
@@ -195,7 +197,7 @@ Scenario: Count access info entities in a specific scope
     Then I get 0 as result
 
 Scenario: Query for all the access info entities of a specific user
-    It must be possible to find all the access info entities that belong 
+    It must be possible to find all the access info entities that belong
     to a specific user.
 
     Given A scope with ID 1
@@ -220,7 +222,7 @@ Scenario: Query for all the access info entities of a specific user
 Scenario: Query for all the access info entities of an invalid user
     If an invalid user is supplied for an entity count, the result list must be empty.
     No exceptions should be thrown.
- 
+
     Given A scope with ID 1
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
@@ -263,7 +265,7 @@ Scenario: Find last created permision
 
 Scenario: Delete an existing access permission entity
     It must be possibel to delete a specific permission entry.
-    
+
     Given A scope with ID 10
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
@@ -278,7 +280,7 @@ Scenario: Delete an existing access permission entity
     Then I get 2 as result
 
 Scenario: Delete a non existing permission entity
-    Atttempting to delete a non existing permission entry must result in 
+    Atttempting to delete a non existing permission entry must result in
     an exception. In this case this is achieved by deleting the same entry twice.
 
     Given A scope with ID 10
@@ -290,13 +292,14 @@ Scenario: Delete a non existing permission entity
     And I create the permission
     When I count the permissions in scope 10
     Then I get 1 as result
+    Then I delete the last created access permission
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type accessPermission"
     When I delete the last created access permission
-    And I delete the last created access permission
     Then An exception was thrown
 
 Scenario: Regular creation of Access Role entity
     It must be possible to create a regular role entity in the dataabse.
-    
+
     Given A scope with ID 10
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
@@ -310,7 +313,7 @@ Scenario: Regular creation of Access Role entity
     And An access role entity was created
 
 Scenario: Creation of access role without an acess info entity
-    The creation of an access role entity without an already existing access info 
+    The creation of an access role entity without an already existing access info
     entry is permitted.
 
     Given A scope with ID 10
@@ -325,20 +328,20 @@ Scenario: Creation of access role without an acess info entity
 
 Scenario: Creation of access role with neither acess info and role entities
     The creation of an access role entity with neither access info nor role
-    entries is permitted. 
+    entries is permitted.
 
-	Given A scope with ID 10
-	And A user such as
-	        | name     | displayName     | email              | phoneNumber     |
-	        | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
-	When I create the access info entity
-	And The permissions "read, write, execute"
-	And The role "test_role_1"
-	When I create the access role
-	Then No exception was thrown
+    Given A scope with ID 10
+    And A user such as
+            | name     | displayName     | email              | phoneNumber     |
+            | kapua-u1 | Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 |
+    When I create the access info entity
+    And The permissions "read, write, execute"
+    And The role "test_role_1"
+    When I create the access role
+    Then No exception was thrown
 
 Scenario: Find an existing access role entity
-    It must be possible to find an existing access role entry in the database 
+    It must be possible to find an existing access role entry in the database
     based on its ID.
 
     Given A scope with ID 10
@@ -353,7 +356,7 @@ Scenario: Find an existing access role entity
     Then I find an access role entity
 
 Scenario: Count access role entities by scope
-    It must be possible to count all the access role entries in specific scopes. If the 
+    It must be possible to count all the access role entries in specific scopes. If the
     requested scope doesn't contain a role or doesn't exist altogether, only an empty
     result list must be returned. No exception must be thrown.
 
@@ -369,7 +372,7 @@ Scenario: Count access role entities by scope
     And I create the access role
     And The role "test_role_3"
     And I create the access role
-    
+
     Given A scope with ID 20
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
@@ -378,13 +381,13 @@ Scenario: Count access role entities by scope
     And The permissions "read, write, execute"
     And The role "test_role_2"
     And I create the access role
-    
+
     Given A scope with ID 30
     And A user such as
         | name     | displayName     | email              | phoneNumber     |
         | kapua-u3 | Kapua User 3    | kapua_u3@kapua.com | +386 31 323 555 |
     When I create the access info entity
-    
+
     When I count the access roles in scope 10
     Then I get 3 as result
     When I count the access roles in scope 20
@@ -418,7 +421,7 @@ Scenario: Delete an existing access role entry
     Then I get 2 as result
 
 Scenario: Delete an existing role twice
-    Attempting to delete a non existing access role entry must result in an exception. In 
+    Attempting to delete a non existing access role entry must result in an exception. In
     this case this is achieved by trying to delete the same entry twice.
 
     Given A scope with ID 10
@@ -429,8 +432,9 @@ Scenario: Delete an existing role twice
     And The permissions "read, write, execute"
     And The role "test_role_1"
     And I create the access role
+    Then I delete the last created access role entry
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type accessRole"
     When I delete the last created access role entry
-    And I delete the last created access role entry
     Then An exception was thrown
 
 Scenario: Access info service sanity checks
@@ -448,7 +452,7 @@ Scenario: Access service comparison sanity checks
 
 Scenario: Create with permissions and a role in the wrong scope
     Such a scenario should cause an exception to bo thrown. The keyword is 'should'.
-    In the current implementation RoleDAO.find will succcessfully find the role 
+    In the current implementation RoleDAO.find will succcessfully find the role
     entity even if it was created in a different scope than the access info entity.
 
     Given A scope with ID 10

--- a/service/security/shiro/src/test/resources/features/DomainService.feature
+++ b/service/security/shiro/src/test/resources/features/DomainService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -11,146 +11,151 @@
 ###############################################################################
 Feature: Domain Service CRUD tests
 
-  Scenario: Count domains in a blank database
-  The default domain table must contain 8 preset entries.
+Scenario: Count domains in a blank database
+    The default domain table must contain 15 preset entries.
 
     When I count the domain entries in the database
-    Then I get 8 as result
+    Then I get 15 as result
 
-  Scenario: Regular domain
-  Create a regular domain entry. The newly created entry must match the
-  creator parameters.
+Scenario: Regular domain
+    Create a regular domain entry. The newly created entry must match the
+    creator parameters.
 
     Given I create the domain
-      | name        | serviceName    | actions    |
-      | test_name_1 | test_service_1 | read,write |
+    |name        |serviceName    |actions   |
+    |test_name_1 |test_service_1 |read,write|
     Then A domain was created
     And The domain matches the creator
 
-  Scenario: Domain with null name
-  It must not be possible to create a domain entry with a null name. In
-  such case the domain service must throw an exception.
+Scenario: Domain with null name
+    It must not be possible to create a domain entry with a null name. In
+    such case the domain service must throw an exception.
 
-    Given I create the domain
-      | serviceName    | actions    |
-      | test_service_1 | read,write |
-    Then An exception was thrown
-
-  Scenario: Domain with null service name
-  It must not be possible to create a domain entry with a null service name. In
-  such case the domain service must throw an exception.
-
-    Given I create the domain
-      | name        | actions    |
-      | test_name_1 | read,write |
-    Then An exception was thrown
-
-  Scenario: Domain with null actions
-  It must not be possible to create a domain entry with a null set of supported actions. In
-  such case the domain service must throw an exception.
-
-    Given I create the domain
-      | name        | serviceName    |
-      | test_name_1 | test_service_1 |
-    Then An exception was thrown
-
-  Scenario: Domains with duplicate names
-  Domain names must be unique in the database. If an already existing name is used for a
-  new domain an exception must be thrown.
-
-    Given I create the domain
-      | name        | serviceName    | actions    |
-      | test_name_1 | test_service_1 | read,write |
-    Then A domain was created
-    And The domain matches the creator
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create the domain
-      | name        | serviceName    | actions    |
-      | test_name_1 | test_service_1 | read,write |
+    |serviceName    |actions   |
+    |test_service_1 |read,write|
     Then An exception was thrown
 
-  Scenario: Find the last created domain entry
-  It must be possible to find a dmain entry based on its unique ID.
+Scenario: Domain with null service name
+    It must not be possible to create a domain entry with a null service name. In
+    such case the domain service must throw an exception.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I create the domain
+    |name        |actions   |
+    |test_name_1 |read,write|
+    Then An exception was thrown
+
+Scenario: Domain with null actions
+    It must not be possible to create a domain entry with a null set of supported actions. In
+    such case the domain service must throw an exception.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I create the domain
+    |name        |serviceName    |
+    |test_name_1 |test_service_1 |
+    Then An exception was thrown
+
+Scenario: Domains with duplicate names
+    Domain names must be unique in the database. If an already existing name is used for a
+    new domain an exception must be thrown.
 
     Given I create the domain
-      | name        | serviceName    | actions      |
-      | test_name_2 | test_service_2 | read,execute |
+    |name        |serviceName    |actions   |
+    |test_name_1 |test_service_1 |read,write|
+    Then A domain was created
+    And The domain matches the creator
+    Given I expect the exception "KapuaException" with the text "Error during Persistence Operation"
+    When I create the domain
+    |name        |serviceName    |actions   |
+    |test_name_1 |test_service_1 |read,write|
+    Then An exception was thrown
+
+Scenario: Find the last created domain entry
+    It must be possible to find a dmain entry based on its unique ID.
+
+    Given I create the domain
+    |name        |serviceName    |actions     |
+    |test_name_2 |test_service_2 |read,execute|
     When I search for the last created domain
     Then The domain matches the creator
 
-  Scenario: Find the first domain entry for the specified service
-  It must be possible to find a domain entry based on the Service name property.
+Scenario: Find the first domain entry for the specified service
+    It must be possible to find a domain entry based on the Service name property.
 
     Given I create the domains
-      | name        | serviceName    | actions      |
-      | test_name_1 | test_service_1 | read,write   |
-      | test_name_2 | test_service_2 | read,execute |
-      | test_name_3 | test_service_3 | write,delete |
+    |name        |serviceName    |actions      |
+    |test_name_1 |test_service_1 |read,write   |
+    |test_name_2 |test_service_2 |read,execute |
+    |test_name_3 |test_service_3 |write,delete |
     When I search for the domains for the service "test_service_2"
     Then The domain matches the parameters
-      | name        | serviceName    | actions      |
-      | test_name_2 | test_service_2 | read,execute |
+    |name        |serviceName    |actions      |
+    |test_name_2 |test_service_2 |read,execute |
 
-  Scenario: Compare domain entries
-  The domain object is comparable.
+Scenario: Compare domain entries
+    The domain object is comparable.
 
     Then I can compare domain objects
 
-  Scenario: Delete the last created domain entry
-  It must be possible to delete an entry from the domain table. The domain is deleted
-  based on its ID.
+Scenario: Delete the last created domain entry
+    It must be possible to delete an entry from the domain table. The domain is deleted
+    based on its ID.
 
     Given I create the domain
-      | name        | serviceName    | actions      |
-      | test_name_2 | test_service_2 | read,execute |
+    |name        |serviceName    |actions     |
+    |test_name_2 |test_service_2 |read,execute|
     When I search for the last created domain
     Then The domain matches the creator
     When I delete the last created domain
     And I search for the last created domain
     Then There is no domain
 
-  Scenario: Delete an inexistent domain
-  If the requested ID is not found in the database, the delete function must throw
-  an exception.
+Scenario: Delete a nonexistent domain
+    If the requested ID is not found in the database, the delete function must throw
+    an exception.
 
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type domain"
     When I try to delete domain with a random ID
     Then An exception was thrown
 
-  Scenario: Count domains in the database
-  It must be possible to count all the domain entries in the domain table.
+Scenario: Count domains in the database
+    It must be possible to count all the domain entries in the domain table.
 
     When I count the domain entries in the database
     Then This is the initial count
     Given I create the domains
-      | name        | serviceName    | actions      |
-      | test_name_1 | test_service_1 | read,write   |
-      | test_name_2 | test_service_2 | read,execute |
-      | test_name_3 | test_service_3 | write,delete |
+    |name        |serviceName    |actions      |
+    |test_name_1 |test_service_1 |read,write   |
+    |test_name_2 |test_service_2 |read,execute |
+    |test_name_3 |test_service_3 |write,delete |
     When I count the domain entries in the database
     Then 3 more domains were created
 
-  Scenario: Domain entry query
-  It must be possible to query domain entries based on the name property.
+Scenario: Domain entry query
+    It must be possible to query domain entries based on the name property.
 
     Given I create the domains
-      | name        | serviceName    | actions      |
-      | test_name_1 | test_service_1 | read,write   |
-      | test_name_2 | test_service_2 | read,execute |
-      | test_name_3 | test_service_3 | write,delete |
+    |name        |serviceName    |actions      |
+    |test_name_1 |test_service_1 |read,write   |
+    |test_name_2 |test_service_2 |read,execute |
+    |test_name_3 |test_service_3 |write,delete |
     When I query for domains with the name "test_name_2"
     Then I get 1 as result
 
-  Scenario: Domain entry query - service name
-  It must be possible to query domain entries based on the service name.
-  The whole list of matching entries must be returned.
+Scenario: Domain entry query - service name
+    It must be possible to query domain entries based on the service name.
+    The whole list of matching entries must be returned.
 
     Given I create the domains
-      | name        | serviceName    | actions      |
-      | test_name_1 | test_service_1 | read,write   |
-      | test_name_2 | test_service_2 | read,execute |
-      | test_name_3 | test_service_3 | write,delete |
-      | test_name_4 | test_service_3 | read,write   |
-      | test_name_5 | test_service_3 | read,execute |
-      | test_name_6 | test_service_2 | write,delete |
+    |name        |serviceName    |actions      |
+    |test_name_1 |test_service_1 |read,write   |
+    |test_name_2 |test_service_2 |read,execute |
+    |test_name_3 |test_service_3 |write,delete |
+    |test_name_4 |test_service_3 |read,write   |
+    |test_name_5 |test_service_3 |read,execute |
+    |test_name_6 |test_service_2 |write,delete |
     When I query for domains with the service name "test_service_2"
     Then I get 2 as result
     When I query for domains with the service name "test_service_3"

--- a/service/security/shiro/src/test/resources/features/DomainService.feature
+++ b/service/security/shiro/src/test/resources/features/DomainService.feature
@@ -12,10 +12,10 @@
 Feature: Domain Service CRUD tests
 
 Scenario: Count domains in a blank database
-    The default domain table must contain 15 preset entries.
+    The default domain table must contain 8 preset entries.
 
     When I count the domain entries in the database
-    Then I get 15 as result
+    Then I get 8 as result
 
 Scenario: Regular domain
     Create a regular domain entry. The newly created entry must match the

--- a/service/security/shiro/src/test/resources/features/GroupService.feature
+++ b/service/security/shiro/src/test/resources/features/GroupService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -12,213 +12,217 @@
 Feature: Group Service CRUD tests
 
 Scenario: Count groups in a blank database
-	The default group table must be empty.
-	
-	When I count the group entries in the database
-	Then I get 0 as result
+    The default group table must be empty.
+
+    When I count the group entries in the database
+    Then I get 0 as result
 
 Scenario: Regular group in root scope
-	Create a regular group entry. The newly created entry must match the 
-	creator parameters.
+    Create a regular group entry. The newly created entry must match the
+    creator parameters.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    1    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    1    |       1       |
-	Given I create the group
-	|scope |name        |
-	|1     |test_name_1 |
-	Then A group was created
-	And The group matches the creator
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    1    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    1    |       1       |
+    Given I create the group
+    |scope |name        |
+    |1     |test_name_1 |
+    Then A group was created
+    And The group matches the creator
 
 Scenario: Regular group in random scope
-	Create a regular group entry. The newly created entry must match the 
-	creator parameters.
+    Create a regular group entry. The newly created entry must match the
+    creator parameters.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |  1234   |       1       |
-	| integer | maxNumberChildEntities     | 5     |  1234   |       1       |
-	Given I create the group
-	|scope |name        |
-	|1234  |test_name_1 |
-	Then A group was created
-	And The group matches the creator
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |  1234   |       1       |
+    | integer | maxNumberChildEntities     | 5     |  1234   |       1       |
+    Given I create the group
+    |scope |name        |
+    |1234  |test_name_1 |
+    Then A group was created
+    And The group matches the creator
 
 Scenario: Duplicate group name in root scope
-	Create a regular group entry. The newly created entry must match the 
-	creator parameters. Try to create a second group entry with the same name.
-	An exception should be thrown.
+    Create a regular group entry. The newly created entry must match the
+    creator parameters. Try to create a second group entry with the same name.
+    An exception should be thrown.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    0    |       1       |
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    0    |       1       |
     | integer | maxNumberChildEntities     | 5     |    0    |       1       |
-	Given I create the group
-	|scope |name        |
-	|0     |test_name_1 |
-	Then A group was created
-	And The group matches the creator
-	When I create the group
-	|scope |name        |
-	|0     |test_name_1 |
-	Then An exception was thrown
-	
-Scenario: Group with a null name
-	Try to create a second group entry with a null name.
-	An exception should be thrown.
+    Given I create the group
+    |scope |name        |
+    |0     |test_name_1 |
+    Then A group was created
+    And The group matches the creator
+    Given I expect the exception "KapuaException" with the text "Error during Persistence Operation"
+    When I create the group
+    |scope |name        |
+    |0     |test_name_1 |
+    Then An exception was thrown
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |   1234  |       1       |
-	| integer | maxNumberChildEntities     | 5     |   1234  |       1       |
-	Given I create the group
-	|scope |
-	|1234  |
-	Then An exception was thrown
+Scenario: Group with a null name
+    Try to create a second group entry with a null name.
+    An exception should be thrown.
+
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |   1234  |       1       |
+    | integer | maxNumberChildEntities     | 5     |   1234  |       1       |
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    Given I create the group
+    |scope |
+    |1234  |
+    Then An exception was thrown
 
 Scenario: Update a group entry in the database
-	Create a regular group entry. Change the entry name. The updated entry 
-	parameters should match the original group.
+    Create a regular group entry. Change the entry name. The updated entry
+    parameters should match the original group.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    0    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    0    |       1       |
-	Given I create the group
-	|scope |name        |
-	|0     |test_name_1 |
-	Then A group was created
-	And The group matches the creator
-	When I update the group name to "test_name_new"
-	Then The group was correctly updated
-	
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    0    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+    Given I create the group
+    |scope |name        |
+    |0     |test_name_1 |
+    Then A group was created
+    And The group matches the creator
+    When I update the group name to "test_name_new"
+    Then The group was correctly updated
+
 Scenario: Update a group entry with a false ID
-	Create a regular group entry. Modify the group object ID to a random value.
-	Trying to update such an group object should raise an exception.
+    Create a regular group entry. Modify the group object ID to a random value.
+    Trying to update such an group object should raise an exception.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    0    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    0    |       1       |
-	Given I create the group
-	|scope |name        |
-	|0     |test_name_1 |
-	Then A group was created
-	And The group matches the creator
-	When I update the group with an incorrect ID
-	Then An exception was thrown
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    0    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+    Given I create the group
+    |scope |name        |
+    |0     |test_name_1 |
+    Then A group was created
+    And The group matches the creator
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type group"
+    When I update the group with an incorrect ID
+    Then An exception was thrown
 
 Scenario: Find a group entry in the database
-	It must be possible to find a specific group entry based on the group 
-	entry ID.
+    It must be possible to find a specific group entry based on the group
+    entry ID.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    0    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    0    |       1       |
-	Given I create the group	
-	|scope |name        |
-	|0     |test_name_1 |
-	Then A group was created
-	And The group matches the creator
-	When I search for the last created group
-	Then The group was correctly found
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    0    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+    Given I create the group
+    |scope |name        |
+    |0     |test_name_1 |
+    Then A group was created
+    And The group matches the creator
+    When I search for the last created group
+    Then The group was correctly found
 
 Scenario: Delete a group from the database
-	It must be possible to delete a group entry from the database. In this test 
-	the last created entry is deleted.
+    It must be possible to delete a group entry from the database. In this test
+    the last created entry is deleted.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    0    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    0    |       1       |
-	Given I create the groups
-	|scope |name        |
-	|0     |test_name_1 |
-	|0     |test_name_2 |
-	When I delete the last created group
-	And I search for the last created group
-	Then No group was found
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    0    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+    Given I create the groups
+    |scope |name        |
+    |0     |test_name_1 |
+    |0     |test_name_2 |
+    When I delete the last created group
+    And I search for the last created group
+    Then No group was found
 
 Scenario: Delete a group from the database - Unknown group ID
-	Trying to delete a group record that does not exist (unknown group ID) should
-	raise an exception.
-	
-	When I try to delete a random group id
-	Then An exception was thrown
+    Trying to delete a group record that does not exist (unknown group ID) should
+    raise an exception.
+
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type group"
+    When I try to delete a random group id
+    Then An exception was thrown
 
 Scenario: Count groups
-	It must be possible to count all the groups belonging to a certain scope.
+    It must be possible to count all the groups belonging to a certain scope.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    0    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    0    |       1       |
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    1    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    1    |       1       |
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    2    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    2    |       1       |
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    3    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    3    |       1       |
-	Given I create the groups
-	|scope |name        |
-	|0     |test_name_1 |
-	|1     |test_name_2 |
-	|2     |test_name_3 |
-	|2     |test_name_4 |
-	|2     |test_name_5 |
-	|3     |test_name_6 |
-	|3     |test_name_7 |
-	|0     |test_name_8 |
-	When I count all the groups in scope 2
-	Then I get 3 as result
-	When I count all the groups in scope 3
-	Then I get 2 as result
-	When I count all the groups in scope 15
-	Then I get 0 as result
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    0    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    1    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    1    |       1       |
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    2    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    2    |       1       |
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    3    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    3    |       1       |
+    Given I create the groups
+    |scope |name        |
+    |0     |test_name_1 |
+    |1     |test_name_2 |
+    |2     |test_name_3 |
+    |2     |test_name_4 |
+    |2     |test_name_5 |
+    |3     |test_name_6 |
+    |3     |test_name_7 |
+    |0     |test_name_8 |
+    When I count all the groups in scope 2
+    Then I get 3 as result
+    When I count all the groups in scope 3
+    Then I get 2 as result
+    When I count all the groups in scope 15
+    Then I get 0 as result
 
 Scenario: Query for a specific group by name
-	It must be possible to query the database for a specific group by name. Since the 
-	scope ID / name pairs must be unique, only a single entry can be returned by such a query.
+    It must be possible to query the database for a specific group by name. Since the
+    scope ID / name pairs must be unique, only a single entry can be returned by such a query.
 
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    0    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    0    |       1       |
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    1    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    1    |       1       |
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    2    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    2    |       1       |
-	When I configure
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    3    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    3    |       1       |
-	Given I create the groups
-	|scope |name        |
-	|0     |test_name_1 |
-	|1     |test_name_2 |
-	|2     |test_name_1 |
-	|2     |test_name_4 |
-	|2     |test_name_5 |
-	|3     |test_name_6 |
-	|3     |test_name_7 |
-	|0     |test_name_8 |
-	When I query for the group "test_name_1" in scope 0
-	Then I get 1 as result
-	And The group name is "test_name_1"
-	When I query for the group "test_name_1" in scope 2
-	Then I get 1 as result
-	And The group name is "test_name_1"
-	When I query for the group "test_name_15" in scope 1
-	Then I get 0 as result
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    0    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    1    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    1    |       1       |
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    2    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    2    |       1       |
+    When I configure
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    3    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    3    |       1       |
+    Given I create the groups
+    |scope |name        |
+    |0     |test_name_1 |
+    |1     |test_name_2 |
+    |2     |test_name_1 |
+    |2     |test_name_4 |
+    |2     |test_name_5 |
+    |3     |test_name_6 |
+    |3     |test_name_7 |
+    |0     |test_name_8 |
+    When I query for the group "test_name_1" in scope 0
+    Then I get 1 as result
+    And The group name is "test_name_1"
+    When I query for the group "test_name_1" in scope 2
+    Then I get 1 as result
+    And The group name is "test_name_1"
+    When I query for the group "test_name_15" in scope 1
+    Then I get 0 as result

--- a/service/security/shiro/src/test/resources/features/MiscAuthorization.feature
+++ b/service/security/shiro/src/test/resources/features/MiscAuthorization.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -12,5 +12,5 @@
 Feature: Misc Authorization functionality CRUD tests
 
 Scenario: Permission factory sanity checks
-	Then The permission factory returns sane results
-	Then I can compare permission objects
+    Then The permission factory returns sane results
+    Then I can compare permission objects

--- a/service/security/shiro/src/test/resources/features/RoleService.feature
+++ b/service/security/shiro/src/test/resources/features/RoleService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -12,269 +12,274 @@
 Feature: Role Service CRUD tests
 
 Scenario: Regular role creation
-	Create a regular role entry. The entry must match the creator details.
-	
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	Then The role matches the creator
-	When I examine the permissions for the last role
-	Then I find the following actions
-	|actions              |
-	|write, read, connect |
-	And The permissions match
+    Create a regular role entry. The entry must match the creator details.
+
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    Then The role matches the creator
+    When I examine the permissions for the last role
+    Then I find the following actions
+    |actions              |
+    |write, read, connect |
+    And The permissions match
 
 Scenario: Nameless role entry
-	It must not be possible to create a role entry without a name.
-	Such an attempt must throw an exception.
-	
-	Given I create the following role
-	|scopeId |actions              |
-	|1       |write, read, connect |
-	Then An exception was thrown
+    It must not be possible to create a role entry without a name.
+    Such an attempt must throw an exception.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I create the following role
+    |scopeId |actions              |
+    |1       |write, read, connect |
+    Then An exception was thrown
 
 Scenario: Duplicate role names
-	It must not be possible to create role entries with duplicate names.
-	Such an attempt must throw an exception.
-	
-	Given I create the following role
-	|scopeId |name      |actions                 |
-	|1       |test_role |write, read, connect    |
-	|1       |test_role |write, execute, connect |
-	Then An exception was thrown
+    It must not be possible to create role entries with duplicate names.
+    Such an attempt must throw an exception.
+
+    Given I expect the exception "KapuaException" with the text "Error during Persistence Operation"
+    When I create the following role
+    |scopeId |name      |actions                 |
+    |1       |test_role |write, read, connect    |
+    |1       |test_role |write, execute, connect |
+    Then An exception was thrown
 
 Scenario: Role entry with no actions
-	It should be possible to create a role entry without a single action.
-	
-	Given I create the following role
-	|scopeId |name      |
-	|1       |test_role |
-	Then No exception was thrown
-	And The role matches the creator
+    It should be possible to create a role entry without a single action.
+
+    Given I create the following role
+    |scopeId |name      |
+    |1       |test_role |
+    Then No exception was thrown
+    And The role matches the creator
 
 Scenario: Find role by ID
-	It must be possible to find a specific role entry in the database based 
-	on the known role ID.
+    It must be possible to find a specific role entry in the database based
+    on the known role ID.
 
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	When I search for the last created role
-	Then The correct role entry was found
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    When I search for the last created role
+    Then The correct role entry was found
 
 Scenario: Search the role database for a random ID
-	Searching the database for an unknown ID should be silently ignored. No 
-	exception should be raised.
+    Searching the database for an unknown ID should be silently ignored. No
+    exception should be raised.
 
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	When I search for a random role ID
-	Then I find no roles
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    When I search for a random role ID
+    Then I find no roles
 
 Scenario: Delete an existing role
-	It must be possible to delete an existing role item from the database.
-	
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	When I delete the last created role
-	And I search for the last created role
-	Then I find no roles
-	
-Scenario: Delete a non existing role entry
-	Deleting a non existing role must throw an exception. This scenario explores what 
-	happens when it is attempted to delete the same role twice.
+    It must be possible to delete an existing role item from the database.
 
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	When I delete the last created role
-	And I search for the last created role
-	Then I find no roles
-	When I delete the last created role
-	Then An exception was thrown
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    When I delete the last created role
+    And I search for the last created role
+    Then I find no roles
+
+Scenario: Delete a non existing role entry
+    Deleting a non existing role must throw an exception. This scenario explores what
+    happens when it is attempted to delete the same role twice.
+
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    When I delete the last created role
+    And I search for the last created role
+    Then I find no roles
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type role"
+    When I delete the last created role
+    Then An exception was thrown
 
 Scenario: Update existing role name
-	It must be possible to change the name of an already existing role.
+    It must be possible to change the name of an already existing role.
 
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	When I update the last created role name to "test_role_changed"
-	And I search for the last created role
-	Then The role was successfully updated
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    When I update the last created role name to "test_role_changed"
+    And I search for the last created role
+    Then The role was successfully updated
 
 Scenario: Modify a role that was deleted
-	If an update operation is tried on a role that was previously deleted,
-	an exception must be thrown.
-	
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	And I delete the last created role
-	When I update the last created role name to "test_role_changed"
-	Then An exception was thrown
+    If an update operation is tried on a role that was previously deleted,
+    an exception must be thrown.
+
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    And I delete the last created role
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type role"
+    When I update the last created role name to "test_role_changed"
+    Then An exception was thrown
 
 Scenario: Count roles in specific scopes
-	It must be possible to count all the roles defined for specific scopes. If
-	there is no role for a specific domain a 0 should be returned. No error or 
-	exception is expected.
+    It must be possible to count all the roles defined for specific scopes. If
+    there is no role for a specific domain a 0 should be returned. No error or
+    exception is expected.
 
-	When I configure role
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    2    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    2    |       1       |
-	When I configure role
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    3    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    3    |       1       |
-	When I configure role
-	| type    | name                       | value | scopeId | parentScopeId |
-	| boolean | infiniteChildEntities      | true  |    4    |       1       |
-	| integer | maxNumberChildEntities     | 5     |    4    |       1       |
-	Given I create the following roles
-	|scopeId |name        |actions              |
-	|4       |test_role_1 |write, read, connect |
-	|2       |test_role_2 |write, read, connect |
-	|3       |test_role_3 |write, read, connect |
-	|4       |test_role_4 |write, read, connect |
-	|2       |test_role_5 |write, read, connect |
-	|4       |test_role_6 |write, read, connect |
-	|4       |test_role_7 |write, read, connect |
-	|2       |test_role_8 |write, read, connect |
-	When I count the roles in scope 4
-	Then I get 4 as result
-	When I count the roles in scope 2
-	Then I get 3 as result
-	When I count the roles in scope 3
-	Then I get 1 as result
-	When I count the roles in scope 15
-	Then I get 0 as result
+    When I configure role
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    2    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    2    |       1       |
+    When I configure role
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    3    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    3    |       1       |
+    When I configure role
+    | type    | name                       | value | scopeId | parentScopeId |
+    | boolean | infiniteChildEntities      | true  |    4    |       1       |
+    | integer | maxNumberChildEntities     | 5     |    4    |       1       |
+    Given I create the following roles
+    |scopeId |name        |actions              |
+    |4       |test_role_1 |write, read, connect |
+    |2       |test_role_2 |write, read, connect |
+    |3       |test_role_3 |write, read, connect |
+    |4       |test_role_4 |write, read, connect |
+    |2       |test_role_5 |write, read, connect |
+    |4       |test_role_6 |write, read, connect |
+    |4       |test_role_7 |write, read, connect |
+    |2       |test_role_8 |write, read, connect |
+    When I count the roles in scope 4
+    Then I get 4 as result
+    When I count the roles in scope 2
+    Then I get 3 as result
+    When I count the roles in scope 3
+    Then I get 1 as result
+    When I count the roles in scope 15
+    Then I get 0 as result
 
 Scenario: A fresh database must contain 1 default role in the root scope
-	When I count the roles in scope 1
-	Then I get 1 as result
-	
+    When I count the roles in scope 1
+    Then I get 1 as result
+
 Scenario: It must be possible to query for specific entries in the role database
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	When I query for the role "test_role" in scope 1
-	Then I get 1 as result
-	And The correct role entry was found
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    When I query for the role "test_role" in scope 1
+    Then I get 1 as result
+    And The correct role entry was found
 
 Scenario: Empty query results are supported
-	If a query does not yield any result only an empty list must be returned. This is not
-	an error situation.
-	
-	Given I create the following role
-	|scopeId |name      |actions              |
-	|1       |test_role |write, read, connect |
-	When I query for the role "test_role_unknown" in scope 1
-	Then No exception was thrown
-	And I get 0 as result
+    If a query does not yield any result only an empty list must be returned. This is not
+    an error situation.
+
+    Given I create the following role
+    |scopeId |name      |actions              |
+    |1       |test_role |write, read, connect |
+    When I query for the role "test_role_unknown" in scope 1
+    Then No exception was thrown
+    And I get 0 as result
 
 Scenario: Create some regular role permissions
-	Given I create the following role
-	|scopeId |name      |
-	|1       |test_role |
-	And I create the following role permissions
-	|scopeId |actionName | targetScopeId |
-	|1       |read       | 1             |
-	|1       |write      | 1             |
-	|1       |connect    | 3             |
-	Then No exception was thrown
-	When I search for the last created role permission
-	Then The correct role permission entry was found
+    Given I create the following role
+    |scopeId |name      |
+    |1       |test_role |
+    And I create the following role permissions
+    |scopeId |actionName | targetScopeId |
+    |1       |read       | 1             |
+    |1       |write      | 1             |
+    |1       |connect    | 3             |
+    Then No exception was thrown
+    When I search for the last created role permission
+    Then The correct role permission entry was found
 
 Scenario: Delete role permissions
-	It must be possible to delete an existing role permission record from the database.
-	
-	Given I create the following role
-	|scopeId |name      |
-	|1       |test_role |
-	And I create the following role permission
-	|scopeId |actionName |
-	|1       |read       |
-	Then No exception was thrown
-	When I delete the last created role permission
-	And I search for the last created role permission
-	Then I find no permissions
+    It must be possible to delete an existing role permission record from the database.
+
+    Given I create the following role
+    |scopeId |name      |
+    |1       |test_role |
+    And I create the following role permission
+    |scopeId |actionName |
+    |1       |read       |
+    Then No exception was thrown
+    When I delete the last created role permission
+    And I search for the last created role permission
+    Then I find no permissions
 
 Scenario: Delete nonexisting role permission
-	An attempt to delete a non existing role permission from the database must result 
-	in an exception being thrown.
-	
-	Given I create the following role
-	|scopeId |name      |
-	|1       |test_role |
-	And  I create the following role permission
-	|scopeId |actionName |
-	|1       |read       |
-	Then No exception was thrown
-	When I delete the last created role permission
-	And I search for the last created role permission
-	Then I find no permissions
-	When I delete the last created role permission
-	Then An exception was thrown
+    An attempt to delete a non existing role permission from the database must result
+    in an exception being thrown.
+
+    Given I create the following role
+    |scopeId |name      |
+    |1       |test_role |
+    And  I create the following role permission
+    |scopeId |actionName |
+    |1       |read       |
+    Then No exception was thrown
+    When I delete the last created role permission
+    And I search for the last created role permission
+    Then I find no permissions
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type rolePermission"
+    When I delete the last created role permission
+    Then An exception was thrown
 
 Scenario: Count role permissions in specific scopes
-	It must be possible to count all the role permissions defined for specific scopes. If
-	there is no role permission for a specific domain a 0 should be returned. No error or 
-	exception is expected.
-	
-	Given I create the following role
-	|scopeId |name        |
-	|2       |test_role_2 |
-	
-	And I create the following role permissions
-	|scopeId  |actionName |
-	|2        |read       |
-	|2        |read       |
-	|2        |read       |
-	
-	And I create the following role
-	|scopeId |name        |
-	|3       |test_role_3 |
-	
-	And I create the following role permissions
-	|scopeId  |actionName | targetScopeId |
-	|3        |read       | 3             |
-	|3        |read       | 10            |
-	
-	And I create the following role
-	|scopeId |name        |
-	|4       |test_role_4 |
-	
-	And I create the following role permissions
-	|scopeId  |actionName | targetScopeId |
-	|4        |read       | 4             |
-	
-	When I count the permission in scope 2
-	Then I get 3 as result
-	When I count the permission in scope 3
-	Then I get 2 as result
-	When I count the permission in scope 4
-	Then I get 1 as result
-	When I count the permission in scope 5
-	Then I get 0 as result
+    It must be possible to count all the role permissions defined for specific scopes. If
+    there is no role permission for a specific domain a 0 should be returned. No error or
+    exception is expected.
+
+    Given I create the following role
+    |scopeId |name        |
+    |2       |test_role_2 |
+
+    And I create the following role permissions
+    |scopeId  |actionName |
+    |2        |read       |
+    |2        |read       |
+    |2        |read       |
+
+    And I create the following role
+    |scopeId |name        |
+    |3       |test_role_3 |
+
+    And I create the following role permissions
+    |scopeId  |actionName | targetScopeId |
+    |3        |read       | 3             |
+    |3        |read       | 10            |
+
+    And I create the following role
+    |scopeId |name        |
+    |4       |test_role_4 |
+
+    And I create the following role permissions
+    |scopeId  |actionName | targetScopeId |
+    |4        |read       | 4             |
+
+    When I count the permission in scope 2
+    Then I get 3 as result
+    When I count the permission in scope 3
+    Then I get 2 as result
+    When I count the permission in scope 4
+    Then I get 1 as result
+    When I count the permission in scope 5
+    Then I get 0 as result
 
 Scenario: Role creator sanity checks
-	Check that the role factory returns non null objects.
-	
-	Then The role factory returns sane results
+    Check that the role factory returns non null objects.
+
+    Then The role factory returns sane results
 
 Scenario: Role object equality check
-	Check that the role object comparator method correctly compares two objects and returns the
-	expected results.
-	
-	Then The role comparator does its job
+    Check that the role object comparator method correctly compares two objects and returns the
+    expected results.
+
+    Then The role comparator does its job
 
 Scenario: Role service related objects sanity checks
-	Check that the objects related to the shiro role service behave sanely.
+    Check that the objects related to the shiro role service behave sanely.
 
-	Then The role permission factory returns sane results
-	Then The role permission object constructors are sane
-	Then The role permission comparator does its job
+    Then The role permission factory returns sane results
+    Then The role permission object constructors are sane
+    Then The role permission comparator does its job
 


### PR DESCRIPTION
## A slight refactoring of exception handling in Shiro Authorization unit tests
The exception handling in the Shiro authorization service unit tests was improved.
When an expected exception is caught, the type and message are logged in the cucumber html report. If, on the other hand, an unexpected exception is caught, the exception is rethrown and the full stack trace is logged to help diagnose the underlying problem.

### Changes to Maven pom files
No changes.

### Implementation changes
No changes.

### Test changes
The test steps were modified to better handle exceptions.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>