### PR TITLE
Resource file separator

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceSchemaUtilsWithResources.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceSchemaUtilsWithResources.java
@@ -18,8 +18,6 @@ import org.eclipse.kapua.commons.jpa.ResourceSqlScriptExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-
 /**
  * Configurable service database schema utilities with resources based
  * SQL scripts.
@@ -49,8 +47,7 @@ public class KapuaConfigurableServiceSchemaUtilsWithResources {
             em.beginTransaction();
 
             ResourceSqlScriptExecutor sqlScriptExecutor = new ResourceSqlScriptExecutor();
-            String sep = String.valueOf(File.separatorChar);
-            sqlScriptExecutor.addQuery(path + sep + filename);
+            sqlScriptExecutor.addQuery(path + "/" + filename);
             sqlScriptExecutor.executeUpdate(em);
 
             em.commit();


### PR DESCRIPTION
## Resource file separator
KapuaConfigurableServiceSchemaUtilsWithResources uses a system dependent separator (File.separator) in the resource name instead of the '/'-separated path name the Java docs define ([https://docs.oracle.com/javase/7/docs/api/java/lang/ClassLoader.html#getResource(java.lang.String)]). 
On some systems (Windows) this returns the wrong separator ('\\'), which causes test (and possibly runtime) failures.

### Changes to Maven pom files
No changes.

### Implementation changes
The implementation of KapuaConfigurableServiceSchemaUtilsWithResources was modified to use the correct separator.

### Test changes
No changes.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>