### PR TITLE
Fixed refresh button on Device Installed Packages

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -122,6 +122,7 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
                 if (selectedEntity != null &&
                         selectedEntity.isOnline()) {
                     setDirty();
+                    setEntity(selectedEntity);
                     refresh();
                 } else {
                     openDeviceOfflineAlertDialog();


### PR DESCRIPTION
Simple fix to enable refresh button. This is only way to see changes on
installed packages, as push of changes is not possible to console app.

During this I noticed that In Progress tab of package installation is not
working, or am I wrong?

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>