### PR TITLE
Improved exception handling in service unit tests

### DIFF
--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
@@ -200,6 +200,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
 
     @Given("^I expect the exception \"(.+)\" with the text \"(.+)\"$")
     public void setExpectedExceptionDetails(String name, String text) {
+
         exceptionExpected = true;
         exceptionName = name;
         exceptionMessage = text;
@@ -213,6 +214,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @Given("^An existing account with the name \"(.*)\"$")
     public void createTestAccountWithName(String name)
             throws Exception {
+
         accountCreator = prepareRegularAccountCreator(rootScopeId, name);
         try {
             primeException();
@@ -226,6 +228,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @Given("^I create (\\d+) childs for account with Id (\\d+)$")
     public void createANumberOfAccounts(int num, int parentId)
             throws Exception {
+
         for (int i = 0; i < num; i++) {
             accountCreator = prepareRegularAccountCreator(new KapuaEid(BigInteger.valueOf(parentId)), "tmp_acc_" + String.format("%d", i));
             try {
@@ -241,8 +244,8 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @Given("^I create (\\d+) childs for account with name \"(.*)\"$")
     public void createANumberOfChildrenForAccountWithName(int num, String name)
             throws Exception {
+
         Account tmpAcc = accountService.findByName(name);
-        exceptionCaught = false;
         for (int i = 0; i < num; i++) {
             accountCreator = prepareRegularAccountCreator(tmpAcc.getId(), "tmp_acc_" + String.format("%d", i));
             try {
@@ -258,7 +261,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @Given("^I create (\\d+) accounts with organization name \"(.*)\"$")
     public void createANumberOfChildrenForAccountWithOrganizationName(int num, String name)
             throws Exception {
-        exceptionCaught = false;
+
         for (int i = 0; i < num; i++) {
             accountCreator = prepareRegularAccountCreator(rootScopeId, "tmp_acc_" + String.format("%d", i));
             accountCreator.setOrganizationName(name);
@@ -275,6 +278,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I create account \"(.*)\"$")
     public void createAccount(String name)
             throws Exception {
+
         accountCreator = prepareRegularAccountCreator(rootScopeId, name);
         account = accountService.create(accountCreator);
         accountId = account.getId();
@@ -283,6 +287,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I create a duplicate account \"(.*)\"$")
     public void createDuplicateAccount(String name)
             throws Exception {
+
         accountCreator = prepareRegularAccountCreator(rootScopeId, name);
         try {
             primeException();
@@ -295,6 +300,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I create an account with a null name$")
     public void createAccountWithNullName()
             throws Exception {
+
         accountCreator = prepareRegularAccountCreator(rootScopeId, null);
         try {
             primeException();
@@ -307,6 +313,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I modify the account \"(.*)\"$")
     public void changeAccountDetails(String name)
             throws KapuaException {
+
         account = accountService.findByName(name);
         Organization tmpOrg = account.getOrganization();
 
@@ -321,6 +328,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I modify the current account$")
     public void updateAccount()
             throws Exception {
+
         try {
             primeException();
             accountService.update(account);
@@ -332,9 +340,10 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I change the account \"(.*)\" name to \"(.*)\"$")
     public void changeAccountName(String accName, String name)
             throws Exception {
-        Account tmpAcc = accountService.findByName(accName);
 
+        Account tmpAcc = accountService.findByName(accName);
         tmpAcc.setName(name);
+
         try {
             primeException();
             accountService.update(tmpAcc);
@@ -346,10 +355,11 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I change the parent path for account \"(.*)\"$")
     public void changeParentPathForAccount(String name)
             throws Exception {
+
         Account tmpAcc = accountService.findByName(name);
         String modParentPath = tmpAcc.getParentAccountPath() + "/mod";
-
         tmpAcc.setParentAccountPath(modParentPath);
+
         try {
             primeException();
             accountService.update(tmpAcc);
@@ -361,9 +371,10 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I try to change the account \"(.*)\" scope Id to (\\d+)$")
     public void changeAccountScopeId(String name, int newScopeId)
             throws Exception {
-        AccountImpl tmpAcc = (AccountImpl) accountService.findByName(name);
 
+        AccountImpl tmpAcc = (AccountImpl) accountService.findByName(name);
         tmpAcc.setScopeId(new KapuaEid(BigInteger.valueOf(newScopeId)));
+
         try {
             primeException();
             accountService.update(tmpAcc);
@@ -382,6 +393,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I try to delete the system account$")
     public void deleteSystemAccount()
             throws Exception {
+
         String adminUserName = SystemSetting.getInstance().getString(SystemSettingKey.SYS_ADMIN_ACCOUNT);
         Account tmpAcc = accountService.findByName(adminUserName);
 
@@ -399,6 +411,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @When("^I delete a random account$")
     public void deleteRandomAccount()
             throws Exception {
+
         try {
             primeException();
             accountService.delete(rootScopeId, new KapuaEid(IdGenerator.generate()));

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/common/DeviceRegistryValidationTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/common/DeviceRegistryValidationTestSteps.java
@@ -38,6 +38,7 @@ import org.eclipse.kapua.service.device.registry.internal.DeviceCreatorImpl;
 import org.eclipse.kapua.service.device.registry.internal.DeviceFactoryImpl;
 import org.eclipse.kapua.service.device.registry.internal.DeviceImpl;
 import org.eclipse.kapua.service.device.registry.internal.DeviceRegistryServiceImpl;
+import org.eclipse.kapua.service.device.registry.shared.SharedTestSteps;
 import org.eclipse.kapua.test.MockedLocator;
 import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
 import org.mockito.Mockito;
@@ -46,7 +47,6 @@ import cucumber.api.Scenario;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
 
@@ -65,9 +65,6 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
     // Currently executing scenario.
     Scenario scenario;
 
-    // Device validator object
-    // DeviceValidation deviceValidator = null;
-
     // Commons related objects
     KapuaIdFactory kapuaIdFactory = new KapuaIdFactoryImpl();
 
@@ -78,8 +75,8 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
     DeviceImpl device;
     DeviceQuery query;
 
-    // Check if exception was fired in step.
-    boolean exceptionCaught;
+    // Common test steps
+    SharedTestSteps sharedTests = new SharedTestSteps();
 
     // *************************************
     // Definition of Cucumber scenario steps
@@ -91,7 +88,6 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
     public void beforeScenario(Scenario scenario)
             throws Exception {
         this.scenario = scenario;
-        exceptionCaught = false;
 
         // Set up the mock locator
         MockedLocator mockLocator = (MockedLocator) locator;
@@ -190,29 +186,29 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
 
     @When("^I validate the device creator$")
     public void validateExistingDeviceCreator()
-            throws KapuaException {
+            throws Exception {
         try {
-            exceptionCaught = false;
+            sharedTests.primeException();
             DeviceValidation.validateCreatePreconditions(deviceCreator);
         } catch (KapuaException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
     @When("^I validate the device for updates$")
     public void validateExistingDeviceForUpdates()
-            throws KapuaException {
+            throws Exception {
         try {
-            exceptionCaught = false;
+            sharedTests.primeException();
             DeviceValidation.validateUpdatePreconditions(device);
         } catch (KapuaException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
     @When("^Validating a find operation for scope (.+) and device (.+)$")
     public void validateDeviceSearch(String scopeId, String deviceId)
-            throws KapuaException {
+            throws Exception {
         KapuaId scope;
         KapuaId dev;
 
@@ -229,16 +225,16 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
         }
 
         try {
-            exceptionCaught = false;
+            sharedTests.primeException();
             DeviceValidation.validateFindPreconditions(scope, dev);
         } catch (KapuaException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
     @When("^Validating a find operation for scope (.+) and client \"(.*)\"$")
     public void validateDeviceSearchByClientId(String scopeId, String clientId)
-            throws KapuaException {
+            throws Exception {
         KapuaId scope;
         String client;
 
@@ -255,16 +251,16 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
         }
 
         try {
-            exceptionCaught = false;
+            sharedTests.primeException();
             DeviceValidation.validateFindByClientIdPreconditions(scope, client);
         } catch (KapuaException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
     @When("^Validating a delete operation for scope (.+) and device (.+)$")
     public void validateDeviceDelete(String scopeId, String deviceId)
-            throws KapuaException {
+            throws Exception {
         KapuaId scope;
         KapuaId dev;
 
@@ -281,43 +277,33 @@ public class DeviceRegistryValidationTestSteps extends AbstractKapuaSteps {
         }
 
         try {
-            exceptionCaught = false;
+            sharedTests. primeException();
             DeviceValidation.validateDeletePreconditions(scope, dev);
         } catch (KapuaException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
     @When("^I validate a query operation$")
     public void checkQueryOperation()
-            throws KapuaException {
+            throws Exception {
         try {
-            exceptionCaught = false;
+            sharedTests.primeException();
             DeviceValidation.validateQueryPreconditions(query);
         } catch (KapuaException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
     @When("^I validate a count operation$")
     public void checkCountOperation()
-            throws KapuaException {
+            throws Exception {
         try {
-            exceptionCaught = false;
+            sharedTests.primeException();
             DeviceValidation.validateCountPreconditions(query);
         } catch (KapuaException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
-    }
-
-    @Then("^No exception is thrown$")
-    public void checkThatNoExceptionWasCaught() {
-        assertFalse(exceptionCaught);
-    }
-
-    @Then("^An exception is thrown$")
-    public void checkThatAnExceptionWasCaught() {
-        assertTrue(exceptionCaught);
     }
 
     // *******************

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceTestSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -43,6 +43,7 @@ import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 import org.eclipse.kapua.service.device.registry.DeviceStatus;
 import org.eclipse.kapua.service.device.registry.RegistryJAXBContextProvider;
 import org.eclipse.kapua.service.device.registry.TestConfig;
+import org.eclipse.kapua.service.device.registry.shared.SharedTestSteps;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
 import org.eclipse.kapua.test.MockedLocator;
 import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
@@ -87,6 +88,9 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
     KapuaId rootScopeId = new KapuaEid(BigInteger.ONE);
 
+    // Common test steps
+    SharedTestSteps sharedTests;
+
     // Currently executing scenario.
     Scenario scenario;
 
@@ -100,9 +104,6 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
     // The registry ID of a device
     KapuaId deviceId;
-
-    // Check if exception was fired in step.
-    boolean exceptionCaught;
 
     // A list result for device query operations
     DeviceListResult deviceList;
@@ -127,7 +128,6 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
     public void beforeScenario(Scenario scenario)
             throws Exception {
         this.scenario = scenario;
-        exceptionCaught = false;
 
         // Create User Service tables
         enableH2Connection();
@@ -171,6 +171,8 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
         // Setup JAXB context
         XmlUtil.setContextProvider(new RegistryJAXBContextProvider());
+
+        sharedTests = new SharedTestSteps();
     }
 
     @After
@@ -249,7 +251,7 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
     @When("^I configure$")
     public void setConfigurationValue(List<TestConfig> testConfigs)
-            throws KapuaException {
+            throws Exception {
         Map<String, Object> valueMap = new HashMap<>();
         KapuaEid scopeId = null;
         KapuaEid parentScopeId = null;
@@ -260,11 +262,10 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
             parentScopeId = new KapuaEid(BigInteger.valueOf(Long.valueOf(config.getParentScopeId())));
         }
         try {
-            exceptionCaught = false;
-            deviceRegistryService.setConfigValues(scopeId,
-                    parentScopeId, valueMap);
+            sharedTests.primeException();
+            deviceRegistryService.setConfigValues(scopeId, parentScopeId, valueMap);
         } catch (KapuaException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
@@ -302,7 +303,7 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
         // Search for the known bios version string
         tmpQuery.setPredicate(attributeIsEqualTo("biosVersion", version));
-        deviceList = (DeviceListResult) deviceRegistryService.query(tmpQuery);
+        deviceList = deviceRegistryService.query(tmpQuery);
         assertNotNull(deviceList);
     }
 
@@ -313,7 +314,7 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
         // Search for the known bios version string
         tmpQuery.setPredicate(attributeIsNotEqualTo("biosVersion", version));
-        deviceList = (DeviceListResult) deviceRegistryService.query(tmpQuery);
+        deviceList = deviceRegistryService.query(tmpQuery);
         assertNotNull(deviceList);
     }
 
@@ -324,7 +325,7 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
         // Search for the known bios version string
         tmpQuery.setPredicate(attributeIsEqualTo("clientId", id));
-        deviceList = (DeviceListResult) deviceRegistryService.query(tmpQuery);
+        deviceList = deviceRegistryService.query(tmpQuery);
         assertNotNull(deviceList);
     }
 
@@ -373,13 +374,14 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
     @When("^I update a device with an invalid ID$")
     public void updateDeviceWithInvalidId()
-            throws KapuaException {
+            throws Exception {
+
         device.setId(new KapuaEid(IdGenerator.generate()));
         try {
-            exceptionCaught = false;
+            sharedTests.primeException();
             deviceRegistryService.update(device);
         } catch (KapuaEntityNotFoundException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
@@ -393,15 +395,16 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
     @When("^I delete a device with random IDs$")
     public void deleteDeviceWithRandomIds()
-            throws KapuaException {
+            throws Exception {
+
         KapuaId rndScope = new KapuaEid(IdGenerator.generate());
         KapuaId rndDev = new KapuaEid(IdGenerator.generate());
 
         try {
-            exceptionCaught = false;
+            sharedTests.primeException();
             deviceRegistryService.delete(rndScope, rndDev);
         } catch (KapuaEntityNotFoundException ex) {
-            exceptionCaught = true;
+            sharedTests.verifyException(ex);
         }
     }
 
@@ -539,11 +542,6 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
         assertNull(device);
     }
 
-    @Then("^An exception is caught$")
-    public void checkThatAnExceptionWasCaught() {
-        assertTrue(exceptionCaught);
-    }
-
     @Then("^All device factory functions must return non null values$")
     public void exerciseAllDeviceFactoryFunctions() {
         Device tmpDevice = null;
@@ -568,7 +566,6 @@ public class DeviceRegistryServiceTestSteps extends AbstractKapuaSteps {
 
     // Create a device creator object. The creator is pre-filled with default data.
     private DeviceCreator prepareRegularDeviceCreator(KapuaId accountId, String client) {
-        // DeviceCreator tmpDeviceCreator = deviceFactory.newCreator(accountId, client);
         DeviceCreatorImpl tmpDeviceCreator = new DeviceCreatorImpl(accountId);
 
         tmpDeviceCreator.setClientId(client);

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/RunTest.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 @CucumberOptions(features = "classpath:features",
         glue = { "org.eclipse.kapua.service.device.registry.common",
                 "org.eclipse.kapua.service.device.registry.internal",
+                "org.eclipse.kapua.service.device.registry.shared",
                 "org.eclipse.kapua.service.device.registry.connection.internal",
                 "org.eclipse.kapua.service.device.registry.event.internal" },
         plugin = { "pretty",

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/shared/SharedTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/shared/SharedTestSteps.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry.shared;
+
+import javax.inject.Inject;
+import cucumber.api.Scenario;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@ScenarioScoped
+public class SharedTestSteps {
+
+    // Currently executing scenario.
+    private static Scenario scenario;
+
+    // Scratchpad data related to exception checking
+    private static boolean exceptionExpected;
+    private static String exceptionName;
+    private static String exceptionMessage;
+    private static boolean exceptionCaught;
+
+    // Setup and tear-down steps
+
+    @Inject
+    public SharedTestSteps() {}
+
+    @Before
+    public void beforeScenario(Scenario scenario)
+            throws Exception {
+        this.scenario = scenario;
+
+        exceptionExpected = false;
+        exceptionName = "";
+        exceptionMessage = "";
+        exceptionCaught = false;
+    }
+
+    @Given("^I expect the exception \"(.+)\" with the text \"(.+)\"$")
+    public void setExpectedExceptionDetails(String name, String text) {
+        exceptionExpected = true;
+        exceptionName = name;
+        exceptionMessage = text;
+    }
+
+    @Then("^An exception was raised$")
+    public void anExceptionWasRaised() {
+        assertTrue(exceptionCaught);
+    }
+
+    @Then("^There was no exception$")
+    public void noExceptionWasRaised() {
+        assertFalse(exceptionCaught);
+    }
+
+    // Helper functions
+
+    public void primeException() {
+        exceptionCaught = false;
+    }
+
+    // Check the exception that was caught. In case the exception was expected the type and message is shown in the cucumber logs.
+    // Otherwise the exception is rethrown failing the test and dumping the stack trace to help resolving problems.
+    public void verifyException(Exception ex)
+            throws Exception {
+
+        if (!exceptionExpected ||
+                (!exceptionName.isEmpty() && !ex.getClass().toGenericString().contains(exceptionName)) ||
+                (!exceptionMessage.isEmpty() && !exceptionMessage.trim().contentEquals("*") && !ex.getMessage().contains(exceptionMessage))) {
+            scenario.write("An unexpected exception was raised!");
+            throw(ex);
+        }
+
+        scenario.write("Exception raised as expected: " + ex.getClass().getCanonicalName() + ", " + ex.getMessage());
+        exceptionCaught = true;
+    }
+}

--- a/service/device/registry/internal/src/test/resources/features/DeviceEvent.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceEvent.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -10,132 +10,135 @@
 #     Eurotech - initial API and implementation
 ###############################################################################
 Feature: Device Event CRUD tests
-    The Device Event service is responsible for handling the incoming device 
+    The Device Event service is responsible for handling the incoming device
     events.
 
 Background:
-	Given Scope 12
-	And I configure the device service
+    Given Scope 12
+    And I configure the device service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities |  10   |
-	And A "first" device 
-	And A "second" device 
+    And A "first" device
+    And A "second" device
 
 Scenario: Create a regular event
-	Create a regular event. The event should not be null and should 
-	have a regular entity ID. Also the event entity shoould match the event 
-	creator parameters.
-	
-	Given Scope 12
-	And User 5
-	And A "CREATE" event from device "first"
-	Then No exception is thrown
-	And The event matches the creator parameters
+    Create a regular event. The event should not be null and should
+    have a regular entity ID. Also the event entity shoould match the event
+    creator parameters.
+
+    Given Scope 12
+    And User 5
+    And A "CREATE" event from device "first"
+    Then There was no exception
+    And The event matches the creator parameters
 
 Scenario: Create an event with a null scope ID
-	It should be impossible to create an event with a null scope ID. Such attempt
-	must raise an exception.
-	
-	Given Null scope ID
-	And User 5
-	When A "CREATE" event from device "first"
-	Then An event exception is caught
+    It should be impossible to create an event with a null scope ID. Such attempt
+    must raise an exception.
+
+    Given Null scope ID
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    And User 5
+    When A "CREATE" event from device "first"
+    Then An exception was raised
 
 Scenario: Create an event with a null action
-	The database should reject any ebvent entity that has a null action parameter.
-	In such cases an exception must be thrown.
-	
-	Given Scope 12
-	And User 5
-	And An event creator with null action
-	When I create an event from the existing creator
-	Then An event exception is caught
+    The database should reject any ebvent entity that has a null action parameter.
+    In such cases an exception must be thrown.
+
+    Given Scope 12
+    And I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type device with id/name"
+    And User 5
+    And An event creator with null action
+    When I create an event from the existing creator
+    Then An exception was raised
 
 Scenario: Find an event by its ID
-	It must be possible to find an event entity based on the event ID.
-	
-	Given Scope 12
-	And User 5
-	And A "CREATE" event from device "first"
-	When I search for an event with the remembered ID
-	Then The event matches the creator parameters
+    It must be possible to find an event entity based on the event ID.
+
+    Given Scope 12
+    And User 5
+    And A "CREATE" event from device "first"
+    When I search for an event with the remembered ID
+    Then The event matches the creator parameters
 
 Scenario: Find a non existing event
-	Searching for an event with a non existing entity ID should return null. No
-	exception must be thrown.
-	
-	Given Scope 12
-	And User 5
-	And A "CREATE" event from device "first"
-	When I search for an event with a random ID
-	Then There is no such event
+    Searching for an event with a non existing entity ID should return null. No
+    exception must be thrown.
+
+    Given Scope 12
+    And User 5
+    And A "CREATE" event from device "first"
+    When I search for an event with a random ID
+    Then There is no such event
 
 Scenario: Delete an existing event
-	It must be possible to delete an existing event entity from the database.
-	
-	Given Scope 12
-	And User 5
-	And A "CREATE" event from device "first"
-	When I search for an event with the remembered ID
-	Then The event matches the creator parameters
-	When I delete the event with the remembered ID
-	And I search for an event with the remembered ID
-	Then There is no such event
+    It must be possible to delete an existing event entity from the database.
+
+    Given Scope 12
+    And User 5
+    And A "CREATE" event from device "first"
+    When I search for an event with the remembered ID
+    Then The event matches the creator parameters
+    When I delete the event with the remembered ID
+    And I search for an event with the remembered ID
+    Then There is no such event
 
 Scenario: Delete a non existent event
-	Trying to delete a non existent event (no matching entity ID) must cause an 
-	exception to be thrown.
-	
-	Given Scope 12
-	And User 5
-	And A "CREATE" event from device "first"
-	When  I delete an event with a random ID
-	Then An event exception is caught
+    Trying to delete a non existent event (no matching entity ID) must cause an
+    exception to be thrown.
+
+    Given Scope 12
+    And I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type deviceEvent with id/name"
+    And User 5
+    And A "CREATE" event from device "first"
+    When  I delete an event with a random ID
+    Then An exception was raised
 
 Scenario: Count events in scope
-	It must be possible to count all events in a given scope. Only the events for this 
-	scope should counted, all other events must be ignored.
-	
-	Given Scope 12
-	And User 5
-	And I have 15 "CREATE" events from device "first"
-	
-	Given Scope 42
-	And I configure the device service
+    It must be possible to count all events in a given scope. Only the events for this
+    scope should counted, all other events must be ignored.
+
+    Given Scope 12
+    And User 5
+    And I have 15 "CREATE" events from device "first"
+
+    Given Scope 42
+    And I configure the device service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities |  10   |
-	And A "third" device 
-	And I have 25 "READ" events from device "third"
-	When I count events for scope 12
-	Then There are 15 events
+    And A "third" device
+    And I have 25 "READ" events from device "third"
+    When I count events for scope 12
+    Then There are 15 events
 
 Scenario: Count events in empty scope
-	Counting events in an empty (non existing) scope must return a count of 0. No
-	exception must be thrown.
-	
-	Given Scope 12
-	And User 5
-	And I have 15 "CREATE" events from device "first"
-	When I count events for scope 42
-	Then There are 0 events
+    Counting events in an empty (non existing) scope must return a count of 0. No
+    exception must be thrown.
+
+    Given Scope 12
+    And User 5
+    And I have 15 "CREATE" events from device "first"
+    When I count events for scope 42
+    Then There are 0 events
 
 Scenario: Basic Device Event queries
-	It must be possible to perform basic event entity queries.
-	
-	Given Scope 12
-	And User 5
-	And I have 10 "WRITE" events from device "first"
-	And I have 15 "CREATE" events from device "first"
-	And I have 20 "EXECUTE" events from device "first"
-	When I query for "CREATE" events
-	Then I find 15 events
-	When I query for "WRITE" events
-	Then I find 10 events
+    It must be possible to perform basic event entity queries.
+
+    Given Scope 12
+    And User 5
+    And I have 10 "WRITE" events from device "first"
+    And I have 15 "CREATE" events from device "first"
+    And I have 20 "EXECUTE" events from device "first"
+    When I query for "CREATE" events
+    Then I find 15 events
+    When I query for "WRITE" events
+    Then I find 10 events
 
 Scenario: Event factory sanity checks
-	Then All device event factory functions must return non null objects
+    Then All device event factory functions must return non null objects
 
 Scenario: Event service domain check
-	Then The device event domain data can be updated
+    Then The device event domain data can be updated

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistry.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistry.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -14,162 +14,164 @@ Feature: Device Registry Service
     database.
 
 Scenario: Create a single device
-	Create a single test device. The resulting device must have a unique ID assigned
-	by the creation process.
+    Create a single test device. The resulting device must have a unique ID assigned
+    by the creation process.
 
-	When I configure
-		| type    | name                       | value | scopeId | parentScopeId |
-		| boolean | infiniteChildEntities      | true  |    1    |       1       |
-		| integer | maxNumberChildEntities     | 5     |    1    |       1       |
-	Given A device named "test_device"
-	Then The device has a non-null ID
+    When I configure
+        | type    | name                       | value | scopeId | parentScopeId |
+        | boolean | infiniteChildEntities      | true  |    1    |       1       |
+        | integer | maxNumberChildEntities     | 5     |    1    |       1       |
+    Given A device named "test_device"
+    Then The device has a non-null ID
 
 Scenario: All device parameters must match the device creator
-	Create a test device and check whether it was created correctly. All the device 
-	parameters must match the device creator specifications. 
-	
-	Given A device named "test_device"
-	Then The device matches the creator parameters
+    Create a test device and check whether it was created correctly. All the device
+    parameters must match the device creator specifications.
+
+    Given A device named "test_device"
+    Then The device matches the creator parameters
 
 Scenario: Case sensitivness of named device searches
-	Searching by client ID is case sensitive.
-	 
-	Given A device named "CaseSensitiveTestName"
-	Then Named device registry searches are case sesntitive
+    Searching by client ID is case sensitive.
+
+    Given A device named "CaseSensitiveTestName"
+    Then Named device registry searches are case sesntitive
 
 Scenario: Find device by registry ID
-	It must be possible to find a device in the registry by its registry ID.
-	
-	Given A device named "TestDevice"
-	When I search for a device with the remembered ID
-	Then The device matches the creator parameters
+    It must be possible to find a device in the registry by its registry ID.
+
+    Given A device named "TestDevice"
+    When I search for a device with the remembered ID
+    Then The device matches the creator parameters
 
 Scenario: Find device by client ID
-	It must be possible to find a device in the registry by its Client ID.
+    It must be possible to find a device in the registry by its Client ID.
 
-	Given A device named "TestDevice"
-	Then It is possible to find the device based on its client ID
+    Given A device named "TestDevice"
+    Then It is possible to find the device based on its client ID
 
 Scenario: Try to find a device with an invalid registry ID
-	Searching for a nonexistent device should not raise any exception. Only a null 
-	device should be returned.
-	
-	When I search for a device with a random ID
-	Then There is no such device
+    Searching for a nonexistent device should not raise any exception. Only a null
+    device should be returned.
+
+    When I search for a device with a random ID
+    Then There is no such device
 
 Scenario: Try to find a device with an invalid client ID
-	Searching for a nonexistent device should not raise any exception. Only a null 
-	device should be returned.
-	
-	When I search for a device with a random client ID
-	Then There is no such device
+    Searching for a nonexistent device should not raise any exception. Only a null
+    device should be returned.
+
+    When I search for a device with a random client ID
+    Then There is no such device
 
 Scenario: Device query - find by BIOS version
-	It must be possible to construct arbitrary device registry queries. In this case
-	several test devices are created with different BIOS version values.
-	A query based on the BIOS version must only return the corect device.
-	
-	Given A device with BIOS version "1.1.0" named "TestDevice1"
-	Given A device with BIOS version "1.2.0" named "TestDevice2"
-	Given A device with BIOS version "1.3.0" named "TestDevice3"
-	When I query for devices with BIOS version "1.2.0"
-	And I extract the first device
-	Then The device client id is "TestDevice2"
+    It must be possible to construct arbitrary device registry queries. In this case
+    several test devices are created with different BIOS version values.
+    A query based on the BIOS version must only return the corect device.
+
+    Given A device with BIOS version "1.1.0" named "TestDevice1"
+    Given A device with BIOS version "1.2.0" named "TestDevice2"
+    Given A device with BIOS version "1.3.0" named "TestDevice3"
+    When I query for devices with BIOS version "1.2.0"
+    And I extract the first device
+    Then The device client id is "TestDevice2"
 
 Scenario: Device queries
-	Test several variants of device registry queries.
-	
-	Given A device named "TestDevice"
-	Given I create 100 randomly named devices with BIOS version "1.1.0"
-	Given I create 100 randomly named devices with BIOS version "1.2.0"
-	Given I create 100 randomly named devices with BIOS version "1.3.0"
-	When I query for devices with BIOS version "1.1.0"
-	Then I find 100 devices
-	When I query for devices with BIOS version "1.3.0"
-	Then I find 100 devices
-	When I query for devices with BIOS different from "1.2.0"
-	Then I find 201 devices
-	When I query for devices with Client Id "TestDevice"
-	Then I find 1 device
+    Test several variants of device registry queries.
+
+    Given A device named "TestDevice"
+    Given I create 100 randomly named devices with BIOS version "1.1.0"
+    Given I create 100 randomly named devices with BIOS version "1.2.0"
+    Given I create 100 randomly named devices with BIOS version "1.3.0"
+    When I query for devices with BIOS version "1.1.0"
+    Then I find 100 devices
+    When I query for devices with BIOS version "1.3.0"
+    Then I find 100 devices
+    When I query for devices with BIOS different from "1.2.0"
+    Then I find 201 devices
+    When I query for devices with Client Id "TestDevice"
+    Then I find 1 device
 
 Scenario: Count devices in a specific scope
-	It must be possible to count all the devices in a specific scope.
-	To this end several devices are created in 3 different scopes. When 
-	counted, only the number of devices in the specified scope must be returned.
+    It must be possible to count all the devices in a specific scope.
+    To this end several devices are created in 3 different scopes. When
+    counted, only the number of devices in the specified scope must be returned.
 
-	When I configure
-		| type    | name                       | value | scopeId | parentScopeId |
-		| boolean | infiniteChildEntities      | true  |    5    |       1       |
-		| integer | maxNumberChildEntities     | 50    |    5    |       1       |
-	Given I create 20 randomly named devices in scope 5
-	When I configure
-		| type    | name                       | value | scopeId | parentScopeId |
-		| boolean | infiniteChildEntities      | true  |    6    |       1       |
-		| integer | maxNumberChildEntities     | 5     |    6    |       1       |
-	Given I create 30 randomly named devices in scope 6
-	When I configure
-		| type    | name                       | value | scopeId | parentScopeId |
-		| boolean | infiniteChildEntities      | true  |    7    |       1       |
-		| integer | maxNumberChildEntities     | 5     |    7    |       1       |
-	Given I create 45 randomly named devices in scope 7
-	When I count the devices in scope 6
-	Then There are 30 devices
-	When I count the devices in scope 5
-	Then There are 20 devices
-	
+    When I configure
+        | type    | name                       | value | scopeId | parentScopeId |
+        | boolean | infiniteChildEntities      | true  |    5    |       1       |
+        | integer | maxNumberChildEntities     | 50    |    5    |       1       |
+    Given I create 20 randomly named devices in scope 5
+    When I configure
+        | type    | name                       | value | scopeId | parentScopeId |
+        | boolean | infiniteChildEntities      | true  |    6    |       1       |
+        | integer | maxNumberChildEntities     | 5     |    6    |       1       |
+    Given I create 30 randomly named devices in scope 6
+    When I configure
+        | type    | name                       | value | scopeId | parentScopeId |
+        | boolean | infiniteChildEntities      | true  |    7    |       1       |
+        | integer | maxNumberChildEntities     | 5     |    7    |       1       |
+    Given I create 45 randomly named devices in scope 7
+    When I count the devices in scope 6
+    Then There are 30 devices
+    When I count the devices in scope 5
+    Then There are 20 devices
+
 Scenario: Count devices with a specific BIOS version
-	It must be possible to count devices based on arbitrary rules.
-	To this end several devices are created with different BIOS version.
-	A device count based on the BIOS version value is performed. Only
-	the number of devices that match the specified BIOS version is
-	returned.
-	
-	Given I create 15 randomly named devices with BIOS version "1.1.0"
-	Given I create 25 randomly named devices with BIOS version "1.2.0"
-	Given I create 35 randomly named devices with BIOS version "1.3.0"
-	When I count devices with BIOS version "1.2.0"
-	Then There are 25 devices
-	
+    It must be possible to count devices based on arbitrary rules.
+    To this end several devices are created with different BIOS version.
+    A device count based on the BIOS version value is performed. Only
+    the number of devices that match the specified BIOS version is
+    returned.
+
+    Given I create 15 randomly named devices with BIOS version "1.1.0"
+    Given I create 25 randomly named devices with BIOS version "1.2.0"
+    Given I create 35 randomly named devices with BIOS version "1.3.0"
+    When I count devices with BIOS version "1.2.0"
+    Then There are 25 devices
+
 Scenario: Update an existing device
-	Most of the parameters of an existing device are updatable.
-	
-	Given A device named "TestDevice"
-	When I update some device parameters
-	Then The device was correctly updated
+    Most of the parameters of an existing device are updatable.
+
+    Given A device named "TestDevice"
+    When I update some device parameters
+    Then The device was correctly updated
 
 Scenario: Try to update the device client ID
-	The Client ID of a defice cannot be changed after creation. Any attempt to
-	alter this ID must be silently ignored. No exception must be raised.
-	
-	Given A device named "TestDevice"
-	When I update the device cleint ID to "NewClientId"
-	Then The client ID was not changed
+    The Client ID of a defice cannot be changed after creation. Any attempt to
+    alter this ID must be silently ignored. No exception must be raised.
+
+    Given A device named "TestDevice"
+    When I update the device cleint ID to "NewClientId"
+    Then The client ID was not changed
 
 Scenario: Update a non existing device
-	An attempt to update a non existing device should raise an exception.
-	
-	Given A device named "TestDevice"
-	When I update a device with an invalid ID
-	Then An exception is caught
+    An attempt to update a non existing device should raise an exception.
+
+    Given A device named "TestDevice"
+    And I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type device with id/name"
+    When I update a device with an invalid ID
+    Then An exception was raised
 
 Scenario: Delete an existing device from the registry
-	It must be possible to delete a device from theregistry. To this
-	end a test device is created and subsequently deleted.
-	A search for this device should yield a null but no exception.
-	
-	Given A device named "TestDevice"
-	When I delete the device with the cleint id "TestDevice"
-	Then There is no device with the client ID "TestDevice"
+    It must be possible to delete a device from theregistry. To this
+    end a test device is created and subsequently deleted.
+    A search for this device should yield a null but no exception.
+
+    Given A device named "TestDevice"
+    When I delete the device with the cleint id "TestDevice"
+    Then There is no device with the client ID "TestDevice"
 
 Scenario: Try to delete a non existing device from the registry
-	If a user tries to delete a non existing device from the registry an 
-	exception must be raised.
-	
-	When I delete a device with random IDs
-	Then An exception is caught
+    If a user tries to delete a non existing device from the registry an
+    exception must be raised.
+
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type DeviceImpl with id/name"
+    When I delete a device with random IDs
+    Then An exception was raised
 
 Scenario: Device factory sanity checks
-	The Account factory must instantiate and return valid items. For this test it is enough
-	that the items returned are not null.
-	
-	Then All device factory functions must return non null values
+    The Account factory must instantiate and return valid items. For this test it is enough
+    that the items returned are not null.
+
+    Then All device factory functions must return non null values

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistryConnection.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistryConnection.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -10,216 +10,218 @@
 #     Eurotech - initial API and implementation
 ###############################################################################
 Feature: Device Registry Connection tests
-    The Device Registry Connection service is responsible for performing CRUD operations 
+    The Device Registry Connection service is responsible for performing CRUD operations
     regarding device connections on the Kapua database.
-    
-Scenario: Regular connection
-	It must be possible to create a device connection entry in the database. The centry 
-	must match the creator parameters. The connection status must also be 
-	implicitly set to CONNECTED. 
 
-	Given User 1 in scope 1
-	And I have the following connection
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	Then The connection object is regular
-	And The connection details match
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	And The connection status is "CONNECTED"
+Scenario: Regular connection
+    It must be possible to create a device connection entry in the database. The centry
+    must match the creator parameters. The connection status must also be
+    implicitly set to CONNECTED.
+
+    Given User 1 in scope 1
+    And I have the following connection
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    Then The connection object is regular
+    And The connection details match
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    And The connection status is "CONNECTED"
 
 Scenario: Device connection update
-	It must be possible to change the data of an existing device connection database 
-	entry.
+    It must be possible to change the data of an existing device connection database
+    entry.
 
-	Given User 1 in scope 1
-	And I have the following connection
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	When I modify the connection details to
-		| clientIp    | serverIp   | protocol | allowUserChange   |
-		| 127.0.0.109 | 127.0.0.25 | udp      | true              |
-	Then No exception was thrown
-	And The connection details match
-		| clientIp    | serverIp   | protocol | allowUserChange   |
-		| 127.0.0.109 | 127.0.0.25 | udp      | true              |
+    Given User 1 in scope 1
+    And I have the following connection
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    When I modify the connection details to
+        | clientIp    | serverIp   | protocol | allowUserChange   |
+        | 127.0.0.109 | 127.0.0.25 | udp      | true              |
+    Then There was no exception
+    And The connection details match
+        | clientIp    | serverIp   | protocol | allowUserChange   |
+        | 127.0.0.109 | 127.0.0.25 | udp      | true              |
 
 Scenario: Try to modify the connection client ID
-	It must not be possible to change the client ID of an existing device connection.
-	Attempts to change the client ID must be silently ignored. No exceptions must 
-	be thrown.
-	
-	Given User 1 in scope 1
-	And I have the following connection
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	When I try to modify the connection client Id to "testClient2"
-	Then No exception was thrown
-	And The connection client ID remains unchanged
+    It must not be possible to change the client ID of an existing device connection.
+    Attempts to change the client ID must be silently ignored. No exceptions must
+    be thrown.
+
+    Given User 1 in scope 1
+    And I have the following connection
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    When I try to modify the connection client Id to "testClient2"
+    Then There was no exception
+    And The connection client ID remains unchanged
 
 Scenario: Count connections in scope
-	It must be possible to count all the connections in a given scope.
+    It must be possible to count all the connections in a given scope.
 
-	Given A scope with id 1
-	And I have the following connections
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
-		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
-		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
-		| testClient5 | 127.0.0.105 | 127.0.0.10 | tcp      | true              |
-		| testClient6 | 127.0.0.106 | 127.0.0.10 | tcp      | true              |
-		| testClient7 | 127.0.0.107 | 127.0.0.10 | tcp      | true              |
-	Then No exception was thrown
-	And I count 7 connections in scope 1
+    Given A scope with id 1
+    And I have the following connections
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+        | testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
+        | testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
+        | testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
+        | testClient5 | 127.0.0.105 | 127.0.0.10 | tcp      | true              |
+        | testClient6 | 127.0.0.106 | 127.0.0.10 | tcp      | true              |
+        | testClient7 | 127.0.0.107 | 127.0.0.10 | tcp      | true              |
+    Then There was no exception
+    And I count 7 connections in scope 1
 
 Scenario: Count connections in empty scope
-	Counting connections for an empty (nonexisting) scope must not raise any exception.
-	A regular result (in this case 0) must be returned.
-	
-	Given A scope with id 1
-	And I have the following connections
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
-		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
-		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
-		| testClient5 | 127.0.0.105 | 127.0.0.10 | tcp      | true              |
-		| testClient6 | 127.0.0.106 | 127.0.0.10 | tcp      | true              |
-		| testClient7 | 127.0.0.107 | 127.0.0.10 | tcp      | true              |
-	Then I count 0 connections in scope 42
+    Counting connections for an empty (nonexisting) scope must not raise any exception.
+    A regular result (in this case 0) must be returned.
+
+    Given A scope with id 1
+    And I have the following connections
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+        | testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
+        | testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
+        | testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
+        | testClient5 | 127.0.0.105 | 127.0.0.10 | tcp      | true              |
+        | testClient6 | 127.0.0.106 | 127.0.0.10 | tcp      | true              |
+        | testClient7 | 127.0.0.107 | 127.0.0.10 | tcp      | true              |
+    Then I count 0 connections in scope 42
 
 Scenario: Try to change an existing connection ID
-	It must not be possible to change the ID of an existing connection. Trying to 
-	do so must result in an exception being thrown.
-	
-	Given User 1 in scope 1
-	And I have the following connection
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	When I try to modify the connection Id
-	Then An exception was thrown
+    It must not be possible to change the ID of an existing connection. Trying to
+    do so must result in an exception being thrown.
+
+    Given User 1 in scope 1
+    And I have the following connection
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    And I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type deviceConnection with id/name"
+    When I try to modify the connection Id
+    Then An exception was raised
 
 Scenario: Find a connection by its IDs
-	It must be possible to find a specific connection in the database based on 
-	its scope and entity IDs.
+    It must be possible to find a specific connection in the database based on
+    its scope and entity IDs.
 
-	Given User 1 in scope 1
-	And I have the following connection
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	When I search for a connection by scope and connection IDs
-	Then The connection details match
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    Given User 1 in scope 1
+    And I have the following connection
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    When I search for a connection by scope and connection IDs
+    Then The connection details match
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
 
 Scenario: I try to find a non-existing connection
-	Searching for a non existing connection must not raise any exception. A null
-	reference must be returned instead.
+    Searching for a non existing connection must not raise any exception. A null
+    reference must be returned instead.
 
-	Given User 1 in scope 1
-	And I have the following connection
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	When I search for a random connection ID
-	Then No connection was found
+    Given User 1 in scope 1
+    And I have the following connection
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    When I search for a random connection ID
+    Then No connection was found
 
 Scenario: Find a connection by its client ID
-	It must be possible to find a specific connection in the database based on its
-	scope and client IDs.
+    It must be possible to find a specific connection in the database based on its
+    scope and client IDs.
 
-	Given User 1 in scope 1
-	And I have the following connections
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
-		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
-		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
-	When I search for a connection with the client ID "testClient3"
-	Then The connection details match
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
+    Given User 1 in scope 1
+    And I have the following connections
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+        | testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
+        | testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
+        | testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
+    When I search for a connection with the client ID "testClient3"
+    Then The connection details match
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
 
 Scenario: Search for a non existent client ID
-	Searching for a non existing connection must not raise any exception. A null
-	reference must be returned instead.
-	
-	Given User 1 in scope 1
-	And I have the following connections
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
-		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
-		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
-	When I search for a connection with the client ID "nonexistentId"
-	Then No connection was found
+    Searching for a non existing connection must not raise any exception. A null
+    reference must be returned instead.
+
+    Given User 1 in scope 1
+    And I have the following connections
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+        | testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
+        | testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
+        | testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
+    When I search for a connection with the client ID "nonexistentId"
+    Then No connection was found
 
 Scenario: The Client ID is case sensitive
-	Given User 1 in scope 1
-	And I have the following connections
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	When I search for a connection with the client ID "TESTClient1"
-	Then No connection was found
-	When I search for a connection with the client ID "testClient1"
-	Then The connection details match
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    Given User 1 in scope 1
+    And I have the following connections
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    When I search for a connection with the client ID "TESTClient1"
+    Then No connection was found
+    When I search for a connection with the client ID "testClient1"
+    Then The connection details match
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
 
 Scenario: Delete a connection from the database
-	It must be possible to delete a specific entry fron the connection database.
+    It must be possible to delete a specific entry fron the connection database.
 
-	Given User 1 in scope 1
-	And I have the following connections
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-		| testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
-		| testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
-		| testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
-	And I search for a connection with the client ID "testClient3"
-	And I delete the existing connection
-	When I search for a connection with the client ID "testClient3"
-	Then No connection was found
+    Given User 1 in scope 1
+    And I have the following connections
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+        | testClient2 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
+        | testClient3 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
+        | testClient4 | 127.0.0.104 | 127.0.0.10 | tcp      | true              |
+    And I search for a connection with the client ID "testClient3"
+    And I delete the existing connection
+    When I search for a connection with the client ID "testClient3"
+    Then No connection was found
 
-Scenario: Delete a non existing cnnection
-	Trying to delete a non existent connection should result in an exception 
-	being thrown.
-	
-	Given User 1 in scope 1
-	And I have the following connection
-		| clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-	When I try to delete a random connection ID
-	Then An exception was thrown
+Scenario: Delete a non existing connection
+    Trying to delete a non existent connection should result in an exception
+    being thrown.
+
+    Given User 1 in scope 1
+    And I have the following connection
+        | clientId    | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient1 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+    And I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type deviceConnection with id/name"
+    When I try to delete a random connection ID
+    Then An exception was raised
 
 Scenario: Generic connection query
-	It must be possible to query for connections in the database based on various 
-	parameters.
-	
-	Given User 1 in scope 1
-	And I have the following connections
-		| clientId     | clientIp    | serverIp   | protocol | allowUserChange   |
-		| testClient01 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
-		| testClient02 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
-		| testClient03 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
-		| testClient04 | 127.0.0.104 | 127.0.0.11 | tcp      | true              |
-		| testClient05 | 127.0.0.104 | 127.0.0.11 | tcp      | true              |
-		| testClient06 | 127.0.0.104 | 127.0.0.11 | tcp      | true              |
-		| testClient07 | 127.0.0.104 | 127.0.0.11 | udp      | true              |
-		| testClient08 | 127.0.0.104 | 127.0.0.10 | udp      | true              |
-		| testClient09 | 127.0.0.104 | 127.0.0.10 | udp      | true              |
-		| testClient10 | 127.0.0.104 | 127.0.0.10 | udp      | true              |
-		| testClient11 | 127.0.0.104 | 127.0.0.10 | udp      | true              |
-	When I query for all connections with the parameter "protocol" set to "udp"
-	Then I find 5 connections
-	When I query for all connections with the parameter "serverIp" set to "127.0.0.11"
-	Then I find 4 connections
+    It must be possible to query for connections in the database based on various
+    parameters.
+
+    Given User 1 in scope 1
+    And I have the following connections
+        | clientId     | clientIp    | serverIp   | protocol | allowUserChange   |
+        | testClient01 | 127.0.0.101 | 127.0.0.10 | tcp      | true              |
+        | testClient02 | 127.0.0.102 | 127.0.0.10 | tcp      | true              |
+        | testClient03 | 127.0.0.103 | 127.0.0.10 | tcp      | true              |
+        | testClient04 | 127.0.0.104 | 127.0.0.11 | tcp      | true              |
+        | testClient05 | 127.0.0.104 | 127.0.0.11 | tcp      | true              |
+        | testClient06 | 127.0.0.104 | 127.0.0.11 | tcp      | true              |
+        | testClient07 | 127.0.0.104 | 127.0.0.11 | udp      | true              |
+        | testClient08 | 127.0.0.104 | 127.0.0.10 | udp      | true              |
+        | testClient09 | 127.0.0.104 | 127.0.0.10 | udp      | true              |
+        | testClient10 | 127.0.0.104 | 127.0.0.10 | udp      | true              |
+        | testClient11 | 127.0.0.104 | 127.0.0.10 | udp      | true              |
+    When I query for all connections with the parameter "protocol" set to "udp"
+    Then I find 5 connections
+    When I query for all connections with the parameter "serverIp" set to "127.0.0.11"
+    Then I find 4 connections
 
 Scenario: Connection Service factory sanity checks
-	Then All connection factory functions must return non null values
+    Then All connection factory functions must return non null values
 
 Scenario: Check the sanity of the Device Connection Domain data initialization
-	Then The device connection domain defaults are correctly initialized
-	
+    Then The device connection domain defaults are correctly initialized
+
 Scenario: Check the Device Connection Domain data seetting
-	Then The device connection domain data can be updated
+    Then The device connection domain data can be updated

--- a/service/device/registry/internal/src/test/resources/features/DeviceRegistryValidation.feature
+++ b/service/device/registry/internal/src/test/resources/features/DeviceRegistryValidation.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -10,169 +10,184 @@
 #     Eurotech - initial API and implementation
 ###############################################################################
 Feature: Device Registry Validation Tests
-    The Device Registry Validation helper is responsible for validating parameters 
+    The Device Registry Validation helper is responsible for validating parameters
     and permissions before any operation is performed on the database.
 
 Scenario: Validate a regular creator
-	Create a regular device creator. The validator should OK it.
-	
-	Given A regular device creator
-	When I validate the device creator
-	Then No exception is thrown
+    Create a regular device creator. The validator should OK it.
+
+    Given A regular device creator
+    When I validate the device creator
+    Then There was no exception
 
 Scenario: Validate a null creator
-	Create a null device creator. The validator should throw an exception.
-	
-	Given A null device creator
-	When I validate the device creator
-	Then An exception is thrown
-	
+    Create a null device creator. The validator should throw an exception.
+
+    Given A null device creator
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I validate the device creator
+    Then An exception was raised
+
 Scenario: Validate a device creator with a null scope ID
-	Create a regular device creator. Assign a null scope ID. The validator
-	should throw an exception.
-	
-	Given A regular device creator
-	When I set the creator scope ID to null
-	And I validate the device creator
-	Then An exception is thrown
-	
+    Create a regular device creator. Assign a null scope ID. The validator
+    should throw an exception.
+
+    Given A regular device creator
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I set the creator scope ID to null
+    And I validate the device creator
+    Then An exception was raised
+
 Scenario: Validate a device creator with a null client ID
-	Create a regular device creator. Assign a null client ID. The validator
-	should throw an exception.
-	
-	Given A regular device creator
-	When I set the creator client ID to null
-	And I validate the device creator
-	Then An exception is thrown	
-	
+    Create a regular device creator. Assign a null client ID. The validator
+    should throw an exception.
+
+    Given A regular device creator
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I set the creator client ID to null
+    And I validate the device creator
+    Then An exception was raised
+
 Scenario: Validate a regular device
-	Create a regular device object. the update validator should OK it.
-	
-	Given A regular device
-	When I validate the device for updates	
-	Then No exception is thrown
+    Create a regular device object. the update validator should OK it.
+
+    Given A regular device
+    When I validate the device for updates
+    Then There was no exception
 
 Scenario: Validate a null device
-	Create a null device object. The validator should throw an
-	exception.
-	
-	Given A null device
-	When I validate the device for updates	
-	Then An exception is thrown
+    Create a null device object. The validator should throw an
+    exception.
+
+    Given A null device
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I validate the device for updates
+    Then An exception was raised
 
 Scenario: Validate a regular device search
-	Validate the parameters for a device search. Both ScopeID and DeviceID 
-	are not null. The validator should be OK with it.
-	
-	When Validating a find operation for scope 15 and device 4321
-	Then No exception is thrown
-	
+    Validate the parameters for a device search. Both ScopeID and DeviceID
+    are not null. The validator should be OK with it.
+
+    When Validating a find operation for scope 15 and device 4321
+    Then There was no exception
+
 Scenario: Validate a device search with a null device ID
-	Validate the parameters for a device search. ScopeID is valid, but the DeviceID 
-	is null. The validator should throw an exception.
-	
-	When Validating a find operation for scope 15 and device null
-	Then An exception is thrown
-	
+    Validate the parameters for a device search. ScopeID is valid, but the DeviceID
+    is null. The validator should throw an exception.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When Validating a find operation for scope 15 and device null
+    Then An exception was raised
+
 Scenario: Validate a device search with a null scope ID
-	Validate the parameters for a device search. DeviceID is valid, but ScopeID 
-	is null. The validator should throw an exception.
-	
-	When Validating a find operation for scope null and device 2
-	Then An exception is thrown
-	
+    Validate the parameters for a device search. DeviceID is valid, but ScopeID
+    is null. The validator should throw an exception.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When Validating a find operation for scope null and device 2
+    Then An exception was raised
+
 Scenario: Validate a regular device deletion
-	Validate the parameters for deleting a device. Both ScopeID and DeviceID 
-	are not null. The validator should be OK with it.
-	
-	When Validating a delete operation for scope 15 and device 4321
-	Then No exception is thrown
-	
+    Validate the parameters for deleting a device. Both ScopeID and DeviceID
+    are not null. The validator should be OK with it.
+
+    When Validating a delete operation for scope 15 and device 4321
+    Then There was no exception
+
 Scenario: Validate deleting a device with a null device ID
-	Validate the parameters for deleting a device. ScopeID is valid, but the DeviceID 
-	is null. The validator should throw an exception.
-	
-	When Validating a delete operation for scope 15 and device null
-	Then An exception is thrown
-	
+    Validate the parameters for deleting a device. ScopeID is valid, but the DeviceID
+    is null. The validator should throw an exception.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When Validating a delete operation for scope 15 and device null
+    Then An exception was raised
+
 Scenario: Validate deleting a device with a null scope ID
-	Validate the parameters for deleting a device. DeviceID is valid, but ScopeID 
-	is null. The validator should throw an exception.
-	
-	When Validating a delete operation for scope null and device 2
-	Then An exception is thrown	
-	
-Scenario: Validate a regular device client search	
-	Validate the parameters for a client id based search. Both the Scope ID and the 
-	Client ID are valid. The validator should OK it.
+    Validate the parameters for deleting a device. DeviceID is valid, but ScopeID
+    is null. The validator should throw an exception.
 
-	When Validating a find operation for scope 42 and client "test_client"
-	Then No exception is thrown
-	
-Scenario: Validate a device client search with null scope	
-	Validate the parameters for a client id based search. The Scope ID is null and the 
-	Client ID is valid. The validator should throw an exception.
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When Validating a delete operation for scope null and device 2
+    Then An exception was raised
 
-	When Validating a find operation for scope null and client "test_client"
-	Then An exception is thrown	
-	
-Scenario: Validate a device client based search with a null client ID	
-	Validate the parameters for a client id based search. The Scope ID is valid but the 
-	Client ID is null. The validator should throw an exception.
-	Note: a string with the content 'null' is taken as a null string. Just a cucumber workaround.
-	
-	When Validating a find operation for scope 42 and client "null"
-	Then An exception is thrown	
-	
-Scenario: Validate a device client based search with an empty client ID	
-	Validate the parameters for a client id based search. The Scope ID is valid while the 
-	Client ID is an empty string. The validator should throw an exception.
-	
-	When Validating a find operation for scope 42 and client ""
-	Then An exception is thrown		
-	
+Scenario: Validate a regular device client search
+    Validate the parameters for a client id based search. Both the Scope ID and the
+    Client ID are valid. The validator should OK it.
+
+    When Validating a find operation for scope 42 and client "test_client"
+    Then There was no exception
+
+Scenario: Validate a device client search with null scope
+    Validate the parameters for a client id based search. The Scope ID is null and the
+    Client ID is valid. The validator should throw an exception.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When Validating a find operation for scope null and client "test_client"
+    Then An exception was raised
+
+Scenario: Validate a device client based search with a null client ID
+    Validate the parameters for a client id based search. The Scope ID is valid but the
+    Client ID is null. The validator should throw an exception.
+    Note: a string with the content 'null' is taken as a null string. Just a cucumber workaround.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When Validating a find operation for scope 42 and client "null"
+    Then An exception was raised
+
+Scenario: Validate a device client based search with an empty client ID
+    Validate the parameters for a client id based search. The Scope ID is valid while the
+    Client ID is an empty string. The validator should throw an exception.
+
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When Validating a find operation for scope 42 and client ""
+    Then An exception was raised
+
 Scenario: Validate a regular device query
-	Validate the parameters for a regulat device query. Neither the query nor the query 
-	Scope ID is null. The validator should be OK with it.
-	
-	Given A regular query
-	When I validate a query operation
-	Then No exception is thrown
+    Validate the parameters for a regulat device query. Neither the query nor the query
+    Scope ID is null. The validator should be OK with it.
+
+    Given A regular query
+    When I validate a query operation
+    Then There was no exception
 
 Scenario: Validate a null device query
-	Validate a null device query. The validator should throw an exception.
+    Validate a null device query. The validator should throw an exception.
 
-	Given A null query
-	When I validate a query operation
-	Then An exception is thrown
+    Given A null query
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I validate a query operation
+    Then An exception was raised
 
 Scenario: Validate a device query with a null Scope ID
-	Validate a faulty device query. The query is not null, but the query Scope ID 
-	is null. The validator should throw an exception.
-	
-	Given A query with a null Scope ID
-	When I validate a query operation
-	Then An exception is thrown
+    Validate a faulty device query. The query is not null, but the query Scope ID
+    is null. The validator should throw an exception.
+
+    Given A query with a null Scope ID
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I validate a query operation
+    Then An exception was raised
 
 Scenario: Validate a regular device count
-	Validate the parameters for a regulat device count. Neither the query nor the query 
-	Scope ID is null. The validator should be OK with it.
-	
-	Given A regular query
-	When I validate a count operation
-	Then No exception is thrown
+    Validate the parameters for a regulat device count. Neither the query nor the query
+    Scope ID is null. The validator should be OK with it.
+
+    Given A regular query
+    When I validate a count operation
+    Then There was no exception
 
 Scenario: Validate a null device count
-	Validate a device count with a null query. The validator should throw an exception.
-	
-	Given A null query
-	When I validate a count operation
-	Then An exception is thrown
+    Validate a device count with a null query. The validator should throw an exception.
+
+    Given A null query
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I validate a count operation
+    Then An exception was raised
 
 Scenario: Validate a device count with a null Scope ID
-	Validate a device count with a faulty query. The query is not null, but the query Scope ID is.
-	The validator should throw an exception.
-	
-	Given A query with a null Scope ID
-	When I validate a count operation
-	Then An exception is thrown	
+    Validate a device count with a faulty query. The query is not null, but the query Scope ID is.
+    The validator should throw an exception.
+
+    Given A query with a null Scope ID
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I validate a count operation
+    Then An exception was raised

--- a/service/user/internal/src/test/resources/features/UserService.feature
+++ b/service/user/internal/src/test/resources/features/UserService.feature
@@ -43,7 +43,8 @@ Scenario: Create user with short name
         | integer | lockoutPolicy.maxFailures  | 3     |
         | integer | lockoutPolicy.resetAfter   | 300   |
         | integer | lockoutPolicy.lockDuration | 3     |
-    Given I have following user
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided"
+    And I have following user
         | name | displayName        | email              | phoneNumber     | status  |
         | u1   |    Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 | ENABLED |
     Then I get Kapua exception
@@ -59,7 +60,8 @@ Scenario: Create user that has more than DB allowed length
         | integer | lockoutPolicy.maxFailures  | 3     |
         | integer | lockoutPolicy.resetAfter   | 300   |
         | integer | lockoutPolicy.lockDuration | 3     |
-    Given I have following user
+    Given I expect the exception "KapuaException" with the text "*"
+    And I have following user
         | name | displayName        | email              | phoneNumber     | status  |
         | uuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaauuuuuuuuuuaaaaaaaaaa  |    Kapua User 1    | kapua_u1@kapua.com | +386 31 323 555 | ENABLED |
     Then I get Kapua exception
@@ -76,7 +78,8 @@ Scenario: Create user with special characters in his name
         | integer | lockoutPolicy.maxFailures  | 3     |
         | integer | lockoutPolicy.resetAfter   | 300   |
         | integer | lockoutPolicy.lockDuration | 3     |
-    Given I have following user
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided"
+    And I have following user
         | name      | displayName        | email              | phoneNumber     | status  |
         | ###$$$%%% | Kapua User 1       | kapua_u1@kapua.com | +386 31 323 555 | ENABLED |
     Then I get Kapua exception
@@ -211,14 +214,16 @@ Scenario: Create user that already exist
         | integer | lockoutPolicy.lockDuration | 3     |
     Given User with name "kapua-user" in scope with id 42
     When I create user
-    And I create same user
+    And I expect the exception "KapuaException" with the text "Error during Persistence Operation"
+    When I create same user
     Then I get Kapua exception
 
 Scenario: Update user that doesn't exist
     Create user that is not persisted and than run update statement on that user.
     As user doesn't exist KapuaException should be thrown.
 
-    Given User that doesn't exist
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
+    And User that doesn't exist
     When I update nonexistent user
     Then I get Kapua exception
 
@@ -226,7 +231,8 @@ Scenario: Delete user that doesn't exist
     Create user that is not persisted and than try to delete that user. As user
     doesn't exist KapuaException should be thrown.
 
-    Given User that doesn't exist
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type user with id/name"
+    And User that doesn't exist
     When I delete nonexistent user
     Then I get Kapua exception
 
@@ -249,6 +255,7 @@ Scenario: Delete Kapua system user
     for "kapua-sys" user and than delete it. KapuaException should be thrown.
 
     Given I search for user with name "kapua-sys"
+    And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided"
     When I delete user
     Then I get Kapua exception
 


### PR DESCRIPTION
## A refactoring of the exception handling in service unit tests
The exception handling in most service unit tests was improved.
When an expected exception is caught, the type and message are logged in the cucumber html report. If, on the other hand, an unexpected exception is caught, the exception is rethrown and the full stack trace is logged to help diagnose the underlying problem.

### Changes to Maven pom files
No changes.

### Implementation changes
No changes.

### Test changes
The test steps were modified to better handle exceptions.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>