### PR TITLE
Removed schemaName property from Liquibase XMLs

### DIFF
--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/account-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/account-foreignkey.xml
@@ -11,16 +11,16 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-account-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="sys_configuration" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="sys_configuration"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_sys_configuration_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_access_token-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_access_token-foreignkey.xml
@@ -11,20 +11,20 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-atht_access_token-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="atht_access_token" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="atht_access_token"/>
+                <tableExists tableName="act_account"/>
             </and>
             <and>
-                <tableExists tableName="atht_access_token" schemaName="KAPUADB"/>
-                <tableExists tableName="usr_user" schemaName="KAPUADB"/>
+                <tableExists tableName="atht_access_token"/>
+                <tableExists tableName="usr_user"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_atht_access_token_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_credential-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_credential-foreignkey.xml
@@ -11,20 +11,20 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-atht_credential-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="atht_credential" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="atht_credential"/>
+                <tableExists tableName="act_account"/>
             </and>
             <and>
-                <tableExists tableName="atht_credential" schemaName="KAPUADB"/>
-                <tableExists tableName="usr_user" schemaName="KAPUADB"/>
+                <tableExists tableName="atht_credential"/>
+                <tableExists tableName="usr_user"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_atht_credential_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_access_info-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_access_info-foreignkey.xml
@@ -11,20 +11,20 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-athz_access_info-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="athz_access_info" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="athz_access_info"/>
+                <tableExists tableName="act_account"/>
             </and>
             <and>
-                <tableExists tableName="athz_access_info" schemaName="KAPUADB"/>
-                <tableExists tableName="usr_user" schemaName="KAPUADB"/>
+                <tableExists tableName="athz_access_info"/>
+                <tableExists tableName="usr_user"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_athz_access_info_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_group-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_group-foreignkey.xml
@@ -11,16 +11,16 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-athz_group-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="athz_group" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="athz_group"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_athz_group_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_role-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_role-foreignkey.xml
@@ -11,16 +11,16 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-athz_role-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="athz_role" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="athz_role"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_athz_role_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-connection-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-connection-foreignkey.xml
@@ -11,16 +11,16 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-device-connection-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="dvc_device_connection" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="dvc_device_connection"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_dvc_device_connection_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-foreignkey.xml
@@ -11,20 +11,20 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-device-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="dvc_device" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="dvc_device"/>
+                <tableExists tableName="act_account"/>
             </and>
             <and>
-                <tableExists tableName="dvc_device" schemaName="KAPUADB"/>
-                <tableExists tableName="athz_group" schemaName="KAPUADB"/>
+                <tableExists tableName="dvc_device"/>
+                <tableExists tableName="athz_group"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_dvc_device_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-tag-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-tag-foreignkey.xml
@@ -11,16 +11,16 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-device-tag-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="dvc_device_tag" schemaName="KAPUADB"/>
-                <tableExists tableName="tag_tag" schemaName="KAPUADB"/>
+                <tableExists tableName="dvc_device_tag"/>
+                <tableExists tableName="tag_tag"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_dvc_device_tag_tagId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job-foreignkey.xml
@@ -19,8 +19,8 @@
     <changeSet id="changelog-job-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="job_job" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="job_job"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_job_job_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job_step_definition-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job_step_definition-foreignkey.xml
@@ -19,8 +19,8 @@
     <changeSet id="changelog-job-step-definition-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="job_job_step_definition" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="job_job_step_definition"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_job_job_step_definition_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/tag-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/tag-foreignkey.xml
@@ -11,16 +11,16 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-tag-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="tag_tag" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="tag_tag"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_tag_tag_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/trigger-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/trigger-foreignkey.xml
@@ -20,8 +20,8 @@
     <changeSet id="changelog-trigger-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="schdl_trigger" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="schdl_trigger"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_schdl_trigger_scopeId"

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/user-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/user-foreignkey.xml
@@ -11,16 +11,16 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-    logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-0.3.0.xml">
 
     <changeSet id="changelog-user-foreignkey-0.3.0" author="eurotech">
         <preConditions onFail="CONTINUE">
             <and>
-                <tableExists tableName="usr_user" schemaName="KAPUADB"/>
-                <tableExists tableName="act_account" schemaName="KAPUADB"/>
+                <tableExists tableName="usr_user"/>
+                <tableExists tableName="act_account"/>
             </and>
         </preConditions>
         <addForeignKeyConstraint constraintName="fk_usr_user_scopeId"

--- a/service/tag/internal/src/main/resources/liquibase/0.3.0/tag.xml
+++ b/service/tag/internal/src/main/resources/liquibase/0.3.0/tag.xml
@@ -11,22 +11,15 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-  logicalFilePath="KapuaDB/changelog-tag-0.3.0.xml">
+        logicalFilePath="KapuaDB/changelog-tag-0.3.0.xml">
 
-    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
     <changeSet id="changelog-tag-0.3.0_createTable" author="eurotech">
-        <!-- Old SQL file
-        <sqlFile relativeToChangelogFile="true" path="./tag.sql" />
-        -->
-        <preConditions onFail="MARK_RAN">
-            <not><tableExists tableName="tag_tag"></tableExists></not>
-        </preConditions>
-        
         <createTable tableName="tag_tag">
             <column name="scope_id" type="bigint(21) unsigned">
                 <constraints nullable="false" checkConstraint=">= 0"/>
@@ -46,21 +39,21 @@
             <column name="modified_by" type="bigint(21) unsigned">
                 <constraints nullable="false" checkConstraint=">= 0"/>
             </column>
-            
+
             <column name="name" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            
-            <column name="optlock" type="int unsigned" />
-            <column name="attributes" type="text" />
-            <column name="properties" type="text" />
+
+            <column name="optlock" type="int unsigned"/>
+            <column name="attributes" type="text"/>
+            <column name="properties" type="text"/>
         </createTable>
 
         <createIndex tableName="tag_tag" indexName="idx_tag_name" unique="true">
             <column name="scope_id"/>
             <column name="name"/>
         </createIndex>
-        
+
         <rollback>
             <dropIndex tableName="tag_tag" indexName="idx_tag_name"/>
             <dropTable tableName="tag_tag"/>


### PR DESCRIPTION
This PR fixes #1198 .

Removed the `schemaName` property from the Liquibase XMLs.
This will allow usage of different schema names for a Kapua deployment.

Regards, 

_Alberto_