### PR TITLE
Fixed dependencies in kapua-console-module-device

### DIFF
--- a/console/module/device/pom.xml
+++ b/console/module/device/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-console-module-device</artifactId>
-    
+
     <dependencies>
         <!-- Console modules -->
         <dependency>
@@ -47,6 +47,11 @@
             <artifactId>kapua-device-registry-api</artifactId>
         </dependency>
         <dependency>
+            <!-- This dependency is required to being able to import DeviceEventDomain class-->
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-internal</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-asset-api</artifactId>
         </dependency>
@@ -66,15 +71,7 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-command-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-translator-kapua-kura</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-translator-kura-mqtt</artifactId>
-        </dependency>
-        
+
         <!-- External dependencies -->
         <dependency>
             <groupId>org.apache.poi</groupId>
@@ -85,10 +82,8 @@
             <artifactId>opencsv</artifactId>
         </dependency>
         <dependency>
-            <!-- Imaging utils used to handle device component configuration
-                icons -->
-            <!-- former commons-imaging changed because the 1.0-FINAL was
-                not contined/supported in maven -->
+            <!-- Imaging utils used to handle device component configuration icons -->
+            <!-- former commons-imaging changed because the 1.0-FINAL was not contined/supported in maven -->
             <groupId>org.apache.sanselan</groupId>
             <artifactId>sanselan</artifactId>
             <version>0.97-incubator</version>

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -47,6 +47,15 @@
             <artifactId>kapua-foreignkeys</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-kapua-kura</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-kura-mqtt</artifactId>
+        </dependency>
+
         <!-- External dependencies -->
         <dependency>
             <groupId>com.google.gwt</groupId>


### PR DESCRIPTION
This PR fixes #1269

Moved dependencies to proper module.

Added dependency `kapua-device-registri-internal` to `kapua-console-module-device` to being able to use `DeviceEventDomain`. This dependency was transient to one of the two dependencies moved. 