### PR TITLE
Fixed Certficate Xml Mappings

### DIFF
--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
@@ -20,6 +20,8 @@ import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlInlineBinaryData;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -42,7 +44,9 @@ import java.util.Set;
         "privateKey",
         "ca",
         "caId",
-        "password"
+        "password",
+        "certificateUsages",
+        "keyUsageSettings"
 }, factoryClass = CertificateXmlRegistry.class, factoryMethod = "newCertificate")
 public interface Certificate extends KapuaNamedEntity {
 
@@ -91,9 +95,11 @@ public interface Certificate extends KapuaNamedEntity {
 
     public void setStatus(CertificateStatus status);
 
+    @XmlInlineBinaryData
+    @XmlElement(name = "signature")
     public byte[] getSignature();
 
-    public void setSignature(byte[] digest);
+    public void setSignature(byte[] signature);
 
     public String getPrivateKey();
 

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
@@ -15,6 +15,7 @@ import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -35,8 +36,9 @@ import java.util.Set;
         "status",
         "privateKey",
         "caId",
-        "password"
-})
+        "password",
+        "certificateUsages"
+}, factoryClass = CertificateXmlRegistry.class, factoryMethod = "newCreator")
 public interface CertificateCreator extends KapuaNamedEntityCreator<Certificate> {
 
     String getCertificate();

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateListResult.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateListResult.java
@@ -14,10 +14,13 @@ package org.eclipse.kapua.service.certificate;
 import org.eclipse.kapua.model.query.KapuaListResult;
 import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name = "certificates")
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = CertificateXmlRegistry.class, factoryMethod = "newListResult")
 public interface CertificateListResult extends KapuaListResult<Certificate> {
 

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateUsage.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateUsage.java
@@ -11,6 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate;
 
+import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement(name = "certificateUsage")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(
+        factoryClass = CertificateXmlRegistry.class, //
+        factoryMethod = "newCertificateUsage")
 public interface CertificateUsage {
 
     public String getName();

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/xml/CertificateXmlRegistry.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/xml/CertificateXmlRegistry.java
@@ -13,9 +13,11 @@ package org.eclipse.kapua.service.certificate.xml;
 
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.certificate.Certificate;
+import org.eclipse.kapua.service.certificate.CertificateCreator;
 import org.eclipse.kapua.service.certificate.CertificateFactory;
 import org.eclipse.kapua.service.certificate.CertificateListResult;
 import org.eclipse.kapua.service.certificate.CertificateQuery;
+import org.eclipse.kapua.service.certificate.CertificateUsage;
 
 import javax.xml.bind.annotation.XmlRegistry;
 
@@ -29,11 +31,19 @@ public class CertificateXmlRegistry {
         return FACTORY.newEntity(null);
     }
 
+    public CertificateCreator newCreator() {
+        return FACTORY.newCreator(null);
+    }
+
     public CertificateQuery newQuery() {
         return FACTORY.newQuery(null);
     }
 
     public CertificateListResult newListResult() {
         return FACTORY.newListResult();
+    }
+
+    public CertificateUsage newCertificateUsage() {
+        return FACTORY.newCertificateUsage(null);
     }
 }


### PR DESCRIPTION
This PR fixes few issues with Xml mappings in the Certificate Service API .
This needs to be backported in 0.3.x