### PR TITLE
Fixed problems with filter query fields without limits

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountFilterPanel.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
 import org.eclipse.kapua.app.console.module.account.client.messages.ConsoleAccountMessages;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
@@ -23,20 +24,20 @@ import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccountQuery
 
 import com.extjs.gxt.ui.client.widget.Label;
 import com.extjs.gxt.ui.client.widget.VerticalPanel;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 
 public class AccountFilterPanel extends EntityFilterPanel<GwtAccount> {
 
     private static final int WIDTH = 200;
+    private static final int MAX_LEN = 255;
     private static final ConsoleAccountMessages MSGS = GWT.create(ConsoleAccountMessages.class);
 
     private EntityGrid<GwtAccount> entityGrid;
     private final GwtSession currentSession;
 
-    private final TextField<String> accountNameField;
-    private final TextField<String> accountOrgNameField;
-    private final TextField<String> accountOrgEmailField;
+    private final KapuaTextField<String> accountNameField;
+    private final KapuaTextField<String> accountOrgNameField;
+    private final KapuaTextField<String> accountOrgEmailField;
 
     public AccountFilterPanel(AbstractEntityView<GwtAccount> entityView, GwtSession currentSession) {
         super(entityView, currentSession);
@@ -53,9 +54,10 @@ public class AccountFilterPanel extends EntityFilterPanel<GwtAccount> {
         accountNameLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(accountNameLabel);
 
-        accountNameField = new TextField<String>();
+        accountNameField = new KapuaTextField<String>();
         accountNameField.setName("name");
         accountNameField.setWidth(WIDTH);
+        accountNameField.setMaxLength(MAX_LEN);
         accountNameField.setStyleAttribute("margin-top", "0px");
         accountNameField.setStyleAttribute("margin-left", "5px");
         accountNameField.setStyleAttribute("margin-right", "5px");
@@ -67,9 +69,10 @@ public class AccountFilterPanel extends EntityFilterPanel<GwtAccount> {
         accountOrgNameLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(accountOrgNameLabel);
 
-        accountOrgNameField = new TextField<String>();
+        accountOrgNameField = new KapuaTextField<String>();
         accountOrgNameField.setName("orgName");
         accountOrgNameField.setWidth(WIDTH);
+        accountOrgNameField.setMaxLength(MAX_LEN);
         accountOrgNameField.setStyleAttribute("margin-top", "0px");
         accountOrgNameField.setStyleAttribute("margin-left", "5px");
         accountOrgNameField.setStyleAttribute("margin-right", "5px");
@@ -81,9 +84,10 @@ public class AccountFilterPanel extends EntityFilterPanel<GwtAccount> {
         accountOrgEmailLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(accountOrgEmailLabel);
 
-        accountOrgEmailField = new TextField<String>();
+        accountOrgEmailField = new KapuaTextField<String>();
         accountOrgEmailField.setName("name");
         accountOrgEmailField.setWidth(WIDTH);
+        accountOrgEmailField.setMaxLength(MAX_LEN);
         accountOrgEmailField.setStyleAttribute("margin-top", "0px");
         accountOrgEmailField.setStyleAttribute("margin-left", "5px");
         accountOrgEmailField.setStyleAttribute("margin-right", "5px");

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupFilterPanel.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,22 +14,23 @@ package org.eclipse.kapua.app.console.module.authorization.client.group;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsoleGroupMessages;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
 
 import com.extjs.gxt.ui.client.widget.Label;
 import com.extjs.gxt.ui.client.widget.VerticalPanel;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroupQuery;
 
 public class GroupFilterPanel extends EntityFilterPanel<GwtGroup> {
 
     private static final int WIDTH = 200;
+    private static final int MAX_LEN = 255;
     private final EntityGrid<GwtGroup> entityGrid;
     private final GwtSession currentSession;
-    private final TextField<String> nameField;
+    private final KapuaTextField<String> nameField;
     private static final ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
 
     public GroupFilterPanel(AbstractEntityView<GwtGroup> entityView, GwtSession currentSession) {
@@ -44,9 +45,10 @@ public class GroupFilterPanel extends EntityFilterPanel<GwtGroup> {
         nameLabel.setWidth(WIDTH);
         nameLabel.setStyleAttribute("margin", "5px");
         verticalPanel.add(nameLabel);
-        nameField = new TextField<String>();
+        nameField = new KapuaTextField<String>();
         nameField.setName("name");
         nameField.setWidth(WIDTH);
+        nameField.setMaxLength(MAX_LEN);
         nameField.setStyleAttribute("margin-top", "0px");
         nameField.setStyleAttribute("margin-left", "5px");
         nameField.setStyleAttribute("margin-right", "5px");

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsoleRoleMessages;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
@@ -23,18 +24,18 @@ import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRoleQu
 
 import com.extjs.gxt.ui.client.widget.Label;
 import com.extjs.gxt.ui.client.widget.VerticalPanel;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 
 public class RoleFilterPanel extends EntityFilterPanel<GwtRole> {
 
     private final static ConsoleRoleMessages ROLE_MSGS = GWT.create(ConsoleRoleMessages.class);
     private final static int WIDTH = 200;
+    private static final int MAX_LEN = 255;
 
     private final EntityGrid<GwtRole> entityGrid;
     private final GwtSession currentSession;
 
-    private final TextField<String> nameField;
+    private final KapuaTextField<String> nameField;
 
     public RoleFilterPanel(AbstractEntityView<GwtRole> entityView, GwtSession currentSession) {
         super(entityView, currentSession);
@@ -53,9 +54,10 @@ public class RoleFilterPanel extends EntityFilterPanel<GwtRole> {
 
         fieldsPanel.add(roleNameLabel);
 
-        nameField = new TextField<String>();
+        nameField = new KapuaTextField<String>();
         nameField.setName("name");
         nameField.setWidth(WIDTH);
+        nameField.setMaxLength(MAX_LEN);
         nameField.setStyleAttribute("margin-top", "0px");
         nameField.setStyleAttribute("margin-left", "5px");
         nameField.setStyleAttribute("margin-right", "5px");

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionFilterPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleConnectionMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQueryPredicates;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
@@ -26,19 +27,19 @@ import com.extjs.gxt.ui.client.widget.Label;
 import com.extjs.gxt.ui.client.widget.VerticalPanel;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 
 public class ConnectionFilterPanel extends EntityFilterPanel<GwtDeviceConnection> {
 
     private static final int WIDTH = 200;
+    private static final int MAX_LEN = 255;
     private static final ConsoleConnectionMessages MSGS = GWT.create(ConsoleConnectionMessages.class);
 
     private EntityGrid<GwtDeviceConnection> entityGrid;
     private final GwtSession currentSession;
 
-    private final TextField<String> clientIdField;
-    private final TextField<String> clientIPFilter;
+    private final KapuaTextField<String> clientIdField;
+    private final KapuaTextField<String> clientIPFilter;
     private final SimpleComboBox<GwtDeviceQueryPredicates.GwtDeviceConnectionStatus> connectionStatusCombo;
 
     public ConnectionFilterPanel(AbstractEntityView<GwtDeviceConnection> entityView, GwtSession currentSession) {
@@ -54,9 +55,10 @@ public class ConnectionFilterPanel extends EntityFilterPanel<GwtDeviceConnection
         clientIdLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(clientIdLabel);
 
-        clientIdField = new TextField<String>();
+        clientIdField = new KapuaTextField<String>();
         clientIdField.setName("name");
         clientIdField.setWidth(WIDTH);
+        clientIdField.setMaxLength(MAX_LEN);
         clientIdField.setStyleAttribute("margin-top", "0px");
         clientIdField.setStyleAttribute("margin-left", "5px");
         clientIdField.setStyleAttribute("margin-right", "5px");
@@ -92,9 +94,10 @@ public class ConnectionFilterPanel extends EntityFilterPanel<GwtDeviceConnection
         clientIPFilterLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(clientIPFilterLabel);
 
-        clientIPFilter = new TextField<String>();
+        clientIPFilter = new KapuaTextField<String>();
         clientIPFilter.setName("Client IP");
         clientIPFilter.setWidth(WIDTH);
+        clientIPFilter.setMaxLength(MAX_LEN);
         clientIPFilter.setStyleAttribute("margin-top", "0px");
         clientIPFilter.setStyleAttribute("margin-left", "5px");
         clientIPFilter.setStyleAttribute("margin-right", "5px");

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceFilterPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,7 +17,6 @@ import com.extjs.gxt.ui.client.widget.VerticalPanel;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
@@ -26,6 +25,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
@@ -47,6 +47,7 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private static final ConsoleDeviceMessages DEVICE_MSGS = GWT.create(ConsoleDeviceMessages.class);
     private static final int WIDTH = 200;
+    private static final int MAX_LEN = 255;
 
     private EntityGrid<GwtDevice> entityGrid;
 
@@ -54,15 +55,15 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
     private final GwtTagServiceAsync tagService = GWT.create(GwtTagService.class);
     private final GwtSession currentSession;
 
-    private final TextField<String> clientIdField;
-    private final TextField<String> serialNumberField;
-    private final TextField<String> displayNameField;
+    private final KapuaTextField<String> clientIdField;
+    private final KapuaTextField<String> serialNumberField;
+    private final KapuaTextField<String> displayNameField;
     private final SimpleComboBox<GwtDeviceQueryPredicates.GwtDeviceStatus> statusCombo;
     private final SimpleComboBox<GwtDeviceQueryPredicates.GwtDeviceConnectionStatus> connectionStatusCombo;
-    private final TextField<String> iotFrameworkVersionField;
-    private final TextField<String> applicationIdentifiersField;
-    private final TextField<String> customAttribute1Field;
-    private final TextField<String> customAttribute2Field;
+    private final KapuaTextField<String> iotFrameworkVersionField;
+    private final KapuaTextField<String> applicationIdentifiersField;
+    private final KapuaTextField<String> customAttribute1Field;
+    private final KapuaTextField<String> customAttribute2Field;
 
     private ComboBox<GwtGroup> groupsCombo;
     private GwtGroup allGroup;
@@ -88,9 +89,10 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
 
         fieldsPanel.add(clientIdLabel);
 
-        clientIdField = new TextField<String>();
+        clientIdField = new KapuaTextField<String>();
         clientIdField.setName("clientId");
         clientIdField.setWidth(WIDTH);
+        clientIdField.setMaxLength(MAX_LEN);
         clientIdField.setStyleAttribute("margin-top", "0px");
         clientIdField.setStyleAttribute("margin-left", "5px");
         clientIdField.setStyleAttribute("margin-right", "5px");
@@ -104,9 +106,10 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
         displayNameLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(displayNameLabel);
 
-        displayNameField = new TextField<String>();
+        displayNameField = new KapuaTextField<String>();
         displayNameField.setName("displayName");
         displayNameField.setWidth(WIDTH);
+        displayNameField.setMaxLength(MAX_LEN);
         displayNameField.setStyleAttribute("margin-top", "0px");
         displayNameField.setStyleAttribute("margin-left", "5px");
         displayNameField.setStyleAttribute("margin-right", "5px");
@@ -120,9 +123,10 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
         serialNumberLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(serialNumberLabel);
 
-        serialNumberField = new TextField<String>();
+        serialNumberField = new KapuaTextField<String>();
         serialNumberField.setName("serialNumber");
         serialNumberField.setWidth(WIDTH);
+        serialNumberField.setMaxLength(MAX_LEN);
         serialNumberField.setStyleAttribute("margin-top", "0px");
         serialNumberField.setStyleAttribute("margin-left", "5px");
         serialNumberField.setStyleAttribute("margin-right", "5px");
@@ -189,9 +193,10 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
         iotFrameworkVersionLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(iotFrameworkVersionLabel);
 
-        iotFrameworkVersionField = new TextField<String>();
+        iotFrameworkVersionField = new KapuaTextField<String>();
         iotFrameworkVersionField.setName("iotFrameworkVersion");
         iotFrameworkVersionField.setWidth(WIDTH);
+        iotFrameworkVersionField.setMaxLength(MAX_LEN);
         iotFrameworkVersionField.setStyleAttribute("margin-top", "0px");
         iotFrameworkVersionField.setStyleAttribute("margin-left", "5px");
         iotFrameworkVersionField.setStyleAttribute("margin-right", "5px");
@@ -205,9 +210,10 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
         applicationIdentifiersLabel.setStyleAttribute("margin", "5px");
         fieldsPanel.add(applicationIdentifiersLabel);
 
-        applicationIdentifiersField = new TextField<String>();
+        applicationIdentifiersField = new KapuaTextField<String>();
         applicationIdentifiersField.setName("applicationIdentifiers");
         applicationIdentifiersField.setWidth(WIDTH);
+        applicationIdentifiersField.setMaxLength(MAX_LEN);
         applicationIdentifiersField.setStyleAttribute("margin-top", "0px");
         applicationIdentifiersField.setStyleAttribute("margin-left", "5px");
         applicationIdentifiersField.setStyleAttribute("margin-right", "5px");
@@ -221,9 +227,10 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
         customAttribute1Label.setStyleAttribute("margin", "5px");
         fieldsPanel.add(customAttribute1Label);
 
-        customAttribute1Field = new TextField<String>();
+        customAttribute1Field = new KapuaTextField<String>();
         customAttribute1Field.setName("customAttribute1");
         customAttribute1Field.setWidth(WIDTH);
+        customAttribute1Field.setMaxLength(MAX_LEN);
         customAttribute1Field.setStyleAttribute("margin-top", "0px");
         customAttribute1Field.setStyleAttribute("margin-left", "5px");
         customAttribute1Field.setStyleAttribute("margin-right", "5px");
@@ -237,9 +244,10 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
         customAttribute2Label.setStyleAttribute("margin", "5px");
         fieldsPanel.add(customAttribute2Label);
 
-        customAttribute2Field = new TextField<String>();
+        customAttribute2Field = new KapuaTextField<String>();
         customAttribute2Field.setName("customAttribute1");
         customAttribute2Field.setWidth(WIDTH);
+        customAttribute2Field.setMaxLength(MAX_LEN);
         customAttribute2Field.setStyleAttribute("margin-top", "0px");
         customAttribute2Field.setStyleAttribute("margin-left", "5px");
         customAttribute2Field.setStyleAttribute("margin-right", "5px");

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagFilterPanel.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,11 +14,11 @@ package org.eclipse.kapua.app.console.module.tag.client;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
 
 import com.extjs.gxt.ui.client.widget.Label;
 import com.extjs.gxt.ui.client.widget.VerticalPanel;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 import org.eclipse.kapua.app.console.module.tag.client.messages.ConsoleTagMessages;
 import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
@@ -27,9 +27,10 @@ import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTagQuery;
 public class TagFilterPanel extends EntityFilterPanel<GwtTag> {
 
     private static final int WIDTH = 200;
+    private static final int MAX_LEN = 255;
     private final EntityGrid<GwtTag> entityGrid;
     private final GwtSession currentSession;
-    private final TextField<String> nameField;
+    private final KapuaTextField<String> nameField;
     private static final ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
 
     public TagFilterPanel(AbstractEntityView<GwtTag> entityView, GwtSession currentSession) {
@@ -44,9 +45,10 @@ public class TagFilterPanel extends EntityFilterPanel<GwtTag> {
         nameLabel.setWidth(WIDTH);
         nameLabel.setStyleAttribute("margin", "5px");
         verticalPanel.add(nameLabel);
-        nameField = new TextField<String>();
+        nameField = new KapuaTextField<String>();
         nameField.setName("name");
         nameField.setWidth(WIDTH);
+        nameField.setMaxLength(MAX_LEN);
         nameField.setStyleAttribute("margin-top", "0px");
         nameField.setStyleAttribute("margin-left", "5px");
         nameField.setStyleAttribute("margin-right", "5px");

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserFilterPanel.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,13 +16,13 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
 import org.eclipse.kapua.app.console.module.user.client.messages.ConsoleUserMessages;
 import org.eclipse.kapua.app.console.module.user.shared.model.user.GwtUser;
 
 import com.extjs.gxt.ui.client.widget.Label;
 import com.extjs.gxt.ui.client.widget.VerticalPanel;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
@@ -32,11 +32,12 @@ public class UserFilterPanel extends EntityFilterPanel<GwtUser> {
 
     private final static ConsoleUserMessages USER_MSGS = GWT.create(ConsoleUserMessages.class);
     private final static int WIDTH = 200;
+    private static final int MAX_LEN = 255;
 
     private final EntityGrid<GwtUser> entityGrid;
     private final GwtSession currentSession;
 
-    private final TextField<String> nameField;
+    private final KapuaTextField<String> nameField;
     private final SimpleComboBox<GwtUser.GwtUserStatus> statusCombo;
 
     public UserFilterPanel(AbstractEntityView<GwtUser> entityView, GwtSession currentSession) {
@@ -56,9 +57,10 @@ public class UserFilterPanel extends EntityFilterPanel<GwtUser> {
 
         fieldsPanel.add(clientIdLabel);
 
-        nameField = new TextField<String>();
+        nameField = new KapuaTextField<String>();
         nameField.setName("name");
         nameField.setWidth(WIDTH);
+        nameField.setMaxLength(MAX_LEN);
         nameField.setStyleAttribute("margin-top", "0px");
         nameField.setStyleAttribute("margin-left", "5px");
         nameField.setStyleAttribute("margin-right", "5px");


### PR DESCRIPTION
Solving problem with extremely long query filters that break browser and eventually also backend.

This solves issues:
- 1174
- 1176
- 1179
- 1195
- 1196

During process I noticed that same issue might occur on Devices and Connections
filters, so I added checks there too.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>