### PR TITLE
Feature endpoint info service

### DIFF
--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -11,7 +11,7 @@
         Eurotech - initial API and implementation
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
@@ -52,6 +52,14 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-broker-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-api</artifactId>
         </dependency>
 
         <!-- External Dependencies -->

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -82,7 +82,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.security.MessageDigest;
@@ -233,8 +232,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
             EndpointInfoListResult endpointInfos = ENDPOINT_INFO_SERVICE.query(ENDPOINT_INFO_FACTORY.newQuery(account.getId()));
 
             for (EndpointInfo ei : endpointInfos.getItems()) {
-                URI nodeUri = new URI(ei.getSchema(), null, ei.getDns(), ei.getPort(), null, null, null);
-                accountPropertiesPairs.add(new GwtGroupedNVPair("deploymentInfo", ei.getSecure() ? "deploymentNodeUriSecure" : "deploymentNodeUri", nodeUri.toString()));
+                accountPropertiesPairs.add(new GwtGroupedNVPair("deploymentInfo", ei.getSecure() ? "deploymentNodeUriSecure" : "deploymentNodeUri", ei.toStringURI()));
             }
 
             accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationName", account.getOrganization().getName()));

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -391,7 +391,8 @@ accountCreatedOn=Created On
 accountCreatedBy=Created By
 
 deploymentInfo=Deployment Info
-deploymentNodeURI=Node URI
+deploymentNodeUri=Broker URI
+deploymentNodeUriSecure=Secure Broker URI
 deploymentVpnURL=Vpn URL
 deploymentBrokerImageName=Broker Image Name
 
@@ -520,7 +521,7 @@ simProvisioning = SIM Provider Provisioning Informations
 simProvisionStatus = Provisioning Status
 simProvisionOn = Provisioning Timestamp
 simModifiedOn = Last SIM Update
- 
+
 simSession = 2. SIM Card Last Communication Sessions Info
 simActive = Session Active
 simIpAddress = IP Address
@@ -536,7 +537,7 @@ simProvSessionLastNotificationFailureReason = Notification Failure Reason
 simProvSessionPreviousNormalTimestamp = Last non-zero Packet Data Timestamp
 simProvSessionLastAuthFailureTimestamp = Authentication Failure Timestamp
 simProvSessionLastAuthFailureReason = Authentication Failure Reason
-                
+
 publicKeyInfo=Public Key Informations
 ttl=TTL
 deviceId=Device ID

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -48,6 +48,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-foreignkeys</artifactId>
         </dependency>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -79,6 +79,9 @@
         <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService</api>
         <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory</api>
 
+        <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
+        <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
+
         <api>org.eclipse.kapua.service.tag.TagFactory</api>
         <api>org.eclipse.kapua.service.tag.TagService</api>
 
@@ -110,7 +113,7 @@
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-        
+
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>
     <packages>

--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,16 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-endpoint-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-endpoint-internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-datastore-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1322,7 +1332,7 @@
                 <artifactId>jose4j</artifactId>
                 <version>0.5.2</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.qpid</groupId>
                 <artifactId>qpid-jms-client</artifactId>

--- a/rest-api/resources/pom.xml
+++ b/rest-api/resources/pom.xml
@@ -10,7 +10,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.eclipse.kapua</groupId>
@@ -28,6 +29,14 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-account-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import com.google.common.base.Strings;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.CountResult;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.EntityId;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
+import org.eclipse.kapua.commons.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
+import org.eclipse.kapua.service.endpoint.EndpointInfoFactory;
+import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
+import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
+import org.eclipse.kapua.service.endpoint.EndpointInfoService;
+import org.eclipse.kapua.service.endpoint.internal.EndpointInfoPredicates;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Api(value = "EndpointInfos", authorizations = { @Authorization(value = "kapuaAccessToken") })
+@Path("{scopeId}/endpointInfos")
+public class EndpointInfos extends AbstractKapuaResource {
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final EndpointInfoService endpointInfoService = locator.getService(EndpointInfoService.class);
+    private final EndpointInfoFactory endpointInfoFactory = locator.getFactory(EndpointInfoFactory.class);
+
+    /**
+     * Gets the {@link EndpointInfo} list in the scope.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param usage   The {@link EndpointInfo} usage to filter results
+     * @param offset  The result set offset.
+     * @param limit   The result set limit.
+     * @return The {@link EndpointInfoListResult} of all the endpointInfos associated to the current selected scope.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @ApiOperation(nickname = "endpointInfoSimpleQuery",
+            value = "Gets the EndpointInfo list in the scope", //
+            notes = "Returns the list of all the endpointInfos associated to the current selected scope.", //
+            response = EndpointInfoListResult.class)
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public EndpointInfoListResult simpleQuery(
+            @ApiParam(value = "The ScopeId in which to search results.", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The endpointInfo usage to filter results.") @QueryParam("usage") String usage,
+            @ApiParam(value = "The result set offset.", defaultValue = "0") @QueryParam("offset") @DefaultValue("0") int offset,
+            @ApiParam(value = "The result set limit.", defaultValue = "50") @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
+        EndpointInfoQuery query = endpointInfoFactory.newQuery(scopeId);
+
+        AndPredicate andPredicate = new AndPredicate();
+        if (!Strings.isNullOrEmpty(usage)) {
+            andPredicate.and(new AttributePredicate<>(EndpointInfoPredicates.USAGES, endpointInfoFactory.newEndpointUsage(usage)));
+        }
+        query.setPredicate(andPredicate);
+
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return query(scopeId, query);
+    }
+
+    /**
+     * Queries the results with the given {@link EndpointInfoQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link EndpointInfoQuery} to use to filter results.
+     * @return The {@link EndpointInfoListResult} of all the result matching the given {@link EndpointInfoQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @ApiOperation(nickname = "endpointInfoQuery",
+            value = "Queries the EndpointInfos", //
+            notes = "Queries the EndpointInfos with the given EndpointInfoQuery parameter returning all matching EndpointInfos", //
+            response = EndpointInfoListResult.class)
+    @POST
+    @Path("_query")
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    public EndpointInfoListResult query(
+            @ApiParam(value = "The ScopeId in which to search results.", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The EndpointInfoQuery to use to filter results.", required = true) EndpointInfoQuery query) throws Exception {
+        query.setScopeId(scopeId);
+
+        return endpointInfoService.query(query);
+    }
+
+    /**
+     * Counts the results with the given {@link EndpointInfoQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link EndpointInfoQuery} to use to filter results.
+     * @return The count of all the result matching the given {@link EndpointInfoQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @ApiOperation(nickname = "endpointInfoCount",
+            value = "Counts the EndpointInfos", //
+            notes = "Counts the EndpointInfos with the given EndpointInfoQuery parameter returning the number of matching EndpointInfos", //
+            response = CountResult.class)
+    @POST
+    @Path("_count")
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    public CountResult count(
+            @ApiParam(value = "The ScopeId in which to count results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The EndpointInfoQuery to use to filter count results", required = true) EndpointInfoQuery query) throws Exception {
+        query.setScopeId(scopeId);
+
+        return new CountResult(endpointInfoService.count(query));
+    }
+
+    /**
+     * Creates a new EndpointInfo based on the information provided in EndpointInfoCreator
+     * parameter.
+     *
+     * @param scopeId             The {@link ScopeId} in which to create the {@link EndpointInfo}
+     * @param endpointInfoCreator Provides the information for the new {@link EndpointInfo} to be created.
+     * @return The newly created {@link EndpointInfo} object.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @ApiOperation(nickname = "createEndpointInfo",
+            value = "Create a EndpointInfo", //
+            notes = "Creates a new EndpointInfo based on the information provided in EndpointInfoCreator parameter.", //
+            response = EndpointInfo.class)
+    @POST
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    public EndpointInfo create(
+            @ApiParam(value = "The ScopeId in which to create the EndpointInfo", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "Provides the information for the new EndpointInfo to be created", required = true) EndpointInfoCreator endpointInfoCreator) throws Exception {
+        endpointInfoCreator.setScopeId(scopeId);
+
+        return endpointInfoService.create(endpointInfoCreator);
+    }
+
+    /**
+     * Returns the EndpointInfo specified by the "endpointInfoId" path parameter.
+     *
+     * @param scopeId        The {@link ScopeId} of the requested {@link EndpointInfo}.
+     * @param endpointInfoId The id of the requested EndpointInfo.
+     * @return The requested EndpointInfo object.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @ApiOperation(nickname = "endpointInfoFind",
+            value = "Get a EndpointInfo", //
+            notes = "Returns the EndpointInfo specified by the \"endpointInfoId\" path parameter.", //
+            response = EndpointInfo.class)
+    @GET
+    @Path("{endpointInfoId}")
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    public EndpointInfo find(
+            @ApiParam(value = "The ScopeId of the requested EndpointInfo.", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The id of the requested EndpointInfo", required = true) @PathParam("endpointInfoId") EntityId endpointInfoId) throws Exception {
+        EndpointInfo endpointInfo = endpointInfoService.find(scopeId, endpointInfoId);
+
+        if (endpointInfo == null) {
+            throw new KapuaEntityNotFoundException(EndpointInfo.TYPE, endpointInfoId);
+        }
+
+        return endpointInfo;
+    }
+
+    /**
+     * Updates the EndpointInfo based on the information provided in the EndpointInfo parameter.
+     *
+     * @param scopeId        The ScopeId of the requested {@link EndpointInfo}.
+     * @param endpointInfoId The id of the requested {@link EndpointInfo}
+     * @param endpointInfo   The modified EndpointInfo whose attributed need to be updated.
+     * @return The updated endpointInfo.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @ApiOperation(nickname = "endpointInfoUpdate",
+            value = "Update a EndpointInfo", //
+            notes = "Updates a new EndpointInfo based on the information provided in the EndpointInfo parameter.", //
+            response = EndpointInfo.class)
+    @PUT
+    @Path("{endpointInfoId}")
+    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    public EndpointInfo update(
+            @ApiParam(value = "The ScopeId of the requested EndpointInfo.", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The id of the requested EndpointInfo", required = true) @PathParam("endpointInfoId") EntityId endpointInfoId,
+            @ApiParam(value = "The modified EndpointInfo whose attributed need to be updated", required = true) EndpointInfo endpointInfo) throws Exception {
+        endpointInfo.setScopeId(scopeId);
+        endpointInfo.setId(endpointInfoId);
+
+        return endpointInfoService.update(endpointInfo);
+    }
+
+    /**
+     * Deletes the EndpointInfo specified by the "endpointInfoId" path parameter.
+     *
+     * @param scopeId        The ScopeId of the requested {@link EndpointInfo}.
+     * @param endpointInfoId The id of the EndpointInfo to be deleted.
+     * @return HTTP 200 if operation has completed successfully.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @ApiOperation(nickname = "endpointInfoDelete",
+            value = "Delete an EndpointInfo", //
+            notes = "Deletes the EndpointInfo specified by the \"endpointInfoId\" path parameter.")
+    @DELETE
+    @Path("{endpointInfoId}")
+    public Response deleteEndpointInfo(
+            @ApiParam(value = "The ScopeId of the EndpointInfo to delete.", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The id of the EndpointInfo to be deleted", required = true) @PathParam("endpointInfoId") EntityId endpointInfoId) throws Exception {
+        endpointInfoService.delete(scopeId, endpointInfoId);
+
+        return returnOk();
+    }
+}

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -110,6 +110,11 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-internal</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-security-shiro</artifactId>
         </dependency>
         <dependency>

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -157,6 +157,12 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventQuery;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventXmlRegistry;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
+import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
+import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
+import org.eclipse.kapua.service.endpoint.EndpointInfoXmlRegistry;
+import org.eclipse.kapua.service.endpoint.EndpointUsage;
 import org.eclipse.kapua.service.tag.Tag;
 import org.eclipse.kapua.service.tag.TagCreator;
 import org.eclipse.kapua.service.tag.TagListResult;
@@ -350,6 +356,14 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
 
                     // Permission
                     Permission.class,
+
+                    // Endpoint Info
+                    EndpointUsage.class,
+                    EndpointInfo.class,
+                    EndpointInfoListResult.class,
+                    EndpointInfoCreator.class,
+                    EndpointInfoQuery.class,
+                    EndpointInfoXmlRegistry.class,
 
                     // Roles
                     Role.class,

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -87,6 +87,9 @@
         <api>org.eclipse.kapua.service.datastore.DatastoreObjectFactory</api>
         <api>org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory</api>
 
+        <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
+        <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
+
         <api>org.eclipse.kapua.service.tag.TagFactory</api>
         <api>org.eclipse.kapua.service.tag.TagService</api>
 

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -50,31 +50,12 @@ securityManager.rememberMeManager.cookie.maxAge = 0
 # in web applications.  We'll discuss this section in the
 # Web documentation
 /v1/test						= kapuaAuthcAccessToken, noSessionCreation
+# Authentication
 /v1/authentication/logout		= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/accounts.xml				= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/accounts.json				= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/accounts/**				= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/clients.xml			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/clients.json			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/clients/**			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/channels.xml			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/channels.json		= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/channels/**			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/messages.xml			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/messages.json		= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/messages/**			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/metrics.xml			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/metrics.json			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/metrics/**			= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/devices.json				= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/devices.xml				= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/devices/**				= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/deviceconnections.json	= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/deviceconnections.xml		= kapuaAuthcAccessToken, noSessionCreation
-/v1/*/deviceconnections/**		= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/credentials.json			= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/credentials.xml			= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/credentials/**			= kapuaAuthcAccessToken, noSessionCreation
+# Authorization
 /v1/*/accessinfos.xml			= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/accessinfos.json			= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/accessinfos/**			= kapuaAuthcAccessToken, noSessionCreation
@@ -87,10 +68,41 @@ securityManager.rememberMeManager.cookie.maxAge = 0
 /v1/*/roles.xml					= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/roles.json				= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/roles/**					= kapuaAuthcAccessToken, noSessionCreation
+# Account
+/v1/*/accounts.xml				= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/accounts.json				= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/accounts/**				= kapuaAuthcAccessToken, noSessionCreation
+# Datastore
+/v1/*/data/clients.xml			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/clients.json			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/clients/**			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/channels.xml			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/channels.json		= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/channels/**			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/messages.xml			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/messages.json		= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/messages/**			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/metrics.xml			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/metrics.json			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/metrics/**			= kapuaAuthcAccessToken, noSessionCreation
+# Device and Device Management
+/v1/*/devices.json				= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/devices.xml				= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/devices/**				= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/deviceconnections.json	= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/deviceconnections.xml		= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/deviceconnections/**		= kapuaAuthcAccessToken, noSessionCreation
+# Device and Device Management
+/v1/*/endpointInfos.json		= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/endpointInfos.xml			= kapuaAuthcAccessToken, noSessionCreation
+/v1/*/endpointInfos/**			= kapuaAuthcAccessToken, noSessionCreation
+# Streams
 /v1/*/streams/**                = kapuaAuthcAccessToken, noSessionCreation
+# Tag
 /v1/*/tags.json					= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/tags.xml					= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/tags/**					= kapuaAuthcAccessToken, noSessionCreation
+# User
 /v1/*/users.json				= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/users.xml					= kapuaAuthcAccessToken, noSessionCreation
 /v1/*/users/**					= kapuaAuthcAccessToken, noSessionCreation

--- a/service/account/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.account.AccountService.xml
+++ b/service/account/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.account.AccountService.xml
@@ -12,9 +12,9 @@
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kapua.service.account.AccountService"
-         name="AccountService" 
+         name="AccountService"
          description="This is the configuration for the kapua AccountService. ">
-        
+
         <Icon resource="OSGI-INF/account-service.png" size="32"/>
 
         <AD id="infiniteChildEntities"
@@ -26,30 +26,18 @@
             description="Whether to allow infinite child accounts for this account.">
         </AD>
 
-        <AD id="maxNumberChildEntities"  
+        <AD id="maxNumberChildEntities"
             name="maxNumberChildAccounts"
             type="Integer"
-            cardinality="0" 
+            cardinality="0"
             required="true"
-            default="0" 
+            default="0"
             min="0"
             description="Maximum number of child accounts that are allowed to be created for this account.">
         </AD>
 
-        <AD id="messagingServiceUri"
-            name="messagingServiceUri"
-            type="String"
-            cardinality="0"
-            required="false"
-            default=""
-            description="Broker Cluster URI"
-            showOnlyForActor="ROOT"
-            showOnlyForTarget="ROOT_AND_CHILDREN"
-            allowSelfEdit="true">
-        </AD>
-
     </OCD>
-    
+
     <Designate pid="org.eclipse.kapua.service.account.AccountService">
         <Object ocdref="org.eclipse.kapua.service.account.AccountService"/>
     </Designate>

--- a/service/endpoint/api/pom.xml
+++ b/service/endpoint/api/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kapua-endpoint</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kapua-endpoint-api</artifactId>
+
+
+    <dependencies>
+        <!-- Extended service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
@@ -60,7 +60,7 @@ public interface EndpointInfo extends KapuaUpdatableEntity {
 
     public void setSecure(boolean secure);
 
-    @XmlElement(name = "usage")
+    @XmlElement(name = "usages")
     public <E extends EndpointUsage> Set<E> getUsages();
 
     public void setUsages(Set<EndpointUsage> endpointUsages);

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Set;
+
+/**
+ * {@link EndpointInfo} entity definition.<br>
+ *
+ * @since 1.0.0
+ */
+@XmlRootElement(name = "endpointInfo")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = EndpointInfoXmlRegistry.class, factoryMethod = "newEntity")
+public interface EndpointInfo extends KapuaUpdatableEntity {
+
+    public static final String TYPE = "endpointInfo";
+
+    @Override
+    public default String getType() {
+        return TYPE;
+    }
+
+    @XmlElement(name = "schema")
+    public String getSchema();
+
+    public void setSchema(String schema);
+
+    @XmlElement(name = "dns")
+    public String getDns();
+
+    public void setDns(String dns);
+
+    @XmlElement(name = "port")
+    public int getPort();
+
+    public void setPort(int port);
+
+    @XmlElement(name = "secure")
+    public boolean getSecure();
+
+    public void setSecure(boolean secure);
+
+    @XmlElement(name = "usage")
+    public <E extends EndpointUsage> Set<E> getUsages();
+
+    public void setUsages(Set<EndpointUsage> endpointUsages);
+
+}

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.endpoint;
 
+import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -18,6 +19,8 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Set;
 
 /**
@@ -62,4 +65,19 @@ public interface EndpointInfo extends KapuaUpdatableEntity {
 
     public void setUsages(Set<EndpointUsage> endpointUsages);
 
+    public default String toStringURI() {
+        try {
+            return new URI(
+                    getSchema(),
+                    null,
+                    getDns(),
+                    getPort(),
+                    null,
+                    null,
+                    null
+            ).toString();
+        } catch (URISyntaxException e) {
+            throw KapuaRuntimeException.internalError(e, "Unable to build URI for EndpointInfo: " + getId().toCompactId());
+        }
+    }
 }

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoCreator.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoCreator.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.model.KapuaEntityCreator;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import java.util.Set;
+
+/**
+ * {@link EndpointInfo} creator definition.<br>
+ * It is used to create a new {@link EndpointInfo}.
+ *
+ * @since 1.0.0
+ */
+@XmlRootElement(name = "endpointInfoCreator")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = EndpointInfoXmlRegistry.class, factoryMethod = "newCreator")
+public interface EndpointInfoCreator extends KapuaEntityCreator<EndpointInfo> {
+
+    public String getSchema();
+
+    public void setSchema(String schema);
+
+    public String getDns();
+
+    public void setDns(String dns);
+
+    public int getPort();
+
+    public void setPort(int port);
+
+    public boolean getSecure();
+
+    public void setSecure(boolean secure);
+
+    public Set<EndpointUsage> getUsages();
+
+    public void setUsages(Set<EndpointUsage> usages);
+}

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoFactory.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoFactory.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.model.KapuaEntityFactory;
+
+/**
+ * {@link EndpointInfo} object factory.
+ *
+ * @since 1.0.0
+ */
+public interface EndpointInfoFactory extends KapuaEntityFactory<EndpointInfo, EndpointInfoCreator, EndpointInfoQuery, EndpointInfoListResult> {
+
+    public EndpointUsage newEndpointUsage(String name);
+}

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoListResult.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoListResult.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.model.query.KapuaListResult;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * {@link EndpointInfo} list result definition.
+ *
+ * @since 1.0.0
+ */
+@XmlRootElement(name = "endpointInfos")
+@XmlType(factoryClass = EndpointInfoXmlRegistry.class, factoryMethod = "newListResult")
+public interface EndpointInfoListResult extends KapuaListResult<EndpointInfo> {
+
+}

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoPredicates.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoPredicates.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntityPredicates;
+
+public interface EndpointInfoPredicates extends KapuaUpdatableEntityPredicates {
+
+    public static final String SCHEMA = "schema";
+    public static final String DNS = "dns";
+    public static final String PORT = "port";
+    public static final String SECURE = "secure";
+    public static final String USAGES = "usages";
+
+}

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoQuery.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoQuery.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.model.query.KapuaQuery;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * {@link EndpointInfo} query definition.
+ *
+ * @since 1.0.0
+ */
+@XmlRootElement(name = "query")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = EndpointInfoXmlRegistry.class, factoryMethod = "newQuery")
+public interface EndpointInfoQuery extends KapuaQuery<EndpointInfo> {
+
+}

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoService.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoService.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.KapuaEntityService;
+import org.eclipse.kapua.service.KapuaUpdatableEntityService;
+
+/**
+ * {@link EndpointInfo} service definition.
+ *
+ * @since 1.0.0
+ */
+public interface EndpointInfoService extends KapuaEntityService<EndpointInfo, EndpointInfoCreator>, KapuaUpdatableEntityService<EndpointInfo> {
+
+    /**
+     * Returns the {@link EndpointInfoListResult} with elements matching the provided query.
+     *
+     * @param query The {@link EndpointInfoQuery} used to filter results.
+     * @return The {@link EndpointInfoListResult} with elements matching the query parameter.
+     * @throws KapuaException
+     * @since 1.0.0
+     */
+    @Override
+    public EndpointInfoListResult query(KapuaQuery<EndpointInfo> query)
+            throws KapuaException;
+}

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoXmlRegistry.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoXmlRegistry.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class EndpointInfoXmlRegistry {
+
+    private final static KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private final static EndpointInfoFactory FACTORY = LOCATOR.getFactory(EndpointInfoFactory.class);
+
+    /**
+     * Creates a new {@link EndpointInfo} instance
+     *
+     * @return
+     */
+    public EndpointInfo newEntity() {
+        return FACTORY.newEntity(null);
+    }
+
+    /**
+     * Creates a new {@link EndpointInfoCreator} instance
+     *
+     * @return
+     */
+    public EndpointInfoCreator newCreator() {
+        return FACTORY.newCreator(null);
+    }
+
+    /**
+     * Creates a new {@link EndpointInfoListResult}
+     *
+     * @return
+     */
+    public EndpointInfoListResult newListResult() {
+        return FACTORY.newListResult();
+    }
+
+    /**
+     * Creates a new {@link EndpointInfoQuery}
+     *
+     * @return
+     */
+    public EndpointInfoQuery newQuery() {
+        return FACTORY.newQuery(null);
+    }
+
+    public EndpointUsage newEndpointUsage() {
+        return FACTORY.newEndpointUsage(null);
+    }
+}

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointUsage.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointUsage.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement(name = "endpointUsage")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = EndpointInfoXmlRegistry.class, factoryMethod = "newEndpointUsage")
+public interface EndpointUsage {
+
+    public String getName();
+
+    public void setName(String name);
+
+}

--- a/service/endpoint/internal/pom.xml
+++ b/service/endpoint/internal/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>kapua-endpoint</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-endpoint-internal</artifactId>
+
+    <dependencies>
+        <!-- Implemented service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-api</artifactId>
+        </dependency>
+
+        <!-- -->
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-guice</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointEntityManagerFactory.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointEntityManagerFactory.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.AbstractEntityManagerFactory;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Entity manager factory for the endpointInfo module.
+ *
+ * @since 1.0.0
+ */
+public class EndpointEntityManagerFactory extends AbstractEntityManagerFactory implements EntityManagerFactory {
+
+    private static final String PERSISTENCE_UNIT_NAME = "kapua-endpoint";
+    private static final String DATASOURCE_NAME = "kapua-dbpool";
+    private static final Map<String, String> UNIQUE_CONSTRAINTS = new HashMap<>();
+
+    private static EndpointEntityManagerFactory instance = new EndpointEntityManagerFactory();
+
+    /**
+     * Constructs a new entity manager factory and configure it to use the endpointInfo persistence unit.
+     */
+    private EndpointEntityManagerFactory() {
+        super(PERSISTENCE_UNIT_NAME,
+                DATASOURCE_NAME,
+                UNIQUE_CONSTRAINTS);
+    }
+
+    /**
+     * Return the {@link EntityManager} singleton instance
+     *
+     * @return
+     * @throws KapuaException
+     */
+    public static EntityManager getEntityManager()
+            throws KapuaException {
+        return instance.createEntityManager();
+    }
+
+    /**
+     * Return the {@link EntityManager} singleton instance
+     *
+     * @return
+     */
+    public static EndpointEntityManagerFactory getInstance() {
+        return instance;
+    }
+
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoCreatorImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoCreatorImpl.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.commons.model.AbstractKapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
+import org.eclipse.kapua.service.endpoint.EndpointUsage;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * {@link EndpointInfoCreator} implementation.
+ *
+ * @since 1.0.0
+ */
+public class EndpointInfoCreatorImpl extends AbstractKapuaEntityCreator<EndpointInfo> implements EndpointInfoCreator {
+
+    private String schema;
+    private String dns;
+    private int port;
+    private boolean secure;
+    private Set<EndpointUsage> usages;
+
+    protected EndpointInfoCreatorImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+
+    @Override
+    public String getSchema() {
+        return schema;
+    }
+
+    @Override
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public String getDns() {
+        return dns;
+    }
+
+    @Override
+    public void setDns(String dns) {
+        this.dns = dns;
+    }
+
+    @Override
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public boolean getSecure() {
+        return secure;
+    }
+
+    @Override
+    public void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+
+    @Override
+    public Set<EndpointUsage> getUsages() {
+        if (usages == null) {
+            usages = new HashSet<>();
+        }
+
+        return usages;
+    }
+
+    @Override
+    public void setUsages(Set<EndpointUsage> usages) {
+        this.usages = usages;
+    }
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoDAO.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoDAO.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.service.internal.ServiceDAO;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
+import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
+import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
+
+/**
+ * {@link EndpointInfo} DAO
+ *
+ * @since 1.0.0
+ */
+public class EndpointInfoDAO extends ServiceDAO {
+
+    /**
+     * Creates and returns new {@link EndpointInfo}
+     *
+     * @param em      The {@link EntityManager} that holds the transaction.
+     * @param creator The {@link EndpointInfoCreator} object from which create the new {@link EndpointInfo}.
+     * @return The newly created {@link EndpointInfo}.
+     * @throws KapuaException On create error.
+     * @since 1.0.0
+     */
+    public static EndpointInfo create(EntityManager em, EndpointInfoCreator creator) throws KapuaException {
+
+        EndpointInfo endpointInfo = new EndpointInfoImpl(creator.getScopeId());
+        endpointInfo.setSchema(creator.getSchema());
+        endpointInfo.setDns(creator.getDns());
+        endpointInfo.setPort(creator.getPort());
+        endpointInfo.setSecure(creator.getSecure());
+        endpointInfo.setUsages(creator.getUsages());
+
+        return ServiceDAO.create(em, endpointInfo);
+    }
+
+    /**
+     * Updates and returns the updated {@link EndpointInfo}
+     *
+     * @param em           The {@link EntityManager} that holds the transaction.
+     * @param endpointInfo The {@link EndpointInfo} to update
+     * @return The updated {@link EndpointInfo}.
+     * @throws KapuaEntityNotFoundException If {@link EndpointInfo} is not found.
+     */
+    public static EndpointInfo update(EntityManager em, EndpointInfo endpointInfo) throws KapuaEntityNotFoundException {
+        EndpointInfoImpl endpointInfoImpl = (EndpointInfoImpl) endpointInfo;
+        return ServiceDAO.update(em, EndpointInfoImpl.class, endpointInfoImpl);
+    }
+
+    /**
+     * Finds the {@link EndpointInfo} by {@link EndpointInfo} identifier
+     *
+     * @param em             The {@link EntityManager} that holds the transaction.
+     * @param endpointInfoId The {@link EndpointInfo} id to search.
+     * @return The found {@link EndpointInfo} or {@code null} if not found.
+     * @since 1.0.0
+     */
+    public static EndpointInfo find(EntityManager em, KapuaId endpointInfoId) {
+        return em.find(EndpointInfoImpl.class, endpointInfoId);
+    }
+
+    /**
+     * Deletes the {@link EndpointInfo} by {@link EndpointInfo} identifier
+     *
+     * @param em             The {@link EntityManager} that holds the transaction.
+     * @param endpointInfoId The {@link EndpointInfo} id to delete.
+     * @throws KapuaEntityNotFoundException If {@link EndpointInfo} is not found.
+     * @since 1.0.0
+     */
+    public static void delete(EntityManager em, KapuaId endpointInfoId) throws KapuaEntityNotFoundException {
+        ServiceDAO.delete(em, EndpointInfoImpl.class, endpointInfoId);
+    }
+
+    /**
+     * Returns the {@link EndpointInfo} list matching the provided query.
+     *
+     * @param em                The {@link EntityManager} that holds the transaction.
+     * @param endpointInfoQuery The {@link EndpointInfoQuery} used to filter results.
+     * @return The list of {@link EndpointInfo}s that matches the given query.
+     * @throws KapuaException On query error.
+     * @since 1.0.0
+     */
+    public static EndpointInfoListResult query(EntityManager em, KapuaQuery<EndpointInfo> endpointInfoQuery)
+            throws KapuaException {
+        return ServiceDAO.query(em, EndpointInfo.class, EndpointInfoImpl.class, new EndpointInfoListResultImpl(), endpointInfoQuery);
+    }
+
+    /**
+     * Return the {@link EndpointInfo} count matching the provided query
+     *
+     * @param em                The {@link EntityManager} that holds the transaction.
+     * @param endpointInfoQuery The {@link EndpointInfoQuery} used to filter results
+     * @return The count of {@link EndpointInfo}s that matches the given query.
+     * @throws KapuaException
+     * @since 1.0.0
+     */
+    public static long count(EntityManager em, KapuaQuery<EndpointInfo> endpointInfoQuery)
+            throws KapuaException {
+        return ServiceDAO.count(em, EndpointInfo.class, EndpointInfoImpl.class, endpointInfoQuery);
+    }
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoDomain.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoDomain.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import com.google.common.collect.Lists;
+import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoService;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * {@link EndpointInfo} domain.<br>
+ * Used to describe the {@link EndpointInfo} {@link Domain} in the {@link EndpointInfoService}.
+ *
+ * @since 1.0.0
+ */
+public class EndpointInfoDomain extends AbstractKapuaEntity implements Domain {
+
+    private static final long serialVersionUID = 3782336558657796495L;
+
+    private String name = "endpointInfo";
+    private String serviceName = "endpointInfoService";
+    private Set<Actions> actions = new HashSet<>(Lists.newArrayList(Actions.read, Actions.delete, Actions.write));
+    private boolean groupable;
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    @Override
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    @Override
+    public void setActions(Set<Actions> actions) {
+        this.actions = actions;
+    }
+
+    @Override
+    public Set<Actions> getActions() {
+        return actions;
+    }
+
+    @Override
+    public void setGroupable(boolean groupable) {
+        this.groupable = groupable;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return groupable;
+    }
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoFactoryImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoFactoryImpl.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
+import org.eclipse.kapua.service.endpoint.EndpointInfoFactory;
+import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
+import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
+import org.eclipse.kapua.service.endpoint.EndpointUsage;
+
+/**
+ * {@link EndpointInfoFactory} implementation.
+ *
+ * @since 1.0.0
+ */
+@KapuaProvider
+public class EndpointInfoFactoryImpl implements EndpointInfoFactory {
+
+    @Override
+    public EndpointInfo newEntity(KapuaId scopeId) {
+        return new EndpointInfoImpl(scopeId);
+    }
+
+    @Override
+    public EndpointInfoListResult newListResult() {
+        return new EndpointInfoListResultImpl();
+    }
+
+    @Override
+    public EndpointInfoQuery newQuery(KapuaId scopeId) {
+        return new EndpointInfoQueryImpl(scopeId);
+    }
+
+    @Override
+    public EndpointInfoCreator newCreator(KapuaId scopeId) {
+        return new EndpointInfoCreatorImpl(scopeId);
+    }
+
+    @Override
+    public EndpointUsage newEndpointUsage(String name) {
+        return new EndpointUsageImpl(name);
+    }
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoImpl.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointUsage;
+
+import javax.persistence.Basic;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * {@link EndpointInfo} implementation.
+ *
+ * @since 1.0.0
+ */
+@Entity(name = "EndpointInfo")
+@Table(name = "endp_endpoint_info")
+public class EndpointInfoImpl extends AbstractKapuaUpdatableEntity implements EndpointInfo {
+
+    @Basic
+    @Column(name = "schema", updatable = true, nullable = false)
+    private String schema;
+
+    @Basic
+    @Column(name = "dns", updatable = true, nullable = false)
+    private String dns;
+
+    @Basic
+    @Column(name = "port", updatable = true, nullable = false)
+    private int port;
+
+    @Basic
+    @Column(name = "secure", updatable = true, nullable = false)
+    private boolean secure;
+
+    @ElementCollection
+    @CollectionTable(name = "endp_endpoint_info_usage", joinColumns = @JoinColumn(name = "endpoint_info_id", referencedColumnName = "id"))
+    private Set<EndpointUsageImpl> usages;
+
+    protected EndpointInfoImpl() {
+        super();
+    }
+
+    /**
+     * Constructor
+     *
+     * @param scopeId
+     */
+    public EndpointInfoImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+
+    @Override
+    public String getSchema() {
+        return schema;
+    }
+
+    @Override
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public String getDns() {
+        return dns;
+    }
+
+    @Override
+    public void setDns(String dns) {
+        this.dns = dns;
+    }
+
+    @Override
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public boolean getSecure() {
+        return secure;
+    }
+
+    @Override
+    public void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+
+    @Override
+    public Set<EndpointUsageImpl> getUsages() {
+        if (usages == null) {
+            usages = new HashSet<>();
+        }
+
+        return usages;
+    }
+
+    @Override
+    public void setUsages(Set<EndpointUsage> usages) {
+        this.usages = new HashSet<>();
+
+        usages.forEach(u -> this.usages.add(EndpointUsageImpl.parse(u)));
+    }
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoImpl.java
@@ -36,7 +36,7 @@ import java.util.Set;
 public class EndpointInfoImpl extends AbstractKapuaUpdatableEntity implements EndpointInfo {
 
     @Basic
-    @Column(name = "schema", updatable = true, nullable = false)
+    @Column(name = "scheme", updatable = true, nullable = false)
     private String schema;
 
     @Basic

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoListResultImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoListResultImpl.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
+
+/**
+ * {@link EndpointInfoListResult} implementation.
+ *
+ * @since 1.0.0
+ */
+public class EndpointInfoListResultImpl extends KapuaListResultImpl<EndpointInfo> implements EndpointInfoListResult {
+
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoPredicates.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoPredicates.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntityPredicates;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.KapuaPredicate;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+
+/**
+ * {@link KapuaQuery} {@link KapuaPredicate} name for {@link EndpointInfo} entity.
+ *
+ * @since 1.0.0
+ */
+public interface EndpointInfoPredicates extends KapuaUpdatableEntityPredicates {
+
+    public static final String SCHEMA = "schema";
+    /**
+     * {@link EndpointInfo} DNS
+     */
+    public static final String DNS = "dns";
+
+    public static final String PORT = "port";
+
+    public static final String USAGES = "usages";
+
+    public static final String SECURE = "secure";
+
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoQueryImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoQueryImpl.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.commons.model.query.predicate.AbstractKapuaQuery;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
+
+/**
+ * {@link EndpointInfoQuery} implementation.
+ *
+ * @since 1.0.0
+ */
+public class EndpointInfoQueryImpl extends AbstractKapuaQuery<EndpointInfo> implements EndpointInfoQuery {
+
+    public EndpointInfoQueryImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.permission.Actions;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
+import org.eclipse.kapua.service.endpoint.EndpointInfoFactory;
+import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
+import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
+import org.eclipse.kapua.service.endpoint.EndpointInfoService;
+
+/**
+ * {@link EndpointInfoService} implementation.
+ *
+ * @since 1.0.0
+ */
+@KapuaProvider
+public class EndpointInfoServiceImpl
+        extends AbstractKapuaConfigurableResourceLimitedService<EndpointInfo, EndpointInfoCreator, EndpointInfoService, EndpointInfoListResult, EndpointInfoQuery, EndpointInfoFactory>
+        implements EndpointInfoService {
+
+    private static final Domain ENDPOINT_DOMAIN = new EndpointInfoDomain();
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+
+    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
+    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+
+    public EndpointInfoServiceImpl() {
+        super(EndpointInfoService.class.getName(), ENDPOINT_DOMAIN, EndpointEntityManagerFactory.getInstance(), EndpointInfoService.class, EndpointInfoFactory.class);
+    }
+
+    @Override
+    public EndpointInfo create(EndpointInfoCreator endpointInfoCreator)
+            throws KapuaException {
+        ArgumentValidator.notNull(endpointInfoCreator, "endpointInfoCreator");
+        ArgumentValidator.notNull(endpointInfoCreator.getScopeId(), "endpointInfoCreator.scopeId");
+        ArgumentValidator.notEmptyOrNull(endpointInfoCreator.getSchema(), "endpointCreator.schema");
+        ArgumentValidator.notEmptyOrNull(endpointInfoCreator.getDns(), "endpointCreator.dns");
+        ArgumentValidator.notNegative(endpointInfoCreator.getPort(), "endpointCreator.port");
+
+        //
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ENDPOINT_DOMAIN, Actions.write, null));
+
+        //
+        // Do create
+        return entityManagerSession.onTransactedInsert(em -> EndpointInfoDAO.create(em, endpointInfoCreator));
+    }
+
+    @Override
+    public EndpointInfo update(EndpointInfo endpointInfo) throws KapuaException {
+        ArgumentValidator.notNull(endpointInfo, "endpointInfo");
+        ArgumentValidator.notNull(endpointInfo.getScopeId(), "endpointInfo.scopeId");
+        ArgumentValidator.notEmptyOrNull(endpointInfo.getSchema(), "endpointInfo.schema");
+        ArgumentValidator.notEmptyOrNull(endpointInfo.getDns(), "endpointInfo.dns");
+        ArgumentValidator.notNegative(endpointInfo.getPort(), "endpointInfo.port");
+
+        //
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ENDPOINT_DOMAIN, Actions.write, null));
+
+        //
+        // Do update
+        return entityManagerSession.onTransactedInsert(em -> EndpointInfoDAO.update(em, endpointInfo));
+    }
+
+    @Override
+    public void delete(KapuaId scopeId, KapuaId endpointInfoId) throws KapuaException {
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(endpointInfoId, "endpointInfoId");
+
+        //
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ENDPOINT_DOMAIN, Actions.delete, null));
+
+        //
+        // Do delete
+        entityManagerSession.onTransactedAction(em -> EndpointInfoDAO.delete(em, endpointInfoId));
+    }
+
+    @Override
+    public EndpointInfo find(KapuaId scopeId, KapuaId endpointInfoId)
+            throws KapuaException {
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(endpointInfoId, "endpointInfoId");
+
+        //
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ENDPOINT_DOMAIN, Actions.read, scopeId));
+
+        //
+        // Do find
+        return entityManagerSession.onResult(em -> EndpointInfoDAO.find(em, endpointInfoId));
+    }
+
+    @Override
+    public EndpointInfoListResult query(KapuaQuery<EndpointInfo> query)
+            throws KapuaException {
+        ArgumentValidator.notNull(query, "query");
+
+        //
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ENDPOINT_DOMAIN, Actions.read, query.getScopeId()));
+
+        //
+        // Do Query
+        return entityManagerSession.onResult(em -> EndpointInfoDAO.query(em, query));
+    }
+
+    @Override
+    public long count(KapuaQuery<EndpointInfo> query)
+            throws KapuaException {
+        ArgumentValidator.notNull(query, "query");
+
+        //
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ENDPOINT_DOMAIN, Actions.read, query.getScopeId()));
+
+        //
+        // Do count
+        return entityManagerSession.onResult(em -> EndpointInfoDAO.count(em, query));
+    }
+}

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointUsageImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointUsageImpl.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.service.endpoint.EndpointUsage;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+public class EndpointUsageImpl implements EndpointUsage {
+
+    @Basic
+    @Column(name = "name", nullable = false, updatable = false)
+    private String name;
+
+    public EndpointUsageImpl(String name) {
+        setName(name);
+    }
+
+    public EndpointUsageImpl(EndpointUsage endpointUsage) {
+        setName(endpointUsage.getName());
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public EndpointUsageImpl() {
+        super();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EndpointUsageImpl that = (EndpointUsageImpl) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    public static EndpointUsageImpl parse(EndpointUsage endpointUsage) {
+        return endpointUsage != null ? endpointUsage instanceof EndpointUsageImpl ? (EndpointUsageImpl) endpointUsage : new EndpointUsageImpl(endpointUsage) : null;
+    }
+}

--- a/service/endpoint/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/endpoint/internal/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation   
+ -->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+
+    <persistence-unit name="kapua-endpoint" transaction-type="RESOURCE_LOCAL">
+
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+
+        <class>org.eclipse.kapua.service.endpoint.internal.EndpointInfoImpl</class>
+        <class>org.eclipse.kapua.service.endpoint.internal.EndpointUsageImpl</class>
+
+        <!-- Base classes and External classes -->
+        <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity</class>
+        <class>org.eclipse.kapua.commons.configuration.ServiceConfigImpl</class>
+
+        <properties>
+            <property name="javax.persistence.lock.timeout" value="1000"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.post.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.post.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-endpoint-1.0.0.xml">
+
+    <include relativeToChangelogFile="true" file="./endpoint_info-domain.xml"/>
+
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-endpoint-1.0.0.xml">
+
+    <include relativeToChangelogFile="true" file="./endpoint_info.xml"/>
+    <include relativeToChangelogFile="true" file="./endpoint_info_usage.xml"/>
+
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info-domain.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info-domain.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-endpoint_info-domain-1.0.0.xml">
+
+    <property name="selectEndpointDomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'endpointInfo')"/>
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-endpoint_info-domain-1.0.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_domain"/>
+                <tableExists tableName="athz_domain_actions"/>
+            </and>
+        </preConditions>
+
+        <!-- Seed values -->
+        <insert tableName="athz_domain">
+            <column name="created_on" valueComputed="${now}"/>
+            <column name="created_by" value="1"/>
+            <column name="name" value="endpointInfo"/>
+            <column name="serviceName" value="endpointInfoService"/>
+        </insert>
+
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectEndpointDomainQuery}"/>
+            <column name="action" value="read"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectEndpointDomainQuery}"/>
+            <column name="action" value="write"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectEndpointDomainQuery}"/>
+            <column name="action" value="delete"/>
+        </insert>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info.xml
@@ -36,7 +36,7 @@
             <column name="modified_on" type="timestamp(3)" defaultValueComputed="${now}"/>
             <column name="modified_by" type="bigint(21) unsigned"/>
 
-            <column name="schema" type="varchar(64)">
+            <column name="scheme" type="varchar(64)">
                 <constraints nullable="false"/>
             </column>
             <column name="dns" type="varchar(1024)">

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-endpoint_info-1.0.0_create.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-endpoint_info-1.0.0_create" author="eurotech">
+        <createTable tableName="endp_endpoint_info">
+            <column name="scope_id" type="bigint(21) unsigned">
+                <constraints nullable="false"/>
+            </column>
+            <column name="id" type="bigint(21) unsigned">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="created_on" type="timestamp(3)" defaultValueComputed="${now}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="bigint(21) unsigned">
+                <constraints nullable="false"/>
+            </column>
+            <column name="modified_on" type="timestamp(3)" defaultValueComputed="${now}"/>
+            <column name="modified_by" type="bigint(21) unsigned"/>
+
+            <column name="schema" type="varchar(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="dns" type="varchar(1024)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="port" type="int unsigned">
+                <constraints nullable="false"/>
+            </column>
+            <column name="secure" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="optlock" type="int unsigned"/>
+            <column name="attributes" type="text"/>
+            <column name="properties" type="text"/>
+        </createTable>
+
+        <createIndex tableName="endp_endpoint_info" indexName="idx_endp_endpoint_info_scope_id">
+            <column name="scope_id"/>
+        </createIndex>
+
+    </changeSet>
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info_usage.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info_usage.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-endpoint_info-1.0.0_createUsage">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-endpoint_info-1.0.0_createUsage" author="eurotech">
+        <createTable tableName="endp_endpoint_info_usage">
+            <column name="endpoint_info_id" type="bigint(21) unsigned">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+        </createTable>
+
+    </changeSet>
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.post.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.post.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./1.0.0/changelog-endpoint-1.0.0.post.xml"/>
+
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./1.0.0/changelog-endpoint-1.0.0.xml"/>
+
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+ <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <property name="now" value="sysdate" dbms="oracle"/>
+    <property name="now" value="now()" dbms="postgresql"/>
+    <property name="now" value="current_timestamp()" dbms="mysql,h2"/>
+</databaseChangeLog>

--- a/service/endpoint/pom.xml
+++ b/service/endpoint/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>kapua-service</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+
+    <artifactId>kapua-endpoint</artifactId>
+
+    <modules>
+        <module>api</module>
+        <module>internal</module>
+    </modules>
+
+</project>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -10,8 +10,8 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -28,17 +28,18 @@
         <module>liquibase</module>
 
         <module>api</module>
-        
+
         <module>account</module>
         <module>datastore</module>
         <module>device</module>
+        <module>endpoint</module>
         <module>job</module>
         <module>scheduler</module>
         <module>security</module>
         <module>stream</module>
         <module>tag</module>
         <module>user</module>
-        
+
     </modules>
 
 </project>


### PR DESCRIPTION
This issue closes #1342 .

This service has been also integrated with the rest of the component.

Only the root account can manage EndpointInfo entities while all other accounts get the EndpointInfo from their self or the first ancestor that has one, scaling up to the default platform value returned by invoking `SystemUtils.getNodeURI()`. 