### PR TITLE
connector descriptor fix pluggability

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
@@ -30,7 +30,6 @@ import org.eclipse.kapua.broker.core.message.CamelUtil;
 import org.eclipse.kapua.broker.core.message.JmsUtil;
 import org.eclipse.kapua.broker.core.message.MessageConstants;
 import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.commons.metric.MetricServiceFactory;
 import org.eclipse.kapua.commons.metric.MetricsService;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -76,7 +75,7 @@ public abstract class AbstractKapuaConverter {
      * @throws KapuaException
      *             if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
      */
-    protected CamelKapuaMessage<?> convertTo(Exchange exchange, Object value, MessageType messageType) throws KapuaException {
+    protected CamelKapuaMessage<?> convertTo(Exchange exchange, Object value, String messageType) throws KapuaException {
         // assume that the message is a Camel Jms message
         JmsMessage message = exchange.getIn(JmsMessage.class);
         if (message.getJmsMessage() instanceof BytesMessage) {

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaDataConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaDataConverter.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.converter;
 
+import static org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider.MSG_DATA_TYPE;
+
 import java.util.UUID;
 
 import org.apache.camel.Converter;
@@ -18,7 +20,6 @@ import org.apache.camel.Exchange;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.message.CamelKapuaMessage;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,7 @@ public class KapuaDataConverter extends AbstractKapuaConverter {
     @Converter
     public CamelKapuaMessage<?> convertToData(Exchange exchange, Object value) throws KapuaException {
         metricConverterDataMessage.inc();
-        CamelKapuaMessage<?> message = convertTo(exchange, value, MessageType.DATA);
+        CamelKapuaMessage<?> message = convertTo(exchange, value, MSG_DATA_TYPE);
         if (StringUtils.isEmpty(message.getDatastoreId())) {
             message.setDatastoreId(UUID.randomUUID().toString());
         }
@@ -67,7 +68,7 @@ public class KapuaDataConverter extends AbstractKapuaConverter {
         if (value instanceof CamelKapuaMessage<?>) {
             message = (CamelKapuaMessage<?>) value;
         } else {
-            message = convertTo(exchange, value, MessageType.DATA);
+            message = convertTo(exchange, value, MSG_DATA_TYPE);
         }
         if (StringUtils.isEmpty(message.getDatastoreId())) {
             logger.warn("Reprocessing message without datastore message id.");

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaLifeCycleConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaLifeCycleConverter.java
@@ -11,11 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.converter;
 
+import static org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider.MSG_APP_TYPE;
+import static org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider.MSG_BIRTH_TYPE;
+import static org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider.MSG_DISCONNECT_TYPE;
+import static org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider.MSG_MISSING_TYPE;
+import static org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider.MSG_NOTIFY_TYPE;
+
 import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.message.CamelKapuaMessage;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +62,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
     @Converter
     public CamelKapuaMessage<?> convertToApps(Exchange exchange, Object value) throws KapuaException {
         metricConverterAppMessage.inc();
-        return convertTo(exchange, value, MessageType.APP);
+        return convertTo(exchange, value, MSG_APP_TYPE);
     }
 
     /**
@@ -72,7 +77,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
     @Converter
     public CamelKapuaMessage<?> convertToBirth(Exchange exchange, Object value) throws KapuaException {
         metricConverterBirthMessage.inc();
-        return convertTo(exchange, value, MessageType.BIRTH);
+        return convertTo(exchange, value, MSG_BIRTH_TYPE);
     }
 
     /**
@@ -87,7 +92,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
     @Converter
     public CamelKapuaMessage<?> convertToDisconnect(Exchange exchange, Object value) throws KapuaException {
         metricConverterDcMessage.inc();
-        return convertTo(exchange, value, MessageType.DISCONNECT);
+        return convertTo(exchange, value, MSG_DISCONNECT_TYPE);
     }
 
     /**
@@ -102,7 +107,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
     @Converter
     public CamelKapuaMessage<?> convertToMissing(Exchange exchange, Object value) throws KapuaException {
         metricConverterMissingMessage.inc();
-        return convertTo(exchange, value, MessageType.MISSING);
+        return convertTo(exchange, value, MSG_MISSING_TYPE);
     }
 
     /**
@@ -116,7 +121,7 @@ public class KapuaLifeCycleConverter extends AbstractKapuaConverter {
     @Converter
     public CamelKapuaMessage<?> convertToNotify(Exchange exchange, Object value) throws KapuaException {
         metricConverterNotifyMessage.inc();
-        return convertTo(exchange, value, MessageType.NOTIFY);
+        return convertTo(exchange, value, MSG_NOTIFY_TYPE);
     }
 
 }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/JmsUtil.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/JmsUtil.java
@@ -21,9 +21,8 @@ import javax.jms.Topic;
 import org.apache.activemq.command.ActiveMQMessage;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.converter.AbstractKapuaConverter;
+import org.eclipse.kapua.broker.core.plugin.AclConstants;
 import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor;
-import org.eclipse.kapua.broker.core.plugin.KapuaSecurityBrokerFilter;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
@@ -72,7 +71,7 @@ public class JmsUtil {
      * @throws JMSException
      * @throws KapuaException
      */
-    public static CamelKapuaMessage<?> convertToKapuaMessage(ConnectorDescriptor connectorDescriptor, MessageType messageType, BytesMessage jmsMessage, KapuaId connectionId, String clientId)
+    public static CamelKapuaMessage<?> convertToKapuaMessage(ConnectorDescriptor connectorDescriptor, String messageType, BytesMessage jmsMessage, KapuaId connectionId, String clientId)
             throws JMSException, KapuaException {
         String jmsTopic = jmsMessage.getStringProperty(MessageConstants.PROPERTY_ORIGINAL_TOPIC);
         Date queuedOn = new Date(jmsMessage.getLongProperty(MessageConstants.PROPERTY_ENQUEUED_TIMESTAMP));
@@ -134,7 +133,7 @@ public class JmsUtil {
      * @return
      * @throws KapuaException
      */
-    public static CamelKapuaMessage<?> convertToCamelKapuaMessage(ConnectorDescriptor connectorDescriptor, MessageType messageType, byte[] messageBody, String jmsTopic, Date queuedOn,
+    public static CamelKapuaMessage<?> convertToCamelKapuaMessage(ConnectorDescriptor connectorDescriptor, String messageType, byte[] messageBody, String jmsTopic, Date queuedOn,
             KapuaId connectionId, String clientId)
             throws KapuaException {
         KapuaMessage<?, ?> kapuaMessage = convertToKapuaMessage(connectorDescriptor.getDeviceClass(messageType), connectorDescriptor.getKapuaClass(messageType), messageBody, jmsTopic, queuedOn,
@@ -178,7 +177,7 @@ public class JmsUtil {
      * @throws KapuaException
      * @throws ClassNotFoundException
      */
-    public static JmsMessage convertToJmsMessage(ConnectorDescriptor connectorDescriptor, MessageType messageType, KapuaMessage<?, ?> kapuaMessage) throws KapuaException, ClassNotFoundException {
+    public static JmsMessage convertToJmsMessage(ConnectorDescriptor connectorDescriptor, String messageType, KapuaMessage<?, ?> kapuaMessage) throws KapuaException, ClassNotFoundException {
         // first step... from Kapua to device level dependent protocol (unknown)
         Translator<KapuaMessage<?, ?>, DeviceMessage<?, ?>> translatorFromKapua = Translator
                 .getTranslatorFor(connectorDescriptor.getKapuaClass(messageType), connectorDescriptor.getDeviceClass(messageType));

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
@@ -33,42 +33,8 @@ public class ConnectorDescriptor implements Serializable {
 
     private static final long serialVersionUID = -7220383679289083726L;
 
-    /**
-     * Allowed message types
-     */
-    public static enum MessageType {
-        /**
-         * Application message type
-         */
-        APP,
-        /**
-         * Birth message type
-         */
-        BIRTH,
-        /**
-         * Disconnect message type
-         */
-        DISCONNECT,
-        /**
-         * Missing message type
-         */
-        MISSING,
-        /**
-         * Notify message type
-         */
-        NOTIFY,
-        /**
-         * Unmatched filtering message type
-         */
-        UNMATCHED,
-        /**
-         * Data message type
-         */
-        DATA
-    }
-
-    private final Map<MessageType, Class<? extends DeviceMessage<?, ?>>> deviceClass;
-    private final Map<MessageType, Class<? extends KapuaMessage<?, ?>>> kapuaClass;
+    private final Map<String, Class<? extends DeviceMessage<?, ?>>> deviceClass;
+    private final Map<String, Class<? extends KapuaMessage<?, ?>>> kapuaClass;
 
     private String transportProtocol;
 
@@ -80,7 +46,7 @@ public class ConnectorDescriptor implements Serializable {
      * @param kapuaClass
      *            Kapua level messages implementation classes
      */
-    public ConnectorDescriptor(String transportProtocol, Map<MessageType, Class<? extends DeviceMessage<?, ?>>> deviceClass, Map<MessageType, Class<? extends KapuaMessage<?, ?>>> kapuaClass) {
+    public ConnectorDescriptor(String transportProtocol, Map<String, Class<? extends DeviceMessage<?, ?>>> deviceClass, Map<String, Class<? extends KapuaMessage<?, ?>>> kapuaClass) {
         requireNonNull(deviceClass);
         requireNonNull(kapuaClass);
         requireNonNull(transportProtocol);
@@ -90,11 +56,11 @@ public class ConnectorDescriptor implements Serializable {
         this.transportProtocol = transportProtocol;
     }
 
-    public Class<? extends DeviceMessage<?, ?>> getDeviceClass(MessageType messageType) throws KapuaException {
+    public Class<? extends DeviceMessage<?, ?>> getDeviceClass(String messageType) throws KapuaException {
         return this.deviceClass.get(messageType);
     }
 
-    public Class<? extends KapuaMessage<?, ?>> getKapuaClass(MessageType messageType) throws KapuaException {
+    public Class<? extends KapuaMessage<?, ?>> getKapuaClass(String messageType) throws KapuaException {
         return this.kapuaClass.get(messageType);
     }
 

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProvider.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProvider.java
@@ -16,6 +16,14 @@ package org.eclipse.kapua.broker.core.plugin;
  */
 public interface ConnectorDescriptorProvider {
 
+    String MSG_DATA_TYPE = "DATA";
+    String MSG_APP_TYPE = "APP";
+    String MSG_BIRTH_TYPE = "BIRTH";
+    String MSG_DISCONNECT_TYPE = "DISCONNECT";
+    String MSG_MISSING_TYPE = "MISSING";
+    String MSG_NOTIFY_TYPE = "NOTIFY";
+    String MSG_UNMATCHED_TYPE = "UNMATCHED";
+
     /**
      * Get a {@link ConnectorDescriptor} for the given transport name
      * 

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultConnectorDescriptionProvider.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultConnectorDescriptionProvider.java
@@ -13,11 +13,12 @@ package org.eclipse.kapua.broker.core.plugin;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.broker.core.setting.BrokerSetting;
 import org.eclipse.kapua.broker.core.setting.BrokerSettingKey;
 import org.eclipse.kapua.message.KapuaMessage;
@@ -65,6 +66,17 @@ class DefaultConnectorDescriptionProvider implements ConnectorDescriptorProvider
 
     private final Map<String, ConnectorDescriptor> configuration = new HashMap<>();
     private final ConnectorDescriptor defaultDescriptor;
+    private static List<String> availableMessagesType = new ArrayList<>();
+
+    static {
+        availableMessagesType.add(MSG_APP_TYPE);
+        availableMessagesType.add(MSG_BIRTH_TYPE);
+        availableMessagesType.add(MSG_DISCONNECT_TYPE);
+        availableMessagesType.add(MSG_MISSING_TYPE);
+        availableMessagesType.add(MSG_NOTIFY_TYPE);
+        availableMessagesType.add(MSG_UNMATCHED_TYPE);
+        availableMessagesType.add(MSG_DATA_TYPE);
+    }
 
     DefaultConnectorDescriptionProvider() {
         if (!BrokerSetting.getInstance().getBoolean(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR, false)) {
@@ -113,15 +125,15 @@ class DefaultConnectorDescriptionProvider implements ConnectorDescriptorProvider
 
     private static ConnectorDescriptor loadFromProperties(Properties p, String transport) throws ClassNotFoundException {
 
-        final Map<MessageType, Class<? extends DeviceMessage<?, ?>>> deviceClasses = new HashMap<>();
-        final Map<MessageType, Class<? extends KapuaMessage<?, ?>>> kapuaClasses = new HashMap<>();
+        final Map<String, Class<? extends DeviceMessage<?, ?>>> deviceClasses = new HashMap<>();
+        final Map<String, Class<? extends KapuaMessage<?, ?>>> kapuaClasses = new HashMap<>();
 
         String transportProtocol = p.getProperty(String.format("%s.transport_protocol", transport));
 
-        for (MessageType mt : MessageType.values()) {
+        for (String mt : availableMessagesType) {
 
             {
-                final String key = String.format("%s.device.%s", transport, mt.name());
+                final String key = String.format("%s.device.%s", transport, mt);
                 final String clazzName = p.getProperty(key);
                 if (clazzName != null && !clazzName.isEmpty()) {
                     @SuppressWarnings("unchecked")
@@ -133,7 +145,7 @@ class DefaultConnectorDescriptionProvider implements ConnectorDescriptorProvider
             }
 
             {
-                final String key = String.format("%s.kapua.%s", transport, mt.name());
+                final String key = String.format("%s.kapua.%s", transport, mt);
                 final String clazzName = p.getProperty(key);
                 if (clazzName != null && !clazzName.isEmpty()) {
                     @SuppressWarnings("unchecked")
@@ -155,23 +167,23 @@ class DefaultConnectorDescriptionProvider implements ConnectorDescriptorProvider
      * @return the default instance, never returns {@code null}
      */
     private static ConnectorDescriptor createDefaultDescriptor() {
-        final Map<MessageType, Class<? extends DeviceMessage<?, ?>>> deviceClass = new HashMap<>();
-        deviceClass.put(MessageType.APP, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage.class);
-        deviceClass.put(MessageType.BIRTH, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraBirthMessage.class);
-        deviceClass.put(MessageType.DISCONNECT, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraDisconnectMessage.class);
-        deviceClass.put(MessageType.MISSING, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraMissingMessage.class);
-        deviceClass.put(MessageType.NOTIFY, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraNotifyMessage.class);
-        deviceClass.put(MessageType.UNMATCHED, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraUnmatchedMessage.class);
-        deviceClass.put(MessageType.DATA, org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage.class);
+        final Map<String, Class<? extends DeviceMessage<?, ?>>> deviceClass = new HashMap<>();
+        deviceClass.put(MSG_APP_TYPE, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage.class);
+        deviceClass.put(MSG_BIRTH_TYPE, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraBirthMessage.class);
+        deviceClass.put(MSG_DISCONNECT_TYPE, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraDisconnectMessage.class);
+        deviceClass.put(MSG_MISSING_TYPE, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraMissingMessage.class);
+        deviceClass.put(MSG_NOTIFY_TYPE, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraNotifyMessage.class);
+        deviceClass.put(MSG_UNMATCHED_TYPE, org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraUnmatchedMessage.class);
+        deviceClass.put(MSG_DATA_TYPE, org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage.class);
 
-        final Map<MessageType, Class<? extends KapuaMessage<?, ?>>> kapuaClass = new HashMap<>();
-        kapuaClass.put(MessageType.APP, org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage.class);
-        kapuaClass.put(MessageType.BIRTH, org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage.class);
-        kapuaClass.put(MessageType.DISCONNECT, org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectMessage.class);
-        kapuaClass.put(MessageType.MISSING, org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage.class);
-        kapuaClass.put(MessageType.NOTIFY, org.eclipse.kapua.message.device.lifecycle.KapuaNotifyMessage.class);
-        kapuaClass.put(MessageType.UNMATCHED, org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedMessage.class);
-        kapuaClass.put(MessageType.DATA, org.eclipse.kapua.message.device.data.KapuaDataMessage.class);
+        final Map<String, Class<? extends KapuaMessage<?, ?>>> kapuaClass = new HashMap<>();
+        kapuaClass.put(MSG_APP_TYPE, org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage.class);
+        kapuaClass.put(MSG_BIRTH_TYPE, org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage.class);
+        kapuaClass.put(MSG_DISCONNECT_TYPE, org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectMessage.class);
+        kapuaClass.put(MSG_MISSING_TYPE, org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage.class);
+        kapuaClass.put(MSG_NOTIFY_TYPE, org.eclipse.kapua.message.device.lifecycle.KapuaNotifyMessage.class);
+        kapuaClass.put(MSG_UNMATCHED_TYPE, org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedMessage.class);
+        kapuaClass.put(MSG_DATA_TYPE, org.eclipse.kapua.message.device.data.KapuaDataMessage.class);
 
         return new ConnectorDescriptor(DEFAULT_TRANSPORT_PROTOCOL, deviceClass, kapuaClass);
     }

--- a/broker-core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
+++ b/broker-core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
@@ -12,6 +12,8 @@
 package org.eclipse.kapua.broker.core.plugin;
 
 import static org.eclipse.kapua.broker.core.plugin.Tests.runWithProperties;
+import static org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider.MSG_APP_TYPE;
+import static org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider.MSG_DATA_TYPE;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +21,6 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.broker.core.setting.BrokerSetting;
 import org.eclipse.kapua.broker.core.setting.BrokerSettingKey;
 import org.junit.Assert;
@@ -143,11 +144,11 @@ public class ConnectorDescriptorTest {
             ConnectorDescriptor descriptor = provider.getDescriptor("mqtt");
             Assert.assertNotNull(descriptor);
 
-            Assert.assertEquals(org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage.class, descriptor.getDeviceClass(MessageType.APP));
-            Assert.assertEquals(org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage.class, descriptor.getKapuaClass(MessageType.APP));
+            Assert.assertEquals(org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage.class, descriptor.getDeviceClass(MSG_APP_TYPE));
+            Assert.assertEquals(org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage.class, descriptor.getKapuaClass(MSG_APP_TYPE));
 
-            Assert.assertNull(descriptor.getDeviceClass(MessageType.DATA));
-            Assert.assertNull(descriptor.getKapuaClass(MessageType.DATA));
+            Assert.assertNull(descriptor.getDeviceClass(MSG_DATA_TYPE));
+            Assert.assertNull(descriptor.getKapuaClass(MSG_DATA_TYPE));
         });
     }
 


### PR DESCRIPTION
Allow the customization of the message translator chain also from outside Kapua codebase.
So an extension module can plug its own messages types and then the translators.

Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>