### PR TITLE
Bumped Jetty version to 9.4.6.v20170531 - Solves CVE-2017-9735

### DIFF
--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -9,9 +9,11 @@
 
     Contributors:
         Red Hat Inc - initial API and implementation
+        Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -50,7 +52,7 @@
                                         <runCmds>
                                             <runCmd><![CDATA[
                                     cd /home/kapua && \
-                                    curl -s https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.2.v20170220/jetty-distribution-9.4.2.v20170220.tar.gz -o jetty-distribution.tar.gz && \
+                                    curl -s https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.6.v20170531/jetty-distribution-9.4.6.v20170531.tar.gz -o jetty-distribution.tar.gz && \
                                     mkdir -p jetty && cd jetty && \
                                     tar --strip=1 -xzf ../jetty-distribution.tar.gz && \
                                     rm ../jetty-distribution.tar.gz && \

--- a/console/README.md
+++ b/console/README.md
@@ -8,7 +8,7 @@ please see the branch `impl-consoleV2`.
 It is possible to run the web console locally by starting the docker containers `kapua-sql`, `kapua-broker` and `kapua-elasticsearch` according to "[Running docker containers](../assembly/README.md#run)" first and then by running:
 
 
-    mvn org.eclipse.jetty:jetty-maven-plugin:9.4.2.v20170220:run-exploded -nsu -Pdev -DuseTestScope=true -Djetty.daemon=false -Dcommons.db.connection.host=localhost
+    mvn org.eclipse.jetty:jetty-maven-plugin:9.4.6.v20170531:run-exploded -nsu -Pdev -DuseTestScope=true -Djetty.daemon=false -Dcommons.db.connection.host=localhost
 
 **Note:** Be sure that the port 8080 is open before starting the web console.
  


### PR DESCRIPTION
This PR fixes #1189 

Secutity issue `CVE-2017-9735` is solved by later version of Jetty. 
Bumped to 9.4.6.v20170531

Regards, 

_Alberto_

