### PR TITLE
Fix for error messages on un-connected device

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.button.DiscardButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.SaveButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.label.Label;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaLoadListener;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
@@ -495,7 +496,7 @@ public class DeviceAssetsValues extends LayoutContainer {
         public void loaderLoadException(LoadEvent le) {
 
             if (le.exception != null) {
-                FailureHandler.handle(le.exception);
+                ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
             }
 
             List<ModelData> assets = new ArrayList<ModelData>();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -44,6 +44,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaLoadListener;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
@@ -391,7 +392,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
         public void loaderLoadException(LoadEvent le) {
 
             if (le.exception != null) {
-                FailureHandler.handle(le.exception);
+                ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
             }
             startButton.disable();
             stopButton.disable();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -56,6 +56,7 @@ import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
 
 public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
 
+    private static final String UNDEFINED_ERROR = "Error: ";
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private static final ConsoleDeviceMessages DEVICE_MSGS = GWT.create(ConsoleDeviceMessages.class);
 
@@ -198,6 +199,9 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
 
                     String errorMessage = htmlResult.substring(errorMessageStartIndex, errorMessageEndIndex);
 
+                    if (UNDEFINED_ERROR.equals(errorMessage)) {
+                        errorMessage = DEVICE_MSGS.deviceConnectionError();
+                    }
                     MessageBox.alert(MSGS.error(), MSGS.fileUploadFailure() + ":<br/>" + errorMessage, null);
                     commandInput.unmask();
                 } else {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -53,6 +53,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.button.DiscardButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.SaveButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.label.Label;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaLoadListener;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtConfigComponent;
@@ -492,8 +493,9 @@ public class DeviceConfigComponents extends LayoutContainer {
                                             new AsyncCallback<Void>() {
 
                                                 public void onFailure(Throwable caught) {
-                                                    FailureHandler.handle(caught);
+                                                    ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
                                                     dirty = true;
+                                                    refresh();
                                                 }
 
                                                 public void onSuccess(Void arg0) {
@@ -605,7 +607,7 @@ public class DeviceConfigComponents extends LayoutContainer {
         public void loaderLoadException(LoadEvent le) {
 
             if (le.exception != null) {
-                FailureHandler.handle(le.exception);
+                ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
             }
 
             List<ModelData> comps = new ArrayList<ModelData>();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
@@ -18,6 +18,7 @@ import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.FileUploadDialog;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaLoadListener;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
@@ -502,7 +503,7 @@ public class DeviceConfigSnapshots extends LayoutContainer {
         public void loaderLoadException(LoadEvent le) {
 
             if (le.exception != null) {
-                FailureHandler.handle(le.exception);
+                ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
             }
             store.removeAll();
             grid.unmask();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,7 +19,7 @@ import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDevice
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.TabItem;
-import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtBundleInfo;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeploymentPackage;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
@@ -156,7 +156,7 @@ public class DeviceTabPackagesInstalled extends TabItem {
 
                     @Override
                     public void onFailure(Throwable caught) {
-                        FailureHandler.handle(caught);
+                        ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
                         treeGrid.unmask();
                     }
                 });

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -348,3 +348,5 @@ dialogDeviceTagDeleteInfo=Are you sure you want to remove {0} tag from the devic
 dialogDeviceTagDeleteConfirmation=Tag successfully removed
 dialogDeviceTagDeleteError=Error while removing tag: {0}
 dialogDeviceDeleteError=Error when deleting device: {0}
+
+deviceConnectionError=Selected device not connected. Please refresh device list.


### PR DESCRIPTION
Fixing empty error messages when device is disconnected and this
    is not reflected on device tab. When changes are made to this device
    error messages are displayed nothing that device is not connected.
    
    There are multiple tabs that have this message implemented:
    
    - bundles
    - packages
    - exectute command
    - assets
    
    This fixes issue #1316
    
    Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>