### PR TITLE
Fix for display of long user name

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
@@ -47,6 +47,7 @@ import com.extjs.gxt.ui.client.widget.layout.TableLayout;
 import com.extjs.gxt.ui.client.widget.menu.Menu;
 import com.extjs.gxt.ui.client.widget.menu.MenuItem;
 import com.extjs.gxt.ui.client.widget.menu.SeparatorMenuItem;
+import com.extjs.gxt.ui.client.widget.tips.ToolTipConfig;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -55,6 +56,9 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class NorthView extends LayoutContainer {
 
+    private static final int USER_WIDTH = 200;
+    private static final int MAX_USER_TOOLTIP_WIDTH = 300;
+    private static final int USER_TOOLTIP_LINE_LEN = 50;
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private final GwtAuthorizationServiceAsync gwtAuthorizationService = GWT.create(GwtAuthorizationService.class);
     private final GwtAccountServiceAsync gwtAccountService = GWT.create(GwtAccountService.class);
@@ -202,6 +206,7 @@ public class NorthView extends LayoutContainer {
         });
         userActionButton.setId("header-button");
         userActionButton.addStyleName("x-btn-arrow-custom");
+        userActionButton.setWidth(USER_WIDTH);
 
         updateUserActionButtonLabel();
 
@@ -360,6 +365,8 @@ public class NorthView extends LayoutContainer {
      * {displayName} @ {selectedAccountName}<br/>
      * else:<br/>
      * {username} @ {selectedAccountName}<br/>
+     * If username and displayname are too long, this string is truncated
+     * and padded with ellipsis which is defined in console.css for header-button.
      */
     private void updateUserActionButtonLabel() {
         // Current selected scope
@@ -371,5 +378,39 @@ public class NorthView extends LayoutContainer {
             userDisplayName = username;
         }
         userActionButton.setText(MSGS.consoleHeaderUserActionButtonLabel(userDisplayName, accountName));
+        ToolTipConfig toolTipConfig = new ToolTipConfig();
+        toolTipConfig.setMaxWidth(MAX_USER_TOOLTIP_WIDTH);
+        String toolTipText = splitLongString(MSGS.consoleHeaderUserActionButtonLabel(userDisplayName, accountName),
+                USER_TOOLTIP_LINE_LEN);
+        toolTipConfig.setText(toolTipText);
+        userActionButton.setToolTip(toolTipConfig);
+    }
+
+    /**
+     * Split long string into multiple rows.
+     * Used for correct display of tooltip with user and account name.
+     *
+     * @param source long input string
+     * @param lineLen length of single line
+     * @return single string with line separators
+     */
+    private String splitLongString(String source, int lineLen) {
+        StringBuilder multiRowStr = new StringBuilder();
+
+        for (int start = 0; start <= source.length(); start += lineLen) {
+            int end = start;
+
+            if ((end + lineLen) <= source.length()) {
+                end += lineLen;
+            } else {
+                end = source.length();
+            }
+            multiRowStr.append(source.substring(start, end));
+            if (end < source.length()) {
+                multiRowStr.append("\n");
+            }
+        }
+
+        return multiRowStr.toString();
     }
 }

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
@@ -56,9 +56,10 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class NorthView extends LayoutContainer {
 
+    private static final int SUB_ACCT_WIDTH = 700;
     private static final int USER_WIDTH = 200;
     private static final int MAX_USER_TOOLTIP_WIDTH = 300;
-    private static final int USER_TOOLTIP_LINE_LEN = 50;
+    private static final int USER_TOOLTIP_LINE_LEN = 45;
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private final GwtAuthorizationServiceAsync gwtAuthorizationService = GWT.create(GwtAuthorizationService.class);
     private final GwtAccountServiceAsync gwtAccountService = GWT.create(GwtAccountService.class);
@@ -228,7 +229,7 @@ public class NorthView extends LayoutContainer {
         rootAccountMenuItem.addSelectionListener(switchToAccountListener);
 
         subAccountMenu = new Menu();
-        subAccountMenu.setAutoWidth(true);
+        subAccountMenu.setWidth(SUB_ACCT_WIDTH);
         subAccountMenu.add(rootAccountMenuItem);
         subAccountMenu.add(new SeparatorMenuItem());
 
@@ -278,6 +279,9 @@ public class NorthView extends LayoutContainer {
                                 childAccountMenuItem.setText(item.getValue());
                                 childAccountMenuItem.setTitle(item.getValue());
                                 childAccountMenuItem.setId(String.valueOf(item.getId()));
+                                childAccountMenuItem.setStyleAttribute("white-space", "nowrap");
+                                childAccountMenuItem.setStyleAttribute("text-overflow", "ellipsis");
+                                childAccountMenuItem.setStyleAttribute("overflow", "hidden");
                                 menu.add(childAccountMenuItem);
 
                                 // Add selection listener to make the switch happen when selected
@@ -286,7 +290,7 @@ public class NorthView extends LayoutContainer {
                                 // Search for its children
                                 if (item.hasChildAccount()) {
                                     Menu childMenu = new Menu();
-                                    childMenu.setAutoWidth(true);
+                                    childMenu.setWidth(SUB_ACCT_WIDTH);
                                     childAccountMenuItem.setSubMenu(childMenu);
 
                                     populateNavigatorMenu(childMenu, item.getId());
@@ -407,7 +411,7 @@ public class NorthView extends LayoutContainer {
             }
             multiRowStr.append(source.substring(start, end));
             if (end < source.length()) {
-                multiRowStr.append("<br>");
+                multiRowStr.append("</br>");
             }
         }
 

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
@@ -407,7 +407,7 @@ public class NorthView extends LayoutContainer {
             }
             multiRowStr.append(source.substring(start, end));
             if (end < source.length()) {
-                multiRowStr.append("\n");
+                multiRowStr.append("<br>");
             }
         }
 

--- a/console/web/src/main/webapp/css/console.css
+++ b/console/web/src/main/webapp/css/console.css
@@ -203,6 +203,9 @@ table#header-button td, table#header-button button{
 	background-color: rgb(6,39,68) !important;
 	color: #FFFFFF !important;
 	font-weight: bold !important;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 .x-menu-item-icon.fa {


### PR DESCRIPTION
This solves issue wher use name is too long and is not correctyl displayed
in console header.
Name is shortende and ellipsis is added.
When mouse is hoovered over username its full name is displayed in tooltip.

Solution was first tried by setting style on button, but it didn't work, so
I had to resolve to changing console.css for button.

This solves issue 1191.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>