### PR TITLE
Fix service duplicate name check

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AndPredicate.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AndPredicate.java
@@ -11,17 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model.query.predicate;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.google.common.collect.Lists;
 import org.eclipse.kapua.model.query.predicate.KapuaAndPredicate;
 import org.eclipse.kapua.model.query.predicate.KapuaPredicate;
 
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 /**
- * Kapua sql and predicate reference implementation.
- * 
- * @since 1.0
+ * {@link KapuaAndPredicate} reference implementation.
  *
+ * @since 0.1.0
  */
 public class AndPredicate implements KapuaAndPredicate {
 
@@ -29,13 +31,37 @@ public class AndPredicate implements KapuaAndPredicate {
 
     /**
      * Constructor
+     *
+     * @since 0.1.0
      */
     public AndPredicate() {
-        this.predicates = new ArrayList<KapuaPredicate>();
+        setPredicates(new ArrayList<>());
     }
 
+    /**
+     * Constructor which accepts a not null array of {@link KapuaPredicate}s.
+     *
+     * @param predicates the {@link KapuaPredicate}s to add.
+     * @throws NullPointerException if the given parameter is {@code null}.
+     * @since 1.0.0
+     */
+    public AndPredicate(@NotNull KapuaPredicate... predicates) {
+        Objects.requireNonNull(predicates);
+
+        setPredicates(Lists.newArrayList(predicates));
+    }
+
+    /**
+     * Adds a new {@link KapuaPredicate} to this {@link KapuaAndPredicate}.
+     *
+     * @param predicate The {@link KapuaPredicate} to add
+     * @return {@code this} {@link AndPredicate}.
+     * @throws NullPointerException if the given parameter is {@code null}.
+     */
     @Override
-    public AndPredicate and(KapuaPredicate predicate) {
+    public AndPredicate and(@NotNull KapuaPredicate predicate) {
+        Objects.requireNonNull(predicates);
+
         this.predicates.add(predicate);
         return this;
     }
@@ -43,5 +69,9 @@ public class AndPredicate implements KapuaAndPredicate {
     @Override
     public List<KapuaPredicate> getPredicates() {
         return this.predicates;
+    }
+
+    private void setPredicates(List<KapuaPredicate> predicates) {
+        this.predicates = predicates;
     }
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -41,6 +40,7 @@ import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 
+import javax.inject.Inject;
 import javax.persistence.TypedQuery;
 import java.util.Map;
 import java.util.Objects;
@@ -56,10 +56,11 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
     private static final Domain ACCOUNT_DOMAIN = new AccountDomain();
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    @Inject
+    private AuthorizationService authorizationService;
 
-    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
-    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+    @Inject
+    private PermissionFactory permissionFactory;
 
     /**
      * Constructor.
@@ -84,7 +85,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.write, accountCreator.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.write, accountCreator.getScopeId()));
 
         //
         // Check child account policy
@@ -144,10 +145,10 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         // Check Access
         if (KapuaSecurityUtils.getSession().getScopeId().equals(account.getId())) {
             // Editing self
-            AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.write, account.getId()));
+            authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.write, account.getId()));
         } else {
             // Editing child
-            AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.write, account.getScopeId()));
+            authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.write, account.getScopeId()));
         }
 
         //
@@ -189,7 +190,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         //
         // Check Access
         Actions action = Actions.delete;
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, action, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, action, scopeId));
 
         //
         // Check if it has children
@@ -229,7 +230,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.read, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.read, scopeId));
 
         //
         // Do find
@@ -244,7 +245,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.read, accountId));
+        authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.read, accountId));
 
         //
         // Make sure account exists
@@ -265,7 +266,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
             //
             // Check Access
             if (account != null) {
-                AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.read, account.getId()));
+                authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.read, account.getId()));
             }
 
             return account;
@@ -287,7 +288,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.read, account.getId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.read, account.getId()));
 
         return entityManagerSession.onResult(em -> {
             AccountListResult result = null;
@@ -310,7 +311,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.read, query.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.read, query.getScopeId()));
 
         //
         // Do query
@@ -326,7 +327,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ACCOUNT_DOMAIN, Actions.read, query.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(ACCOUNT_DOMAIN, Actions.read, query.getScopeId()));
 
         //
         // Do count

--- a/service/account/internal/src/test/resources/features/AccountService.feature
+++ b/service/account/internal/src/test/resources/features/AccountService.feature
@@ -104,7 +104,7 @@ Scenario: Delete an existing account
 Scenario: Delete the Kapua system account
     It must not be possible to delete the system account.
 
-    Given I expect the exception "KapuaIllegalAccessException" with the text "The current subject is not authorized for write"
+    Given I expect the exception "KapuaIllegalAccessException" with the text "The current subject is not authorized for delete"
     When I try to delete the system account
     Then An exception is caught
     And The System account exists

--- a/service/datastore/internal/src/test/resources/locator.xml
+++ b/service/datastore/internal/src/test/resources/locator.xml
@@ -13,14 +13,9 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.datastore.ClientInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.DatastoreObjectFactory</api>
-        <api>org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreService</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoRegistryService</api>
         <api>org.eclipse.kapua.service.account.AccountService</api>
         <api>org.eclipse.kapua.service.account.AccountFactory</api>
+
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
@@ -35,12 +30,24 @@
         <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
         <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
         <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
+        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
+
+        <api>org.eclipse.kapua.service.datastore.ClientInfoRegistryService</api>
+        <api>org.eclipse.kapua.service.datastore.DatastoreObjectFactory</api>
+        <api>org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory</api>
+        <api>org.eclipse.kapua.service.datastore.MessageStoreService</api>
+        <api>org.eclipse.kapua.service.datastore.ChannelInfoRegistryService</api>
+        <api>org.eclipse.kapua.service.datastore.MetricInfoRegistryService</api>
+
         <api>org.eclipse.kapua.service.user.UserService</api>
+
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
         <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
     </provided>
     <packages>
+        <package>org.eclipse.kapua.commons.configuration</package>
+
         <package>org.eclipse.kapua.service.account.internal</package>
         <package>org.eclipse.kapua.service.authorization.access.shiro</package>
         <package>org.eclipse.kapua.service.authorization.domain.shiro</package>
@@ -48,7 +55,7 @@
         <package>org.eclipse.kapua.service.authorization.permission.shiro</package>
         <package>org.eclipse.kapua.service.authorization.role.shiro</package>
         <package>org.eclipse.kapua.service.datastore.internal</package>
-        <package>org.eclipse.kapua.commons.configuration</package>
+        
         <package>org.eclipse.kapua.test.steps</package>
         <package>org.eclipse.kapua.test.account</package>
         <package>org.eclipse.kapua.test.user</package>

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -15,12 +15,14 @@ import org.eclipse.kapua.KapuaDuplicateNameException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
@@ -61,22 +63,29 @@ public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimited
     }
 
     @Override
-    public JobStep create(JobStepCreator creator) throws KapuaException {
+    public JobStep create(JobStepCreator jobStepCreator) throws KapuaException {
         //
-        // Argument Validation
-        ArgumentValidator.notNull(creator, "jobStepCreator");
-        ArgumentValidator.notNull(creator.getScopeId(), "jobStepCreator.scopeId");
-        ArgumentValidator.notEmptyOrNull(creator.getName(), "jobStepCreator.name");
-        ArgumentValidator.numRange(creator.getName().length(), 1, 255, "jobStepCreator.name");
-        ArgumentValidator.notNull(creator.getJobStepDefinitionId(), "jobStepCreator.stepDefinitionId");
-        if (creator.getDescription() != null) {
-            ArgumentValidator.numRange(creator.getDescription().length(), 0, 8192, "jobStepCreator.description");
+        // Argument validation
+        ArgumentValidator.notNull(jobStepCreator, "jobStepCreator");
+        ArgumentValidator.notNull(jobStepCreator.getScopeId(), "jobStepCreator.scopeId");
+        ArgumentValidator.notEmptyOrNull(jobStepCreator.getName(), "jobStepCreator.name");
+        ArgumentValidator.numRange(jobStepCreator.getName().length(), 1, 255, "jobStepCreator.name");
+        ArgumentValidator.notNull(jobStepCreator.getJobStepDefinitionId(), "jobStepCreator.stepDefinitionId");
+
+        if (jobStepCreator.getDescription() != null) {
+            ArgumentValidator.numRange(jobStepCreator.getDescription().length(), 0, 8192, "jobStepCreator.description");
         }
 
-        JobStepDefinition jobStepDefinition = JOB_STEP_DEFINITION_SERVICE.find(creator.getScopeId(), creator.getJobStepDefinitionId());
+        //
+        // Check access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(JOB_DOMAIN, Actions.write, jobStepCreator.getScopeId()));
+
+        //
+        // Check job step definition
+        JobStepDefinition jobStepDefinition = JOB_STEP_DEFINITION_SERVICE.find(jobStepCreator.getScopeId(), jobStepCreator.getJobStepDefinitionId());
         ArgumentValidator.notNull(jobStepDefinition, "jobStepCreator.jobStepDefinitionId");
 
-        for (JobStepProperty jsp : creator.getStepProperties()) {
+        for (JobStepProperty jsp : jobStepCreator.getStepProperties()) {
             for (JobStepProperty jsdp : jobStepDefinition.getStepProperties()) {
                 if (jsp.getName().equals(jsdp.getName())) {
                     ArgumentValidator.areEqual(jsp.getPropertyType(), jsdp.getPropertyType(), "jobStepCreator.stepProperties{}." + jsp.getName());
@@ -85,33 +94,49 @@ public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimited
             }
         }
 
-        JobStepFactory jobStepFactory = LOCATOR.getFactory(JobStepFactory.class);
-        JobStepQuery query = jobStepFactory.newQuery(creator.getScopeId());
-        AttributePredicate<String> jobStepNamePredicate = new AttributePredicate<>(JobStepPredicates.NAME, creator.getName());
-        query.setPredicate(jobStepNamePredicate);
-        JobStepListResult result = query(query);
-        if (!result.isEmpty()) {
-            throw new KapuaDuplicateNameException(creator.getName());
+        //
+        // Check duplicate name
+        JobStepQuery query = new JobStepQueryImpl(jobStepCreator.getScopeId());
+        query.setPredicate(
+                new AndPredicate(
+                        new AttributePredicate<>(JobStepPredicates.JOB_ID, jobStepCreator.getJobId()),
+                        new AttributePredicate<>(JobStepPredicates.NAME, jobStepCreator.getName(), Operator.NOT_EQUAL)
+                )
+        );
+
+        if (count(query) > 0) {
+            throw new KapuaDuplicateNameException(jobStepCreator.getName());
         }
 
         //
-        // Check access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(JOB_DOMAIN, Actions.write, creator.getScopeId()));
-
-        //
         // Do create
-        return entityManagerSession.onTransactedInsert(em -> JobStepDAO.create(em, creator));
+        return entityManagerSession.onTransactedInsert(em -> JobStepDAO.create(em, jobStepCreator));
     }
 
     @Override
     public JobStep update(JobStep jobStep) throws KapuaException {
         //
-        // Argument Validation
+        // Argument validation
         ArgumentValidator.notNull(jobStep, "jobStep");
         ArgumentValidator.notNull(jobStep.getScopeId(), "jobStep.scopeId");
         ArgumentValidator.notNull(jobStep.getName(), "jobStep.name");
         ArgumentValidator.notNull(jobStep.getJobStepDefinitionId(), "jobStep.stepDefinitionId");
+        if (jobStep.getDescription() != null) {
+            ArgumentValidator.numRange(jobStep.getDescription().length(), 0, 8192, "jobStep.description");
+        }
 
+        //
+        // Check access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(JOB_DOMAIN, Actions.write, jobStep.getScopeId()));
+
+        //
+        // Check existence
+        if (find(jobStep.getScopeId(), jobStep.getId()) == null) {
+            throw new KapuaEntityNotFoundException(jobStep.getType(), jobStep.getId());
+        }
+
+        //
+        // Check job step definition
         JobStepDefinition jobStepDefinition = JOB_STEP_DEFINITION_SERVICE.find(jobStep.getScopeId(), jobStep.getJobStepDefinitionId());
         ArgumentValidator.notNull(jobStepDefinition, "jobStepCreator.jobStepDefinitionId");
 
@@ -123,18 +148,19 @@ public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimited
             }
         }
 
-        JobStepFactory jobStepFactory = LOCATOR.getFactory(JobStepFactory.class);
-        JobStepQuery query = jobStepFactory.newQuery(jobStep.getScopeId());
-        AttributePredicate<String> jobStepNamePredicate = new AttributePredicate<>(JobStepPredicates.NAME, jobStep.getName());
-        query.setPredicate(jobStepNamePredicate);
-        JobStepListResult result = query(query);
-        if (!result.isEmpty()) {
+        JobStepQuery query = new JobStepQueryImpl(jobStep.getScopeId());
+        query.setPredicate(
+                new AndPredicate(
+                        new AttributePredicate<>(JobStepPredicates.NAME, jobStep.getId(), Operator.NOT_EQUAL),
+                        new AttributePredicate<>(JobStepPredicates.JOB_ID, jobStep.getJobId()),
+                        new AttributePredicate<>(JobStepPredicates.NAME, jobStep.getName())
+
+                )
+        );
+
+        if (count(query) > 0) {
             throw new KapuaDuplicateNameException(jobStep.getName());
         }
-
-        //
-        // Check access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(JOB_DOMAIN, Actions.write, jobStep.getScopeId()));
 
         return entityManagerSession.onTransactedResult(em -> JobStepDAO.update(em, jobStep));
     }
@@ -199,14 +225,13 @@ public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimited
         AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(JOB_DOMAIN, Actions.delete, scopeId));
 
         //
+        // Check existence
+        if (find(scopeId, jobStepId) == null) {
+            throw new KapuaEntityNotFoundException(JobStep.TYPE, jobStepId);
+        }
+
+        //
         // Do delete
-        entityManagerSession.onTransactedAction(em -> {
-            if (JobStepDAO.find(em, jobStepId) == null) {
-                throw new KapuaEntityNotFoundException(JobStep.TYPE, jobStepId);
-            }
-
-            JobStepDAO.delete(em, jobStepId);
-        });
-
+        entityManagerSession.onTransactedAction(em -> JobStepDAO.delete(em, jobStepId));
     }
 }

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
@@ -12,32 +12,30 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.internal;
 
-import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsEqualTo;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-
-import java.math.BigInteger;
-import java.security.acl.Permission;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.inject.Inject;
-
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtils;
 import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.job.JobCreator;
 import org.eclipse.kapua.service.job.JobFactory;
 import org.eclipse.kapua.service.job.JobJAXBContextProvider;
+import org.eclipse.kapua.service.job.JobPredicates;
 import org.eclipse.kapua.service.job.JobQuery;
 import org.eclipse.kapua.service.job.JobService;
 import org.eclipse.kapua.service.job.common.CommonData;
@@ -51,13 +49,16 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import cucumber.api.Scenario;
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
-import cucumber.runtime.java.guice.ScenarioScoped;
+import javax.inject.Inject;
+import java.math.BigInteger;
+import java.security.acl.Permission;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.eclipse.kapua.commons.model.query.predicate.AttributePredicate.attributeIsEqualTo;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 
 // ****************************************************************************************
 // * Implementation of Gherkin steps used in JobService.feature scenarios.                *
@@ -238,12 +239,12 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
             throws Exception {
 
         JobCreator tmpCreator = jobFactory.newCreator(commonData.currentScopeId);
-        tmpCreator.setName(name);
         tmpCreator.setDescription("TestJobDescription");
 
         try {
             commonData.primeException();
             for (int i = 0; i < num; i++) {
+                tmpCreator.setName(name + "_" + i);
                 jobService.create(tmpCreator);
             }
         } catch (KapuaException ex) {
@@ -374,12 +375,12 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
         }
     }
 
-    @When("^I count the jobs with the name \"(.+)\"$")
+    @When("^I count the jobs with the name starting with \"(.+)\"$")
     public void countJobsWithName(String name)
             throws Exception {
 
         JobQuery tmpQuery = jobFactory.newQuery(commonData.currentScopeId);
-        tmpQuery.setPredicate(attributeIsEqualTo("name", name));
+        tmpQuery.setPredicate(new AttributePredicate<>(JobPredicates.NAME, name, Operator.STARTS_WITH));
 
         try {
             commonData.primeException();
@@ -394,7 +395,7 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
             throws Exception {
 
         JobQuery tmpQuery = jobFactory.newQuery(commonData.currentScopeId);
-        tmpQuery.setPredicate(attributeIsEqualTo("name", name));
+        tmpQuery.setPredicate(attributeIsEqualTo(JobPredicates.NAME, name));
 
         try {
             commonData.primeException();
@@ -409,7 +410,7 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
 
         assertEquals("The job scope does not match the creator.", jobData.jobCreator.getScopeId(), jobData.job.getScopeId());
         assertEquals("The job name does not match the creator.", jobData.jobCreator.getName(), jobData.job.getName());
-        assertEquals("The job description does not match the creator.",jobData. jobCreator.getDescription(), jobData.job.getDescription());
+        assertEquals("The job description does not match the creator.", jobData.jobCreator.getDescription(), jobData.job.getDescription());
     }
 
     @Then("^The job has (\\d+) steps$")

--- a/service/job/internal/src/test/resources/features/JobService.feature
+++ b/service/job/internal/src/test/resources/features/JobService.feature
@@ -10,33 +10,33 @@
 #     Eurotech - initial API and implementation
 ###############################################################################
 Feature: Job service CRUD tests
-    The Job service is responsible for executing scheduled actions on various targets.
+  The Job service is responsible for executing scheduled actions on various targets.
 
-Scenario: Regular job creation
+  Scenario: Regular job creation
 
-    Given A regular job creator with the name "TestJob"
+    Given A regular job creator with the name "TestJob_1"
     When I create a new job entity from the existing creator
     Then No exception was thrown
     When I search for the job in the database
     Then No exception was thrown
     And The job entity matches the creator
 
-Scenario: Job with a null scope ID
+  Scenario: Job with a null scope ID
 
     Given A null scope
-    And A regular job creator with the name "TestJob"
+    And A regular job creator with the name "TestJob_1"
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "scopeId"
     When I create a new job entity from the existing creator
     Then An exception was thrown
 
-Scenario: Job with a null name
+  Scenario: Job with a null name
 
     And A job creator with a null name
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "name"
     When I create a new job entity from the existing creator
     Then An exception was thrown
 
-Scenario: Job with an empty name
+  Scenario: Job with an empty name
 
     Given A job creator with an empty name
     When I create a new job entity from the existing creator
@@ -44,16 +44,17 @@ Scenario: Job with an empty name
     When I search for the job in the database
     Then The job entity matches the creator
 
-Scenario: Job with a duplicate name
+  Scenario: Job with a duplicate name
 
-    Given A regular job creator with the name "TestJob"
+    Given A regular job creator with the name "TestJob_2"
     Then I create a new job entity from the existing creator
+    Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name TestJob_2 already exists."
     When I create a new job entity from the existing creator
-    Then No exception was thrown
+    Then An exception was thrown
 
-Scenario: Delete a job
+  Scenario: Delete a job
 
-    Given A regular job creator with the name "TestJob"
+    Given A regular job creator with the name "TestJob_3"
     When I create a new job entity from the existing creator
     When I search for the job in the database
     And The job entity matches the creator
@@ -61,36 +62,36 @@ Scenario: Delete a job
     And I search for the job in the database
     Then There is no such job item in the database
 
-Scenario: Delete a job twice
+  Scenario: Delete a job twice
 
-    Given A regular job creator with the name "TestJob"
+    Given A regular job creator with the name "TestJob_4"
     And I create a new job entity from the existing creator
     And I delete the job
     Given I expect the exception "KapuaEntityNotFoundException" with the text "type job"
     And I delete the job
     Then An exception was thrown
 
-Scenario: Update a job name
+  Scenario: Update a job name
 
-    Given A regular job creator with the name "TestJob"
+    Given A regular job creator with the name "TestJob_5"
     Then I create a new job entity from the existing creator
     When I change the job name to "SomeRandomNewName"
     Then No exception was thrown
     When I search for the job in the database
     Then The job name is "SomeRandomNewName"
 
-Scenario: Update a job description
+  Scenario: Update a job description
 
-    Given A regular job creator with the name "TestJob"
+    Given A regular job creator with the name "TestJob_6"
     Then I create a new job entity from the existing creator
     When I change the job description to "SomeRandomNewDescription"
     Then No exception was thrown
     When I search for the job in the database
     Then The job description is "SomeRandomNewDescription"
 
-Scenario: Update a job XML definition
+  Scenario: Update a job XML definition
 
-    Given A regular job creator with the name "TestJob"
+    Given A regular job creator with the name "TestJob_7"
     Then I create a new job entity from the existing creator
     When I change the job XML definition to "SomeRandomNewDefinition"
     Then No exception was thrown
@@ -120,22 +121,22 @@ Scenario: Update a job XML definition
 #    # This should be 2!!! For some reason the update method does not update the job entity steps.
 #    Then The job has 0 steps
 
-Scenario: Update a nonexistent job
+  Scenario: Update a nonexistent job
 
-    Given A regular job creator with the name "TestJob"
+    Given A regular job creator with the name "TestJob_8"
     Then I create a new job entity from the existing creator
     And I delete the job
-    Given I expect the exception "KapuaEntityNotFoundException" with the text "JobImpl"
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type job"
     When I change the job name to "SomeRandomNewName"
     Then An exception was thrown
 
-Scenario: Count job items
+  Scenario: Count job items
 
     Given I create 10 job items
     When I count the jobs in the database
     Then There are exactly 10 items
 
-Scenario: Count job items in wrong (empty) scope
+  Scenario: Count job items in wrong (empty) scope
 
     Given I create 10 job items
     Given Scope with ID 20
@@ -151,15 +152,15 @@ Scenario: Count job items in wrong (empty) scope
 #    When I query for jobs in scope 10
 #    Then There are exactly 10 items
 
-Scenario: Query for jobs with specified name
+  Scenario: Query for jobs with specified name
 
-    Given I create 10 job items with the name "TestJob1"
-    And I create 15 job items with the name "TestJob2"
-    And I create 20 job items with the name "TestJob3"
-    When I count the jobs with the name "TestJob2"
+    Given I create 10 job items with the name "TestJobA"
+    And I create 15 job items with the name "TestJobB"
+    And I create 20 job items with the name "TestJobC"
+    When I count the jobs with the name starting with "TestJobB"
     Then There are exactly 15 items
 
-Scenario: Job factory sanity checks
+  Scenario: Job factory sanity checks
 
     When I test the sanity of the job factory
     Then No exception was thrown

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -50,6 +49,7 @@ import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.quartz.impl.StdSchedulerFactory;
 
+import javax.inject.Inject;
 import java.util.TimeZone;
 
 /**
@@ -63,10 +63,11 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
     private static final Domain SCHEDULER_DOMAIN = new SchedulerDomain();
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    @Inject
+    private AuthorizationService authorizationService;
 
-    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
-    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+    @Inject
+    private PermissionFactory permissionFactory;
 
     /**
      * Constructor.
@@ -87,7 +88,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.write, triggerCreator.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.write, triggerCreator.getScopeId()));
 
         //
         // Check duplicate name
@@ -176,7 +177,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.write, trigger.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.write, trigger.getScopeId()));
 
         //
         // Check existence
@@ -212,7 +213,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.delete, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.delete, scopeId));
 
         //
         // Check existence
@@ -248,7 +249,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.read, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.read, scopeId));
 
         //
         // Do find
@@ -264,7 +265,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.read, query.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.read, query.getScopeId()));
 
         //
         // Do query
@@ -280,7 +281,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.read, query.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.read, query.getScopeId()));
 
         //
         // Do count

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupPredicates.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupPredicates.java
@@ -11,20 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group.shiro;
 
+import org.eclipse.kapua.model.KapuaUpdatableEntityPredicates;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.KapuaPredicate;
 import org.eclipse.kapua.service.authorization.group.Group;
 
 /**
  * {@link KapuaQuery} {@link KapuaPredicate} name for {@link Group} entity.
- * 
+ *
  * @since 1.0
- * 
  */
-public class GroupPredicates {
-
-    private GroupPredicates() {
-    }
+public interface GroupPredicates extends KapuaUpdatableEntityPredicates {
 
     /**
      * {@link Group} name

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
@@ -23,6 +24,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.group.Group;
@@ -40,146 +42,161 @@ import org.slf4j.LoggerFactory;
 /**
  * {@link GroupService} implementation.
  *
- * @since 1.0
- *
+ * @since 1.0.0
  */
 @KapuaProvider
 public class GroupServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Group, GroupCreator, GroupService, GroupListResult, GroupQuery, GroupFactory> implements GroupService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GroupServiceImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(GroupServiceImpl.class);
 
     private static final Domain GROUP_DOMAIN = new GroupDomain();
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+
+    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
+    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     public GroupServiceImpl() {
         super(GroupService.class.getName(), GROUP_DOMAIN, AuthorizationEntityManagerFactory.getInstance(), GroupService.class, GroupFactory.class);
     }
 
     @Override
-    public Group create(GroupCreator groupCreator)
-            throws KapuaException {
+    public Group create(GroupCreator groupCreator) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(groupCreator, "groupCreator");
         ArgumentValidator.notNull(groupCreator.getScopeId(), "roleCreator.scopeId");
         ArgumentValidator.notEmptyOrNull(groupCreator.getName(), "groupCreator.name");
 
-        KapuaLocator locator = KapuaLocator.getInstance();
-
         //
         // Check Access
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(GROUP_DOMAIN, Actions.write, groupCreator.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(GROUP_DOMAIN, Actions.write, groupCreator.getScopeId()));
 
+        //
+        // Check limits
         if (allowedChildEntities(groupCreator.getScopeId()) <= 0) {
             throw new KapuaIllegalArgumentException("scopeId", "max groups reached");
         }
 
+        //
+        // Check duplicate name
         GroupQuery query = new GroupQueryImpl(groupCreator.getScopeId());
         query.setPredicate(new AttributePredicate<>(GroupPredicates.NAME, groupCreator.getName()));
-        GroupListResult groupListResult = query(query);
-        if (!groupListResult.isEmpty()) {
-             throw new KapuaDuplicateNameException(groupCreator.getName());
+
+        if (count(query) > 0) {
+            throw new KapuaDuplicateNameException(groupCreator.getName());
         }
 
+        //
+        // Do create
         return entityManagerSession.onTransactedInsert(em -> GroupDAO.create(em, groupCreator));
     }
 
     @Override
     public Group update(Group group) throws KapuaException {
+        //
+        // Argument validator
         ArgumentValidator.notNull(group, "group");
         ArgumentValidator.notNull(group.getScopeId(), "group.scopeId");
+        ArgumentValidator.notNull(group.getId(), "group.id");
         ArgumentValidator.notEmptyOrNull(group.getName(), "group.name");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(GROUP_DOMAIN, Actions.write, group.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(GROUP_DOMAIN, Actions.write, group.getScopeId()));
 
+        //
+        // Check existence
+        if (find(group.getScopeId(), group.getId()) == null) {
+            throw new KapuaEntityNotFoundException(Group.TYPE, group.getId());
+        }
+
+        //
+        // Check duplicate name
         GroupQuery query = new GroupQueryImpl(group.getScopeId());
-        query.setPredicate(new AttributePredicate<>(GroupPredicates.NAME, group.getName()));
-        GroupListResult groupListResult = query(query);
-        if (!groupListResult.isEmpty()) {
+        query.setPredicate(
+                new AndPredicate(
+                        new AttributePredicate<>(GroupPredicates.NAME, group.getName()),
+                        new AttributePredicate<>(GroupPredicates.ENTITY_ID, group.getId(), Operator.NOT_EQUAL)
+                )
+        );
+
+        if (count(query) > 0) {
             throw new KapuaDuplicateNameException(group.getName());
         }
 
-        return entityManagerSession.onTransactedInsert(em -> {
-
-            Group currentGroup = GroupDAO.find(em, group.getId());
-            if (currentGroup == null) {
-                throw new KapuaEntityNotFoundException(Group.TYPE, group.getId());
-            }
-
-            return GroupDAO.update(em, group);
-        });
+        //
+        // Do update
+        return entityManagerSession.onTransactedInsert(em -> GroupDAO.update(em, group));
     }
 
     @Override
     public void delete(KapuaId scopeId, KapuaId groupId) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(groupId, "groupId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(GROUP_DOMAIN, Actions.delete, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(GROUP_DOMAIN, Actions.delete, scopeId));
 
-        entityManagerSession.onTransactedAction(em -> {
-            if (GroupDAO.find(em, groupId) == null) {
-                throw new KapuaEntityNotFoundException(Group.TYPE, groupId);
-            }
+        //
+        // Check existence
+        if (find(scopeId, groupId) == null) {
+            throw new KapuaEntityNotFoundException(Group.TYPE, groupId);
+        }
 
-            GroupDAO.delete(em, groupId);
-        });
+        //
+        // Do delete
+        entityManagerSession.onTransactedAction(em -> GroupDAO.delete(em, groupId));
     }
 
     @Override
-    public Group find(KapuaId scopeId, KapuaId groupId)
-            throws KapuaException {
+    public Group find(KapuaId scopeId, KapuaId groupId) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(groupId, "groupId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(GROUP_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(GROUP_DOMAIN, Actions.read, scopeId));
 
+        //
+        // Do find
         return entityManagerSession.onResult(em -> GroupDAO.find(em, groupId));
     }
 
     @Override
-    public GroupListResult query(KapuaQuery<Group> query)
-            throws KapuaException {
+    public GroupListResult query(KapuaQuery<Group> query) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(GROUP_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(GROUP_DOMAIN, Actions.read, query.getScopeId()));
 
+        //
+        // Do query
         return entityManagerSession.onResult(em -> GroupDAO.query(em, query));
     }
 
     @Override
-    public long count(KapuaQuery<Group> query)
-            throws KapuaException {
+    public long count(KapuaQuery<Group> query) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(GROUP_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(GROUP_DOMAIN, Actions.read, query.getScopeId()));
 
+        //
+        // Do count
         return entityManagerSession.onResult(em -> GroupDAO.count(em, query));
     }
 
@@ -188,17 +205,15 @@ public class GroupServiceImpl extends AbstractKapuaConfigurableResourceLimitedSe
         if (kapuaEvent == null) {
             //service bus error. Throw some exception?
         }
-        LOGGER.info("GroupService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
+
+        LOG.info("GroupService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
         if ("account".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
             deleteGroupByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }
 
     private void deleteGroupByAccountId(KapuaId scopeId, KapuaId accountId) throws KapuaException {
-        KapuaLocator locator = KapuaLocator.getInstance();
-        GroupFactory groupFactory = locator.getFactory(GroupFactory.class);
-
-        GroupQuery query = groupFactory.newQuery(accountId);
+        GroupQuery query = new GroupQueryImpl(accountId);
 
         GroupListResult groupsToDelete = query(query);
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -144,7 +144,7 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         //
         // Check existence
         if (find(role.getScopeId(), role.getId()) == null) {
-            throw new KapuaEntityNotFoundException(role.getType(), role.getId());
+            throw new KapuaEntityNotFoundException(Role.TYPE, role.getId());
         }
 
         //

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
@@ -23,6 +24,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
@@ -42,41 +44,61 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Role service implementation.
+ * {@link RoleService} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @KapuaProvider
 public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Role, RoleCreator, RoleService, RoleListResult, RoleQuery, RoleFactory> implements RoleService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RoleServiceImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RoleServiceImpl.class);
 
     private static final Domain ROLE_DOMAIN = new RoleDomain();
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
+    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+
+    private static final RolePermissionFactory ROLE_PERMISSION_FACTORY = LOCATOR.getFactory(RolePermissionFactory.class);
 
     public RoleServiceImpl() {
         super(RoleService.class.getName(), ROLE_DOMAIN, AuthorizationEntityManagerFactory.getInstance(), RoleService.class, RoleFactory.class);
     }
 
     @Override
-    public Role create(RoleCreator roleCreator)
-            throws KapuaException {
+    public Role create(RoleCreator roleCreator) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(roleCreator, "roleCreator");
+        ArgumentValidator.notNull(roleCreator.getScopeId(), "roleCreator.scopeId");
         ArgumentValidator.notEmptyOrNull(roleCreator.getName(), "roleCreator.name");
         ArgumentValidator.notNull(roleCreator.getPermissions(), "roleCreator.permissions");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(ROLE_DOMAIN, Actions.write, roleCreator.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ROLE_DOMAIN, Actions.write, roleCreator.getScopeId()));
+
+        //
+        // Check limits
+        if (allowedChildEntities(roleCreator.getScopeId()) <= 0) {
+            throw new KapuaIllegalArgumentException("scopeId", "max roles reached");
+        }
+
+        //
+        // Check duplicate name
+        RoleQuery query = new RoleQueryImpl(roleCreator.getScopeId());
+        query.setPredicate(new AttributePredicate<>(RolePredicates.NAME, roleCreator.getName()));
+
+        if (count(query) > 0) {
+            throw new KapuaDuplicateNameException(roleCreator.getName());
+        }
 
         //
         // If permission are created out of the role scope, check that the current user has the permission on the external scopeId.
         if (roleCreator.getPermissions() != null) {
             for (Permission p : roleCreator.getPermissions()) {
                 if (p.getTargetScopeId() == null || !p.getTargetScopeId().equals(roleCreator.getScopeId())) {
-                    authorizationService.checkPermission(p);
+                    AUTHORIZATION_SERVICE.checkPermission(p);
                 }
             }
         }
@@ -85,25 +107,15 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         // Check that the given permission matches the definition of the Domains.
         PermissionValidator.validatePermissions(roleCreator.getPermissions());
 
-        if (allowedChildEntities(roleCreator.getScopeId()) <= 0) {
-            throw new KapuaIllegalArgumentException("scopeId", "max roles reached");
-        }
-
-        RoleQuery query = new RoleQueryImpl(roleCreator.getScopeId());
-        query.setPredicate(new AttributePredicate<>(RolePredicates.NAME, roleCreator.getName()));
-        RoleListResult roleListResult = query(query);
-        if (!roleListResult.isEmpty()) {
-             throw new KapuaDuplicateNameException(roleCreator.getName());
-        }
-
+        //
+        // Do create
         return entityManagerSession.onTransactedInsert(em -> {
             Role role = RoleDAO.create(em, roleCreator);
 
             if (!roleCreator.getPermissions().isEmpty()) {
-                RolePermissionFactory rolePermissionFactory = locator.getFactory(RolePermissionFactory.class);
                 for (Permission p : roleCreator.getPermissions()) {
 
-                    RolePermissionCreator rolePermissionCreator = rolePermissionFactory.newCreator(roleCreator.getScopeId());
+                    RolePermissionCreator rolePermissionCreator = ROLE_PERMISSION_FACTORY.newCreator(roleCreator.getScopeId());
 
                     rolePermissionCreator.setRoleId(role.getId());
                     rolePermissionCreator.setPermission(p);
@@ -118,96 +130,109 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
     @Override
     public Role update(Role role) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(role, "role");
+        ArgumentValidator.notNull(role.getScopeId(), "role.scopeId");
+        ArgumentValidator.notNull(role.getId(), "role.id");
         ArgumentValidator.notEmptyOrNull(role.getName(), "role.name");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(ROLE_DOMAIN, Actions.write, role.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ROLE_DOMAIN, Actions.write, role.getScopeId()));
 
+        //
+        // Check existence
+        if (find(role.getScopeId(), role.getId()) == null) {
+            throw new KapuaEntityNotFoundException(role.getType(), role.getId());
+        }
+
+        //
+        // Check duplicate name
         RoleQuery query = new RoleQueryImpl(role.getScopeId());
-        query.setPredicate(new AttributePredicate<>(RolePredicates.NAME, role.getName()));
-        RoleListResult roleListResult = query(query);
-        if (!roleListResult.isEmpty()) {
+        query.setPredicate(
+                new AndPredicate(
+                        new AttributePredicate<>(RolePredicates.NAME, role.getName()),
+                        new AttributePredicate<>(RolePredicates.ENTITY_ID, role.getId(), Operator.NOT_EQUAL)
+                )
+        );
+
+        if (count(query) > 0) {
             throw new KapuaDuplicateNameException(role.getName());
         }
 
-        return entityManagerSession.onTransactedInsert(em -> {
-
-            Role currentRole = RoleDAO.find(em, role.getId());
-            if (currentRole == null) {
-                throw new KapuaEntityNotFoundException(Role.TYPE, role.getId());
-            }
-
-            return RoleDAO.update(em, role);
-        });
+        //
+        // Do update
+        return entityManagerSession.onTransactedInsert(em -> RoleDAO.update(em, role));
     }
 
     @Override
     public void delete(KapuaId scopeId, KapuaId roleId) throws KapuaException {
-        // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(ROLE_DOMAIN, Actions.delete, scopeId));
-
-        entityManagerSession.onTransactedAction(em -> {
-            if (RoleDAO.find(em, roleId) == null) {
-                throw new KapuaEntityNotFoundException(Role.TYPE, roleId);
-            }
-
-            RoleDAO.delete(em, roleId);
-        });
-    }
-
-    @Override
-    public Role find(KapuaId scopeId, KapuaId roleId)
-            throws KapuaException {
-        ArgumentValidator.notNull(scopeId, "accountId");
+        //
+        // Argument validation
+        ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(roleId, "roleId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(ROLE_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ROLE_DOMAIN, Actions.delete, scopeId));
 
+        //
+        // Check existence
+        if (find(scopeId, roleId) == null) {
+            throw new KapuaEntityNotFoundException(Role.TYPE, roleId);
+        }
+
+        //
+        // Do delete
+        entityManagerSession.onTransactedAction(em -> RoleDAO.delete(em, roleId));
+    }
+
+    @Override
+    public Role find(KapuaId scopeId, KapuaId roleId) throws KapuaException {
+        //
+        // Argument validation
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(roleId, "roleId");
+
+        //
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ROLE_DOMAIN, Actions.read, scopeId));
+
+        //
+        // Do find
         return entityManagerSession.onResult(em -> RoleDAO.find(em, roleId));
     }
 
     @Override
-    public RoleListResult query(KapuaQuery<Role> query)
-            throws KapuaException {
+    public RoleListResult query(KapuaQuery<Role> query) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(ROLE_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ROLE_DOMAIN, Actions.read, query.getScopeId()));
 
+        //
+        // Do query
         return entityManagerSession.onResult(em -> RoleDAO.query(em, query));
     }
 
     @Override
-    public long count(KapuaQuery<Role> query)
-            throws KapuaException {
+    public long count(KapuaQuery<Role> query) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(ROLE_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(ROLE_DOMAIN, Actions.read, query.getScopeId()));
 
+        //
+        // Do count
         return entityManagerSession.onResult(em -> RoleDAO.count(em, query));
     }
 
@@ -216,17 +241,16 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         if (kapuaEvent == null) {
             //service bus error. Throw some exception?
         }
-        LOGGER.info("RoleService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
+
+        LOG.info("RoleService: received kapua event from {}, operation {}", kapuaEvent.getService(), kapuaEvent.getOperation());
         if ("account".equals(kapuaEvent.getService()) && "delete".equals(kapuaEvent.getOperation())) {
             deleteRoleByAccountId(kapuaEvent.getScopeId(), kapuaEvent.getEntityId());
         }
     }
 
     private void deleteRoleByAccountId(KapuaId scopeId, KapuaId accountId) throws KapuaException {
-        KapuaLocator locator = KapuaLocator.getInstance();
-        RoleFactory roleFactory = locator.getFactory(RoleFactory.class);
 
-        RoleQuery query = roleFactory.newQuery(accountId);
+        RoleQuery query = new RoleQueryImpl(accountId);
 
         RoleListResult rolesToDelete = query(query);
 

--- a/service/security/shiro/src/test/resources/features/GroupService.feature
+++ b/service/security/shiro/src/test/resources/features/GroupService.feature
@@ -109,7 +109,7 @@ Feature: Group Service CRUD tests
       | 0     | test_name_4 |
     Then A group was created
     And The group matches the creator
-    Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name"
+    Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type group"
     When I update the group with an incorrect ID
     Then An exception was thrown
 

--- a/service/security/shiro/src/test/resources/features/GroupService.feature
+++ b/service/security/shiro/src/test/resources/features/GroupService.feature
@@ -12,176 +12,176 @@
 @security
 Feature: Group Service CRUD tests
 
-Scenario: Count groups in a blank database
-    The default group table must be empty.
+  Scenario: Count groups in a blank database
+  The default group table must be empty.
 
     When I count the group entries in the database
     Then I get 0 as result
 
-Scenario: Regular group in root scope
-    Create a regular group entry. The newly created entry must match the
-    creator parameters.
+  Scenario: Regular group in root scope
+  Create a regular group entry. The newly created entry must match the
+  creator parameters.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    1    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    1    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 1       | 1             |
+      | integer | maxNumberChildEntities | 5     | 1       | 1             |
     Given I create the group
-    |scope |name        |
-    |1     |test_name_1 |
+      | scope | name        |
+      | 1     | test_name_1 |
     Then A group was created
     And The group matches the creator
 
-Scenario: Regular group in random scope
-    Create a regular group entry. The newly created entry must match the
-    creator parameters.
+  Scenario: Regular group in random scope
+  Create a regular group entry. The newly created entry must match the
+  creator parameters.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |  1234   |       1       |
-    | integer | maxNumberChildEntities     | 5     |  1234   |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 1234    | 1             |
+      | integer | maxNumberChildEntities | 5     | 1234    | 1             |
     Given I create the group
-    |scope |name        |
-    |1234  |test_name_1 |
+      | scope | name        |
+      | 1234  | test_name_1 |
     Then A group was created
     And The group matches the creator
 
-Scenario: Duplicate group name in root scope
-    Create a regular group entry. The newly created entry must match the
-    creator parameters. Try to create a second group entry with the same name.
-    An exception should be thrown.
+  Scenario: Duplicate group name in root scope
+  Create a regular group entry. The newly created entry must match the
+  creator parameters. Try to create a second group entry with the same name.
+  An exception should be thrown.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    0    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1             |
+      | integer | maxNumberChildEntities | 5     | 0       | 1             |
     Given I create the group
-    |scope |name        |
-    |0     |test_name_1 |
+      | scope | name        |
+      | 0     | test_name_2 |
     Then A group was created
     And The group matches the creator
-    Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name test_name_1 already exists."
+    Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name test_name_2 already exists."
     When I create the group
-    |scope |name        |
-    |0     |test_name_1 |
+      | scope | name        |
+      | 0     | test_name_2 |
     Then An exception was thrown
 
-Scenario: Group with a null name
-    Try to create a second group entry with a null name.
-    An exception should be thrown.
+  Scenario: Group with a null name
+  Try to create a second group entry with a null name.
+  An exception should be thrown.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |   1234  |       1       |
-    | integer | maxNumberChildEntities     | 5     |   1234  |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 1234    | 1             |
+      | integer | maxNumberChildEntities | 5     | 1234    | 1             |
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
     Given I create the group
-    |scope |
-    |1234  |
+      | scope |
+      | 1234  |
     Then An exception was thrown
 
-Scenario: Update a group entry in the database
-    Create a regular group entry. Change the entry name. The updated entry
-    parameters should match the original group.
+  Scenario: Update a group entry in the database
+  Create a regular group entry. Change the entry name. The updated entry
+  parameters should match the original group.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    0    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1             |
+      | integer | maxNumberChildEntities | 5     | 0       | 1             |
     Given I create the group
-    |scope |name        |
-    |0     |test_name_1 |
+      | scope | name        |
+      | 0     | test_name_3 |
     Then A group was created
     And The group matches the creator
     When I update the group name to "test_name_new"
     Then The group was correctly updated
 
-Scenario: Update a group entry with a false ID
-    Create a regular group entry. Modify the group object ID to a random value.
-    Trying to update such an group object should raise an exception.
+  Scenario: Update a group entry with a false ID
+  Create a regular group entry. Modify the group object ID to a random value.
+  Trying to update such an group object should raise an exception.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    0    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1             |
+      | integer | maxNumberChildEntities | 5     | 0       | 1             |
     Given I create the group
-    |scope |name        |
-    |0     |test_name_1 |
+      | scope | name        |
+      | 0     | test_name_4 |
     Then A group was created
     And The group matches the creator
     Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name"
     When I update the group with an incorrect ID
     Then An exception was thrown
 
-Scenario: Find a group entry in the database
-    It must be possible to find a specific group entry based on the group
-    entry ID.
+  Scenario: Find a group entry in the database
+  It must be possible to find a specific group entry based on the group
+  entry ID.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    0    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1             |
+      | integer | maxNumberChildEntities | 5     | 0       | 1             |
     Given I create the group
-    |scope |name        |
-    |0     |test_name_1 |
+      | scope | name        |
+      | 0     | test_name_5 |
     Then A group was created
     And The group matches the creator
     When I search for the last created group
     Then The group was correctly found
 
-Scenario: Delete a group from the database
-    It must be possible to delete a group entry from the database. In this test
-    the last created entry is deleted.
+  Scenario: Delete a group from the database
+  It must be possible to delete a group entry from the database. In this test
+  the last created entry is deleted.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    0    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1             |
+      | integer | maxNumberChildEntities | 5     | 0       | 1             |
     Given I create the groups
-    |scope |name        |
-    |0     |test_name_1 |
-    |0     |test_name_2 |
+      | scope | name        |
+      | 0     | test_name_6 |
+      | 0     | test_name_7 |
     When I delete the last created group
     And I search for the last created group
     Then No group was found
 
-Scenario: Delete a group from the database - Unknown group ID
-    Trying to delete a group record that does not exist (unknown group ID) should
-    raise an exception.
+  Scenario: Delete a group from the database - Unknown group ID
+  Trying to delete a group record that does not exist (unknown group ID) should
+  raise an exception.
 
     Given I expect the exception "KapuaEntityNotFoundException" with the text "The entity of type group"
     When I try to delete a random group id
     Then An exception was thrown
 
-Scenario: Count groups
-    It must be possible to count all the groups belonging to a certain scope.
+  Scenario: Count groups
+  It must be possible to count all the groups belonging to a certain scope.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    0    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1             |
+      | integer | maxNumberChildEntities | 5     | 0       | 1             |
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    1    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    1    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 1       | 1             |
+      | integer | maxNumberChildEntities | 5     | 1       | 1             |
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    2    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    2    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 2       | 1             |
+      | integer | maxNumberChildEntities | 5     | 2       | 1             |
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    3    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    3    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 3       | 1             |
+      | integer | maxNumberChildEntities | 5     | 3       | 1             |
     Given I create the groups
-    |scope |name        |
-    |0     |test_name_1 |
-    |1     |test_name_2 |
-    |2     |test_name_3 |
-    |2     |test_name_4 |
-    |2     |test_name_5 |
-    |3     |test_name_6 |
-    |3     |test_name_7 |
-    |0     |test_name_8 |
+      | scope | name         |
+      | 0     | test_name_8  |
+      | 1     | test_name_9  |
+      | 2     | test_name_10 |
+      | 2     | test_name_11 |
+      | 2     | test_name_12 |
+      | 3     | test_name_13 |
+      | 3     | test_name_14 |
+      | 0     | test_name_15 |
     When I count all the groups in scope 2
     Then I get 3 as result
     When I count all the groups in scope 3
@@ -189,41 +189,41 @@ Scenario: Count groups
     When I count all the groups in scope 15
     Then I get 0 as result
 
-Scenario: Query for a specific group by name
-    It must be possible to query the database for a specific group by name. Since the
-    scope ID / name pairs must be unique, only a single entry can be returned by such a query.
+  Scenario: Query for a specific group by name
+  It must be possible to query the database for a specific group by name. Since the
+  scope ID / name pairs must be unique, only a single entry can be returned by such a query.
 
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    0    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    0    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1             |
+      | integer | maxNumberChildEntities | 5     | 0       | 1             |
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    1    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    1    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 1       | 1             |
+      | integer | maxNumberChildEntities | 5     | 1       | 1             |
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    2    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    2    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 2       | 1             |
+      | integer | maxNumberChildEntities | 5     | 2       | 1             |
     When I configure
-    | type    | name                       | value | scopeId | parentScopeId |
-    | boolean | infiniteChildEntities      | true  |    3    |       1       |
-    | integer | maxNumberChildEntities     | 5     |    3    |       1       |
+      | type    | name                   | value | scopeId | parentScopeId |
+      | boolean | infiniteChildEntities  | true  | 3       | 1             |
+      | integer | maxNumberChildEntities | 5     | 3       | 1             |
     Given I create the groups
-    |scope |name        |
-    |0     |test_name_1 |
-    |1     |test_name_2 |
-    |2     |test_name_1 |
-    |2     |test_name_4 |
-    |2     |test_name_5 |
-    |3     |test_name_6 |
-    |3     |test_name_7 |
-    |0     |test_name_8 |
-    When I query for the group "test_name_1" in scope 0
+      | scope | name         |
+      | 0     | test_name_16 |
+      | 1     | test_name_17 |
+      | 2     | test_name_18 |
+      | 2     | test_name_19 |
+      | 2     | test_name_20 |
+      | 3     | test_name_21 |
+      | 3     | test_name_22 |
+      | 0     | test_name_23 |
+    When I query for the group "test_name_16" in scope 0
     Then I get 1 as result
-    And The group name is "test_name_1"
-    When I query for the group "test_name_1" in scope 2
+    And The group name is "test_name_16"
+    When I query for the group "test_name_18" in scope 2
     Then I get 1 as result
-    And The group name is "test_name_1"
-    When I query for the group "test_name_15" in scope 1
+    And The group name is "test_name_18"
+    When I query for the group "test_name_25" in scope 1
     Then I get 0 as result

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
@@ -44,139 +45,151 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
     private static final Domain TAG_DOMAIN = new TagDomain();
 
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+
+    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
+    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+
     public TagServiceImpl() {
         super(TagService.class.getName(), TAG_DOMAIN, TagEntityManagerFactory.getInstance(), TagService.class, TagFactory.class);
     }
 
     @Override
-    public Tag create(TagCreator tagCreator)
-            throws KapuaException {
+    public Tag create(TagCreator tagCreator) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(tagCreator, "tagCreator");
-        ArgumentValidator.notNull(tagCreator.getScopeId(), "roleCreator.scopeId");
+        ArgumentValidator.notNull(tagCreator.getScopeId(), "tagCreator.scopeId");
         ArgumentValidator.notEmptyOrNull(tagCreator.getName(), "tagCreator.name");
-
-        KapuaLocator locator = KapuaLocator.getInstance();
 
         //
         // Check Access
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(TAG_DOMAIN, Actions.write, tagCreator.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TAG_DOMAIN, Actions.write, tagCreator.getScopeId()));
 
+        //
+        // Check limit
         if (allowedChildEntities(tagCreator.getScopeId()) <= 0) {
             throw new KapuaIllegalArgumentException("scopeId", "max tags reached");
         }
 
+        //
+        // Check duplicate name
         TagQuery query = new TagQueryImpl(tagCreator.getScopeId());
         query.setPredicate(new AttributePredicate<>(TagPredicates.NAME, tagCreator.getName()));
-        TagListResult tagListResult = query(query);
-        if (!tagListResult.isEmpty()) {
+
+        if (count(query) > 0) {
             throw new KapuaDuplicateNameException(tagCreator.getName());
         }
 
+        //
+        // Do create
         return entityManagerSession.onTransactedInsert(em -> TagDAO.create(em, tagCreator));
     }
 
     @Override
     public Tag update(Tag tag) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(tag, "tag");
         ArgumentValidator.notNull(tag.getScopeId(), "tag.scopeId");
+        ArgumentValidator.notNull(tag.getId(), "tag.id");
         ArgumentValidator.notEmptyOrNull(tag.getName(), "tag.name");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(TAG_DOMAIN, Actions.write, tag.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TAG_DOMAIN, Actions.write, tag.getScopeId()));
 
+        //
+        // Check existence
+        if (find(tag.getScopeId(), tag.getId()) == null) {
+            throw new KapuaEntityNotFoundException(Tag.TYPE, tag.getId());
+        }
+
+        //
         // Check duplicate name
-        AndPredicate andPredicate = new AndPredicate();
-
         TagQuery query = new TagQueryImpl(tag.getScopeId());
-        query.setPredicate(new AttributePredicate<>(TagPredicates.NAME, tag.getName()));
-        TagListResult tagListResult = query(query);
-        if (!tagListResult.isEmpty()) {
+        query.setPredicate(
+                new AndPredicate(
+                        new AttributePredicate<>(TagPredicates.NAME, tag.getName()),
+                        new AttributePredicate<>(TagPredicates.ENTITY_ID, tag.getId(), Operator.NOT_EQUAL)
+                ));
+
+        if (count(query) > 0) {
             throw new KapuaDuplicateNameException(tag.getName());
         }
 
-        return entityManagerSession.onTransactedInsert(em -> {
-
-            Tag currentTag = TagDAO.find(em, tag.getId());
-            if (currentTag == null) {
-                throw new KapuaEntityNotFoundException(Tag.TYPE, tag.getId());
-            }
-
-            return TagDAO.update(em, tag);
-        });
+        //
+        // Do Update
+        return entityManagerSession.onTransactedInsert(em -> TagDAO.update(em, tag));
     }
 
     @Override
     public void delete(KapuaId scopeId, KapuaId tagId) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(tagId, "tagId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(TAG_DOMAIN, Actions.delete, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TAG_DOMAIN, Actions.delete, scopeId));
 
-        entityManagerSession.onTransactedAction(em -> {
-            if (TagDAO.find(em, tagId) == null) {
-                throw new KapuaEntityNotFoundException(Tag.TYPE, tagId);
-            }
+        //
+        // Check existence
+        if (find(scopeId, tagId) == null) {
+            throw new KapuaEntityNotFoundException(Tag.TYPE, tagId);
+        }
 
-            TagDAO.delete(em, tagId);
-        });
+        //
+        //
+        entityManagerSession.onTransactedAction(em -> TagDAO.delete(em, tagId));
     }
 
     @Override
-    public Tag find(KapuaId scopeId, KapuaId tagId)
-            throws KapuaException {
+    public Tag find(KapuaId scopeId, KapuaId tagId) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(scopeId, "scopeId");
         ArgumentValidator.notNull(tagId, "tagId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(TAG_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TAG_DOMAIN, Actions.read, scopeId));
 
+        //
+        // Do find
         return entityManagerSession.onResult(em -> TagDAO.find(em, tagId));
     }
 
     @Override
-    public TagListResult query(KapuaQuery<Tag> query)
-            throws KapuaException {
+    public TagListResult query(KapuaQuery<Tag> query) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(TAG_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TAG_DOMAIN, Actions.read, query.getScopeId()));
 
+        //
+        // Do query
         return entityManagerSession.onResult(em -> TagDAO.query(em, query));
     }
 
     @Override
-    public long count(KapuaQuery<Tag> query)
-            throws KapuaException {
+    public long count(KapuaQuery<Tag> query) throws KapuaException {
+        //
+        // Argument validation
         ArgumentValidator.notNull(query, "query");
         ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(TAG_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TAG_DOMAIN, Actions.read, query.getScopeId()));
 
+        //
+        // Do count
         return entityManagerSession.onResult(em -> TagDAO.count(em, query));
     }
 }

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -26,7 +27,6 @@ import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Actions;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
-
 import org.eclipse.kapua.service.tag.Tag;
 import org.eclipse.kapua.service.tag.TagCreator;
 import org.eclipse.kapua.service.tag.TagFactory;
@@ -36,7 +36,7 @@ import org.eclipse.kapua.service.tag.TagService;
 
 /**
  * {@link TagService} implementation.
- * 
+ *
  * @since 1.0.0
  */
 @KapuaProvider
@@ -71,7 +71,7 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
         query.setPredicate(new AttributePredicate<>(TagPredicates.NAME, tagCreator.getName()));
         TagListResult tagListResult = query(query);
         if (!tagListResult.isEmpty()) {
-             throw new KapuaDuplicateNameException(tagCreator.getName());
+            throw new KapuaDuplicateNameException(tagCreator.getName());
         }
 
         return entityManagerSession.onTransactedInsert(em -> TagDAO.create(em, tagCreator));
@@ -89,6 +89,9 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(TAG_DOMAIN, Actions.write, tag.getScopeId()));
+
+        // Check duplicate name
+        AndPredicate andPredicate = new AndPredicate();
 
         TagQuery query = new TagQueryImpl(tag.getScopeId());
         query.setPredicate(new AttributePredicate<>(TagPredicates.NAME, tag.getName()));

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -23,7 +23,6 @@ import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -41,6 +40,7 @@ import org.eclipse.kapua.service.user.UserType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.util.Objects;
 
 import static org.eclipse.kapua.commons.util.ArgumentValidator.notEmptyOrNull;
@@ -55,10 +55,11 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
     private static final Domain USER_DOMAIN = new UserDomain();
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    @Inject
+    private AuthorizationService authorizationService;
 
-    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
-    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+    @Inject
+    private PermissionFactory permissionFactory;
 
     /**
      * Constructor
@@ -91,7 +92,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(USER_DOMAIN, Actions.write, userCreator.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(USER_DOMAIN, Actions.write, userCreator.getScopeId()));
 
         //
         // Check duplicate name
@@ -130,7 +131,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(USER_DOMAIN, Actions.write, user.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(USER_DOMAIN, Actions.write, user.getScopeId()));
 
         //
         // Check existence
@@ -163,7 +164,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(USER_DOMAIN, Actions.write, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(USER_DOMAIN, Actions.write, scopeId));
 
         //
         // Check existence
@@ -197,7 +198,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(USER_DOMAIN, Actions.read, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(USER_DOMAIN, Actions.read, scopeId));
 
         // Do the find
         return entityManagerSession.onResult(em -> UserDAO.find(em, userId));
@@ -235,7 +236,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(USER_DOMAIN, Actions.read, query.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(USER_DOMAIN, Actions.read, query.getScopeId()));
 
         //
         // Do query
@@ -252,7 +253,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(USER_DOMAIN, Actions.read, query.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(USER_DOMAIN, Actions.read, query.getScopeId()));
 
         //
         // Do count
@@ -267,7 +268,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
     private User checkReadAccess(final User user) throws KapuaException {
         if (user != null) {
-            AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(USER_DOMAIN, Actions.read, user.getScopeId()));
+            authorizationService.checkPermission(permissionFactory.newPermission(USER_DOMAIN, Actions.read, user.getScopeId()));
         }
         return user;
     }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -19,6 +19,8 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -44,7 +46,7 @@ import java.util.Objects;
 import static org.eclipse.kapua.commons.util.ArgumentValidator.notEmptyOrNull;
 
 /**
- * User service implementation.
+ * {@link UserService} implementation.
  */
 @KapuaProvider
 public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<User, UserCreator, UserService, UserListResult, UserQuery, UserFactory> implements UserService {
@@ -270,11 +272,11 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         return user;
     }
 
-    private void validateSystemUser(String name)
-            throws KapuaException {
-        // FIXME-KAPUA: AuthenticationService get system user name via config
-        if ("kapua-sys".equals(name)) {
-            throw new KapuaIllegalArgumentException("name", "kapua-sys");
+    private void validateSystemUser(String name) throws KapuaException {
+        String adminUsername = SystemSetting.getInstance().getString(SystemSettingKey.SYS_ADMIN_USERNAME);
+
+        if (adminUsername.equals(name)) {
+            throw new KapuaIllegalArgumentException("name", adminUsername);
         }
     }
 
@@ -292,7 +294,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
     private void deleteUserByAccountId(KapuaId scopeId, KapuaId accountId) throws KapuaException {
         UserQuery query = new UserQueryImpl(accountId);
         UserListResult usersToDelete = query(query);
-        
+
         for (User u : usersToDelete.getItems()) {
             delete(u.getScopeId(), u.getId());
         }


### PR DESCRIPTION
This PR fixes the strategy of checking done to avoid duplicate names on entities. 
The check made before on the `.update(Entity)` methods was querying the DB filtering only by the name of the entity. This made impossible to update an entity without changing its name, because on update with `name` unchanged, the original record was matched and therefore causing an error. 
Also updated to use `.count(...)` instead of `.query(...)` which is more appropriate for the check, since we are not interested in the content of the matched entities.

Some refactoring of the services has been done on the Services involved in these changes. 

Improved the implementation of the `AndPredicate` implementation (
604c2bf) to allow ease of use when adding multiple clauses.

This PR also replaces #1379 which was the initial work of fixing the test `GroupService.feature` which then became a much bigger work