### PR TITLE
Added permission.groupId checking for not groupable domains

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/BrokerDomain.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/BrokerDomain.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 public class BrokerDomain extends AbstractKapuaEntity implements Domain {
 
@@ -27,6 +26,7 @@ public class BrokerDomain extends AbstractKapuaEntity implements Domain {
     private String name = "broker";
     private String serviceName = "brokerService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.connect));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -56,5 +56,15 @@ public class BrokerDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDomain.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDomain.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model.misc;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 public class CollisionEntityDomain extends AbstractKapuaEntity implements Domain {
 
@@ -27,6 +26,7 @@ public class CollisionEntityDomain extends AbstractKapuaEntity implements Domain
     private String name = "collisionEntity";
     private String serviceName = "collistionEntityService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -56,5 +56,15 @@ public class CollisionEntityDomain extends AbstractKapuaEntity implements Domain
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
@@ -11,8 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authorization.client.role.dialog;
 
-import java.util.List;
-
+import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
+import com.extjs.gxt.ui.client.event.SelectionChangedListener;
+import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.form.CheckBox;
+import com.extjs.gxt.ui.client.widget.form.CheckBoxGroup;
+import com.extjs.gxt.ui.client.widget.form.ComboBox;
+import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
+import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
@@ -32,16 +40,7 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGrou
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRoleService;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRoleServiceAsync;
 
-import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
-import com.extjs.gxt.ui.client.event.SelectionChangedListener;
-import com.extjs.gxt.ui.client.store.ListStore;
-import com.extjs.gxt.ui.client.widget.form.CheckBox;
-import com.extjs.gxt.ui.client.widget.form.CheckBoxGroup;
-import com.extjs.gxt.ui.client.widget.form.ComboBox;
-import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
-import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import java.util.List;
 
 public class RolePermissionAddDialog extends EntityAddEditDialog {
 
@@ -64,10 +63,11 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
 
     public RolePermissionAddDialog(GwtSession currentSession) {
         super(currentSession);
-        DialogUtils.resizeDialog(this, 400, 250);
         allGroup = new GwtGroup();
         allGroup.setId(null);
         allGroup.setGroupName("ALL");
+
+        DialogUtils.resizeDialog(this, 500, 250);
     }
 
     public void setSelectedRole(GwtRole selectedRole) {
@@ -112,7 +112,9 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
 
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtDomain> se) {
-                GWT_DOMAIN_SERVICE.findActionsByDomainName(se.getSelectedItem().getDomainName(), new AsyncCallback<List<GwtAction>>() {
+                final GwtDomain selectedDomain = se.getSelectedItem();
+
+                GWT_DOMAIN_SERVICE.findActionsByDomainName(selectedDomain.getDomainName(), new AsyncCallback<List<GwtAction>>() {
 
                     @Override
                     public void onFailure(Throwable caught) {
@@ -128,6 +130,16 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
                         actionsCombo.add(result);
                         actionsCombo.setSimpleValue(allAction);
                         actionsCombo.enable();
+
+                        if (selectedDomain.getGroupable()) {
+                            groupsCombo.setEnabled(selectedDomain.getGroupable());
+                            groupsCombo.setValue(allGroup);
+
+                        } else {
+                            groupsCombo.setEnabled(selectedDomain.getGroupable());
+                            groupsCombo.setRawValue(MSGS.permissionAddDialogGroupNotGroupable());
+                        }
+
                     }
                 });
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -11,13 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authorization.client.tabs.permission;
 
-import java.util.List;
-
-import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
-import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
-import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
-import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
-
 import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
 import com.extjs.gxt.ui.client.event.SelectionChangedListener;
 import com.extjs.gxt.ui.client.store.ListStore;
@@ -29,6 +22,10 @@ import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
+import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
+import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsolePermissionMessages;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtAccessInfo;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtAccessPermission;
@@ -45,6 +42,8 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtDoma
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtDomainServiceAsync;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGroupService;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGroupServiceAsync;
+
+import java.util.List;
 
 public class PermissionAddDialog extends EntityAddEditDialog {
 
@@ -90,7 +89,7 @@ public class PermissionAddDialog extends EntityAddEditDialog {
             }
         });
 
-        DialogUtils.resizeDialog(this, 400, 400);
+        DialogUtils.resizeDialog(this, 500, 250);
     }
 
     @Override
@@ -182,7 +181,9 @@ public class PermissionAddDialog extends EntityAddEditDialog {
 
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtDomain> se) {
-                GWT_DOMAIN_SERVICE.findActionsByDomainName(se.getSelectedItem().getDomainName(), new AsyncCallback<List<GwtAction>>() {
+                final GwtDomain selectedDomain = se.getSelectedItem();
+
+                GWT_DOMAIN_SERVICE.findActionsByDomainName(selectedDomain.getDomainName(), new AsyncCallback<List<GwtAction>>() {
 
                     @Override
                     public void onFailure(Throwable caught) {
@@ -198,6 +199,15 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                         actionsCombo.add(result);
                         actionsCombo.setSimpleValue(allAction);
                         actionsCombo.enable();
+
+                        if (selectedDomain.getGroupable()) {
+                            groupsCombo.setEnabled(selectedDomain.getGroupable());
+                            groupsCombo.setValue(allGroup);
+
+                        } else {
+                            groupsCombo.setEnabled(selectedDomain.getGroupable());
+                            groupsCombo.setRawValue(MSGS.dialogAddPermissionGroupIdNotGroupable());
+                        }
                     }
                 });
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtDomainServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtDomainServiceImpl.java
@@ -11,14 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authorization.server;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
-import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtDomain;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtPermission.GwtAction;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtDomainService;
@@ -33,6 +29,10 @@ import org.eclipse.kapua.service.authorization.domain.DomainQuery;
 import org.eclipse.kapua.service.authorization.domain.DomainService;
 import org.eclipse.kapua.service.authorization.domain.shiro.DomainPredicates;
 import org.eclipse.kapua.service.authorization.permission.Action;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class GwtDomainServiceImpl extends KapuaRemoteServiceServlet implements GwtDomainService {
 
@@ -49,7 +49,7 @@ public class GwtDomainServiceImpl extends KapuaRemoteServiceServlet implements G
             DomainListResult list = domainService.query(query);
 
             for (Domain domain : list.getItems()) {
-                gwtDomainList.add(KapuaGwtAuthorizationModelConverter.convertDomain(domain.getName()));
+                gwtDomainList.add(KapuaGwtAuthorizationModelConverter.convertDomain(domain));
             }
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtDomain.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtDomain.java
@@ -45,4 +45,13 @@ public class GwtDomain extends KapuaBaseModel implements IsSerializable, Compara
     public String name() {
         return getDomainName();
     }
+
+    public Boolean getGroupable() {
+        return get("groupable");
+    }
+
+    public void setGroupable(boolean groupable) {
+        set("groupable", groupable);
+    }
+
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/KapuaGwtAuthorizationModelConverter.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/KapuaGwtAuthorizationModelConverter.java
@@ -24,6 +24,7 @@ import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRolePe
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
 import org.eclipse.kapua.service.authorization.access.AccessPermission;
 import org.eclipse.kapua.service.authorization.access.AccessRole;
+import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.group.Group;
 import org.eclipse.kapua.service.authorization.permission.Action;
 import org.eclipse.kapua.service.authorization.permission.Actions;
@@ -269,12 +270,16 @@ public class KapuaGwtAuthorizationModelConverter {
     /**
      * Converts a {@link String} domain into a {@link GwtDomain}
      *
-     * @param domainName The name of the domain to convert
+     * @param domain the {@link Domain} to convert
      * @return The converted {@link GwtDomain}
      * @since 1.0.0
      */
-    public static GwtDomain convertDomain(String domainName) {
-        return new GwtDomain(domainName);
+    public static GwtDomain convertDomain(Domain domain) {
+        GwtDomain gwtDomain = new GwtDomain();
+        gwtDomain.setDomainName(domain.getName());
+        gwtDomain.setGroupable(domain.getGroupable());
+
+        return gwtDomain;
     }
 
     /**

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
@@ -108,6 +108,7 @@ dialogAddPermissionInfo=Select the Permissions to be granted to the user.
 dialogAddPermissionDomain=Domain
 dialogAddPermissionAction=Action
 dialogAddPermissionGroupId=Access Group
+dialogAddPermissionGroupIdNotGroupable=The selected domain is not groupable domain.
 dialogAddPermissionForwardable=Forwardable
 dialogAddPermissionErrorAccessInfo=Error retrieving AccessInfo: {0}
 dialogAddPermissionErrorDomains=Error retrieving domains: {0}

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
@@ -86,6 +86,7 @@ permissionAddDialogMessage=Add New Permission.
 permissionAddDialogAction=Action
 permissionAddDialogDomain=Domain
 permissionAddDialogGroup=Access Group
+permissionAddDialogGroupNotGroupable=The selected domain is not groupable domain.
 permissionAddDialogForwardable=Forwardable
 permissionAddDialogLoading=Loading...
 

--- a/dev-tools/src/main/database/all_delete.sql
+++ b/dev-tools/src/main/database/all_delete.sql
@@ -18,7 +18,7 @@ DELETE FROM atht_access_token;
 
 DELETE FROM athz_role WHERE NOT (scope_id = 1 AND id = 1);
 
-DELETE FROM athz_role_permission WHERE NOT (scope_id = 1 AND role_id = 1 AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15));
+DELETE FROM athz_role_permission WHERE NOT (scope_id = 1 AND role_id = 1 AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16));
 
 DELETE FROM dvc_device_connection;
 
@@ -36,8 +36,8 @@ DELETE FROM athz_access_permission WHERE NOT (scope_id = 1 AND id = 1);
 
 DELETE FROM athz_access_role WHERE NOT (scope_id = 1 AND id = 1);
 
-DELETE FROM athz_domain_actions WHERE domain_id NOT IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
+DELETE FROM athz_domain_actions WHERE domain_id NOT IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
 
-DELETE FROM athz_domain WHERE NOT (scope_id IS null AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15));
+DELETE FROM athz_domain WHERE NOT (scope_id IS null AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16));
 
 DELETE FROM athz_group;

--- a/qa-steps/src/main/resources/database/all_delete.sql
+++ b/qa-steps/src/main/resources/database/all_delete.sql
@@ -18,7 +18,7 @@ DELETE FROM atht_access_token;
 
 DELETE FROM athz_role WHERE NOT (scope_id = 1 AND id = 1);
 
-DELETE FROM athz_role_permission WHERE NOT (scope_id = 1 AND role_id = 1 AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15));
+DELETE FROM athz_role_permission WHERE NOT (scope_id = 1 AND role_id = 1 AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16));
 
 DELETE FROM dvc_device_connection;
 
@@ -36,8 +36,8 @@ DELETE FROM athz_access_permission WHERE NOT (scope_id = 1 AND id = 1);
 
 DELETE FROM athz_access_role WHERE NOT (scope_id = 1 AND id = 1);
 
-DELETE FROM athz_domain_actions WHERE domain_id NOT IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15);
+DELETE FROM athz_domain_actions WHERE domain_id NOT IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16);
 
-DELETE FROM athz_domain WHERE NOT (scope_id IS null AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15));
+DELETE FROM athz_domain WHERE NOT (scope_id IS null AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16));
 
 DELETE FROM athz_group;

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDomain.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDomain.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Account permission domain.<br>
  * Account to describe the account domain in the {@link Permission}
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class AccountDomain extends AbstractKapuaEntity implements Domain {
 
@@ -35,6 +33,7 @@ public class AccountDomain extends AbstractKapuaEntity implements Domain {
     private String name = "account";
     private String serviceName = "accountService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -64,5 +63,15 @@ public class AccountDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreDomain.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreDomain.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Datastore permission domain.<br>
  * Datastore to describe the datastore domain in the {@link Permission}
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class DatastoreDomain extends AbstractKapuaEntity implements Domain {
 
@@ -35,6 +33,7 @@ public class DatastoreDomain extends AbstractKapuaEntity implements Domain {
     private String name = "datastore";
     private String serviceName = "datastoreService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -64,5 +63,15 @@ public class DatastoreDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceManagementDomain.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceManagementDomain.java
@@ -11,20 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.commons;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Device management domain
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class DeviceManagementDomain extends AbstractKapuaEntity implements Domain {
 
@@ -33,6 +31,7 @@ public class DeviceManagementDomain extends AbstractKapuaEntity implements Domai
     private String name = "device_management";
     private String serviceName = "deviceManagementService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.execute, Actions.read, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -62,5 +61,15 @@ public class DeviceManagementDomain extends AbstractKapuaEntity implements Domai
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifecycleDomain.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifecycleDomain.java
@@ -11,20 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.lifecycle;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Device life cycle domain.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class DeviceLifecycleDomain extends AbstractKapuaEntity implements Domain {
 
@@ -33,6 +31,7 @@ public class DeviceLifecycleDomain extends AbstractKapuaEntity implements Domain
     private String name = "device_lifecycle";
     private String serviceName = "deviceLifecycleService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -62,5 +61,15 @@ public class DeviceLifecycleDomain extends AbstractKapuaEntity implements Domain
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDomain.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDomain.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Device connection domain
@@ -32,6 +31,7 @@ public class DeviceConnectionDomain extends AbstractKapuaEntity implements Domai
     private String name = "device_connection";
     private String serviceName = "DeviceConnectionService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -61,5 +61,15 @@ public class DeviceConnectionDomain extends AbstractKapuaEntity implements Domai
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDomain.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDomain.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.event.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Device event domain.
@@ -32,6 +31,7 @@ public class DeviceEventDomain extends AbstractKapuaEntity implements Domain {
     private String name = "device_event";
     private String serviceName = "deviceEventService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -62,4 +62,15 @@ public class DeviceEventDomain extends AbstractKapuaEntity implements Domain {
     public Set<Actions> getActions() {
         return actions;
     }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
+    }
+
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDomain.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDomain.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Device domanin.
@@ -34,6 +33,7 @@ public class DeviceDomain extends AbstractKapuaEntity implements Domain {
     private String name = "device";
     private String serviceName = "deviceRegistryService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable = true;
 
     @Override
     public void setName(String name) {
@@ -63,5 +63,15 @@ public class DeviceDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.1/changelog-device-0.3.1.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.1/changelog-device-0.3.1.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-device-0.3.1.xml">
+
+    <include relativeToChangelogFile="true" file="./device-domain_set_groupable.xml"/>
+
+</databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.1/device-domain_set_groupable.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.1/device-domain_set_groupable.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-device-0.3.1.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-device-domain-0.3.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_domain"/>
+                <tableExists tableName="athz_domain_actions"/>
+            </and>
+        </preConditions>
+
+        <update tableName="athz_domain">
+            <column name="groupable" value="true"/>
+            <where>name = 'device'</where>
+        </update>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobDomain.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobDomain.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 public class JobDomain extends AbstractKapuaEntity implements Domain {
 
@@ -27,6 +26,7 @@ public class JobDomain extends AbstractKapuaEntity implements Domain {
     private String name = "job";
     private String serviceName = "jobService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write, Actions.execute));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -56,5 +56,15 @@ public class JobDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/SchedulerDomain.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/SchedulerDomain.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.quartz;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Scheduler permission domain.<br>
  * Scheduler to describe the scheduler domain in the {@link Permission}
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class SchedulerDomain extends AbstractKapuaEntity implements Domain {
 
@@ -35,6 +33,7 @@ public class SchedulerDomain extends AbstractKapuaEntity implements Domain {
     private String name = "scheduler";
     private String serviceName = "schedulerService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -64,5 +63,15 @@ public class SchedulerDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/changelog-scheduler-0.3.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/changelog-scheduler-0.3.0.xml
@@ -20,6 +20,7 @@
     <include relativeToChangelogFile="true" file="./trigger_properties.xml"/>
     <include relativeToChangelogFile="true" file="./trigger-configuration.xml"/>
 
+    <include relativeToChangelogFile="true" file="./scheduler-domain.xml"/>
     <include relativeToChangelogFile="true" file="./scheduler-engine-quartz.xml"/>
 
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/scheduler-domain.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/scheduler-domain.xml
@@ -15,13 +15,13 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-job-0.3.0.xml">
+        logicalFilePath="KapuaDB/changelog-scheduler-0.3.0.xml">
 
-    <property name="selectJobDomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'job')"/>
+    <property name="selectSchedulerDomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'scheduler')"/>
 
     <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
-    <changeSet id="changelog-job-domain-0.3.0" author="eurotech">
+    <changeSet id="changelog-scheduler-domain-0.3.0" author="eurotech">
 
         <preConditions onFail="CONTINUE">
             <and>
@@ -34,20 +34,20 @@
         <insert tableName="athz_domain">
             <column name="created_on" valueComputed="${now}"/>
             <column name="created_by" value="1"/>
-            <column name="name" value="job"/>
-            <column name="serviceName" value="jobService"/>
+            <column name="name" value="scheduler"/>
+            <column name="serviceName" value="schedulerService"/>
         </insert>
 
         <insert tableName="athz_domain_actions">
-            <column name="domain_id" valueComputed="${selectJobDomainQuery}"/>
+            <column name="domain_id" valueComputed="${selectSchedulerDomainQuery}"/>
             <column name="action" value="read"/>
         </insert>
         <insert tableName="athz_domain_actions">
-            <column name="domain_id" valueComputed="${selectJobDomainQuery}"/>
+            <column name="domain_id" valueComputed="${selectSchedulerDomainQuery}"/>
             <column name="action" value="write"/>
         </insert>
         <insert tableName="athz_domain_actions">
-            <column name="domain_id" valueComputed="${selectJobDomainQuery}"/>
+            <column name="domain_id" valueComputed="${selectSchedulerDomainQuery}"/>
             <column name="action" value="delete"/>
         </insert>
     </changeSet>

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.domain;
 
-import java.util.Set;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.Permission;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -19,28 +22,27 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaEntity;
-import org.eclipse.kapua.service.KapuaService;
-import org.eclipse.kapua.service.authorization.permission.Actions;
+import java.util.Set;
 
 /**
- * Domain entity definition.<br>
- * Domain contains the information about the available {@link Actions} for a entity domain<br>
- * Services needs to register their own domain
+ * {@link Domain} entity definition.<br>
+ * {@link Domain} contains the information about the available {@link Actions} for a entity {@link Domain}<br>
+ * Services needs to register their own specific {@link Domain}.
  * {@link Domain#getName()} must be unique.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "domain")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "name",
         "serviceName",
-        "actions" })
+        "actions",
+        "groupable" })
 public interface Domain extends KapuaEntity {
 
     public static final String TYPE = "domain";
 
+    @Override
     public default String getType() {
         return TYPE;
     }
@@ -48,16 +50,15 @@ public interface Domain extends KapuaEntity {
     /**
      * Sets the {@link Domain} name.<br>
      * It must be unique within the scope.
-     * 
-     * @param name
-     *            The name of the {@link Domain}
+     *
+     * @param name The name of the {@link Domain}
      * @since 1.0.0
      */
     public void setName(String name);
 
     /**
      * Gets the {@link Domain} name.
-     * 
+     *
      * @return The {@link Domain} name.
      * @since 1.0.0
      */
@@ -72,9 +73,8 @@ public interface Domain extends KapuaEntity {
      * <li>org.eclipse.kapua.service.authorization.DomainService</li>
      * <li>org.eclipse.kapua.service.authorization.RoleService</li>
      * </ul>
-     * 
-     * @param serviceName
-     *            The {@link KapuaService} that use this {@link Domain}.<br>
+     *
+     * @param serviceName The {@link KapuaService} that use this {@link Domain}.<br>
      * @since 1.0.0
      */
     public void setServiceName(String serviceName);
@@ -82,7 +82,7 @@ public interface Domain extends KapuaEntity {
     /**
      * Gets the {@link KapuaService} name that use this {@link Domain}.<br>
      * The value represent the {@code interface} fully qualified name of the implemented {@link KapuaService}<br>
-     * 
+     *
      * @return The {@link KapuaService} that use this {@link Domain}.<br>
      * @since 1.0.0
      */
@@ -92,9 +92,8 @@ public interface Domain extends KapuaEntity {
     /**
      * Sets the set of {@link Actions} available in this {@link Domain}.<br>
      * It up to the implementation class to make a clone of the set or use the given set.
-     * 
-     * @param actions
-     *            The set of {@link Actions}.
+     *
+     * @param actions The set of {@link Actions}.
      * @since 1.0.0
      */
     public void setActions(Set<Actions> actions);
@@ -102,12 +101,31 @@ public interface Domain extends KapuaEntity {
     /**
      * Gets the set of {@link Actions} available in this {@link Domain}.<br>
      * The implementation must return the reference of the set and not make a clone.
-     * 
+     *
      * @return The set of {@link Actions}.
      * @since 1.0.0
      */
     @XmlElementWrapper(name = "actions")
     @XmlElement(name = "action")
     public Set<Actions> getActions();
+
+    /**
+     * Sets whether or not this {@link Domain} is group-able or not.
+     * This determines if the {@link org.eclipse.kapua.service.authorization.permission.Permission} in this {@link Domain} can have a {@link org.eclipse.kapua.service.authorization.group.Group} or not.
+     * This is related to the {@link org.eclipse.kapua.service.authorization.group.Groupable} property of a {@link KapuaEntity}.
+     *
+     * @param groupable {@code true} if the {@link org.eclipse.kapua.service.authorization.permission.Permission} on this {@link Domain} can have the {@link Permission#getGroupId()} property set, {@code false} otherwise.
+     * @since 0.3.1
+     */
+    public void setGroupable(boolean groupable);
+
+    /**
+     * Gets whether or not this {@link Domain} is group-able or not.
+     *
+     * @return {@code true} if the {@link Permission#getGroupId()} can be set, {@code false} otherwise.
+     * @since 0.3.1
+     */
+    @XmlElement(name = "groupable")
+    public boolean getGroupable();
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
@@ -11,23 +11,23 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.domain;
 
-import java.util.Set;
+import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.authorization.permission.Action;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.Permission;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import org.eclipse.kapua.model.KapuaEntityCreator;
-import org.eclipse.kapua.service.KapuaService;
-import org.eclipse.kapua.service.authorization.permission.Action;
-import org.eclipse.kapua.service.authorization.permission.Actions;
+import java.util.Set;
 
 /**
  * {@link Domain} creator definition.<br>
  * It is used to create a new {@link Domain} with {@link Action}s associated
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "domainCreator")
@@ -36,17 +36,15 @@ public interface DomainCreator extends KapuaEntityCreator<Domain> {
 
     /**
      * Sets the {@link Domain} name.
-     * 
-     * @param name
-     *            The {@link Domain} name.
-     * 
+     *
+     * @param name The {@link Domain} name.
      * @since 1.0.0
      */
     public void setName(String name);
 
     /**
      * Gets the {@link Domain} name.
-     * 
+     *
      * @return The {@link Domain} name.
      * @since 1.0.0
      */
@@ -55,17 +53,15 @@ public interface DomainCreator extends KapuaEntityCreator<Domain> {
 
     /**
      * Sets the {@link KapuaService} name that uses the {@link Domain}.
-     * 
-     * @param serviceName
-     *            The {@link KapuaService} name that uses the {@link Domain}.
-     * 
+     *
+     * @param serviceName The {@link KapuaService} name that uses the {@link Domain}.
      * @since 1.0.0
      */
     public void setServiceName(String serviceName);
 
     /**
      * Gets the {@link KapuaService} name that uses the {@link Domain}.
-     * 
+     *
      * @return The {@link KapuaService} name that uses the {@link Domain}.
      * @since 1.0.0
      */
@@ -75,9 +71,8 @@ public interface DomainCreator extends KapuaEntityCreator<Domain> {
     /**
      * Sets the set of {@link Actions} available in the {@link Domain}.<br>
      * It up to the implementation class to make a clone of the set or use the given set.
-     * 
-     * @param actions
-     *            The set of {@link Actions}.
+     *
+     * @param actions The set of {@link Actions}.
      * @since 1.0.0
      */
     public void setActions(Set<Actions> actions);
@@ -85,12 +80,31 @@ public interface DomainCreator extends KapuaEntityCreator<Domain> {
     /**
      * Gets the set of {@link Actions} available in the {@link Domain}.<br>
      * The implementation must return the reference of the set and not make a clone.
-     * 
+     *
      * @return The set of {@link Actions}.
      * @since 1.0.0
      */
     @XmlElementWrapper(name = "actions")
     @XmlElement(name = "action")
     public Set<Actions> getActions();
+
+    /**
+     * Sets whether or not this {@link Domain} is group-able or not.
+     * This determines if the {@link org.eclipse.kapua.service.authorization.permission.Permission} in this {@link Domain} can have a {@link org.eclipse.kapua.service.authorization.group.Group} or not.
+     * This is related to the {@link org.eclipse.kapua.service.authorization.group.Groupable} property of a {@link KapuaEntity}.
+     *
+     * @param groupable {@code true} if the {@link org.eclipse.kapua.service.authorization.permission.Permission} on this {@link Domain} can have the {@link Permission#getGroupId()} property set, {@code false} otherwise.
+     * @since 0.3.1
+     */
+    public void setGroupable(boolean groupable);
+
+    /**
+     * Gets whether or not this {@link Domain} is group-able or not.
+     *
+     * @return {@code true} if the {@link Permission#getGroupId()} can be set, {@code false} otherwise.
+     * @since 0.3.1
+     */
+    @XmlElement(name = "groupable")
+    public boolean getGroupable();
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
@@ -91,7 +91,7 @@ public interface DomainCreator extends KapuaEntityCreator<Domain> {
     /**
      * Sets whether or not this {@link Domain} is group-able or not.
      * This determines if the {@link org.eclipse.kapua.service.authorization.permission.Permission} in this {@link Domain} can have a {@link org.eclipse.kapua.service.authorization.group.Group} or not.
-     * This is related to the {@link org.eclipse.kapua.service.authorization.group.Groupable} property of a {@link KapuaEntity}.
+     * This is related to the {@link org.eclipse.kapua.service.authorization.group.Groupable} property of a {@link KapuaEntityCreator}.
      *
      * @param groupable {@code true} if the {@link org.eclipse.kapua.service.authorization.permission.Permission} on this {@link Domain} can have the {@link Permission#getGroupId()} property set, {@code false} otherwise.
      * @since 0.3.1

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainService.java
@@ -18,44 +18,41 @@ import org.eclipse.kapua.service.KapuaEntityService;
 
 /**
  * {@link Domain} service definition.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 public interface DomainService extends KapuaEntityService<Domain, DomainCreator> {
 
     /**
      * Creates a new {@link Domain} based on the parameters provided in the {@link DomainCreator}.<br>
      * {@link Domain} must have a unique name.
-     * 
-     * @param domainCreator
-     *            The creator object from which to create the {@link Domain}.
+     *
+     * @param domainCreator The creator object from which to create the {@link Domain}.
      * @return The created {@link Domain}
-     * @throws KapuaException
+     * @throws KapuaException When there is an oeror22
      * @since 1.0.0
      */
+    @Override
     public Domain create(DomainCreator domainCreator)
             throws KapuaException;
 
     /**
      * Finds the {@link Domain} by scope identifier and {@link Domain} id.
-     * 
-     * @param scopeId
-     *            The scope id in which to search.
-     * @param domainId
-     *            The {@link Domain} id to search.
+     *
+     * @param scopeId  The scope id in which to search.
+     * @param domainId The {@link Domain} id to search.
      * @return The {@link Domain} found or {@code null} if no entity was found.
      * @throws KapuaException
      * @since 1.0.0
      */
+    @Override
     public Domain find(KapuaId scopeId, KapuaId domainId)
             throws KapuaException;
 
     /**
      * Finds the {@link Domain} by the service name.
-     * 
-     * @param servicename
-     *            The service name to search.
+     *
+     * @param servicename The service name to search.
      * @return The {@link Domain} found or {@code null} if no entity was found.
      * @throws KapuaException
      * @since 1.0.0
@@ -65,38 +62,37 @@ public interface DomainService extends KapuaEntityService<Domain, DomainCreator>
 
     /**
      * Returns the {@link DomainListResult} with elements matching the provided query.
-     * 
-     * @param query
-     *            The {@link DomainQuery} used to filter results.
+     *
+     * @param query The {@link DomainQuery} used to filter results.
      * @return The {@link DomainListResult} with elements matching the query parameter.
      * @throws KapuaException
      * @since 1.0.0
      */
+    @Override
     public DomainListResult query(KapuaQuery<Domain> query)
             throws KapuaException;
 
     /**
      * Returns the count of the {@link Domain} elements matching the provided query.
-     * 
-     * @param query
-     *            The {@link DomainQuery} used to filter results.
+     *
+     * @param query The {@link DomainQuery} used to filter results.
      * @return The count of the {@link Domain} elements matching the provided query.
      * @throws KapuaException
      * @since 1.0.0
      */
+    @Override
     public long count(KapuaQuery<Domain> query)
             throws KapuaException;
 
     /**
      * Delete the {@link Domain} by scope id and {@link Domain} id.
-     * 
-     * @param scopeId
-     *            The scope id in which to delete.
-     * @param roleId
-     *            The {@link Domain} id to delete.
+     *
+     * @param scopeId The scope id in which to delete.
+     * @param roleId  The {@link Domain} id to delete.
      * @throws KapuaException
      * @since 1.0.0
      */
+    @Override
     public void delete(KapuaId scopeId, KapuaId roleId)
             throws KapuaException;
 

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,8 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
-import java.security.Permissions;
-import java.util.Set;
+import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.service.authorization.permission.Permission;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -20,38 +20,35 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaEntityCreator;
-import org.eclipse.kapua.service.authorization.permission.Permission;
+import java.security.Permissions;
+import java.util.Set;
 
 /**
  * {@link Role} creator definition.<br>
  * It is used to create a new {@link Role} with {@link Permission}s associated
- * 
+ *
  * @since 1.0.0
  */
-@XmlRootElement(name="roleCreator")
+@XmlRootElement(name = "roleCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(propOrder = { "name",
-                      "permissions"
-                     }, 
-         factoryClass = RoleXmlRegistry.class,
-         factoryMethod = "newRoleCreator")
+        "permissions"
+},
+        factoryClass = RoleXmlRegistry.class,
+        factoryMethod = "newRoleCreator")
 public interface RoleCreator extends KapuaEntityCreator<Role> {
 
     /**
      * Sets the {@link Role} name.
-     * 
-     * @param name
-     *            The {@link Role} name.
-     * 
+     *
+     * @param name The {@link Role} name.
      * @since 1.0.0
      */
     public void setName(String name);
 
     /**
      * Gets the {@link Role} name.
-     * 
+     *
      * @return The {@link Role} name.
      * @since 1.0.0
      */
@@ -61,9 +58,8 @@ public interface RoleCreator extends KapuaEntityCreator<Role> {
     /**
      * Sets the set of {@link Permissions} to assign to the {@link Role} created entity.
      * It up to the implementation class to make a clone of the set or use the given set.
-     * 
-     * @param permissions
-     *            The set of {@link Permissions}.
+     *
+     * @param permissions The set of {@link Permissions}.
      * @since 1.0.0
      */
     public void setPermissions(Set<Permission> permissions);
@@ -71,7 +67,8 @@ public interface RoleCreator extends KapuaEntityCreator<Role> {
     /**
      * Gets the set of {@link Permission} added to this {@link Role}.
      * The implementation must return the reference of the set and not make a clone.
-     * 
+     *
+     * @param <P> The {@link Permission} class implementation.
      * @return The set of {@link Permission}.
      * @since 1.0.0
      */

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
@@ -11,6 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+
 import javax.management.relation.RoleInfo;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -18,12 +24,6 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.authorization.permission.Permission;
 
 /**
  * Role permission entity.<br>
@@ -33,7 +33,7 @@ import org.eclipse.kapua.service.authorization.permission.Permission;
  * <br>
  * This is a not editable entity so it can be only removed or created and therefore any change to
  * {@link RolePermission#getRoleId()} and {@link RolePermission#getPermission()} property is forbidden.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "rolePermission")
@@ -46,22 +46,22 @@ public interface RolePermission extends KapuaEntity {
 
     public static final String TYPE = "rolePermission";
 
+    @Override
     public default String getType() {
         return TYPE;
     }
 
     /**
      * Sets the {@link Role} id of which this {@link RolePermission} belongs.
-     * 
-     * @param roleId
-     *            The {@link RoleInfo} id.
+     *
+     * @param roleId The {@link RoleInfo} id.
      * @since 1.0.0
      */
     public void setRoleId(KapuaId roleId);
 
     /**
      * Gets the {@link Role} id of which this {@link RolePermission} belongs.
-     * 
+     *
      * @return The {@link Role} id.
      * @since 1.0.0
      */
@@ -73,17 +73,18 @@ public interface RolePermission extends KapuaEntity {
     /**
      * Sets the {@link Permission} that this {@link RolePermission} has.<br>
      * It up to the implementation class to make a clone of the given {@link Permission} or use the given {@link Permission}.
-     * 
-     * @param permission
-     *            The {@link Permission} to set for this {@link RolePermission}.
+     *
+     * @param permission The {@link Permission} to set for this {@link RolePermission}.
      * @since 1.0.0
      */
     public void setPermission(Permission permission);
 
     /**
      * Gets the {@link Permission} that this {@link RolePermission} has.
-     * 
+     *
+     * @param <P> The {@link Permission} class implementation.
      * @return The {@link Permission} that this {@link RolePermission} has.
+     * @since 1.0.0
      */
     @XmlElement(name = "permission")
     public <P extends Permission> P getPermission();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialDomain.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialDomain.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential.shiro;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Credential domain.<br>
  * Used to describe the credential domain in the {@link Permission}
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class CredentialDomain extends AbstractKapuaEntity implements Domain {
 
@@ -35,6 +33,7 @@ public class CredentialDomain extends AbstractKapuaEntity implements Domain {
     private String name = "credential";
     private String serviceName = "credentialService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -64,5 +63,15 @@ public class CredentialDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenDomain.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenDomain.java
@@ -11,21 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.token.shiro;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Access token domain.<br>
  * Used to describe the access token domain.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class AccessTokenDomain extends AbstractKapuaEntity implements Domain {
 
@@ -34,6 +32,7 @@ public class AccessTokenDomain extends AbstractKapuaEntity implements Domain {
     private String name = "access_token";
     private String serviceName = "accessTokenService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -63,5 +62,15 @@ public class AccessTokenDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDomain.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDomain.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access.shiro;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Access info domain.<br>
  * Used to describe the access info domain in the {@link Permission}.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class AccessInfoDomain extends AbstractKapuaEntity implements Domain {
 
@@ -35,6 +33,7 @@ public class AccessInfoDomain extends AbstractKapuaEntity implements Domain {
     private String name = "access_info";
     private String serviceName = "accessInfoService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -64,5 +63,15 @@ public class AccessInfoDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
@@ -38,6 +38,7 @@ import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionValidator;
 import org.eclipse.kapua.service.authorization.role.Role;
 import org.eclipse.kapua.service.authorization.role.RoleService;
 import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerFactory;
@@ -46,7 +47,7 @@ import org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizationException
 
 /**
  * {@link AccessInfoService} implementation based on JPA.
- * 
+ *
  * @since 1.0.0
  */
 @KapuaProvider
@@ -57,7 +58,7 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
     /**
      * Constructor.<br>
      * It initialize the {@link AbstractEntityManagerFactory} with the specific {@link AuthorizationEntityManagerFactory#getInstance()}.
-     * 
+     *
      * @since 1.0.0
      */
     public AccessInfoServiceImpl() {
@@ -85,6 +86,8 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
                 }
             }
         }
+
+        PermissionValidator.validatePermissions(accessInfoCreator.getPermissions());
 
         RoleService roleService = locator.getService(RoleService.class);
         if (accessInfoCreator.getRoleIds() != null) {
@@ -159,7 +162,7 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(ACCESS_INFO_DOMAIN, Actions.read, scopeId));
         AccessInfoQuery query = accessInfoFactory.newQuery(scopeId);
-        query.setPredicate(new AttributePredicate<KapuaId>(AccessInfoPredicates.USER_ID, userId));
+        query.setPredicate(new AttributePredicate<>(AccessInfoPredicates.USER_ID, userId));
         AccessInfoListResult result = entityManagerSession.onResult(em -> AccessInfoDAO.query(em, query));
         if (!result.isEmpty()) {
             return result.getFirstItem();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionServiceImpl.java
@@ -31,13 +31,13 @@ import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionValidator;
 import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerFactory;
 
 /**
  * {@link AccessPermission} service implementation.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @KapuaProvider
 public class AccessPermissionServiceImpl extends AbstractKapuaService implements AccessPermissionService {
@@ -68,6 +68,8 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
         if (permission.getTargetScopeId() == null || !permission.getTargetScopeId().equals(accessPermissionCreator.getScopeId())) {
             authorizationService.checkPermission(permission);
         }
+
+        PermissionValidator.validatePermission(permission);
 
         return entityManagerSession.onTransactedInsert(em -> {
             //
@@ -127,7 +129,7 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
         //
         // Build query
         AccessPermissionQuery query = new AccessPermissionQueryImpl(scopeId);
-        query.setPredicate(new AttributePredicate<KapuaId>(AccessPermissionPredicates.ACCESS_INFO_ID, accessInfoId));
+        query.setPredicate(new AttributePredicate<>(AccessPermissionPredicates.ACCESS_INFO_ID, accessInfoId));
 
         return query(query);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImpl.java
@@ -11,19 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.domain.shiro;
 
-import java.util.Set;
-
 import org.eclipse.kapua.commons.model.AbstractKapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.domain.DomainCreator;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
+import java.util.Set;
+
 /**
  * Role creator service implementation.
- * 
+ *
  * @since 1.0
- * 
  */
 public class DomainCreatorImpl extends AbstractKapuaEntityCreator<Domain> implements DomainCreator {
 
@@ -32,15 +31,13 @@ public class DomainCreatorImpl extends AbstractKapuaEntityCreator<Domain> implem
     private String name;
     private String serviceName;
     private Set<Actions> actions;
+    private boolean groupable;
 
     /**
      * Constructor
-     * 
-     * @param name
-     *            The name to set for this {@link DomainCreator}.
-     * @param serviceName
-     *            The service name that creates this {@link DomainCreator}.
-     * 
+     *
+     * @param name        The name to set for this {@link DomainCreator}.
+     * @param serviceName The service name that creates this {@link DomainCreator}.
      * @since 1.0.0
      */
     public DomainCreatorImpl(String name, String serviceName) {
@@ -79,4 +76,15 @@ public class DomainCreatorImpl extends AbstractKapuaEntityCreator<Domain> implem
     public void setActions(Set<Actions> actions) {
         this.actions = actions;
     }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDAO.java
@@ -24,18 +24,16 @@ import org.eclipse.kapua.service.authorization.domain.DomainQuery;
 
 /**
  * {@link Domain} DAO
- * 
+ *
  * @since 1.0.0
  */
 public class DomainDAO extends ServiceDAO {
 
     /**
      * Creates and returns new {@link Domain}
-     * 
-     * @param em
-     *            The {@link EntityManager} that holds the transaction.
-     * @param creator
-     *            The {@link DomainCreator} object from which create the new {@link Domain}.
+     *
+     * @param em      The {@link EntityManager} that holds the transaction.
+     * @param creator The {@link DomainCreator} object from which create the new {@link Domain}.
      * @return The newly created {@link Domain}.
      * @throws KapuaException
      * @since 1.0.0
@@ -46,6 +44,7 @@ public class DomainDAO extends ServiceDAO {
 
         domain.setName(creator.getName());
         domain.setServiceName(creator.getServiceName());
+        domain.setGroupable(creator.getGroupable());
 
         if (creator.getActions() != null) {
             domain.setActions(creator.getActions());
@@ -56,11 +55,9 @@ public class DomainDAO extends ServiceDAO {
 
     /**
      * Finds the {@link Domain} by {@link Domain} identifier
-     * 
-     * @param em
-     *            The {@link EntityManager} that holds the transaction.
-     * @param domainId
-     *            The {@link Domain} id to search.
+     *
+     * @param em       The {@link EntityManager} that holds the transaction.
+     * @param domainId The {@link Domain} id to search.
      * @return The found {@link Domain} or {@code null} if not found.
      * @since 1.0.0
      */
@@ -70,13 +67,10 @@ public class DomainDAO extends ServiceDAO {
 
     /**
      * Deletes the {@link Domain} by {@link Domain} identifier
-     * 
-     * @param em
-     *            The {@link EntityManager} that holds the transaction.
-     * @param domainId
-     *            The {@link Domain} id to delete.
-     * @throws KapuaEntityNotFoundException
-     *             If {@link Domain} is not found.
+     *
+     * @param em       The {@link EntityManager} that holds the transaction.
+     * @param domainId The {@link Domain} id to delete.
+     * @throws KapuaEntityNotFoundException If {@link Domain} is not found.
      * @since 1.0.0
      */
     public static void delete(EntityManager em, KapuaId domainId) throws KapuaEntityNotFoundException {
@@ -85,11 +79,9 @@ public class DomainDAO extends ServiceDAO {
 
     /**
      * Returns the {@link Domain} list matching the provided query.
-     * 
-     * @param em
-     *            The {@link EntityManager} that holds the transaction.
-     * @param domainQuery
-     *            The {@link DomainQuery} used to filter results.
+     *
+     * @param em          The {@link EntityManager} that holds the transaction.
+     * @param domainQuery The {@link DomainQuery} used to filter results.
      * @return The list of {@link Domain}s that matches the given query.
      * @throws KapuaException
      * @since 1.0.0
@@ -102,11 +94,9 @@ public class DomainDAO extends ServiceDAO {
 
     /**
      * Return the {@link Domain} count matching the provided query
-     * 
-     * @param em
-     *            The {@link EntityManager} that holds the transaction.
-     * @param domainQuery
-     *            The {@link DomainQuery} used to filter results.
+     *
+     * @param em          The {@link EntityManager} that holds the transaction.
+     * @param domainQuery The {@link DomainQuery} used to filter results.
      * @return
      * @throws KapuaException
      * @since 1.0.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDomain.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDomain.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.domain.shiro;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Role domain.<br>
  * Used to describe the role domain in the {@link Permission}.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class DomainDomain extends AbstractKapuaEntity implements Domain {
 
@@ -35,6 +33,7 @@ public class DomainDomain extends AbstractKapuaEntity implements Domain {
     private String name = "domain";
     private String serviceName = "domainService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -65,4 +64,15 @@ public class DomainDomain extends AbstractKapuaEntity implements Domain {
     public Set<Actions> getActions() {
         return actions;
     }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
+    }
+
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.domain.shiro;
 
-import java.util.Set;
+import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.permission.Actions;
 
 import javax.persistence.Basic;
 import javax.persistence.CollectionTable;
@@ -22,11 +25,8 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
-
-import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.domain.Domain;
-import org.eclipse.kapua.service.authorization.permission.Actions;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * {@link Domain} implementation.
@@ -35,7 +35,6 @@ import org.eclipse.kapua.service.authorization.permission.Actions;
  */
 @Entity(name = "Domain")
 @Table(name = "athz_domain")
-// @Embeddable
 public class DomainImpl extends AbstractKapuaEntity implements Domain {
 
     private static final long serialVersionUID = 3878607249074632729L;
@@ -53,6 +52,10 @@ public class DomainImpl extends AbstractKapuaEntity implements Domain {
     @Column(name = "action", nullable = false)
     @Enumerated(EnumType.STRING)
     private Set<Actions> actions;
+
+    @Basic
+    @Column(name = "groupable", nullable = false, updatable = false)
+    private boolean groupable;
 
     /**
      * Constructor
@@ -91,53 +94,37 @@ public class DomainImpl extends AbstractKapuaEntity implements Domain {
     }
 
     @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
+    }
+
+    @Override
     public void setActions(Set<Actions> actions) {
         this.actions = actions;
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (actions == null ? 0 : actions.hashCode());
-        result = prime * result + (name == null ? 0 : name.hashCode());
-        result = prime * result + (serviceName == null ? 0 : serviceName.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DomainImpl domain = (DomainImpl) o;
+        return groupable == domain.groupable &&
+                Objects.equals(name, domain.name) &&
+                Objects.equals(serviceName, domain.serviceName) &&
+                Objects.equals(actions, domain.actions);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        DomainImpl other = (DomainImpl) obj;
-        if (actions == null) {
-            if (other.actions != null) {
-                return false;
-            }
-        } else if (!actions.equals(other.actions)) {
-            return false;
-        }
-        if (name == null) {
-            if (other.name != null) {
-                return false;
-            }
-        } else if (!name.equals(other.name)) {
-            return false;
-        }
-        if (serviceName == null) {
-            if (other.serviceName != null) {
-                return false;
-            }
-        } else if (!serviceName.equals(other.serviceName)) {
-            return false;
-        }
-        return true;
+    public int hashCode() {
+        return Objects.hash(name, serviceName, actions, groupable);
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainPredicates.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainPredicates.java
@@ -13,9 +13,8 @@ package org.eclipse.kapua.service.authorization.domain.shiro;
 
 /**
  * Query predicate attribute name for role entity.
- * 
+ *
  * @since 1.0
- * 
  */
 public class DomainPredicates {
 
@@ -31,4 +30,5 @@ public class DomainPredicates {
      * Domain service name
      */
     public static final String SERVICE_NAME = "serviceName";
+
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupDomain.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupDomain.java
@@ -11,23 +11,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group.shiro;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.group.Group;
 import org.eclipse.kapua.service.authorization.group.GroupService;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Group domain.<br>
  * Used to describe the {@link Group} domain in the {@link GroupService}.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class GroupDomain extends AbstractKapuaEntity implements Domain {
 
@@ -36,6 +34,7 @@ public class GroupDomain extends AbstractKapuaEntity implements Domain {
     private String name = "group";
     private String serviceName = "groupService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -65,5 +64,15 @@ public class GroupDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionValidator.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionValidator.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.permission.shiro;
+
+import com.google.common.collect.Sets;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.domain.DomainFactory;
+import org.eclipse.kapua.service.authorization.domain.DomainListResult;
+import org.eclipse.kapua.service.authorization.domain.DomainService;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+
+import java.util.Set;
+
+public class PermissionValidator {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DomainService DOMAIN_SERVICE = LOCATOR.getService(DomainService.class);
+    private static final DomainFactory DOMAIN_FACTORY = LOCATOR.getFactory(DomainFactory.class);
+
+    private PermissionValidator() {
+    }
+
+    public static void validatePermission(Permission permission) throws KapuaException {
+        validatePermissions(Sets.newHashSet(permission));
+    }
+
+    public static void validatePermissions(Set<Permission> permissions) throws KapuaException {
+
+        if (permissions != null) {
+            DomainListResult domains = DOMAIN_SERVICE.query(DOMAIN_FACTORY.newQuery(null));
+
+            for (Permission p : permissions) {
+                if (p.getDomain() != null) {
+                    boolean matched = false;
+                    for (Domain domain : domains.getItems()) {
+                        if (domain.getName().equals(p.getDomain())) {
+                            matched = true;
+                            if (!domain.getGroupable() && p.getGroupId() != null) {
+                                throw new KapuaIllegalArgumentException("permission.groupId", p.getGroupId().toStringId());
+                            }
+                            break;
+                        }
+                    }
+
+                    if (!matched) {
+                        throw new KapuaIllegalArgumentException("permission.domain", p.getDomain());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDomain.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDomain.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role.shiro;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Role domain.<br>
  * Used to describe the role domain in the {@link Permission}.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class RoleDomain extends AbstractKapuaEntity implements Domain {
 
@@ -35,6 +33,7 @@ public class RoleDomain extends AbstractKapuaEntity implements Domain {
     private String name = "role";
     private String serviceName = "roleService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -64,5 +63,15 @@ public class RoleDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionValidator;
 import org.eclipse.kapua.service.authorization.role.Role;
 import org.eclipse.kapua.service.authorization.role.RolePermission;
 import org.eclipse.kapua.service.authorization.role.RolePermissionCreator;
@@ -36,9 +37,8 @@ import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerF
 
 /**
  * {@link RolePermission} service implementation.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @KapuaProvider
 public class RolePermissionServiceImpl extends AbstractKapuaService implements RolePermissionService {
@@ -69,6 +69,10 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
         if (ROLE_SERVICE.find(rolePermissionCreator.getScopeId(), rolePermissionCreator.getRoleId()) == null) {
             throw new KapuaEntityNotFoundException(Role.TYPE, rolePermissionCreator.getRoleId());
         }
+
+        //
+        // Check that the given permission matches the definition of the Domains.
+        PermissionValidator.validatePermission(rolePermissionCreator.getPermission());
 
         //
         // If permission are created out of the role permission scope, check that the current user has the permission on the external scopeId.

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionValidator;
 import org.eclipse.kapua.service.authorization.role.Role;
 import org.eclipse.kapua.service.authorization.role.RoleCreator;
 import org.eclipse.kapua.service.authorization.role.RoleFactory;
@@ -37,9 +38,8 @@ import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerF
 
 /**
  * Role service implementation.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @KapuaProvider
 public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Role, RoleCreator, RoleService, RoleListResult, RoleQuery, RoleFactory> implements RoleService {
@@ -73,6 +73,10 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
                 }
             }
         }
+
+        //
+        // Check that the given permission matches the definition of the Domains.
+        PermissionValidator.validatePermissions(roleCreator.getPermissions());
 
         if (allowedChildEntities(roleCreator.getScopeId()) <= 0) {
             throw new KapuaIllegalArgumentException("scopeId", "max roles reached");

--- a/service/security/shiro/src/main/resources/liquibase/0.3.1/athz_domain-add_groupable.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.1/athz_domain-add_groupable.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authorization-0.3.1.xml">
+
+    <changeSet id="athz_domain-add_groupable-0.3.1" author="eurotech">
+        <addColumn tableName="athz_domain">
+            <column name="groupable" type="boolean" defaultValue="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/0.3.1/changelog-authorization-0.3.1.pre.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.1/changelog-authorization-0.3.1.pre.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authorization-0.3.1.pre.xml">
+
+    <include relativeToChangelogFile="true" file="./athz_domain-add_groupable.xml"/>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.pre.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.pre.xml
@@ -16,5 +16,6 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <include relativeToChangelogFile="true" file="./0.2.0/changelog-authorization-0.2.0.pre.xml"/>
+    <include relativeToChangelogFile="true" file="./0.3.1/changelog-authorization-0.3.1.pre.xml"/>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.xml
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./0.2.0/changelog-authorization-0.2.0.xml" />
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-authorization-0.3.0.xml" />
+    <include relativeToChangelogFile="true" file="./0.2.0/changelog-authorization-0.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./0.3.0/changelog-authorization-0.3.0.xml"/>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/TestDomain.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/TestDomain.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Test domain.<br>
@@ -32,6 +31,7 @@ public class TestDomain extends AbstractKapuaEntity implements Domain {
     private String name = "test";
     private String serviceName = "testService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -61,5 +61,15 @@ public class TestDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
     }
 }

--- a/service/security/shiro/src/test/resources/features/DomainService.feature
+++ b/service/security/shiro/src/test/resources/features/DomainService.feature
@@ -12,151 +12,151 @@
 @security
 Feature: Domain Service CRUD tests
 
-Scenario: Count domains in a blank database
-    The default domain table must contain 8 preset entries.
+  Scenario: Count domains in a blank database
+  The default domain table must contain 8 preset entries.
 
     When I count the domain entries in the database
-    Then I get 8 as result
+    Then I get 10 as result
 
-Scenario: Regular domain
-    Create a regular domain entry. The newly created entry must match the
-    creator parameters.
+  Scenario: Regular domain
+  Create a regular domain entry. The newly created entry must match the
+  creator parameters.
 
     Given I create the domain
-    |name        |serviceName    |actions   |
-    |test_name_1 |test_service_1 |read,write|
+      | name        | serviceName    | actions    |
+      | test_name_1 | test_service_1 | read,write |
     Then A domain was created
     And The domain matches the creator
 
-Scenario: Domain with null name
-    It must not be possible to create a domain entry with a null name. In
-    such case the domain service must throw an exception.
+  Scenario: Domain with null name
+  It must not be possible to create a domain entry with a null name. In
+  such case the domain service must throw an exception.
 
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create the domain
-    |serviceName    |actions   |
-    |test_service_1 |read,write|
+      | serviceName    | actions    |
+      | test_service_1 | read,write |
     Then An exception was thrown
 
-Scenario: Domain with null service name
-    It must not be possible to create a domain entry with a null service name. In
-    such case the domain service must throw an exception.
+  Scenario: Domain with null service name
+  It must not be possible to create a domain entry with a null service name. In
+  such case the domain service must throw an exception.
 
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create the domain
-    |name        |actions   |
-    |test_name_1 |read,write|
+      | name        | actions    |
+      | test_name_1 | read,write |
     Then An exception was thrown
 
-Scenario: Domain with null actions
-    It must not be possible to create a domain entry with a null set of supported actions. In
-    such case the domain service must throw an exception.
+  Scenario: Domain with null actions
+  It must not be possible to create a domain entry with a null set of supported actions. In
+  such case the domain service must throw an exception.
 
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     When I create the domain
-    |name        |serviceName    |
-    |test_name_1 |test_service_1 |
+      | name        | serviceName    |
+      | test_name_1 | test_service_1 |
     Then An exception was thrown
 
-Scenario: Domains with duplicate names
-    Domain names must be unique in the database. If an already existing name is used for a
-    new domain an exception must be thrown.
+  Scenario: Domains with duplicate names
+  Domain names must be unique in the database. If an already existing name is used for a
+  new domain an exception must be thrown.
 
     Given I create the domain
-    |name        |serviceName    |actions   |
-    |test_name_1 |test_service_1 |read,write|
+      | name        | serviceName    | actions    |
+      | test_name_1 | test_service_1 | read,write |
     Then A domain was created
     And The domain matches the creator
     Given I expect the exception "KapuaException" with the text "Error during Persistence Operation"
     When I create the domain
-    |name        |serviceName    |actions   |
-    |test_name_1 |test_service_1 |read,write|
+      | name        | serviceName    | actions    |
+      | test_name_1 | test_service_1 | read,write |
     Then An exception was thrown
 
-Scenario: Find the last created domain entry
-    It must be possible to find a dmain entry based on its unique ID.
+  Scenario: Find the last created domain entry
+  It must be possible to find a dmain entry based on its unique ID.
 
     Given I create the domain
-    |name        |serviceName    |actions     |
-    |test_name_2 |test_service_2 |read,execute|
+      | name        | serviceName    | actions      |
+      | test_name_2 | test_service_2 | read,execute |
     When I search for the last created domain
     Then The domain matches the creator
 
-Scenario: Find the first domain entry for the specified service
-    It must be possible to find a domain entry based on the Service name property.
+  Scenario: Find the first domain entry for the specified service
+  It must be possible to find a domain entry based on the Service name property.
 
     Given I create the domains
-    |name        |serviceName    |actions      |
-    |test_name_1 |test_service_1 |read,write   |
-    |test_name_2 |test_service_2 |read,execute |
-    |test_name_3 |test_service_3 |write,delete |
+      | name        | serviceName    | actions      |
+      | test_name_1 | test_service_1 | read,write   |
+      | test_name_2 | test_service_2 | read,execute |
+      | test_name_3 | test_service_3 | write,delete |
     When I search for the domains for the service "test_service_2"
     Then The domain matches the parameters
-    |name        |serviceName    |actions      |
-    |test_name_2 |test_service_2 |read,execute |
+      | name        | serviceName    | actions      |
+      | test_name_2 | test_service_2 | read,execute |
 
-Scenario: Compare domain entries
-    The domain object is comparable.
+  Scenario: Compare domain entries
+  The domain object is comparable.
 
     Then I can compare domain objects
 
-Scenario: Delete the last created domain entry
-    It must be possible to delete an entry from the domain table. The domain is deleted
-    based on its ID.
+  Scenario: Delete the last created domain entry
+  It must be possible to delete an entry from the domain table. The domain is deleted
+  based on its ID.
 
     Given I create the domain
-    |name        |serviceName    |actions     |
-    |test_name_2 |test_service_2 |read,execute|
+      | name        | serviceName    | actions      |
+      | test_name_2 | test_service_2 | read,execute |
     When I search for the last created domain
     Then The domain matches the creator
     When I delete the last created domain
     And I search for the last created domain
     Then There is no domain
 
-Scenario: Delete a nonexistent domain
-    If the requested ID is not found in the database, the delete function must throw
-    an exception.
+  Scenario: Delete a nonexistent domain
+  If the requested ID is not found in the database, the delete function must throw
+  an exception.
 
     Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type domain"
     When I try to delete domain with a random ID
     Then An exception was thrown
 
-Scenario: Count domains in the database
-    It must be possible to count all the domain entries in the domain table.
+  Scenario: Count domains in the database
+  It must be possible to count all the domain entries in the domain table.
 
     When I count the domain entries in the database
     Then This is the initial count
     Given I create the domains
-    |name        |serviceName    |actions      |
-    |test_name_1 |test_service_1 |read,write   |
-    |test_name_2 |test_service_2 |read,execute |
-    |test_name_3 |test_service_3 |write,delete |
+      | name        | serviceName    | actions      |
+      | test_name_1 | test_service_1 | read,write   |
+      | test_name_2 | test_service_2 | read,execute |
+      | test_name_3 | test_service_3 | write,delete |
     When I count the domain entries in the database
     Then 3 more domains were created
 
-Scenario: Domain entry query
-    It must be possible to query domain entries based on the name property.
+  Scenario: Domain entry query
+  It must be possible to query domain entries based on the name property.
 
     Given I create the domains
-    |name        |serviceName    |actions      |
-    |test_name_1 |test_service_1 |read,write   |
-    |test_name_2 |test_service_2 |read,execute |
-    |test_name_3 |test_service_3 |write,delete |
+      | name        | serviceName    | actions      |
+      | test_name_1 | test_service_1 | read,write   |
+      | test_name_2 | test_service_2 | read,execute |
+      | test_name_3 | test_service_3 | write,delete |
     When I query for domains with the name "test_name_2"
     Then I get 1 as result
 
-Scenario: Domain entry query - service name
-    It must be possible to query domain entries based on the service name.
-    The whole list of matching entries must be returned.
+  Scenario: Domain entry query - service name
+  It must be possible to query domain entries based on the service name.
+  The whole list of matching entries must be returned.
 
     Given I create the domains
-    |name        |serviceName    |actions      |
-    |test_name_1 |test_service_1 |read,write   |
-    |test_name_2 |test_service_2 |read,execute |
-    |test_name_3 |test_service_3 |write,delete |
-    |test_name_4 |test_service_3 |read,write   |
-    |test_name_5 |test_service_3 |read,execute |
-    |test_name_6 |test_service_2 |write,delete |
+      | name        | serviceName    | actions      |
+      | test_name_1 | test_service_1 | read,write   |
+      | test_name_2 | test_service_2 | read,execute |
+      | test_name_3 | test_service_3 | write,delete |
+      | test_name_4 | test_service_3 | read,write   |
+      | test_name_5 | test_service_3 | read,execute |
+      | test_name_6 | test_service_2 | write,delete |
     When I query for domains with the service name "test_service_2"
     Then I get 2 as result
     When I query for domains with the service name "test_service_3"

--- a/service/security/shiro/src/test/resources/liquibase/0.2.0/athz_test-domain.xml
+++ b/service/security/shiro/src/test/resources/liquibase/0.2.0/athz_test-domain.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authorization_test-0.2.0.xml">
+
+    <property name="selectTest1DomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'test')"/>
+    <property name="selectTest2DomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'test_domain')"/>
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-test1-domain-0.2.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_domain"/>
+                <tableExists tableName="athz_domain_actions"/>
+            </and>
+        </preConditions>
+
+        <!-- Seed values -->
+        <insert tableName="athz_domain">
+            <column name="created_on" valueComputed="${now}"/>
+            <column name="created_by" value="1"/>
+            <column name="name" value="test"/>
+            <column name="serviceName" value="testService"/>
+        </insert>
+
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectTest1DomainQuery}"/>
+            <column name="action" value="read"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectTest1DomainQuery}"/>
+            <column name="action" value="write"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectTest1DomainQuery}"/>
+            <column name="action" value="delete"/>
+        </insert>
+
+    </changeSet>
+
+    <changeSet id="changelog-test2-domain-0.2.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_domain"/>
+                <tableExists tableName="athz_domain_actions"/>
+            </and>
+        </preConditions>
+
+        <!-- Seed values -->
+        <insert tableName="athz_domain">
+            <column name="created_on" valueComputed="${now}"/>
+            <column name="created_by" value="1"/>
+            <column name="name" value="test_domain"/>
+            <column name="serviceName" value="testService"/>
+        </insert>
+
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectTest2DomainQuery}"/>
+            <column name="action" value="read"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectTest2DomainQuery}"/>
+            <column name="action" value="write"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectTest2DomainQuery}"/>
+            <column name="action" value="delete"/>
+        </insert>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/test/resources/liquibase/0.2.0/changelog-authorization_test-0.2.0.xml
+++ b/service/security/shiro/src/test/resources/liquibase/0.2.0/changelog-authorization_test-0.2.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authorization_test-0.2.0.xml">
+
+    <include relativeToChangelogFile="true" file="./athz_test-domain.xml"/>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/test/resources/liquibase/changelog-authorization_test-master.xml
+++ b/service/security/shiro/src/test/resources/liquibase/changelog-authorization_test-master.xml
@@ -15,8 +15,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./0.2.0/changelog-device-0.2.0.xml"/>
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-device-0.3.0.xml"/>
-    <include relativeToChangelogFile="true" file="./0.3.1/changelog-device-0.3.1.xml"/>
+    <include relativeToChangelogFile="true" file="./0.2.0/changelog-authorization_test-0.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagDomain.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagDomain.java
@@ -11,23 +11,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.tag.Tag;
 import org.eclipse.kapua.service.tag.TagService;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
- * Tag domain.<br>
- * Used to describe the {@link Tag} domain in the {@link TagService}.
- * 
- * @since 1.0.0
+ * {@link Tag} domain.<br>
+ * Used to describe the {@link Tag} {@link Domain} in the {@link TagService}.
  *
+ * @since 1.0.0
  */
 public class TagDomain extends AbstractKapuaEntity implements Domain {
 
@@ -36,6 +34,7 @@ public class TagDomain extends AbstractKapuaEntity implements Domain {
     private String name = "tag";
     private String serviceName = "tagService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -65,5 +64,15 @@ public class TagDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDomain.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDomain.java
@@ -11,22 +11,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.internal;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.user.User;
 
-import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
- * User domain.<br>
- * Used to describe the user domain in the {@link Permission}
- * 
- * @since 1.0
+ * {@link User} domain.<br>
+ * Used to describe the {@link User} {@link Domain} in the {@link Permission}
  *
+ * @since 1.0
  */
 public class UserDomain extends AbstractKapuaEntity implements Domain {
 
@@ -35,6 +34,7 @@ public class UserDomain extends AbstractKapuaEntity implements Domain {
     private String name = "user";
     private String serviceName = "userService";
     private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
 
     @Override
     public void setName(String name) {
@@ -64,5 +64,15 @@ public class UserDomain extends AbstractKapuaEntity implements Domain {
     @Override
     public Set<Actions> getActions() {
         return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
     }
 }

--- a/test/src/main/java/org/eclipse/kapua/test/authorization/PermissionFactoryMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/authorization/PermissionFactoryMock.java
@@ -37,5 +37,4 @@ public class PermissionFactoryMock implements PermissionFactory {
     public Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId, boolean forwardable) {
         return null;
     }
-
 }


### PR DESCRIPTION
Hi all,

This issue fixes #1007 .

Now permission are checked for domain existence and `permission.groupId` property can be set only for `domain.groupable` set.

This fix has requested some test fixes which previously they were using domain names that did not existed.

Regards, 

_Alberto_