### PR TITLE
Updated test reports to include all cucumber based test results

### DIFF
--- a/dev-tools/cucumber-reports/src/main/descriptors/kapua-cucumber-report.xml
+++ b/dev-tools/cucumber-reports/src/main/descriptors/kapua-cucumber-report.xml
@@ -30,11 +30,6 @@
         </fileSet>
 
         <fileSet>
-            <outputDirectory>shiro-authorization</outputDirectory>
-            <directory>../../service/security/shiro/target/cucumber</directory>
-        </fileSet>
-
-        <fileSet>
             <outputDirectory>account-service</outputDirectory>
             <directory>../../service/account/internal/target/cucumber</directory>
         </fileSet>
@@ -60,8 +55,23 @@
         </fileSet>
 
         <fileSet>
+            <outputDirectory>user-service-lockout-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/LockoutExpirationI9n</directory>
+        </fileSet>
+
+        <fileSet>
             <outputDirectory>device-service-i9n</outputDirectory>
             <directory>../../qa/target/cucumber/DeviceI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>device-lifecycle-service-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/DeviceLifecycleI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>connection-user-coupling-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/ConnectionI9n</directory>
         </fileSet>
 
         <fileSet>
@@ -70,7 +80,12 @@
         </fileSet>
 
         <fileSet>
-            <outputDirectory>device-broker-ACL-i9n</outputDirectory>
+            <outputDirectory>device-data-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/DeviceDataI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>broker-ACL-i9n</outputDirectory>
             <directory>../../qa/target/cucumber/BrokerACLI9n</directory>
         </fileSet>
 
@@ -88,6 +103,11 @@
             <outputDirectory>datastore-rest-i9n</outputDirectory>
             <directory>../../qa/target/cucumber/DatastoreRestI9n</directory>
         </fileSet>
-    </fileSets>
+
+        <fileSet>
+            <outputDirectory>tag-service-i9n</outputDirectory>
+            <directory>../../qa/target/cucumber/TagService</directory>
+        </fileSet>
+        </fileSets>
 
 </assembly>

--- a/dev-tools/cucumber-reports/src/main/resources/html/cucumber/index.html
+++ b/dev-tools/cucumber-reports/src/main/resources/html/cucumber/index.html
@@ -49,7 +49,6 @@
                     tested in isolation, with all other services mocked and not included in test.
                   </p>
                   <ul>
-                    <li><a href="shiro-authorization/index.html">Authorization service</a></li>
                     <li><a href="user-service/index.html">User service</a></li>
                     <li><a href="account-service/index.html">Account service</a></li>
                     <li><a href="device-registry-service/index.html">Device registry service</a></li>
@@ -67,12 +66,17 @@
                   </p>
                   <ul>
                     <li><a href="user-service-i9n/index.html">User service</a></li>
+                    <li><a href="user-service-lockout-i9n/index.html">User lockout tests</a></li>
                     <li><a href="device-service-i9n/index.html">Device service</a></li>
+                    <li><a href="device-lifecycle-service-i9n/index.html">Device lifecycle tests</a></li>
                     <li><a href="device-broker-i9n/index.html">Device registration with active MQTT broker</a></li>
-                    <li><a href="device-broker-ACL-i9n/index.html">Access control for broker connections</a></li>
+                    <li><a href="device-data-i9n/index.html">Base device data publishing tests</a></li>
+                    <li><a href="broker-ACL-i9n/index.html">Access control for broker connections</a></li>
                     <li><a href="device-manager-ACL-i9n/index.html">Access control for device management</a></li>
+                    <li><a href="connection-user-coupling-i9n/index.html">Tests for management of connection and user copuling</a></li>
                     <li><a href="datastore-transport-i9n/index.html">Datastore with transport client</a></li>
                     <li><a href="datastore-rest-i9n/index.html">Datastore with REST interface</a></li>
+                    <li><a href="tag-service-i9n/index.html">Tagging service tests</a></li>
                     <!--li>Other service</li-->
                   </ul>
                 </div>


### PR DESCRIPTION
## Updated test reports
The test report is updated to include all cucumber test results. The results are stored in the \dev-tools\cucumber-reports\target\kapua-cucumber-report in separate subfolders. The overall report is aggregated in index.html.

### Changes to Maven pom files
No changes.

### Implementation changes
No changes.

### Test changes
No changes.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>