### PR TITLE
Fixed permission check for KapuaId.ANY - issue 841

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdStatic.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdStatic.java
@@ -47,10 +47,10 @@ public final class KapuaIdStatic implements KapuaId {
         if (obj == null) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (getClass() != obj.getClass() && !(obj instanceof KapuaId)) {
             return false;
         }
-        KapuaIdStatic other = (KapuaIdStatic) obj;
+        KapuaId other = (KapuaId) obj;
         if (!getId().equals(other.getId())) {
             return false;
         }


### PR DESCRIPTION
Hi all, 

this PR fixes issue #841 .

There was a problem on the `KapuaIdStatic.equals(..)` implementation caused by another modification on the `PermissionImpl` class ([see here](https://github.com/eclipse/kapua/commit/cf01af69b29692158638924853124d761ae0dd31)).

Regards, 

_Alberto_

