### PR TITLE
Fixed message style for User, Role, Account management

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountForm.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountForm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -366,7 +366,7 @@ public class AccountForm extends Window {
                                         }
 
                                         public void onSuccess(GwtAccount account) {
-                                            ConsoleInfo.display(MSGS.info(), MSGS.accountCreatedConfirmation(account.getUnescapedName()));
+                                            ConsoleInfo.display(MSGS.info(), MSGS.accountCreatedConfirmation());
                                             newAccount = account;
                                             // gwtAccountUtils.loadChildAccounts();
                                             hide();
@@ -417,7 +417,7 @@ public class AccountForm extends Window {
                                         }
 
                                         public void onSuccess(GwtAccount account) {
-                                            ConsoleInfo.display(MSGS.info(), MSGS.accountUpdatedConfirmation(account.getUnescapedName()));
+                                            ConsoleInfo.display(MSGS.info(), MSGS.accountUpdatedConfirmation());
                                             existingAccount = account;
                                             hide();
                                         }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -251,7 +251,7 @@ public class AccountAddDialog extends EntityAddEditDialog {
                     }
 
                     public void onSuccess(GwtAccount account) {
-                        ConsoleInfo.display(MSGS.info(), MSGS.accountCreatedConfirmation(account.getUnescapedName()));
+                        ConsoleInfo.display(MSGS.info(), MSGS.accountCreatedConfirmation());
                         hide();
                     }
                 });

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -44,7 +44,7 @@ public class AccountDeleteDialog extends EntityDeleteDialog {
             public void onSuccess(Void v) {
                 exitStatus = true;
                 ConsoleInfo.display(MSGS.info(),
-                        MSGS.accountDeletedConfirmation(selectedAccount.getUnescapedName()));
+                        MSGS.accountDeletedConfirmation());
                 hide();
             }
 

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -104,7 +104,7 @@ public class AccountEditDialog extends AccountAddDialog {
                     }
 
                     public void onSuccess(GwtAccount account) {
-                        ConsoleInfo.display(MSGS.info(), MSGS.accountUpdatedConfirmation(account.getUnescapedName()));
+                        ConsoleInfo.display(MSGS.info(), MSGS.accountUpdatedConfirmation());
                         hide();
                     }
                 });

--- a/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/client/messages/ConsoleAccountMessages.properties
+++ b/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/client/messages/ConsoleAccountMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -64,20 +64,20 @@ accountFormOrgCity=City
 accountFormOrgState=State/Province
 accountFormOrgCountry=Country
 
-accountCreatedConfirmation=The account {0} has been created.
+accountCreatedConfirmation=Account successfully created.
 info=Confirmation
 
 #
 # Account Edit dialog
 accountEditDialogHeader=Edit Chlid Account: {0}
 accountEditInfoMessage=Edit Child Account: {0}.
-accountUpdatedConfirmation=The account {0} has been updated.
+accountUpdatedConfirmation=Account successfully updated.
 
 #
 # Account Delete dialog
 accountDeleteDialogHeader=Delete account
 accountDeleteInfoMessage=Delete account {0}.
-accountDeletedConfirmation=The account {0} has been deleted.
+accountDeletedConfirmation=Account successfully deleted.
 
 #
 # Account Filter panel

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -265,9 +265,9 @@ accountTableNumDeviceJobs=Device Jobs
 accountTableNumVpnConnections=Vpn Connections
 accountTableDataTtl=Data TTL
 
-accountCreatedConfirmation=The account {0} has been created.
-accountUpdatedConfirmation=The account {0} has been updated.
-accountDeletedConfirmation=The account {0} has been deleted.
+accountCreatedConfirmation=Account successfully created.
+accountUpdatedConfirmation=Account successfully updated.
+accountDeletedConfirmation=Account successfully deleted.
 accountDeleteConfirmation=Are you sure you want to delete account {0}?
 accountProvisionConfirmation=Are you sure you want to re-provision the Broker instance for account {0}?
 accountProvisionedConfirmation=Provisioning for Account {0} started.

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -161,9 +161,11 @@ public class CredentialAddDialog extends EntityAddEditDialog {
                 if (gwtCredentialCreator.getCredentialType() == GwtCredentialType.API_KEY) {
                     ApiKeyConfirmationDialog apiKeyConfirmationDialog = new ApiKeyConfirmationDialog(arg0.getCredentialKey());
                     apiKeyConfirmationDialog.show();
+                    exitMessage = MSGS.dialogAddConfirmationAPI();
+                } else if (gwtCredentialCreator.getCredentialType() == GwtCredentialType.PASSWORD) {
+                    exitMessage = MSGS.dialogAddConfirmationPassword();
                 }
                 exitStatus = true;
-                exitMessage = MSGS.dialogAddConfirmation();
                 hide();
             }
 

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialDeleteDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.authentication.client.messages.ConsoleCredentialMessages;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredential;
+import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialType;
 import org.eclipse.kapua.app.console.module.authentication.shared.service.GwtCredentialService;
 import org.eclipse.kapua.app.console.module.authentication.shared.service.GwtCredentialServiceAsync;
 
@@ -50,7 +51,13 @@ public class CredentialDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onSuccess(Void arg0) {
                 exitStatus = true;
-                exitMessage = MSGS.dialogDeleteConfirmation();
+
+                if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.API_KEY) {
+                    exitMessage = MSGS.dialogDeleteConfirmationAPI();
+                } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
+                    exitMessage = MSGS.dialogDeleteConfirmationPassword();
+                }
+
                 hide();
             }
 

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,6 +24,7 @@ import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.Listener;
 import com.google.gwt.user.client.Element;
 import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredential;
+import org.eclipse.kapua.app.console.module.authentication.shared.model.GwtCredentialType;
 
 public class CredentialEditDialog extends CredentialAddDialog {
 
@@ -62,7 +63,13 @@ public class CredentialEditDialog extends CredentialAddDialog {
             @Override
             public void onSuccess(GwtCredential result) {
                 exitStatus = true;
-                exitMessage = MSGS.dialogEditConfirmation();
+
+                if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.API_KEY) {
+                    exitMessage = MSGS.dialogEditConfirmationAPI();
+                } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
+                    exitMessage = MSGS.dialogEditConfirmationPassword();
+                }
+
                 hide();
             }
         });

--- a/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
+++ b/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -32,7 +32,8 @@ gridCredentialColumnHeaderModifiedBy=Modified By
 dialogAddHeader=New Credentials
 dialogConfirmationAPI=API Key confirmation
 dialogAddInfo=Create a new Credentials and associate it to the selected User. Password are manually inserted, while API Keys will be automatically generated.
-dialogAddConfirmation=Credential created successfully
+dialogAddConfirmationPassword=Password successfully created.
+dialogAddConfirmationAPI=API key successfully created.
 dialogAddError=Credential creation failed: {0}
 dialogAddFieldCredentialType=Credential Type
 dialogAddFieldSubjectType=Subject Type
@@ -51,7 +52,8 @@ dialogAddStatus=Status
 dialogEditHeader=Edit credentials: {0}
 dialogEditInfo=Modify the Credentials for the selected User.
 dialogEditLoadFailed=Cannot load credential: {0}
-dialogEditConfirmation=Credential edited successfully.
+dialogEditConfirmationPassword=Password successfully updated.
+dialogEditConfirmationAPI=API key successfully updated.
 dialogEditError=Credential edit failed: {0}
 dialogEditFieldNewPassword=New Password
 dialogEditFieldConfirmNewPassword=Confirm New Password
@@ -61,7 +63,8 @@ dialogEditLockedUntil=This credential will be locked until {0}
 # Delete dialog
 dialogDeleteHeader=Delete credential: {0}
 dialogDeleteInfo=Delete the selected credential and all associated permission? Also all user will lose this credential if deleted.
-dialogDeleteConfirmation=Credential deleted successfully.
+dialogDeleteConfirmationPassword=Password successfully deleted.
+dialogDeleteConfirmationAPI=API key successfully deleted.
 dialogDeleteError=Credential delete failed: {0}
 
 #

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -50,7 +50,7 @@ roleTabSubjectGridTitle=Subject
 # Add dialog
 dialogAddHeader=Create new role
 dialogAddInfo=Create a new role. 
-dialogAddConfirmation=Role created successfully
+dialogAddConfirmation=Role association successfully added.
 dialogAddError=Role creation failed: {0}
 
 dialogAddFieldName=Name
@@ -114,7 +114,7 @@ dialogAddPermissionErrorAccessInfo=Error retrieving AccessInfo: {0}
 dialogAddPermissionErrorDomains=Error retrieving domains: {0}
 dialogAddPermissionErrorActions=Error retrieving actions: {0}
 dialogAddPermissionErrorGroups=Error retrieving groups: {0}
-dialogAddPermissionConfirmation=Permission granted successfully
+dialogAddPermissionConfirmation=Permission association successfully granted.
 dialogAddPermissionError=Error granting permission: {0}
 dialogAddPermissionLoading=Loading...
 
@@ -122,7 +122,7 @@ dialogAddPermissionLoading=Loading...
 # Delete permission dialog
 dialogDeletePermissionHeader=Revoke Permission
 dialogDeletePermissionInfo=Revoke the permission from the user?
-dialogDeletePermissionConfirmation=Permission association revoked successfully.
+dialogDeletePermissionConfirmation=Permission association successfully revoked.
 dialogDeletePermissionError=Permission association revoked failed: {0}
 
 #
@@ -149,6 +149,6 @@ dialogAddRoleErrorAccessInfo=Error retrieving AccessInfo: {0}
 dialogDeleteTitle=Revoke
 dialogDeleteRoleHeader=Delete role association: {0}
 dialogDeleteRoleInfo=Delete the association between the user and the role?
-dialogDeleteRoleConfirmation=Role association deleted successfully.
+dialogDeleteRoleConfirmation=Role association successfully deleted.
 dialogDeleteRoleError=User association delete failed: {0}
 

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -42,7 +42,7 @@ roleTabSubjectGridTitle=Granted Users
 # Add dialog
 dialogAddHeader=New Role
 dialogAddInfo=Create a new role. 
-dialogAddConfirmation=Role created successfully
+dialogAddConfirmation=Role successfully created.
 dialogAddError=Role creation failed: {0}
 
 dialogAddFieldName=Name
@@ -59,7 +59,7 @@ dialogAddFieldGridRolePermissionTargetScopeId=Target Scope Id
 dialogEditHeader=Edit Role: {0}
 dialogEditInfo=Edit Role&#39;s name.
 dialogEditLoadFailed=Cannot load role: {0}
-dialogEditConfirmation=Role edited successfully.
+dialogEditConfirmation=Role successfully updated.
 dialogEditError=Role edit failed: {0}
 
 dialogEditFieldName=Name
@@ -76,7 +76,7 @@ dialogEditFieldGridRolePermissionCreatedBy=Added By
 # Delete dialog
 dialogDeleteHeader=Delete role: {0}
 dialogDeleteInfo=Delete the selected role and all associated permission? Also all user will lose this role if deleted.
-dialogDeleteConfirmation=Role deleted successfully.
+dialogDeleteConfirmation=Role successfully deleted.
 dialogDeleteError=Role delete failed: {0}
 
 #

--- a/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
+++ b/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -35,7 +35,7 @@ gridUserTabCredentialsLabel=Credentials
 dialogAddHeader=New User
 dialogAddInfo=Create a New User with initial credential.
 dialogAddFieldSet=User Information
-dialogAddConfirmation=User created successfully
+dialogAddConfirmation=User successfully created.
 dialogAddError=User creation failed: {0}
 dialogAddFieldUsername=Username
 dialogAddFieldNameTooltip=The name of the New User. It must be unique.
@@ -54,7 +54,7 @@ dialogEditInfo=Edit User attributes.
 dialogEditHeader=Edit User: {0}
 dialogEditInfo=Edit user attributes.
 dialogEditLoadFailed=Cannot load user: {0}
-dialogEditConfirmation=User edited successfully.
+dialogEditConfirmation=User successfully updated.
 dialogEditError=User edit failed: {0}
 
 dialogEditFieldName=Name
@@ -64,7 +64,7 @@ dialogEditFieldNameTooltip=The name of the User. It must be unique.
 # Delete dialog
 dialogDeleteHeader=Delete user: {0}
 dialogDeleteInfo=Delete the selected user and all associated entities?
-dialogDeleteConfirmation=User deleted successfully.
+dialogDeleteConfirmation=User successfully deleted.
 dialogDeleteError=User delete failed: {0}
 
 #


### PR DESCRIPTION
Messages were changed and in some cases parameters from messages
were removed (Account messages for example).

In case of credential messages, messages were split into API and
Password credentials.

This also solved issue 1309 that was regarding wrong message in case
of role assignment.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>