### PR TITLE
Fixing Broken OpenShift template and docker images for restricted user

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -430,6 +430,9 @@
                                             <runCmd>
                                                 chown -R kapua:kapua /home/kapua
                                             </runCmd>
+                                            <runCmd>
+                                               chmod og+rwx /home/kapua
+                                            </runCmd>
                                         </runCmds>
                                     </build>
                                 </image>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -650,6 +650,9 @@
                                     chmod -R a+rw /maven && \
                                     find /maven -type d -exec chmod a+x {} +
                                     ]]></run>
+                                            <runCmd>
+                                               chmod og+rwx /home/kapua
+                                            </runCmd>
                                         </runCmds>
                                         <volumes>
                                             <volume>/maven/data</volume>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -359,6 +359,9 @@
                                             <runCmd>
                                                 chown -R kapua:kapua /home/kapua
                                             </runCmd>
+                                            <runCmd>
+                                                chmod og+rwx /home/kapua
+                                            </runCmd>
                                         </runCmds>
                                     </build>
                                 </image>

--- a/dev-tools/src/main/openshift/kapua-template.yml
+++ b/dev-tools/src/main/openshift/kapua-template.yml
@@ -229,6 +229,8 @@ objects:
               -Dcommons.db.schema.update=true
               -Dmetrics.enable.jmx=true
               -Ddatastore.elasticsearch.nodes=$ELASTICSEARCH_PORT_9200_TCP_ADDR
+              -Dcertificate.jwt.private.key=file:///home/kapua/key.pk8
+              -Dcertificate.jwt.certificate=file:///home/kapua/cert.pem
               -javaagent:/jolokia-jvm-agent.jar=port=8778,protocol=https,caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,clientPrincipal=cn=system:master-proxy,useSslClientAuthentication=true,extraClientCheck=true,host=0.0.0.0,discoveryEnabled=false,user=${JOLOKIA_USER},password=${JOLOKIA_PASSWORD}
               ${JAVA_OPTS_EXTRA}
           image: ${DOCKER_ACCOUNT}/kapua-broker:${IMAGE_VERSION}
@@ -289,6 +291,8 @@ objects:
               -Dcommons.db.schema.update=true
               -Dbroker.host=$KAPUA_BROKER_SERVICE_HOST
               -Ddatastore.elasticsearch.nodes=$ELASTICSEARCH_PORT_9200_TCP_ADDR
+              -Dcertificate.jwt.private.key=file:///home/kapua/key.pk8
+              -Dcertificate.jwt.certificate=file:///home/kapua/cert.pem
               -javaagent:/jolokia-jvm-agent.jar=port=8778,protocol=https,caCert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt,clientPrincipal=cn=system:master-proxy,useSslClientAuthentication=true,extraClientCheck=true,host=0.0.0.0,discoveryEnabled=false,user=${JOLOKIA_USER},password=${JOLOKIA_PASSWORD}
               ${JAVA_OPTS_EXTRA}
           image: ${DOCKER_ACCOUNT}/kapua-console:${IMAGE_VERSION}


### PR DESCRIPTION
Fixing Broken OpenShift template and docker images for restricted user as per issue #1207 

Basically I've fixed the permissions on assembly `pom.xml` files for kapua-console and kapua-broker.
Then I've added the missing `JAVA_OPTS` and `ACTIVEMQ_OPTS` for kapua-console and kapua-broker in the respective DeploymentConfig on `kapua-template.yml`.

I'm available for any clarification.