### PR TITLE
Base skeleton of the Job service unit test suite

### DIFF
--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -49,6 +49,43 @@
             <artifactId>kapua-liquibase</artifactId>
         </dependency>
 
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-guice</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobCreatorImpl.java
@@ -38,7 +38,7 @@ public class JobCreatorImpl extends AbstractKapuaNamedEntityCreator<Job> impleme
     private List<JobStep> jobSteps;
     private String jobXmlDefinition;
 
-    protected JobCreatorImpl(KapuaId scopeId) {
+    public JobCreatorImpl(KapuaId scopeId) {
         super(scopeId);
     }
 

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
@@ -43,7 +43,7 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
     private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
     private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
-    protected JobServiceImpl() {
+    public JobServiceImpl() {
         super(JobService.class.getName(), JOB_DOMAIN, JobEntityManagerFactory.getInstance(), JobService.class, JobFactory.class);
     }
 

--- a/service/job/internal/src/main/sql/H2/job_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_drop.sql
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *  
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+
+DROP TABLE IF EXISTS job_job_step_properties;
+DROP TABLE IF EXISTS sys_configuration;
+DROP TABLE IF EXISTS job_job_execution;
+DROP TABLE IF EXISTS job_job_step;
+DROP TABLE IF EXISTS job_job_target;
+DROP TABLE IF EXISTS job_job;
+
+DROP TABLE IF EXISTS DATABASECHANGELOG;

--- a/service/job/internal/src/main/sql/H2/job_execution_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_execution_drop.sql
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *  
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+
+DROP TABLE IF EXISTS job_job_execution;
+
+DROP TABLE IF EXISTS DATABASECHANGELOG;

--- a/service/job/internal/src/main/sql/H2/job_step_definition_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_step_definition_drop.sql
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *  
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+
+DROP TABLE IF EXISTS job_job_step_definition;
+DROP TABLE IF EXISTS job_job_step_definition_properties;
+
+DROP TABLE IF EXISTS DATABASECHANGELOG;

--- a/service/job/internal/src/main/sql/H2/job_step_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_step_drop.sql
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *  
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+
+DROP TABLE IF EXISTS job_job_step;
+
+DROP TABLE IF EXISTS DATABASECHANGELOG;

--- a/service/job/internal/src/main/sql/H2/job_target_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_target_drop.sql
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *  
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+
+DROP TABLE IF EXISTS job_job_target;
+
+DROP TABLE IF EXISTS DATABASECHANGELOG;

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/JobJAXBContextProvider.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/JobJAXBContextProvider.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.service.job;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.metatype.TscalarImpl;
+import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
+import org.eclipse.kapua.model.config.metatype.KapuaTad;
+import org.eclipse.kapua.model.config.metatype.KapuaTdesignate;
+import org.eclipse.kapua.model.config.metatype.KapuaTicon;
+import org.eclipse.kapua.model.config.metatype.KapuaTmetadata;
+import org.eclipse.kapua.model.config.metatype.KapuaTobject;
+import org.eclipse.kapua.model.config.metatype.KapuaTocd;
+import org.eclipse.kapua.model.config.metatype.KapuaToption;
+import org.eclipse.kapua.model.config.metatype.MetatypeXmlRegistry;
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+public class JobJAXBContextProvider implements JAXBContextProvider {
+    private static final Logger logger = LoggerFactory.getLogger(JobJAXBContextProvider.class);
+
+    private JAXBContext context;
+
+    @Override
+    public JAXBContext getJAXBContext() throws KapuaException {
+        if (context == null) {
+            Class<?>[] classes = new Class<?>[] {
+                    Job.class,
+                    JobListResult.class,
+                    JobXmlRegistry.class,
+                    KapuaTmetadata.class,
+                    KapuaTocd.class,
+                    KapuaTad.class,
+                    KapuaTicon.class,
+                    TscalarImpl.class,
+                    KapuaToption.class,
+                    KapuaTdesignate.class,
+                    KapuaTobject.class,
+                    MetatypeXmlRegistry.class
+            };
+            try {
+                context = JAXBContextFactory.createContext(classes, null);
+            } catch (JAXBException jaxbException) {
+                logger.warn("Error creating JAXBContext, tests will fail!");
+            }
+        }
+        return context;
+    }
+}

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/RunTest.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/RunTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(features = { "classpath:features/JobService.feature" },
+                 glue = { "org.eclipse.kapua.service.job" },
+                 plugin = { "pretty", "html:target/cucumber",
+                            "json:target/cucumber.json" },
+                 monochrome = true)
+@CucumberProperty(key="locator.class.impl", value="org.eclipse.kapua.test.MockedLocator")
+public class RunTest {
+}

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/common/CommonData.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/common/CommonData.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.common;
+
+import cucumber.api.Scenario;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+
+import javax.inject.Singleton;
+import java.math.BigInteger;
+import java.util.Random;
+
+@Singleton
+public class CommonData {
+
+    // Currently executing scenario.
+    public Scenario scenario;
+
+    // Scratchpad data related to exception checking
+    public boolean exceptionExpected;
+    public String exceptionName;
+    public String exceptionMessage;
+    public boolean exceptionCaught;
+
+    // Misc scratchpad data
+    public KapuaId currentScopeId;
+    public KapuaId currentUserId;
+
+    public long itemCount;
+
+    public CommonData() {
+        exceptionExpected = false;
+        exceptionName = "";
+        exceptionMessage = "";
+        exceptionCaught = false;
+
+        currentScopeId = null;
+        currentUserId = null;
+
+        itemCount = 0;
+    }
+
+    public void cleanup() {
+
+        exceptionExpected = false;
+        exceptionName = "";
+        exceptionMessage = "";
+        exceptionCaught = false;
+
+        currentScopeId = null;
+        currentUserId = null;
+
+        itemCount = 0;
+    }
+
+    // ********************************************************************************************
+    // Exception related helper functions
+    // ********************************************************************************************
+
+    // Set up the exception trap
+    public void primeException() {
+        exceptionCaught = false;
+    }
+
+    // Check the exception that was caught. In case the exception was expected the type and message is shown in the cucumber logs.
+    // Otherwise the exception is rethrown failing the test and dumping the stack trace to help resolving problems.
+    public void verifyException(Exception ex)
+            throws Exception {
+
+        if (!exceptionExpected ||
+                (!exceptionName.isEmpty() && !ex.getClass().toGenericString().contains(exceptionName)) ||
+                (!exceptionMessage.isEmpty() && !exceptionMessage.trim().contentEquals("*") && !ex.getMessage().contains(exceptionMessage))) {
+            scenario.write("An unexpected exception was raised!");
+            throw (ex);
+        }
+
+        scenario.write("Exception raised as expected: " + ex.getClass().getCanonicalName() + ", " + ex.getMessage());
+        exceptionCaught = true;
+    }
+
+    // ********************************************************************************************
+    // Miscellaneous helper functions
+    // ********************************************************************************************
+
+    // Create a random Kapua ID
+    public KapuaId getRandomId() {
+
+        long val = (new Random()).nextLong();
+
+        val = (val > 0) ? val : -val; // Make sure the value is always positive!
+        return new KapuaEid(BigInteger.valueOf(val));
+    }
+}

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/common/CommonSteps.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/common/CommonSteps.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.common;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.service.job.internal.JobServiceTestSteps;
+import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.math.BigInteger;
+
+@ScenarioScoped
+public class CommonSteps extends AbstractKapuaSteps {
+    private static final Logger logger = LoggerFactory.getLogger(JobServiceTestSteps.class);
+
+    CommonData commonData;
+
+    // Default constructor
+    @Inject
+    public CommonSteps(CommonData commonData) {
+        this.commonData = commonData;
+    }
+
+    @Given("^I expect the exception \"(.+)\" with the text \"(.+)\"$")
+    public void setExpectedExceptionDetails(String name, String text) {
+        commonData.exceptionExpected = true;
+        commonData.exceptionName = name;
+        commonData.exceptionMessage = text;
+    }
+
+    @Given("^Scope with ID (\\d+)$")
+    public void setCurrentScope(int id) {
+        commonData.currentScopeId = new KapuaEid(BigInteger.valueOf(id));
+    }
+
+    @Given("^A null scope$")
+    public void setNullScope() {
+        commonData.currentScopeId = null;
+    }
+
+    @Given("^The root scope$")
+    public void setRootScope() {
+        commonData.currentScopeId = new KapuaEid(BigInteger.ONE);
+    }
+
+    @Then("^There (?:are|is) exactly (\\d+) items?$")
+    public void checkNumberOfCountedItems(long cnt) {
+        assertEquals(String.format("Expected %d but counted %d", cnt, commonData.itemCount), cnt, commonData.itemCount);
+    }
+
+    @Then("^No exception was thrown$")
+    public void checkThatNoExceptionWasThrown() {
+        assertFalse("An unexpected exception was caught", commonData.exceptionCaught);
+    }
+
+    @Then("^An exception was thrown$")
+    public void checkThatAnExceptionWasThrown() {
+        assertTrue("An exception was expected but was not caught", commonData.exceptionCaught);
+    }
+}

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobData.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobData.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.internal;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.JobCreator;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class JobData {
+
+    // Step scratchpad data
+    public Job job;
+    public JobCreator jobCreator;
+    public KapuaId currentJobId;
+
+    public JobData() {
+        cleanup();
+    }
+
+    public void cleanup() {
+        jobCreator = null;
+        job = null;
+        currentJobId = null;
+    }
+}

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.internal;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtils;
+import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.job.JobFactory;
+import org.eclipse.kapua.service.job.JobJAXBContextProvider;
+import org.eclipse.kapua.service.job.JobService;
+import org.eclipse.kapua.service.job.common.CommonData;
+import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
+import org.eclipse.kapua.test.MockedLocator;
+import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.math.BigInteger;
+import java.security.acl.Permission;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+
+// ****************************************************************************************
+// * Implementation of Gherkin steps used in JobService.feature scenarios.                *
+// *                                                                                      *
+// * MockedLocator is used for Location Service. Mockito is used to mock other            *
+// * services that the Account services dependent on. Dependent services are:             *
+// * - Authorization Service                                                              *
+// ****************************************************************************************
+
+@ScenarioScoped
+public class JobServiceTestSteps extends AbstractKapuaSteps {
+
+    private static final Logger logger = LoggerFactory.getLogger(JobServiceTestSteps.class);
+
+    private static final String DEFAULT_COMMONS_PATH = "../../../commons";
+    private static final String DROP_JOB_TABLES = "job_drop.sql";
+
+    private static final KapuaId ROOT_ID = new KapuaEid(BigInteger.ONE);
+
+    // Job service objects
+    private JobFactory jobFactory;
+    private JobService jobService;
+
+    // Interstep scratchpads
+    CommonData commonData;
+    JobData jobData;
+
+    // Default constructor
+    @Inject
+    public JobServiceTestSteps(CommonData commonData, JobData jobData) {
+        this.commonData = commonData;
+        this.jobData = jobData;
+    }
+
+    // ************************************************************************************
+    // ************************************************************************************
+    // * Definition of Cucumber scenario steps                                            *
+    // ************************************************************************************
+    // ************************************************************************************
+
+    // ************************************************************************************
+    // * Setup and tear-down steps                                                        *
+    // ************************************************************************************
+
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+
+        commonData.scenario = scenario;
+        locator = KapuaLocator.getInstance();
+
+        // Create User Service tables
+        enableH2Connection();
+
+        // Create the account service tables
+        new KapuaLiquibaseClient("jdbc:h2:mem:kapua;MODE=MySQL", "kapua", "kapua").update();
+
+        MockedLocator mockLocator = (MockedLocator) locator;
+
+        // Inject mocked Authorization Service method checkPermission
+        AuthorizationService mockedAuthorization = mock(AuthorizationService.class);
+        // TODO: Check why does this line needs an explicit cast!
+        Mockito.doNothing().when(mockedAuthorization).checkPermission(
+                (org.eclipse.kapua.service.authorization.permission.Permission) any(Permission.class));
+        mockLocator.setMockedService(org.eclipse.kapua.service.authorization.AuthorizationService.class,
+                mockedAuthorization);
+
+        // Inject mocked Permission Factory
+        PermissionFactory mockedPermissionFactory = mock(PermissionFactory.class);
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.authorization.permission.PermissionFactory.class,
+                mockedPermissionFactory);
+
+        // Inject actual service implementations
+        jobFactory = new JobFactoryImpl();
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.job.JobFactory.class, jobFactory);
+        jobService = new JobServiceImpl();
+        mockLocator.setMockedService(org.eclipse.kapua.service.job.JobService.class, jobService);
+
+        // Set KapuaMetatypeFactory for Metatype configuration
+        mockLocator.setMockedFactory(org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory.class, new KapuaMetatypeFactoryImpl());
+
+        // All operations on database are performed using system user.
+        KapuaSession kapuaSession = new KapuaSession(null, ROOT_ID, ROOT_ID);
+        KapuaSecurityUtils.setSession(kapuaSession);
+
+        XmlUtil.setContextProvider(new JobJAXBContextProvider());
+
+        commonData.currentScopeId = ROOT_ID;
+    }
+
+    @After
+    public void afterScenario()
+            throws Exception {
+        // Drop the Job Service tables
+        scriptSession(JobEntityManagerFactory.getInstance(), DROP_JOB_TABLES);
+        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
+        KapuaSecurityUtils.clearSession();
+    }
+
+    // ************************************************************************************
+    // * Cucumber Test steps                                                              *
+    // ************************************************************************************
+
+    @Given("^A regular job creator with the name \"(.+)\"$")
+    public void prepareARegularJobCreator(String name) {
+        jobData.jobCreator = jobFactory.newCreator(commonData.currentScopeId);
+        jobData.jobCreator.setName(name);
+        jobData.jobCreator.setDescription("Test job");
+    }
+
+    @Given("^I create a job with the name \"(.+)\"$")
+    public void createANamedJob(String name)
+            throws Exception {
+
+        prepareARegularJobCreator(name);
+
+        try {
+            commonData.primeException();
+            jobData.job = jobService.create(jobData.jobCreator);
+            jobData.currentJobId = jobData.job.getId();
+        } catch (KapuaException ex) {
+            commonData.verifyException(ex);
+        }
+    }
+
+    @When("^I create a new job entity from the existing creator$")
+    public void createJobFromCreator()
+            throws Exception {
+
+        try {
+            commonData.primeException();
+            jobData.job = jobService.create(jobData.jobCreator);
+            jobData.currentJobId = jobData.job.getId();
+        } catch (KapuaException ex) {
+            commonData.verifyException(ex);
+        }
+    }
+}

--- a/service/job/internal/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/job/internal/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,0 +1,12 @@
+#################################################################################
+#  Copyright (c) 2017 Eurotech and/or its affiliates and others
+# 
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+# 
+#  Contributors:
+#       Eurotech - initial API and implementation
+#################################################################################
+org.eclipse.kapua.test.CredentialsFactoryMock

--- a/service/job/internal/src/test/resources/features/JobService.feature
+++ b/service/job/internal/src/test/resources/features/JobService.feature
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+Feature: Job service CRUD tests
+    The Job service is responsible for executing scheduled actions on various targets.
+
+Scenario: Regular job creation
+
+    Given A regular job creator with the name "TestJob"
+    When I create a new job entity from the existing creator

--- a/service/job/internal/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/internal/src/test/resources/kapua-environment-setting.properties
@@ -1,0 +1,63 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+commons.sys.provision.account.name=kapua-provision
+commons.sys.admin.account=kapua-sys
+
+commons.version=
+commons.build.version=
+commons.build.number=
+
+#
+# SQL database settings
+#
+commons.db.name=kapuadb
+commons.db.username=kapua
+commons.db.password=kapua
+
+commons.db.jdbcConnectionUrlResolver=H2
+commons.db.jdbc.driver=org.h2.Driver
+commons.db.connection.scheme=jdbc:h2:mem
+commons.db.connection.host=
+commons.db.connection.port=
+commons.db.connection.useSsl=
+commons.db.connection.sslVerify=
+commons.db.connection.trust.store.url=
+commons.db.connection.trust.store.pwd=
+
+commons.db.schema=kapuadb
+commons.db.useTimezone=true
+commons.db.useLegacyDatetimeCode=false
+commons.db.serverTimezone=UTC
+commons.db.characterEncoding=UTF-8
+
+commons.db.pool.size.initial=5
+commons.db.pool.size.min=2
+commons.db.pool.size.max=30
+commons.db.pool.borrow.timeout=15000
+
+#
+# Broker settings
+#
+broker.scheme=tcp
+broker.host=localhost
+broker.port=1884
+
+#
+# Entity settings
+#
+#set the generated ids size (in bits) (please don't use key size greater than 63 with H2 since H2 maps the biginteger to a long. see http://www.h2database.com/html/datatypes.html#bigint_type)
+commons.entity.key.size=63
+commons.entity.insert.max.retry=3
+
+character.encoding=UTF-8
+

--- a/service/job/internal/src/test/resources/locator.xml
+++ b/service/job/internal/src/test/resources/locator.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<locator-config>
+    <provided>
+        <api>org.eclipse.kapua.service.account.AccountService</api>
+        <api>org.eclipse.kapua.service.account.AccountFactory</api>
+        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
+        <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
+        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
+        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
+        <api>org.eclipse.kapua.service.authorization.domain.DomainService</api>
+        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
+        <api>org.eclipse.kapua.service.user.UserService</api>
+        <!-- 
+        <provide>
+            <api></api>
+            <with></with>
+        </provide>
+         -->
+    </provided>
+    <packages>
+        <package>org.eclipse.kapua.commons</package>
+        <package>org.eclipse.kapua.service.account.internal</package>
+        <package>org.eclipse.kapua.test.steps</package>
+        <package>org.eclipse.kapua.test.user</package>
+        <package>org.eclipse.kapua.test.authentication</package>
+        <package>org.eclipse.kapua.test.authorization</package>
+    </packages>
+</locator-config>

--- a/service/job/internal/src/test/resources/logback.xml
+++ b/service/job/internal/src/test/resources/logback.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Red Hat Inc and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Red Hat - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="liquibase" level="WARN" />
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
## The initial skeleton of the Job service unit test suite
The starting implementation of the Job service unit tests is implemented. This includes all the basic plumbing and helper code. A single test scenario is implementes as a proof of concept.

### Changes to Maven pom files
Test dependencies were added to the /service/job/internal/pom.xml.

### Implementation changes
The access to the constructors for JobCreatorImpl and JomServiceImpl was changed to public.

### Test changes
First implementation of Job service tests.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>