### PR TITLE
Kapua ARM64 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,13 +156,20 @@
                 <plugin>
                     <groupId>com.github.os72</groupId>
                     <artifactId>protoc-jar-maven-plugin</artifactId>
-                    <version>3.1.0.5</version>
+                    <version>3.4.0.2</version>
                 </plugin>
 
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>${docker-maven-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.github.jnr</groupId>
+                            <artifactId>jnr-unixsocket</artifactId>
+                            <version>0.14</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
At Cavium we are using Kapua in ARM64 processors and would like to propose our changes to be able to build kapua directly on ARM64 and also generate the necessary docker images.

First issue I found was with protoc compiler, which did not have ARM64 binaries and therefore would not build. I contributed those to protoc project and are now available, so if you bump up the protoc-jar-maven-plugin version to 3.4.0.2 it should work.

In order to get the docker images built for ARM64 you need to use jnr-unixsocket version at least 0.14. jnr-unixsocket is a dependency from docker-maven-plugin.
