### PR TITLE
Clean up of *.gwt.xml config file

### DIFF
--- a/console/core/src/main/resources/org/eclipse/kapua/app/console/core/adminCore.gwt.xml
+++ b/console/core/src/main/resources/org/eclipse/kapua/app/console/core/adminCore.gwt.xml
@@ -11,54 +11,32 @@
         Eurotech - initial API and implementation
         Red Hat Inc
  -->
-<!DOCTYPE xml>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
+
 <module rename-to="adminCore">
-
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.allen_sauer.gwt.log.gwt-log-OFF" />
-    <!-- <inherits name="com.allen_sauer.gwt.log.gwt-log-DEBUG" />      -->
-
-    <!-- We need the JUnit module in the main module,                   -->
-    <!-- otherwise eclipse complains (Google plugin bug?)               -->
-    <!-- inherits name='com.google.gwt.junit.JUnit' />                  -->
 
     <!-- Inherit the default GWT style sheet. You can change            -->
     <!-- the theme of your GWT application by uncommenting              -->
     <!-- any one of the following lines.                                -->
     <!-- <inherits name='com.extjs.gxt.themes.Themes' />                -->
 
-    <inherits name='com.google.gwt.user.theme.standard.Standard' />
+    <inherits name='com.google.gwt.user.theme.standard.Standard'/>
 
-    <!-- <inherits name='com.google.gwt.user.theme.chrome.Chrome'/>     -->
-    <!-- <inherits name='com.google.gwt.user.theme.dark.Dark'/>         -->
-
-    <!-- Other module inherits                                          -->
-    <inherits name='com.extjs.gxt.ui.GXT' />
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-    <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice" />
-    <inherits name="org.eclipse.kapua.app.console.module.user.adminModuleUser" />
-    <inherits name="org.eclipse.kapua.app.console.module.account.adminModuleAccount" />
-    <inherits name="org.eclipse.kapua.app.console.module.authentication.adminModuleAuthentication" />
-    <inherits name="org.eclipse.kapua.app.console.module.authorization.adminModuleAuthorization" />
-    <inherits name="org.eclipse.kapua.app.console.module.data.adminModuleData" />
-    <inherits name="org.eclipse.kapua.app.console.module.about.adminModuleAbout" />
-    <inherits name="org.eclipse.kapua.app.console.module.welcome.adminModuleWelcome" />
-    <inherits name="org.eclipse.kapua.app.console.module.tag.adminModuleTag" />
-    <inherits name="org.eclipse.kapua.app.console.module.job.adminModuleJob" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <!-- Kapua module inherits                                          -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
+    <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice"/>
+    <inherits name="org.eclipse.kapua.app.console.module.user.adminModuleUser"/>
+    <inherits name="org.eclipse.kapua.app.console.module.account.adminModuleAccount"/>
+    <inherits name="org.eclipse.kapua.app.console.module.authentication.adminModuleAuthentication"/>
+    <inherits name="org.eclipse.kapua.app.console.module.authorization.adminModuleAuthorization"/>
+    <inherits name="org.eclipse.kapua.app.console.module.data.adminModuleData"/>
+    <inherits name="org.eclipse.kapua.app.console.module.about.adminModuleAbout"/>
+    <inherits name="org.eclipse.kapua.app.console.module.welcome.adminModuleWelcome"/>
+    <inherits name="org.eclipse.kapua.app.console.module.tag.adminModuleTag"/>
+    <inherits name="org.eclipse.kapua.app.console.module.job.adminModuleJob"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='client' />
-    <source path='shared' />
+    <source path='client'/>
+    <source path='shared'/>
 </module>

--- a/console/module/about/src/main/resources/org/eclipse/kapua/app/console/module/about/adminModuleAbout.gwt.xml
+++ b/console/module/about/src/main/resources/org/eclipse/kapua/app/console/module/about/adminModuleAbout.gwt.xml
@@ -10,29 +10,15 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleAbout">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/adminModuleAccount.gwt.xml
+++ b/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/adminModuleAccount.gwt.xml
@@ -10,32 +10,18 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleAccount">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <!--<inherits name="com.google.gwt.i18n.I18N" />-->
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-    <inherits name="org.eclipse.kapua.app.console.module.user.adminModuleUser" />
-    <inherits name="org.eclipse.kapua.app.console.module.data.adminModuleData" />
-    <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
+    <inherits name="org.eclipse.kapua.app.console.module.user.adminModuleUser"/>
+    <inherits name="org.eclipse.kapua.app.console.module.data.adminModuleData"/>
+    <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/adminModuleApi.gwt.xml
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/adminModuleApi.gwt.xml
@@ -10,29 +10,28 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
+
 
 <module rename-to="adminModuleApi">
 
     <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
+    <inherits name='com.google.gwt.user.User'/>
 
-    <inherits name="com.google.gwt.i18n.I18N" />
+    <inherits name="com.google.gwt.i18n.I18N"/>
 
-    <inherits name='com.extjs.gxt.ui.GXT' />
+    <inherits name='com.extjs.gxt.ui.GXT'/>
 
-    <inherits name="com.allen_sauer.gwt.log.gwt-log-OFF" />
+    <inherits name="com.allen_sauer.gwt.log.gwt-log-OFF"/>
 
     <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
+    <extend-property name="locale" values="en"/>
 
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <set-property-fallback name="locale" value="en"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/adminModuleAuthentication.gwt.xml
+++ b/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/adminModuleAuthentication.gwt.xml
@@ -10,29 +10,15 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleAuthentication">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/adminModuleAuthorization.gwt.xml
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/adminModuleAuthorization.gwt.xml
@@ -10,29 +10,15 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleAuthorization">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/adminModuleData.gwt.xml
+++ b/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/adminModuleData.gwt.xml
@@ -10,29 +10,15 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleData">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/adminModuleDevice.gwt.xml
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/adminModuleDevice.gwt.xml
@@ -10,31 +10,17 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleDevice">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <!--<inherits name="com.google.gwt.i18n.I18N" />-->
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-    <inherits name="org.eclipse.kapua.app.console.module.authorization.adminModuleAuthorization" />
-    <inherits name="org.eclipse.kapua.app.console.module.user.adminModuleUser" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
+    <inherits name="org.eclipse.kapua.app.console.module.authorization.adminModuleAuthorization"/>
+    <inherits name="org.eclipse.kapua.app.console.module.user.adminModuleUser"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/adminModuleJob.gwt.xml
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/adminModuleJob.gwt.xml
@@ -10,30 +10,16 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleJob">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-    <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
+    <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/tag/src/main/resources/org/eclipse/kapua/app/console/module/tag/adminModuleTag.gwt.xml
+++ b/console/module/tag/src/main/resources/org/eclipse/kapua/app/console/module/tag/adminModuleTag.gwt.xml
@@ -10,30 +10,16 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleTag">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-    <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
+    <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/adminModuleUser.gwt.xml
+++ b/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/adminModuleUser.gwt.xml
@@ -10,31 +10,17 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleCredential">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-    <inherits name="org.eclipse.kapua.app.console.module.authentication.adminModuleAuthentication" />
-    <inherits name="org.eclipse.kapua.app.console.module.authorization.adminModuleAuthorization" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
+    <inherits name="org.eclipse.kapua.app.console.module.authentication.adminModuleAuthentication"/>
+    <inherits name="org.eclipse.kapua.app.console.module.authorization.adminModuleAuthorization"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/module/welcome/src/main/resources/org/eclipse/kapua/app/console/module/welcome/adminModuleWelcome.gwt.xml
+++ b/console/module/welcome/src/main/resources/org/eclipse/kapua/app/console/module/welcome/adminModuleWelcome.gwt.xml
@@ -10,29 +10,15 @@
     Contributors:
         Eurotech - initial API and implementation
 -->
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN" "https://raw.githubusercontent.com/gwtproject/gwt/master/distro-source/core/src/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
 
 <module rename-to="adminModuleWelcome">
 
-    <!-- Inherit the core Web Toolkit stuff.                            -->
-    <inherits name='com.google.gwt.user.User' />
-
-    <inherits name="com.google.gwt.i18n.I18N" />
-
-    <inherits name='com.extjs.gxt.ui.GXT' />
-
-    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.module.api.adminModuleApi"/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='shared' />
+    <source path='shared'/>
     <source path="client"/>
 
 </module>

--- a/console/web/src/main/resources/org/eclipse/kapua/app/console/admin.gwt.xml
+++ b/console/web/src/main/resources/org/eclipse/kapua/app/console/admin.gwt.xml
@@ -10,23 +10,17 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<!DOCTYPE xml>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
+
 <module rename-to="admin">
 
-    <inherits name="org.eclipse.kapua.app.console.core.adminCore" />
-
-    <!-- Locales: English language, independent of country              -->
-    <extend-property name="locale" values="en" />
-
-    <set-property-fallback name="locale" value="en" />
-
-    <!-- Target browser GWT permutations                                -->
-    <!-- <set-property name="user.agent" value="gecko1_8"/> -->
+    <inherits name="org.eclipse.kapua.app.console.core.adminCore"/>
 
     <!-- Specify the app entry point class. -->
-    <entry-point class='org.eclipse.kapua.app.console.core.client.KapuaCloudConsole' />
+    <entry-point class='org.eclipse.kapua.app.console.core.client.KapuaCloudConsole'/>
 
     <!-- Specify the paths for translatable code                        -->
-    <source path='client' />
-    <source path='shared' />
+    <source path='client'/>
+    <source path='shared'/>
 </module>

--- a/console/web/src/main/resources/org/eclipse/kapua/app/console/adminDev.gwt.xml
+++ b/console/web/src/main/resources/org/eclipse/kapua/app/console/adminDev.gwt.xml
@@ -10,18 +10,20 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<!DOCTYPE xml>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+        "https://raw.githubusercontent.com/gwtproject/gwt/2.4.0/distro-source/core/src/gwt-module.dtd">
+
 <module rename-to="admin">
-  <inherits name="org.eclipse.kapua.app.console.admin" />
-  <inherits name="com.google.gwt.logging.Logging"/>
+    <inherits name="org.eclipse.kapua.app.console.admin"/>
+    <inherits name="com.google.gwt.logging.Logging"/>
 
-  <!-- The 'user.agent' property can be changed to the developer's
-       favorite browser engine for local testing. Just don't check
-       it in every time -->
-  <set-property name="user.agent" value="gecko1_8" />
+    <!-- The 'user.agent' property can be changed to the developer's
+         favorite browser engine for local testing. Just don't check
+         it in every time -->
+    <set-property name="user.agent" value="gecko1_8"/>
 
-  <set-property name="gwt.logging.enabled" value="TRUE"/>
-  <set-property name="gwt.logging.consoleHandler" value="ENABLED"/>
-  <set-property name="gwt.logging.firebugHandler" value="ENABLED"/>
-  <set-property name="gwt.logging.popupHandler" value="DISABLED"/>
+    <set-property name="gwt.logging.enabled" value="TRUE"/>
+    <set-property name="gwt.logging.consoleHandler" value="ENABLED"/>
+    <set-property name="gwt.logging.firebugHandler" value="ENABLED"/>
+    <set-property name="gwt.logging.popupHandler" value="DISABLED"/>
 </module>


### PR DESCRIPTION
Hi all, 

this PR aims to clean up a bit the `*.gwt.xml` GWT module configuration files from duplicate declarations (most of them can be inherited from the  `org.eclipse.kapua.app.console.module.api.adminModuleApi`) and add/fix the DTD references to allow GWT module definition validation from IDE and ease of modify it.

Regards, 

_Alberto_