### PR TITLE
Fix liquibase foreign keys creation skipped

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -182,6 +182,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-foreignkeys</artifactId>
+        </dependency>
+        <dependency>
             <!-- Google protobuf for message encoding -->
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>

--- a/assembly/api/src/main/descriptors/kapua-api-jetty.xml
+++ b/assembly/api/src/main/descriptors/kapua-api-jetty.xml
@@ -32,6 +32,7 @@
 
             <includes>
                 <include>${pom.groupId}:kapua-rest-api-web:war</include>
+                <include>${pom.groupId}:kapua-foreignkeys</include>
             </includes>
 
         </dependencySet>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -183,6 +183,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-foreignkeys</artifactId>
+        </dependency>
+        <dependency>
             <!-- Google protobuf for message encoding -->
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -177,6 +177,10 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-foreignkeys</artifactId>
+        </dependency>
+        <dependency>
             <!-- Google protobuf for message encoding -->
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>

--- a/assembly/console/src/main/descriptors/kapua-console-jetty.xml
+++ b/assembly/console/src/main/descriptors/kapua-console-jetty.xml
@@ -40,6 +40,7 @@
 
             <includes>
                 <include>${pom.groupId}:kapua-console-web:war</include>
+                <include>${pom.groupId}:kapua-foreignkeys</include>
             </includes>
 
         </dependencySet>

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/account-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/account-foreignkey.xml
@@ -17,6 +17,12 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-account-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="sys_configuration" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_sys_configuration_scopeId"
                                  baseTableName="sys_configuration"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_access_token-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_access_token-foreignkey.xml
@@ -17,6 +17,16 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-atht_access_token-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="atht_access_token" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+            <and>
+                <tableExists tableName="atht_access_token" schemaName="KAPUADB"/>
+                <tableExists tableName="usr_user" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_atht_access_token_scopeId"
                                  baseTableName="atht_access_token"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_credential-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_credential-foreignkey.xml
@@ -17,6 +17,16 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-atht_credential-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="atht_credential" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+            <and>
+                <tableExists tableName="atht_credential" schemaName="KAPUADB"/>
+                <tableExists tableName="usr_user" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_atht_credential_scopeId"
                                  baseTableName="atht_credential"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_access_info-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_access_info-foreignkey.xml
@@ -17,6 +17,16 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-athz_access_info-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_access_info" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+            <and>
+                <tableExists tableName="athz_access_info" schemaName="KAPUADB"/>
+                <tableExists tableName="usr_user" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_athz_access_info_scopeId"
                                  baseTableName="athz_access_info"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_group-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_group-foreignkey.xml
@@ -17,6 +17,12 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-athz_group-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_group" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_athz_group_scopeId"
                                  baseTableName="athz_group"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_role-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_role-foreignkey.xml
@@ -17,6 +17,12 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-athz_role-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_role" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_athz_role_scopeId"
                                  baseTableName="athz_role"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-connection-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-connection-foreignkey.xml
@@ -17,6 +17,12 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-device-connection-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="dvc_device_connection" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_dvc_device_connection_scopeId"
                                  baseTableName="dvc_device_connection"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-foreignkey.xml
@@ -17,6 +17,16 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-device-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="dvc_device" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+            <and>
+                <tableExists tableName="dvc_device" schemaName="KAPUADB"/>
+                <tableExists tableName="athz_group" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_dvc_device_scopeId"
                                  baseTableName="dvc_device"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-tag-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-tag-foreignkey.xml
@@ -17,6 +17,12 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-device-tag-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="dvc_device_tag" schemaName="KAPUADB"/>
+                <tableExists tableName="tag_tag" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_dvc_device_tag_tagId"
                                  baseTableName="dvc_device_tag"
                                  baseColumnNames="tag_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job-foreignkey.xml
@@ -17,6 +17,12 @@
                    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-job-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="job_job" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_job_job_scopeId"
                                  baseTableName="job_job"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job_step_definition-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job_step_definition-foreignkey.xml
@@ -17,6 +17,12 @@
                    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-job-step-definition-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="job_job_step_definition" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_job_job_step_definition_scopeId"
                                  baseTableName="job_job_step_definition"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/tag-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/tag-foreignkey.xml
@@ -17,6 +17,12 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-tag-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="tag_tag" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_tag_tag_scopeId"
                                  baseTableName="tag_tag"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/trigger-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/trigger-foreignkey.xml
@@ -18,6 +18,12 @@
                    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-trigger-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="schdl_trigger" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_schdl_trigger_scopeId"
                                  baseTableName="schdl_trigger"
                                  baseColumnNames="scope_id"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/user-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/user-foreignkey.xml
@@ -17,6 +17,12 @@
     logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-user-foreignkey-0.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="usr_user" schemaName="KAPUADB"/>
+                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+            </and>
+        </preConditions>
         <addForeignKeyConstraint constraintName="fk_usr_user_scopeId"
                                  baseTableName="usr_user"
                                  baseColumnNames="scope_id"

--- a/pom.xml
+++ b/pom.xml
@@ -999,7 +999,11 @@
                 <version>${project.version}</version>
                 <classifier>sources</classifier>
             </dependency>
-
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-foreignkeys</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <!-- External dependencies -->
 


### PR DESCRIPTION
Hi all,

This PR fixes #822 by adding a dependency on `kapua-foreignkeys` to both the broker assembly and the console assembly; additionally it adds precondition in order to instruct Liquibase to skip foreign keys creation if the tables have not been created yet.