### PR TITLE
Fix device edit dialog not freezes when custom attribute is too long

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -87,6 +87,7 @@ public class DeviceEditDialog extends DeviceAddDialog {
             public void onFailure(Throwable caught) {
                 exitStatus = false;
                 exitMessage = DEVICE_MSGS.deviceFormEditError(caught.getLocalizedMessage());
+                hide();
             }
 
             @Override


### PR DESCRIPTION
Issue #1011

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>