### PR TITLE
Removed device-call-kura dependency from device-commons module

### DIFF
--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseCode.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseCode.java
@@ -14,10 +14,16 @@ package org.eclipse.kapua.service.device.call.message.app.response;
 /**
  * Device response code definition.<br>
  * It is used to define a short result for the command response received by a device.
- * 
+ *
  * @since 1.0
- * 
  */
 public interface DeviceResponseCode {
 
+    public boolean isAccepted();
+
+    public boolean isBadRequest();
+
+    public boolean isNotFound();
+
+    public boolean isInternalError();
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponseCode.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/kura/KuraResponseCode.java
@@ -15,9 +15,8 @@ import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponse
 
 /**
  * Kura device response code definition.
- * 
+ *
  * @since 1.0
- * 
  */
 public enum KuraResponseCode implements DeviceResponseCode {
     /**
@@ -41,7 +40,7 @@ public enum KuraResponseCode implements DeviceResponseCode {
 
     /**
      * Constructor
-     * 
+     *
      * @param code
      */
     KuraResponseCode(int code) {
@@ -50,7 +49,7 @@ public enum KuraResponseCode implements DeviceResponseCode {
 
     /**
      * Get the response code
-     * 
+     *
      * @return
      */
     public int getCode() {
@@ -59,7 +58,7 @@ public enum KuraResponseCode implements DeviceResponseCode {
 
     /**
      * Constructs a {@link KuraResponseCode} from a string representation
-     * 
+     *
      * @param responseCode
      * @return
      */
@@ -69,7 +68,7 @@ public enum KuraResponseCode implements DeviceResponseCode {
 
     /**
      * Constructs a {@link KuraResponseCode} from an integer representation
-     * 
+     *
      * @param responseCode
      * @return
      */
@@ -83,5 +82,25 @@ public enum KuraResponseCode implements DeviceResponseCode {
         }
 
         return result;
+    }
+
+    @Override
+    public boolean isAccepted() {
+        return ACCEPTED.equals(this);
+    }
+
+    @Override
+    public boolean isBadRequest() {
+        return BAD_REQUEST.equals(this);
+    }
+
+    @Override
+    public boolean isNotFound() {
+        return NOT_FOUND.equals(this);
+    }
+
+    @Override
+    public boolean isInternalError() {
+        return INTERNAL_ERROR.equals(this);
     }
 }

--- a/service/device/commons/pom.xml
+++ b/service/device/commons/pom.xml
@@ -11,7 +11,8 @@
         Eurotech - initial API and implementation
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -33,19 +34,27 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-registry-api</artifactId>
         </dependency>
-         <dependency>
+        <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-api</artifactId>
         </dependency>
-
-        <!-- Internal dependencies -->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-message-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-call-kura</artifactId>
+            <artifactId>kapua-device-call-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-api</artifactId>
+        </dependency>
+
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-message-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/AbstractDeviceApplicationCallResponseHandler.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/AbstractDeviceApplicationCallResponseHandler.java
@@ -12,9 +12,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.commons.call;
 
+import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponseCode;
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponseMessage;
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponsePayload;
-import org.eclipse.kapua.service.device.call.message.app.response.kura.KuraResponseCode;
 import org.eclipse.kapua.service.device.management.commons.exception.DeviceManagementErrorCodes;
 import org.eclipse.kapua.service.device.management.commons.exception.DeviceManagementException;
 
@@ -22,11 +22,8 @@ import org.eclipse.kapua.service.device.management.commons.exception.DeviceManag
  * Device application call response handler.<br>
  * This handler gets the call response from a device and convert it to the expected object type.
  *
- * @param <T>
- *            expected response type
- *
+ * @param <T> expected response type
  * @since 1.0
- *
  */
 public abstract class AbstractDeviceApplicationCallResponseHandler<T> {
 
@@ -42,20 +39,16 @@ public abstract class AbstractDeviceApplicationCallResponseHandler<T> {
         if (responseMessage != null) {
             DeviceResponsePayload responsePayload = responseMessage.getPayload();
             if (responsePayload != null) {
-                KuraResponseCode responseCode = responsePayload.getResponseCode();
+                DeviceResponseCode responseCode = responsePayload.getResponseCode();
 
-                switch (responseCode) {
-                case ACCEPTED:
+                if (responseCode.isAccepted()) {
                     return handleAcceptedRequest(responseMessage);
-                case BAD_REQUEST:
+                } else if (responseCode.isAccepted()) {
                     handleBadRequestReply(responseMessage);
-                    break;
-                case INTERNAL_ERROR:
-                    handleDeviceInternalErrorReply(responseMessage);
-                    break;
-                case NOT_FOUND:
+                } else if (responseCode.isAccepted()) {
                     handleNotFoundReply(responseMessage);
-                    break;
+                } else if (responseCode.isAccepted()) {
+                    handleDeviceInternalErrorReply(responseMessage);
                 }
             }
         }
@@ -82,7 +75,7 @@ public abstract class AbstractDeviceApplicationCallResponseHandler<T> {
     protected void handleBadRequestReply(DeviceResponseMessage<?, ?> responseMessage)
             throws DeviceManagementException {
         DeviceResponsePayload responsePayload = responseMessage.getPayload();
-        KuraResponseCode responseCode = responsePayload.getResponseCode();
+        DeviceResponseCode responseCode = responsePayload.getResponseCode();
 
         throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_BAD_REQUEST,
                 null,
@@ -100,7 +93,7 @@ public abstract class AbstractDeviceApplicationCallResponseHandler<T> {
     protected void handleDeviceInternalErrorReply(DeviceResponseMessage<?, ?> responseMessage)
             throws DeviceManagementException {
         DeviceResponsePayload responsePayload = responseMessage.getPayload();
-        KuraResponseCode responseCode = responsePayload.getResponseCode();
+        DeviceResponseCode responseCode = responsePayload.getResponseCode();
 
         throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_INTERNAL_ERROR,
                 null,
@@ -118,7 +111,7 @@ public abstract class AbstractDeviceApplicationCallResponseHandler<T> {
     protected void handleNotFoundReply(DeviceResponseMessage<?, ?> responseMessage)
             throws DeviceManagementException {
         DeviceResponsePayload responsePayload = responseMessage.getPayload();
-        KuraResponseCode responseCode = responsePayload.getResponseCode();
+        DeviceResponseCode responseCode = responsePayload.getResponseCode();
 
         throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_NOT_FOUND,
                 null,
@@ -126,5 +119,4 @@ public abstract class AbstractDeviceApplicationCallResponseHandler<T> {
                         responsePayload.getExceptionMessage(),
                         responsePayload.getExceptionStack() });
     }
-
 }


### PR DESCRIPTION
This PR removes the direct dependency of `kapua-device-call-kura` module from the `kapua-device-commons`  which was preventing interchangeability of the implementation of the device call. 

`DeviceResponseCode.java` interface slightly changed to allow this change.