### PR TITLE
Fixing long client id name in header with ...

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/MetricsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/MetricsTable.java
@@ -185,6 +185,9 @@ public class MetricsTable extends LayoutContainer {
 
     public void refresh(GwtDatastoreDevice selectedDevice) {
         if (selectedDevice != null) {
+            tableContainer.getHeader().setStyleAttribute("white-space", "nowrap");
+            tableContainer.getHeader().setStyleAttribute("text-overflow", "ellipsis");
+            tableContainer.getHeader().setStyleAttribute("overflow", "hidden");
             tableContainer.setHeading(MSGS.metricsTableHeaderDevice(selectedDevice.getDevice()));
             if (selectedAsset != null) {
                 tableContainer.setHeading(MSGS.metricsTableHeaderAssets());


### PR DESCRIPTION
This fixes issue #1083 where name in header of topic table is truncated to
width of header and in case of long name ended with ...

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>