### PR TITLE
Feature enable configuration ssl es rest client

### DIFF
--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettingsKey.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettingsKey.java
@@ -52,8 +52,36 @@ public enum ClientSettingsKey implements SettingKey {
     /**
      * Scroll timeout
      */
-    SCROLL_TIMEOUT("datastore.scroll.timeout");
-
+    SCROLL_TIMEOUT("datastore.scroll.timeout"),
+    /**
+     * Enable Elastichsearch client ssl connection (at the present only the rest client supports it)
+     */
+    ELASTICSEARCH_SSL_ENABLED("datastore.elasticsearch.ssl.enabled"),
+    /**
+     * Force Elastichsearch client to trust the server certificate on the ssl connection handshake so, if true, no check will be performed for the server certificate (at the present only the rest
+     * client supports it)
+     */
+    ELASTICSEARCH_SSL_TRUST_SERVER_CERTIFICATE("datastore.elasticsearch.ssl.trust_server_certificate"),
+    /**
+     * Set the keystore type
+     */
+    ELASTICSEARCH_SSL_KEYSTORE_TYPE("datastore.elasticsearch.ssl.keystore_type"),
+    /**
+     * Elastichsearch client key store path (at the present only the rest client supports it)
+     */
+    ELASTICSEARCH_SSL_KEYSTORE_PATH("datastore.elasticsearch.ssl.keystore_path"),
+    /**
+     * Elastichsearch client key store password (at the present only the rest client supports it)
+     */
+    ELASTICSEARCH_SSL_KEYSTORE_PASSWORD("datastore.elasticsearch.ssl.keystore_password"),
+    /**
+     * Elastichsearch client trust store path (at the present only the rest client supports it)
+     */
+    ELASTICSEARCH_SSL_TRUSTSTORE_PATH("datastore.elasticsearch.ssl.truststore_path"),
+    /**
+     * Elastichsearch client trust store password (at the present only the rest client supports it)
+     */
+    ELASTICSEARCH_SSL_TRUSTSTORE_PASSWORD("datastore.elasticsearch.ssl.truststore_password");
 
     private String key;
 

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ssl/SkipCertificateCheckTrustStrategy.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ssl/SkipCertificateCheckTrustStrategy.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.client.rest.ssl;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import org.apache.http.ssl.TrustStrategy;
+
+/**
+ * {@link TrustStrategy} implementation to trust all the certificates.<br>
+ * <b>Unsafe option to be used to skip server side certificate validation.</b>
+ * 
+ * @since 1.0
+ *
+ */
+public class SkipCertificateCheckTrustStrategy implements TrustStrategy {
+
+    @Override
+    public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        return true;
+    }
+
+}

--- a/service/datastore/client-rest/src/main/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/client-rest/src/main/resources/kapua-datastore-rest-client-setting.properties
@@ -29,3 +29,27 @@ datastore.elasticsearch.port=9200
 # A comma separated list of nodes in the form: "host1,host2" or "host1:port,host2:port"
 # **Note:** Using the "nodes" version overrides the "node" property.
 #datastore.elasticsearch.nodes=host1:port1,host2:port2
+
+#Options to customize the ssl behavior of the ES rest client.
+#Available configurations are:
+# 1) enable ssl without any validation: 
+#        ssl.enabled=true
+#        ssl.trust_server_certificate=false
+#        others: unused
+# 2) enable ssl forcing server certificate validation
+#        ssl.enabled=true
+#        ssl.trust_server_certificate=true
+#        keystore_path/ssl.keystore_password empty
+#        if ssl.truststore_path/ssl.truststore_password are empty the default jvm truststore will be used (otherwise the provided truststore).
+# 3) enable ssl allowing client certificate validation and forcing server certificate validation
+#        ssl.enabled=true
+#        ssl.trust_server_certificate=true
+#        keystore_path/ssl.keystore_password valued with the proper key store
+#        if ssl.truststore_path/ssl.truststore_password are empty the default jvm truststore will be used. Otherwise the provided truststore.
+datastore.elasticsearch.ssl.enabled=false
+datastore.elasticsearch.ssl.trust_server_certificate=false
+datastore.elasticsearch.ssl.keystore_path=
+datastore.elasticsearch.ssl.keystore_password=
+datastore.elasticsearch.ssl.truststore_path=
+datastore.elasticsearch.ssl.truststore_password=
+datastore.elasticsearch.ssl.keystore_type=jks

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreClientFactory.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreClientFactory.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.service.datastore.client.DatastoreClient;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.eclipse.kapua.service.datastore.client.ClientException;
 import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
 import org.eclipse.kapua.service.datastore.internal.converter.ModelContextImpl;
 import org.eclipse.kapua.service.datastore.internal.converter.QueryConverterImpl;
@@ -41,7 +42,6 @@ public class DatastoreClientFactory {
     }
 
     private DatastoreClientFactory() {
-
     }
 
     /**
@@ -79,6 +79,25 @@ public class DatastoreClientFactory {
             }
         }
         return instance;
+    }
+
+    /**
+     * Close the client instance
+     * 
+     * @throws ClientException
+     */
+    public static void close() throws ClientException {
+        if (instance != null) {
+            synchronized (DatastoreClientFactory.class) {
+                if (instance != null) {
+                    try {
+                        instance.close();
+                    } finally {
+                        instance = null;
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceSslTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceSslTest.java
@@ -1,0 +1,370 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.kapua.service.datastore.model.query.SortField.descending;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.util.KapuaDateUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataChannelImpl;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataMessageImpl;
+import org.eclipse.kapua.message.internal.device.data.KapuaDataPayloadImpl;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.client.ClientException;
+import org.eclipse.kapua.service.datastore.internal.client.DatastoreClientFactory;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
+import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
+import org.eclipse.kapua.service.datastore.internal.model.query.AndPredicateImpl;
+import org.eclipse.kapua.service.datastore.internal.model.query.MessageQueryImpl;
+import org.eclipse.kapua.service.datastore.internal.model.query.RangePredicateImpl;
+import org.eclipse.kapua.service.datastore.internal.schema.MessageSchema;
+import org.eclipse.kapua.service.datastore.model.StorableId;
+import org.eclipse.kapua.service.datastore.model.query.AndPredicate;
+import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
+import org.eclipse.kapua.service.datastore.model.query.RangePredicate;
+import org.eclipse.kapua.service.datastore.model.query.SortField;
+import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
+import org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory;
+import org.eclipse.kapua.service.datastore.model.query.TermPredicate;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceCreator;
+import org.eclipse.kapua.service.device.registry.DeviceFactory;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(MessageStoreServiceSslTest.class);
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceRegistryService DEVICE_REGISTRY_SERVICE = LOCATOR.getService(DeviceRegistryService.class);
+    private static final DeviceFactory DEVICE_FACTORY = LOCATOR.getFactory(DeviceFactory.class);
+    private static final MessageStoreService MESSAGE_STORE_SERVICE = LOCATOR.getService(MessageStoreService.class);
+    private static final StorablePredicateFactory STORABLE_PREDICATE_FACTORY = LOCATOR.getFactory(StorablePredicateFactory.class);
+
+    /**
+     * This method deletes all indices of the current ES instance
+     * <p>
+     * The method deletes all indices and resets the Kapua internal singleton state.
+     * This is required to ensure that each unit test, as it currently expects, starts with an empty ES setup
+     * </p>
+     * 
+     * @throws Exception
+     *             any case anything goes wrong
+     */
+    // @Before
+    // public void deleteAllIndices() throws Exception {
+    // DatastoreMediator.getInstance().deleteAllIndexes();
+    // }
+
+
+    @Test(expected = DatastoreException.class)
+    @Ignore
+    public void connectNoSsl() throws InterruptedException, KapuaException, ParseException {
+        // datastore.elasticsearch.ssl.enabled=false
+        // datastore.elasticsearch.ssl.trust_server_certificate=false
+        // datastore.elasticsearch.ssl.keystore_path=
+        // datastore.elasticsearch.ssl.keystore_password=
+        // datastore.elasticsearch.ssl.truststore_path=
+        // datastore.elasticsearch.ssl.truststore_password=
+        // datastore.elasticsearch.ssl.keystore_type=jks
+        try {
+            DatastoreClientFactory.getInstance();
+            storeMessage("ssl_test/no_ssl");
+            fail("ClientException should be thrown!");
+        } catch (ClientException e) {
+            // good
+        } finally {
+            DatastoreClientFactory.close();
+        }
+    }
+
+    @Test
+    @Ignore
+    public void connectSsl() throws InterruptedException, KapuaException, ParseException {
+        // datastore.elasticsearch.ssl.enabled=true
+        // datastore.elasticsearch.ssl.trust_server_certificate=false
+        // datastore.elasticsearch.ssl.keystore_path=
+        // datastore.elasticsearch.ssl.keystore_password=
+        // datastore.elasticsearch.ssl.truststore_path=
+        // datastore.elasticsearch.ssl.truststore_password=
+        // datastore.elasticsearch.ssl.keystore_type=jks
+        try {
+            DatastoreClientFactory.getInstance();
+            storeMessage("ssl_test/ssl");
+        } catch (ClientException e) {
+            fail("No ClientException should be thrown!");
+        } finally {
+            DatastoreClientFactory.close();
+        }
+    }
+
+    @Test
+    @Ignore
+    public void connectSslTrustServerNoTrustStoreSet() throws InterruptedException, KapuaException, ParseException {
+        // datastore.elasticsearch.ssl.enabled=true
+        // datastore.elasticsearch.ssl.trust_server_certificate=true
+        // datastore.elasticsearch.ssl.keystore_path=
+        // datastore.elasticsearch.ssl.keystore_password=
+        // datastore.elasticsearch.ssl.truststore_path=
+        // datastore.elasticsearch.ssl.truststore_password=
+        // datastore.elasticsearch.ssl.keystore_type=jks
+        try {
+            DatastoreClientFactory.getInstance();
+            storeMessage("ssl_test/ssl_trust_server_no_trust_store_set");
+        } catch (ClientException e) {
+            fail("No ClientException should be thrown!");
+        } finally {
+            DatastoreClientFactory.close();
+        }
+    }
+
+    @Test
+    @Ignore
+    public void connectSslTrustServerTrustStoreSet() throws InterruptedException, KapuaException, ParseException {
+        // datastore.elasticsearch.ssl.enabled=false
+        // datastore.elasticsearch.ssl.trust_server_certificate=false
+        // datastore.elasticsearch.ssl.keystore_path=
+        // datastore.elasticsearch.ssl.keystore_password=
+        // datastore.elasticsearch.ssl.truststore_path=some valid truststore path
+        // datastore.elasticsearch.ssl.truststore_password=trust store password
+        // datastore.elasticsearch.ssl.keystore_type=jks
+        try {
+            DatastoreClientFactory.getInstance();
+            storeMessage("ssl_test/ssl_trust_server_default_trust_store_set");
+        } catch (ClientException e) {
+            fail("No ClientException should be thrown!");
+        } finally {
+            DatastoreClientFactory.close();
+        }
+    }
+
+    @Test(expected = DatastoreException.class)
+    @Ignore
+    public void connectSslTrustServerSelfSignedTrustStore() throws InterruptedException, KapuaException, ParseException {
+        // datastore.elasticsearch.ssl.enabled=false
+        // datastore.elasticsearch.ssl.trust_server_certificate=false
+        // datastore.elasticsearch.ssl.keystore_path=
+        // datastore.elasticsearch.ssl.keystore_password=
+        // datastore.elasticsearch.ssl.truststore_path=self signed trust store
+        // datastore.elasticsearch.ssl.truststore_password=password
+        // datastore.elasticsearch.ssl.keystore_type=jks
+        try {
+            DatastoreClientFactory.getInstance();
+            storeMessage("ssl_test/ssl_trust_server_self_signed_tust");
+        } catch (ClientException e) {
+            fail("No ClientException should be thrown!");
+        } finally {
+            DatastoreClientFactory.close();
+        }
+    }
+
+    private void storeMessage(String semanticTopic) throws InterruptedException, KapuaException, ParseException {
+        Account account = getTestAccountCreator(adminScopeId);
+
+        String clientId = String.format("device-%d", new Date().getTime());
+        DeviceCreator deviceCreator = DEVICE_FACTORY.newCreator(account.getId(), clientId);
+        Device device = DEVICE_REGISTRY_SERVICE.create(deviceCreator);
+
+        // leave the message index by as default (DEVICE_TIMESTAMP)
+        String stringPayload = "Hello delete by date message!";
+        byte[] payload = stringPayload.getBytes();
+
+        Instant currentInstant = KapuaDateUtils.getKapuaSysDate();
+        Date date = Date.from(currentInstant);
+        int messagesCount = 1;
+        insertMessage(account, clientId, device.getId(), semanticTopic, payload, date);
+
+        // do a first query count
+        DatastoreMediator.getInstance().refreshAllIndexes();
+        MessageQuery messageQuery = getBaseMessageQuery(KapuaEid.ONE, 10);
+        setMessageQueryBaseCriteria(messageQuery, clientId, new DateRange(Date.from(currentInstant.minusSeconds(3600)), date));
+        long count = MESSAGE_STORE_SERVICE.count(messageQuery);
+        assertEquals(messagesCount, count);
+
+    }
+
+    private KapuaDataMessage insertMessage(Account account, String clientId, KapuaId deviceId, String semanticTopic, byte[] payload, Date sentOn) throws InterruptedException, KapuaException {
+        KapuaDataPayloadImpl messagePayload = new KapuaDataPayloadImpl();
+        Map<String, Object> metrics = new HashMap<String, Object>();
+        metrics.put("float", new Float((float) 0.01));
+        messagePayload.setMetrics(metrics);
+        messagePayload.setBody(payload);
+        Date receivedOn = Date.from(KapuaDateUtils.getKapuaSysDate());
+        Date capturedOn = sentOn;
+        KapuaDataMessage message = createMessage(clientId, account.getId(), deviceId, receivedOn, capturedOn, sentOn);
+        setChannel(message, semanticTopic);
+        updatePayload(message, messagePayload);
+        List<StorableId> messageStoredIds = insertMessages(message);
+        return message;
+    }
+
+    // ===========================================================
+    // ===========================================================
+    // utility methods
+    // ===========================================================
+    // ===========================================================
+
+    private List<StorableId> insertMessages(KapuaDataMessage... messages) throws InterruptedException, KapuaException {
+        requireNonNull(messages);
+
+        List<StorableId> storableIds = new ArrayList<>(messages.length);
+        for (KapuaDataMessage message : messages) {
+            storableIds.add(MESSAGE_STORE_SERVICE.store(message));
+        }
+        return storableIds;
+    }
+
+    /**
+     * Creates a new KapuaMessage setting the provided parameters
+     *
+     * @param clientId
+     * @param scopeId
+     * @param deviceId
+     * @param capturedOn
+     * @param sentOn
+     * @return
+     */
+    private KapuaDataMessage createMessage(String clientId, KapuaId scopeId, KapuaId deviceId,
+            Date receivedOn, Date capturedOn, Date sentOn) {
+        KapuaDataMessage message = new KapuaDataMessageImpl();
+        message.setReceivedOn(receivedOn);
+        message.setCapturedOn(capturedOn);
+        message.setSentOn(sentOn);
+        message.setChannel(new KapuaDataChannelImpl());
+        message.setClientId(clientId);
+        message.setDeviceId(deviceId);
+        message.setScopeId(scopeId);
+        return message;
+    }
+
+    /**
+     * Update the KapuaMessage channel with the provided semantic part
+     *
+     * @param message
+     * @param semanticPart
+     */
+    private void setChannel(KapuaDataMessage message, String semanticPart) {
+        final KapuaDataChannelImpl channel = new KapuaDataChannelImpl();
+        channel.setSemanticParts(new ArrayList<>(Arrays.asList(semanticPart.split("/"))));
+
+        message.setChannel(channel);
+    }
+
+    /**
+     * Update the KapuaMessage payload with the provided payload
+     *
+     * @param message
+     * @param messagePayload
+     */
+    private void updatePayload(KapuaDataMessage message, KapuaDataPayload messagePayload) {
+        message.setPayload(messagePayload);
+    }
+
+    //
+    // Utility methods to help to to create message queries
+    //
+
+    /**
+     * Creates a new query setting the default base parameters (fetch style, sort, limit, offset, ...) for the Message schema
+     *
+     * @return
+     */
+    private MessageQuery getBaseMessageQuery(KapuaId scopeId, int limit) {
+        MessageQuery query = new MessageQueryImpl(scopeId);
+        query.setAskTotalCount(true);
+        query.setFetchStyle(StorableFetchStyle.SOURCE_FULL);
+        query.setLimit(limit);
+        query.setOffset(0);
+        List<SortField> order = new ArrayList<>();
+        order.add(descending(MessageSchema.MESSAGE_TIMESTAMP));
+        query.setSortFields(order);
+        return query;
+    }
+
+    /**
+     * Set the query account, message timestamp and client id filter
+     *
+     * @param messageQuery
+     * @param clientId
+     * @param dateRange
+     */
+    private void setMessageQueryBaseCriteria(MessageQuery messageQuery, String clientId, DateRange dateRange) {
+        AndPredicate andPredicate = new AndPredicateImpl();
+        if (!StringUtils.isEmpty(clientId)) {
+            TermPredicate clientPredicate = STORABLE_PREDICATE_FACTORY.newTermPredicate(MessageField.CLIENT_ID, clientId);
+            andPredicate.getPredicates().add(clientPredicate);
+        }
+        if (dateRange != null) {
+            RangePredicate timestampPredicate = new RangePredicateImpl(MessageField.TIMESTAMP, dateRange.getLowerBound(), dateRange.getUpperBound());
+            andPredicate.getPredicates().add(timestampPredicate);
+        }
+        messageQuery.setPredicate(andPredicate);
+    }
+
+    private class DateRange {
+
+        private final Date lowerBound;
+        private final Date upperBound;
+
+        public DateRange(Date lowerBound, Date upperBound) {
+            this.lowerBound = lowerBound;
+            this.upperBound = upperBound;
+        }
+
+        public Date getLowerBound() {
+            return lowerBound;
+        }
+
+        public Date getUpperBound() {
+            return upperBound;
+        }
+
+    }
+
+    /**
+     * Return a new account created just for the test.<br>
+     * <b>WARNING!!!!!!! Current implementation is not compliance with that since it is a temporary implementation that returns the default kapua-sys account</b>
+     *
+     * @param scopeId
+     * @return
+     * @throws KapuaException
+     */
+    private Account getTestAccountCreator(KapuaId scopeId) throws KapuaException {
+        KapuaLocator locator = KapuaLocator.getInstance();
+        Account account = locator.getService(AccountService.class).findByName("kapua-sys");
+        return account;
+    }
+
+}

--- a/service/datastore/internal/src/test/resources/bck_kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/internal/src/test/resources/bck_kapua-datastore-rest-client-setting.properties
@@ -20,17 +20,19 @@ datastore.scroll.timeout=60000
 
 datastore.elasticsearch.cluster=kapua-datastore
 #Elasticsearch node IP/port - current ip/port values are to use the embedded node for test purpose
-datastore.elasticsearch.node=127.0.0.1
-datastore.elasticsearch.port=9200
+#datastore.elasticsearch.node=127.0.0.1
+#datastore.elasticsearch.port=9200
 
 # A comma separated list of nodes in the form: "host1,host2" or "host1:port,host2:port"
 # **Note:** Using the "nodes" version overrides the "node" property.
 #datastore.elasticsearch.nodes=host1:port1,host2:port2
 
 #ssl test
+datastore.elasticsearch.node=search-testriccardo-3poedgqdizesr647laxpspn76y.us-east-1.es.amazonaws.com
+datastore.elasticsearch.port=443
 #Options to customize the ssl behavior of the ES rest client.
 #Available configurations are:
-# 1) enable ssl without any validation:
+# 1) enable ssl without any validation: 
 #        ssl.enabled=true
 #        ssl.trust_server_certificate=false
 #        others: unused
@@ -44,7 +46,7 @@ datastore.elasticsearch.port=9200
 #        ssl.trust_server_certificate=true
 #        keystore_path/ssl.keystore_password valued with the proper key store
 #        if ssl.truststore_path/ssl.truststore_password are empty the default jvm truststore will be used. Otherwise the provided truststore.
-datastore.elasticsearch.ssl.enabled=false
+datastore.elasticsearch.ssl.enabled=true
 datastore.elasticsearch.ssl.trust_server_certificate=false
 datastore.elasticsearch.ssl.keystore_path=
 datastore.elasticsearch.ssl.keystore_password=


### PR DESCRIPTION
fix #934 
Allows to set the Elasticsearch ssl rest client configuration. In the default configuration the ssl is disabled.