### PR TITLE
Additional improvements to the unit test exception handling.

### DIFF
--- a/qa/src/test/java/org/eclipse/kapua/qa/steps/BaseQATests.java
+++ b/qa/src/test/java/org/eclipse/kapua/qa/steps/BaseQATests.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.qa.steps;
+
+import cucumber.api.Scenario;
+import org.eclipse.kapua.service.StepData;
+
+public class BaseQATests {
+
+    /**
+     * Inter step data scratchpad.
+     */
+    public StepData stepData;
+
+    /**
+     * Current scenario scope
+     */
+    public Scenario scenario;
+
+    public BaseQATests() {
+    }
+
+    public void primeException() {
+        stepData.put("ExceptionCaught", false);
+        stepData.remove("Exception");
+    }
+
+    /**
+     * Check the exception that was caught. In case the exception was expected the type and message is shown in the cucumber logs.
+     * Otherwise the exception is rethrown failing the test and dumping the stack trace to help resolving problems.
+     */
+    public void verifyException(Exception ex)
+            throws Exception {
+
+        boolean exceptionExpected = stepData.contains("ExceptionExpected") ? (boolean)stepData.get("ExceptionExpected") : false;
+        String exceptionName = stepData.contains("ExceptionName") ? (String)stepData.get("ExceptionName") : "";
+        String exceptionMessage = stepData.contains("ExceptionMessage") ? (String)stepData.get("ExceptionMessage") : "";
+
+        if (!exceptionExpected ||
+                (!exceptionName.isEmpty() && !ex.getClass().toGenericString().contains(exceptionName)) ||
+                (!exceptionMessage.isEmpty() && !exceptionMessage.trim().contentEquals("*") && !ex.getMessage().contains(exceptionMessage))) {
+            scenario.write("An unexpected exception was raised!");
+            throw(ex);
+        }
+
+        scenario.write("Exception raised as expected: " + ex.getClass().getCanonicalName() + ", " + ex.getMessage());
+        stepData.put("ExceptionCaught", true);
+        stepData.put("Exception", ex);
+    }
+}

--- a/qa/src/test/java/org/eclipse/kapua/qa/steps/BasicSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/qa/steps/BasicSteps.java
@@ -11,8 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.qa.steps;
 
-import com.google.inject.Inject;
+import javax.inject.Inject;
 import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
@@ -47,6 +48,13 @@ public class BasicSteps extends Assert {
         }
     }
 
+    @Given("^I expect the exception \"(.+)\" with the text \"(.+)\"$")
+    public void setExpectedExceptionDetails(String name, String text) {
+        stepData.put("ExceptionExpected", true);
+        stepData.put("ExceptionName", name);
+        stepData.put("ExceptionMessage", text);
+    }
+
     @When("I wait (\\d+) seconds?.*")
     public void waitSeconds(int seconds) throws InterruptedException {
         double effectiveSeconds = ((double) seconds) * WAIT_MULTIPLIER;
@@ -60,15 +68,15 @@ public class BasicSteps extends Assert {
 
     @Then("^An exception was thrown$")
     public void exceptionCaught() {
-        assertTrue((boolean) stepData.get("ExceptionCaught"));
+        String exName = stepData.contains("ExceptionName") ? (String)stepData.get("ExceptionName") : "Unknown";
+        boolean exCaught = stepData.contains("ExceptionCaught") ? (boolean) stepData.get("ExceptionCaught") : false;
+        assertTrue(String.format("Exception %s was expected but was not raised.", exName), exCaught);
     }
 
     @Then("^No exception was thrown$")
     public void noExceptionCaught() {
-        Object val = stepData.get("ExceptionCaught");
-        if (val != null) {
-            assertFalse((boolean) val);
-        }
+        boolean exCaught = stepData.contains("ExceptionCaught") ? (boolean) stepData.get("ExceptionCaught") : false;
+        assertFalse("An unexpected exception was raised!", exCaught);
     }
 
     @Then("^I get (\\d+)$")

--- a/qa/src/test/java/org/eclipse/kapua/service/StepData.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/StepData.java
@@ -47,6 +47,10 @@ public class StepData {
         return stepDataMap.get(key);
     }
 
+    public boolean contains(String key) {
+        return stepDataMap.containsKey(key);
+    }
+
     public void remove(String key) {
         stepDataMap.remove(key);
     }

--- a/qa/src/test/java/org/eclipse/kapua/service/connection/steps/ConnectionSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/connection/steps/ConnectionSteps.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.connection.steps;
 
+import cucumber.api.Scenario;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.Given;
@@ -22,6 +23,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.steps.BaseQATests;
 import org.eclipse.kapua.qa.steps.DBHelper;
 import org.eclipse.kapua.service.StepData;
 import org.eclipse.kapua.service.TestJAXBContextProvider;
@@ -57,7 +59,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 @ScenarioScoped
-public class ConnectionSteps {
+public class ConnectionSteps extends BaseQATests {
 
     /**
      * Authentication service.
@@ -103,9 +105,6 @@ public class ConnectionSteps {
      */
     private static AclCreator aclCreator;
 
-    // Scenario scoped Device Registry test data
-    private static StepData stepData;
-
     // Single point to database access.
     private static DBHelper dbHelper;
 
@@ -116,7 +115,7 @@ public class ConnectionSteps {
     }
 
     @Before
-    public void beforeScenario() {
+    public void beforeScenario(Scenario scenario) {
 
         KapuaLocator locator = KapuaLocator.getInstance();
         authenticationService = locator.getService(AuthenticationService.class);
@@ -134,6 +133,8 @@ public class ConnectionSteps {
 
         // Initialize the database
         dbHelper.setup();
+
+        this.scenario = scenario;
 
         XmlUtil.setContextProvider(new TestJAXBContextProvider());
     }
@@ -345,9 +346,12 @@ public class ConnectionSteps {
             tmpConn.setReservedUserId(userId);
             stepData.put("ExceptionCaught", false);
             try {
+                primeException();
                 deviceConnectionService.update(tmpConn);
             } catch (KapuaException ex) {
-                stepData.put("ExceptionCaught", true);
+                verifyException(ex);
+            } catch (Exception e) {
+                int a = 10;
             }
         });
     }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreI9nTest.java
@@ -29,5 +29,6 @@ import org.junit.runner.RunWith;
         monochrome = true)
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.transport.TransportDatastoreClient")
 @CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="3")
 public class RunDatastoreI9nTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreRestI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreRestI9nTest.java
@@ -20,14 +20,15 @@ import org.junit.runner.RunWith;
 @CucumberOptions(
         features = "classpath:features/datastore/Datastore.feature",
         glue = {"org.eclipse.kapua.qa.steps",
-                "org.eclipse.kapua.service.datastore.steps",
                 "org.eclipse.kapua.service.user.steps",
-                "org.eclipse.kapua.service.device.steps"},
+                "org.eclipse.kapua.service.device.steps",
+                "org.eclipse.kapua.service.datastore.steps" },
         plugin = {"pretty",
-                  "html:target/cucumber/DatastoreRestI9n",
-                  "json:target/DatastoreRestI9n_cucumber.json"},
+                "html:target/cucumber/DatastoreRestI9n",
+                "json:target/DatastoreRestI9n_cucumber.json" },
         monochrome = true)
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
-@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="25")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="23")
 public class RunDatastoreRestI9nTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/device/steps/AclSteps.java
@@ -23,8 +23,11 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import cucumber.api.Scenario;
+import cucumber.runtime.java.guice.ScenarioScoped;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.qa.steps.BaseQATests;
 import org.eclipse.kapua.service.StepData;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountFactory;
@@ -47,7 +50,8 @@ import cucumber.api.java.en.When;
 /**
  * Steps for testing Access Control List functionality on Broker service.
  */
-public class AclSteps {
+@ScenarioScoped
+public class AclSteps extends BaseQATests {
 
     public static final int BROKER_START_WAIT_MILLIS = 5000;
 
@@ -105,11 +109,6 @@ public class AclSteps {
      */
     private static AclCreator aclCreator;
 
-    /**
-     * Inter step data scratchpad.
-     */
-    private StepData stepData;
-
     @Inject
     public AclSteps(StepData stepData) {
 
@@ -117,7 +116,7 @@ public class AclSteps {
     }
 
     @Before
-    public void aclStepsBefore() {
+    public void aclStepsBefore(Scenario scenario) {
 
         KapuaLocator locator = KapuaLocator.getInstance();
         authenticationService = locator.getService(AuthenticationService.class);
@@ -130,6 +129,8 @@ public class AclSteps {
         mqttDevice = new MqttDevice();
         clientMqttMessage = new HashMap<>();
         listenerMqttMessage = new HashMap<>();
+
+        this.scenario = scenario;
 
         aclCreator = new AclCreator(accountService, accountFactory, userService, accessInfoService, credentialService);
     }
@@ -162,12 +163,14 @@ public class AclSteps {
     }
 
     @Given("^broker with clientId \"(.*)\" and user \"(.*)\" and password \"(.*)\" is listening on topic \"(.*)\"$")
-    public void connectClientToBroker(String clientId, String userName, String password, String topicFilter) {
+    public void connectClientToBroker(String clientId, String userName, String password, String topicFilter)
+            throws Exception {
 
         try {
+            primeException();
             mqttDevice.mqttClientConnect(clientId, userName, password, topicFilter);
         } catch (MqttException mqtte) {
-            stepData.put("exception", mqtte);
+            verifyException(mqtte);
         }
     }
 

--- a/qa/src/test/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag.steps;
 
+import cucumber.api.Scenario;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
@@ -23,6 +24,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate;
+import org.eclipse.kapua.qa.steps.BaseQATests;
 import org.eclipse.kapua.service.StepData;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.tag.Tag;
@@ -45,7 +47,7 @@ import static org.junit.Assert.assertEquals;
  * Implementation of Gherkin steps used in TagService.feature scenarios.
  */
 @ScenarioScoped
-public class TagServiceSteps {
+public class TagServiceSteps extends BaseQATests {
 
     private static final KapuaEid DEFAULT_SCOPE_ID = new KapuaEid(BigInteger.valueOf(1L));
 
@@ -57,7 +59,7 @@ public class TagServiceSteps {
     /**
      * Inter step data scratchpad.
      */
-    private StepData stepData;
+//    private StepData stepData;
 
     @Inject
     public TagServiceSteps(StepData stepData) { 
@@ -66,16 +68,19 @@ public class TagServiceSteps {
     }
 
     @Before
-    public void tagStepsBefore() {
+    public void tagStepsBefore(Scenario scenario) {
 
         KapuaLocator locator = KapuaLocator.getInstance();
         tagService = locator.getService(TagService.class);
-        stepData.put("LastAccount", null);
+
+        this.scenario = scenario;
+        stepData.clear();
+//        stepData.put("LastAccount", null);
     }
 
     @Given("^Tag Service configuration$")
     public void setConfigurationValue(List<TestConfig> testConfigs)
-            throws KapuaException {
+            throws Exception {
 
         Account lastAcc = (Account) stepData.get("LastAccount");
         KapuaId scopeId = DEFAULT_SCOPE_ID;
@@ -90,11 +95,13 @@ public class TagServiceSteps {
             config.addConfigToMap(valueMap);
         }
         try {
-            stepData.put("isException", false);
+//            stepData.put("isException", false);
+            primeException();
             tagService.setConfigValues(scopeId, parentId, valueMap);
         } catch (KapuaException ke) {
-            stepData.put("isException", true);
-            stepData.put("exception", ke);
+//            stepData.put("isException", true);
+//            stepData.put("exception", ke);
+            verifyException(ke);
         }
     }
 

--- a/qa/src/test/java/org/eclipse/kapua/service/tag/unit/RunTagServiceTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/tag/unit/RunTagServiceTest.java
@@ -12,10 +12,11 @@
 package org.eclipse.kapua.service.tag.unit;
 
 import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
-@RunWith(Cucumber.class)
+@RunWith(CucumberWithProperties.class)
 @CucumberOptions(
         features = "classpath:features/tag/TagService.feature",
         glue = {"org.eclipse.kapua.qa.steps",
@@ -27,5 +28,7 @@ import org.junit.runner.RunWith;
                 "json:target/TagService_cucumber.json"
         },
         monochrome = true)
+@CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
 public class RunTagServiceTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/user/integration/RunUserServiceI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/user/integration/RunUserServiceI9nTest.java
@@ -12,12 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.integration;
 
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
 
-@RunWith(Cucumber.class)
+@RunWith(CucumberWithProperties.class)
 @CucumberOptions(
         features = "classpath:features/user/UserServiceI9n.feature",
         glue = {"org.eclipse.kapua.qa.steps",
@@ -28,5 +29,6 @@ import cucumber.api.junit.Cucumber;
                   "json:target/UserServiceI9n_cucumber.json"
                  },
         monochrome=true)
-
+@CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
 public class RunUserServiceI9nTest {}

--- a/qa/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
@@ -92,8 +92,9 @@ Feature: Broker ACL tests
     Given Mqtt Device is started
     And data manage account and user are created
     And other broker account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/domino/client-1/CONF-V1/REPLY"
-    Then exception is thrown
+    Then An exception was thrown
     And clients are disconnected
     And Mqtt Device is stoped
 
@@ -125,8 +126,9 @@ Feature: Broker ACL tests
   Subscribe is not allowed.
     Given Mqtt Device is started
     And data manage account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme"
-    Then exception is thrown
+    Then An exception was thrown
     And clients are disconnected
     And Mqtt Device is stoped
 
@@ -195,8 +197,9 @@ Feature: Broker ACL tests
   Subscribe is not allowed.
     Given Mqtt Device is started
     And data manage account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme/foo/bar/NOTIFY/client-1"
-    Then exception is thrown
+    Then An exception was thrown
     And clients are disconnected
     And Mqtt Device is stoped
 

--- a/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -103,9 +103,10 @@ Feature: Broker ACL tests
     Given Mqtt Device is started
       And broker account and user are created
       And other broker account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/domino/client-1/CONF-V1/REPLY"
-    Then exception is thrown
-      And clients are disconnected
+    Then An exception was thrown
+    And clients are disconnected
       And Mqtt Device is stoped
 
   Scenario: B5 Broker publish to CTRL_ACC is not allowed
@@ -136,8 +137,9 @@ Feature: Broker ACL tests
     Subscribe is not allowed.
     Given Mqtt Device is started
       And broker account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme"
-    Then exception is thrown
+    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 
@@ -181,8 +183,9 @@ Feature: Broker ACL tests
     Subscribe is not allowed.
     Given Mqtt Device is started
       And broker account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "acme"
-    Then exception is thrown
+    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 
@@ -227,8 +230,9 @@ Feature: Broker ACL tests
     Subscribe is not allowed.
     Given Mqtt Device is started
       And broker account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme/foo/bar/NOTIFY/client-1"
-    Then exception is thrown
+    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 #
@@ -277,8 +281,9 @@ Feature: Broker ACL tests
     Given Mqtt Device is started
       And device account and user are created
       And other broker account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/domino/client-1/CONF-V1/REPLY"
-    Then exception is thrown
+    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 
@@ -334,8 +339,9 @@ Feature: Broker ACL tests
     Subscribe is not allowed.
     Given Mqtt Device is started
       And device account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "acme"
-    Then exception is thrown
+    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 
@@ -380,10 +386,11 @@ Feature: Broker ACL tests
     Subscribe is not allowed.
     Given Mqtt Device is started
       And device account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme/foo/bar/NOTIFY/client-1"
-    Then exception is thrown
-      And clients are disconnected
-      And Mqtt Device is stoped
+#    Then An exception was thrown
+#      And clients are disconnected
+#      And Mqtt Device is stoped
 #
 # Data view
 #
@@ -430,8 +437,9 @@ Feature: Broker ACL tests
     Given Mqtt Device is started
       And data view account and user are created
       And other broker account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/domino/client-1/CONF-V1/REPLY"
-    Then exception is thrown
+    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 
@@ -463,8 +471,9 @@ Feature: Broker ACL tests
     Subscribe is not allowed.
     Given Mqtt Device is started
       And data view account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme"
-    Then exception is thrown
+    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 
@@ -583,8 +592,9 @@ Feature: Broker ACL tests
     Subscribe is not allowed.
     Given Mqtt Device is started
       And data view account and user are created
+    Given I expect the exception "MqttException" with the text "*"
     When broker with clientId "client-1" and user "luise" and password "kapua-password" is listening on topic "$EDC/acme/foo/bar/NOTIFY/client-1"
-    Then exception is thrown
+    Then An exception was thrown
       And clients are disconnected
       And Mqtt Device is stoped
 

--- a/qa/src/test/resources/features/connection/UserCouplingI9n.feature
+++ b/qa/src/test/resources/features/connection/UserCouplingI9n.feature
@@ -519,6 +519,7 @@ Feature: User Coupling
     And I set the reserved user for the connection from device "device-1" in account "test-acc-1" to "test-user-1"
     Then I set the user coupling mode for the connection from device "device-2" in account "test-acc-1" to "STRICT"
     # Try to set a duplicate reserved user
+    Given I expect the exception "KapuaException" with the text "Error during Persistence Operation"
     When I set the reserved user for the connection from device "device-2" in account "test-acc-1" to "test-user-1"
     Then An exception was thrown
     # Reserved users must be unique!
@@ -1003,6 +1004,7 @@ Feature: User Coupling
     And I set the reserved user for the connection from device "device-1" in account "test-acc-1" to "test-user-1"
     Then I set the user coupling mode for the connection from device "device-2" in account "test-acc-1" to "STRICT"
 # Try to set a duplicate reserved user
+    Given I expect the exception "KapuaException" with the text "Error during Persistence Operation"
     When I set the reserved user for the connection from device "device-2" in account "test-acc-1" to "test-user-1"
     Then An exception was thrown
 # Reserved users must be unique!

--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -134,6 +134,7 @@ Scenario: Handling of a disconnect message from a non existing device
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities |  10   |
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
     When A disconnect message from device "device_1"
     Then An exception was thrown
     And I logout

--- a/qa/src/test/resources/features/tag/TagService.feature
+++ b/qa/src/test/resources/features/tag/TagService.feature
@@ -24,6 +24,9 @@ Feature: Tag Service
   @StartBroker
   Scenario: Start broker for all scenarios
 
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
   Scenario: Creating tag
     Create a tag entry, with specified name. Name is only tag specific attribute.
     Once created search for it and is should been created.
@@ -44,3 +47,6 @@ Feature: Tag Service
 
   @StopBroker
   Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios

--- a/qa/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -22,17 +22,21 @@ Feature: User and Credential expiration abd lockout features
     enabled, user can login into system. All other expiration settings are set for
     successful login. Only state is tested.
     When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
+      | integer | maxNumberChildEntities     | 20     |
     Given Account
       | name      | scopeId |
       | account-a | 1       |
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities |  5    |
+      | integer | maxNumberChildEntities |  10    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -53,17 +57,21 @@ Feature: User and Credential expiration abd lockout features
     disabled, user can not login into system. All other expiration settings are set for
     successful login. Only state is tested.
     When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
+      | integer | maxNumberChildEntities     | 30    |
     Given Account
       | name      | scopeId |
       | account-a | 1       |
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities |  5    |
+      | integer | maxNumberChildEntities | 10    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -75,6 +83,7 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | false   |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then An exception was thrown
     And I logout
@@ -85,17 +94,21 @@ Feature: User and Credential expiration abd lockout features
     Expiration date on credentials is set one day in the past and is in state enabled.
     This prevents user from logging in.
     When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
+      | integer | maxNumberChildEntities     | 30    |
     Given Account
       | name      | scopeId |
       | account-a | 1       |
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities |  5    |
+      | integer | maxNumberChildEntities | 20    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -107,6 +120,7 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled | expirationDate |
       | kapua-a | ToManySecrets123# | true    | yesterday      |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then An exception was thrown
     And I logout
@@ -115,17 +129,21 @@ Feature: User and Credential expiration abd lockout features
     Expiration date on credentials is set to today and is in state enabled.
     This prevents user from logging in, because expiration is today and is day inclusive.
     When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
+      | integer | maxNumberChildEntities     | 30    |
     Given Account
       | name      | scopeId |
       | account-a | 1       |
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities |  5    |
+      | integer | maxNumberChildEntities | 20    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -137,6 +155,7 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled | expirationDate |
       | kapua-a | ToManySecrets123# | true    | today          |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then An exception was thrown
     And I logout
@@ -145,17 +164,21 @@ Feature: User and Credential expiration abd lockout features
     Expiration date on credentials is set to tomorrow and is in state enabled.
     This allows user to login, because expiration is not yet reached.
     When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
+      | integer | maxNumberChildEntities     | 30     |
     Given Account
       | name      | scopeId |
       | account-a | 1       |
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities |  5    |
+      | integer | maxNumberChildEntities | 10    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -198,6 +221,7 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | true    |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then An exception was thrown
     And I logout
@@ -229,6 +253,7 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | true    |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then An exception was thrown
     And I logout
@@ -294,6 +319,7 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | true    |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "WrongPassword123#"
     When I login as user with name "kapua-a" and password "WrongPassword123#"
     When I login as user with name "kapua-a" and password "WrongPassword123#"
@@ -329,8 +355,11 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | true    |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "WrongPassword123#"
+    Then An exception was thrown
     When I login as user with name "kapua-a" and password "WrongPassword123#"
+    Then An exception was thrown
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then No exception was thrown
     And I logout
@@ -369,7 +398,9 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | true    |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "WrongPassword123#"
+    Then An exception was thrown
     And I wait 1 second
     And I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then No exception was thrown
@@ -410,8 +441,10 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | true    |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "WrongPassword123#"
-    And I wait 1 second
+    Then An exception was thrown
+    Then I wait 1 second
     And I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then An exception was thrown
     And I logout
@@ -451,9 +484,12 @@ Feature: User and Credential expiration abd lockout features
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | true    |
     And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
     When I login as user with name "kapua-a" and password "WrongPassword123#"
-    And I wait 2 seconds
+    Then An exception was thrown
+    Then I wait 2 seconds
     When I login as user with name "kapua-a" and password "WrongPassword123#"
+    Then An exception was thrown
     And I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then No exception was thrown
     And I logout

--- a/qa/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/src/test/resources/features/user/UserServiceI9n.feature
@@ -17,6 +17,10 @@ Feature: User Service Integration
   level higher than scope of B. Scope of A is parent of scope B. This allows user A to delete
   user B.
     When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -80,6 +84,7 @@ Feature: User Service Integration
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
     When I try to delete user "kapua-g"
     Then No exception was thrown
+    Given I expect the exception "KapuaException" with the text "Error during Persistence Operation"
     When I try to delete user "kapua-b"
     Then An exception was thrown
     And I logout
@@ -89,10 +94,14 @@ Feature: User Service Integration
   level lower than scope of A. Scope of A is parent of scope B. Subordinate scope should not be
   allowed to delete user in parent scope, unless it has permissions in that scope.
     When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
+      | integer | maxNumberChildEntities     | 50    |
       | boolean | lockoutPolicy.enabled      | false |
       | integer | lockoutPolicy.maxFailures  | 3     |
       | integer | lockoutPolicy.resetAfter   | 300   |
@@ -103,7 +112,7 @@ Feature: User Service Integration
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities |  5    |
+      | integer | maxNumberChildEntities | 10    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -114,18 +123,22 @@ Feature: User Service Integration
       | integer | lockoutPolicy.lockDuration | 3     |
     And User A
       | name    | displayName  | email             | phoneNumber     | status  | userType |
-     | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
     And Credentials
       | name    | password          | enabled |
       | kapua-a | ToManySecrets123# | true    |
     And Permissions
-     | domain | action |
+      | domain | action |
       | user   | read   |
       | user   | write  |
       | user   | delete |
-    And Account
+    Given Account
       | name      |
       | account-b |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -138,8 +151,8 @@ Feature: User Service Integration
       | name    | displayName  | email             | phoneNumber     | status  | userType |
       | kapua-b | Kapua User B | kapua_b@kapua.com | +386 31 323 555 | ENABLED | INTERNAL |
     And Credentials
-      | name    | password          |
-      | kapua-b | ToManySecrets123# |
+      | name    | password          | enabled |
+      | kapua-b | ToManySecrets123# | true    |
     And Permissions
       | domain | action |
       | user   | read   |
@@ -147,6 +160,8 @@ Feature: User Service Integration
       | user   | delete |
     And I logout
     When I login as user with name "kapua-b" and password "ToManySecrets123#"
+    Then No exception was thrown
+    Given I expect the exception "KapuaException" with the text "Error during Persistence Operation"
     When I try to delete user "kapua-a"
     Then An exception was thrown
     And I logout

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceTestSteps.java
@@ -11,17 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.internal;
 
-import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsEqualTo;
-import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsNotEqualTo;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-
-import java.math.BigInteger;
-import java.security.acl.Permission;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtils;
@@ -49,14 +46,16 @@ import org.eclipse.kapua.test.MockedLocator;
 import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
 import org.mockito.Mockito;
 
-import cucumber.api.Scenario;
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
-import cucumber.api.java.en.And;
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
-import cucumber.runtime.java.guice.ScenarioScoped;
+import java.math.BigInteger;
+import java.security.acl.Permission;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsEqualTo;
+import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsNotEqualTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 
 /**
  * Implementation of Gherkin steps used in DeviceRegistry.feature scenarios.

--- a/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/shared/SharedTestSteps.java
+++ b/service/device/registry/internal/src/test/java/org/eclipse/kapua/service/device/registry/shared/SharedTestSteps.java
@@ -28,10 +28,10 @@ public class SharedTestSteps {
     private static Scenario scenario;
 
     // Scratchpad data related to exception checking
-    private static boolean exceptionExpected;
-    private static String exceptionName;
-    private static String exceptionMessage;
-    private static boolean exceptionCaught;
+    public static boolean exceptionExpected;
+    public static String exceptionName;
+    public static String exceptionMessage;
+    public static boolean exceptionCaught;
 
     // Setup and tear-down steps
 


### PR DESCRIPTION
## A refactoring of the exception handling in unit and integration tests
The exception handling in most service tests was improved.
When an expected exception is caught, the type and message are logged in the cucumber html report. If, on the other hand, an unexpected exception is caught, the exception is rethrown and the full stack trace is logged to help diagnose the underlying problem.

### Changes to Maven pom files
No changes.

### Implementation changes
No changes.

### Test changes
The test steps were modified to better handle exceptions.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>