### PR TITLE
Fixed AuthenticationServiceShiroImpl.verifyCredential method

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
@@ -11,17 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authentication.server;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.Callable;
-
 import com.extjs.gxt.ui.client.data.BaseListLoadResult;
 import com.extjs.gxt.ui.client.data.BasePagingLoadResult;
 import com.extjs.gxt.ui.client.data.ListLoadResult;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
@@ -56,6 +52,11 @@ import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserFactory;
 import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.Callable;
 
 public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implements GwtCredentialService {
 
@@ -255,9 +256,9 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
             final String username = user.getName();
             LoginCredentials loginCredentials = credentialsFactory.newUsernamePasswordCredentials(username, oldPassword);
 
-            boolean validPassword = authenticationService.verifyCredentials(loginCredentials);
+            try {
+                authenticationService.verifyCredentials(loginCredentials);
 
-            if (validPassword) {
                 KapuaSecurityUtils.doPrivileged(new Callable<Void>() {
 
                     @Override
@@ -280,8 +281,8 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
                         return null;
                     }
                 });
-            } else {
-                throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS, null, String.format("Wrong existing password for user %s", username));
+            } catch (KapuaException ke) {
+                throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS, ke, String.format("Wrong existing password for user %s", username));
             }
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -19,36 +19,33 @@ import org.eclipse.kapua.service.authentication.token.AccessToken;
  * AuthenticationService exposes APIs to manage User object under an Account.<br>
  * It includes APIs to create, update, find, list and delete Users.<br>
  * Instances of the UserService can be acquired through the ServiceLocator.
- * 
+ *
  * @since 1.0
- * 
  */
 public interface AuthenticationService extends KapuaService {
 
     /**
      * Login the provided user login credentials on the system (if the credentials are valid)
-     * 
+     *
      * @param loginCredentials
      * @return
-     * @throws KapuaException
-     *             an exception is thrown if the credentials are not found on the system, are expired or are disabled
+     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
      */
     public AccessToken login(LoginCredentials loginCredentials)
             throws KapuaException;
 
     /**
      * FIXME: add javadoc
-     * 
+     *
      * @param sessionCredentials
-     * @throws KapuaException
-     *             an exception is thrown if the credentials are not found on the system, are expired or are disabled
+     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
      */
     public void authenticate(SessionCredentials sessionCredentials)
             throws KapuaException;
 
     /**
      * Logout the current logged user
-     * 
+     *
      * @throws KapuaException
      */
     public void logout()
@@ -56,11 +53,10 @@ public interface AuthenticationService extends KapuaService {
 
     /**
      * Return the {@link AccessToken} identified by the provided token identifier
-     * 
+     *
      * @param tokenId
      * @return
-     * @throws KapuaException
-     *             if no {@link AccessToken} is found for that token identifier
+     * @throws KapuaException if no {@link AccessToken} is found for that token identifier
      */
     public AccessToken findAccessToken(String tokenId)
             throws KapuaException;
@@ -70,13 +66,11 @@ public interface AuthenticationService extends KapuaService {
 
     /**
      * Verifies the password of a user without logging him in, and thus create any kind of session
-     * 
+     *
      * @param loginCredentials
-     * @return true if the credentials are valid, false otherwise
-     * @throws KapuaException
-     *             an exception is thrown if the credentials are not found on the system, are expired or are disabled
+     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
      */
-    public boolean verifyCredentials(LoginCredentials loginCredentials)
+    public void verifyCredentials(LoginCredentials loginCredentials)
             throws KapuaException;
 
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -24,6 +24,7 @@ import org.apache.shiro.realm.Realm;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.session.mgt.AbstractSessionManager;
 import org.apache.shiro.session.mgt.AbstractValidatingSessionManager;
+import org.apache.shiro.session.mgt.SimpleSession;
 import org.apache.shiro.subject.Subject;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaRuntimeException;
@@ -73,54 +74,37 @@ import java.util.UUID;
 @KapuaProvider
 public class AuthenticationServiceShiroImpl implements AuthenticationService {
 
-    private final static Logger logger = LoggerFactory.getLogger(AuthenticationServiceShiroImpl.class);
+    private final static Logger LOG = LoggerFactory.getLogger(AuthenticationServiceShiroImpl.class);
 
     static {
-        // org.apache.shiro.config.Ini
-        // org.apache.shiro.config.IniSecurityManagerFactory
-        // org.apache.shiro.util.Factory;
-        // Factory<org.apache.shiro.mgt.SecurityManager> factory = new IniSecurityManagerFactory("classpath:shiro.ini");
-        // org.apache.shiro.mgt.SecurityManager securityManager = factory.getInstance();
-        // SecurityUtils.setSecurityManager(securityManager);
-
         // Make the SecurityManager instance available to the entire application:
         Collection<Realm> realms = new ArrayList<>();
         try {
             realms.add(new org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm());
             realms.add(new org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm());
         } catch (KapuaException e) {
-            // TODO add default realm???
+            LOG.error("Unable to build realms", e);
+            throw new ExceptionInInitializerError(e);
         }
 
         DefaultSecurityManager defaultSecurityManager = new DefaultSecurityManager();
         defaultSecurityManager.setAuthenticator(new KapuaAuthenticator());
-        logger.info("Set '{}' as shiro authenticator", KapuaAuthenticator.class);
-        // if (defaultSecurityManager.getAuthenticator() instanceof ModularRealmAuthenticator) {
-        // KapuaAuthenticationStrategy authenticationStrategy = new KapuaAuthenticationStrategy();
-        // ((ModularRealmAuthenticator) defaultSecurityManager.getAuthenticator()).setAuthenticationStrategy(authenticationStrategy);
-        // logger.info("Set '{}' as shiro authentication strategy ", KapuaAuthenticationStrategy.class);
-        // }
-        // else {
-        // logger.warn("Cannot set '{}' as shiro authentication strategy! Authenticator class is '{}' and this option is only available for ModularRealmAuthenticator!",
-        // new Object[]{KapuaAuthenticationStrategy.class, defaultSecurityManager.getAuthenticator() != null ? defaultSecurityManager.getAuthenticator().getClass() : "null"});
-        // }
-
         defaultSecurityManager.setRealms(realms);
+
         SecurityUtils.setSecurityManager(defaultSecurityManager);
 
-        // TODO in the old application this code was executed only inside the broker context
-        // but now it's no more needed since we are using an external service (that returns a token) to authenticate the broker component
         if (defaultSecurityManager.getSessionManager() instanceof AbstractSessionManager) {
             ((AbstractSessionManager) defaultSecurityManager.getSessionManager()).setGlobalSessionTimeout(-1);
-            logger.info("Shiro global session timeout set to indefinite.");
+            LOG.info("Shiro global session timeout set to indefinite.");
         } else {
-            logger.warn("Cannot set Shiro global session timeout to indefinite.");
+            LOG.warn("Cannot set Shiro global session timeout to indefinite.");
         }
+
         if (defaultSecurityManager.getSessionManager() instanceof AbstractValidatingSessionManager) {
             ((AbstractValidatingSessionManager) defaultSecurityManager.getSessionManager()).setSessionValidationSchedulerEnabled(false);
-            logger.info("Shiro global session validator scheduler disabled.");
+            LOG.info("Shiro global session validator scheduler disabled.");
         } else {
-            logger.warn("Cannot disable Shiro session validator scheduler.");
+            LOG.warn("Cannot disable Shiro session validator scheduler.");
         }
     }
 
@@ -133,8 +117,9 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         // Parse login credentials
         AuthenticationToken shiroAuthenticationToken;
         if (loginCredentials instanceof UsernamePasswordCredentialsImpl) {
-            shiroAuthenticationToken = new UsernamePasswordCredentialsImpl(((UsernamePasswordCredentialsImpl) loginCredentials).getUsername(),
-                    ((UsernamePasswordCredentialsImpl) loginCredentials).getPassword());
+            UsernamePasswordCredentialsImpl usernamePasswordCredentials = (UsernamePasswordCredentialsImpl) loginCredentials;
+
+            shiroAuthenticationToken = new UsernamePasswordCredentialsImpl(usernamePasswordCredentials.getUsername(), usernamePasswordCredentials.getPassword());
         } else if (loginCredentials instanceof ApiKeyCredentialsImpl) {
             shiroAuthenticationToken = new ApiKeyCredentialsImpl(((ApiKeyCredentialsImpl) loginCredentials).getApiKey());
         } else if (loginCredentials instanceof JwtCredentialsImpl) {
@@ -148,48 +133,25 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         AccessToken accessToken;
         Subject currentUser = null;
         try {
-            //
             // Shiro login
             currentUser = SecurityUtils.getSubject();
             currentUser.login(shiroAuthenticationToken);
 
-            //
             // Create the access token
+            // FIXME: It is likely that it possible to use the currentUser instead of getting it again
             Subject shiroSubject = SecurityUtils.getSubject();
             Session shiroSession = shiroSubject.getSession();
             accessToken = createAccessToken(shiroSession);
 
-            //
             // Establish session
             establishSession(shiroSubject, accessToken);
 
-            //
             // Set some logging
             MDC.put(KapuaSecurityUtils.MDC_USER_ID, accessToken.getUserId().toCompactId());
-            logger.info("Login for thread '{}' - '{}' - '{}'", Thread.currentThread().getId(), Thread.currentThread().getName(), shiroSubject);
+            LOG.info("Login for thread '{}' - '{}' - '{}'", Thread.currentThread().getId(), Thread.currentThread().getName(), shiroSubject);
 
         } catch (ShiroException se) {
-
-            KapuaAuthenticationException kae;
-            if (se instanceof UnknownAccountException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.UNKNOWN_LOGIN_CREDENTIAL, se, shiroAuthenticationToken.getPrincipal());
-            } else if (se instanceof LockedAccountException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.LOCKED_LOGIN_CREDENTIAL, se, shiroAuthenticationToken.getPrincipal());
-            } else if (se instanceof DisabledAccountException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.DISABLED_LOGIN_CREDENTIAL, se, shiroAuthenticationToken.getPrincipal());
-            } else if (se instanceof IncorrectCredentialsException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS, se, shiroAuthenticationToken.getPrincipal());
-            } else if (se instanceof ExpiredCredentialsException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.EXPIRED_LOGIN_CREDENTIALS, se, shiroAuthenticationToken.getPrincipal());
-            } else {
-                throw KapuaException.internalError(se);
-            }
-
-            if (currentUser != null) {
-                currentUser.logout();
-            }
-
-            throw kae;
+            throw handleTokenLoginException(se, currentUser, shiroAuthenticationToken);
         }
 
         return accessToken;
@@ -212,24 +174,21 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         // Login the user
         Subject currentUser = null;
         try {
-            //
             // Shiro login
             currentUser = SecurityUtils.getSubject();
             currentUser.login(shiroAuthenticationToken);
 
-            //
             // Retrieve token
             AccessToken accessToken = findAccessToken((String) shiroAuthenticationToken.getCredentials());
 
-            //
             // Enstablish session
             establishSession(currentUser, accessToken);
 
-            //
             // Set some logging
             Subject shiroSubject = SecurityUtils.getSubject();
             MDC.put(KapuaSecurityUtils.MDC_USER_ID, accessToken.getUserId().toCompactId());
-            logger.info("Login for thread '{}' - '{}' - '{}'", Thread.currentThread().getId(), Thread.currentThread().getName(), shiroSubject);
+
+            LOG.info("Login for thread '{}' - '{}' - '{}'", Thread.currentThread().getId(), Thread.currentThread().getName(), shiroSubject);
         } catch (ShiroException se) {
 
             KapuaAuthenticationException kae;
@@ -253,6 +212,42 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             throw kae;
         }
 
+    }
+
+    @Override
+    public void verifyCredentials(LoginCredentials loginCredentials) throws KapuaException {
+        //
+        // Parse login credentials
+        AuthenticationToken shiroAuthenticationToken;
+        if (loginCredentials instanceof UsernamePasswordCredentialsImpl) {
+            shiroAuthenticationToken = new UsernamePasswordCredentialsImpl(((UsernamePasswordCredentialsImpl) loginCredentials).getUsername(),
+                    ((UsernamePasswordCredentialsImpl) loginCredentials).getPassword());
+        } else {
+            throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_CREDENTIALS_TYPE_PROVIDED);
+        }
+
+        //
+        // Login the user
+        Subject verifySubject = null;
+        try {
+            // Create custom subject to verify
+            verifySubject =
+                    new Subject
+                            .Builder()
+                            .session(new SimpleSession())
+                            .sessionCreationEnabled(false)
+                            .authenticated(false)
+                            .buildSubject();
+
+            // Login its token
+            verifySubject.login(shiroAuthenticationToken);
+
+            // Logout after verification has occurred
+            verifySubject.logout();
+
+        } catch (ShiroException se) {
+            handleTokenLoginException(se, verifySubject, shiroAuthenticationToken);
+        }
     }
 
     @Override
@@ -320,53 +315,6 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         return createAccessToken((KapuaEid) expiredAccessToken.getScopeId(), (KapuaEid) expiredAccessToken.getUserId());
     }
 
-    @Override
-    public boolean verifyCredentials(LoginCredentials loginCredentials) throws KapuaException {
-        //
-        // Parse login credentials
-        AuthenticationToken shiroAuthenticationToken;
-        if (loginCredentials instanceof UsernamePasswordCredentialsImpl) {
-            shiroAuthenticationToken = new UsernamePasswordCredentialsImpl(((UsernamePasswordCredentialsImpl) loginCredentials).getUsername(),
-                    ((UsernamePasswordCredentialsImpl) loginCredentials).getPassword());
-        } else {
-            throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_CREDENTIALS_TYPE_PROVIDED);
-        }
-
-        //
-        // Login the user
-        Subject currentUser = null;
-        try {
-            //
-            // Shiro login
-            currentUser = SecurityUtils.getSubject();
-            currentUser.login(shiroAuthenticationToken);
-        } catch (ShiroException se) {
-
-            KapuaAuthenticationException kae;
-            if (se instanceof UnknownAccountException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.UNKNOWN_LOGIN_CREDENTIAL, se, shiroAuthenticationToken.getPrincipal());
-            } else if (se instanceof LockedAccountException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.LOCKED_LOGIN_CREDENTIAL, se, shiroAuthenticationToken.getPrincipal());
-            } else if (se instanceof DisabledAccountException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.DISABLED_LOGIN_CREDENTIAL, se, shiroAuthenticationToken.getPrincipal());
-            } else if (se instanceof IncorrectCredentialsException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS, se, shiroAuthenticationToken.getPrincipal());
-            } else if (se instanceof ExpiredCredentialsException) {
-                kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.EXPIRED_LOGIN_CREDENTIALS, se, shiroAuthenticationToken.getPrincipal());
-            } else {
-                throw KapuaException.internalError(se);
-            }
-
-            if (currentUser != null) {
-                currentUser.logout();
-            }
-
-            throw kae;
-        }
-
-        return true;
-    }
-
     //
     // Private Methods
     //
@@ -383,9 +331,34 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         Subject currentUser = SecurityUtils.getSubject();
 
         if (currentUser != null && currentUser.isAuthenticated()) {
-            logger.info("Thread already authenticated for thread '{}' - '{}' - '{}'", Thread.currentThread().getId(), Thread.currentThread().getName(), currentUser);
+            LOG.info("Thread already authenticated for thread '{}' - '{}' - '{}'", Thread.currentThread().getId(), Thread.currentThread().getName(), currentUser);
             throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.SUBJECT_ALREADY_LOGGED);
         }
+    }
+
+    private KapuaException handleTokenLoginException(ShiroException se, Subject currentSubject, AuthenticationToken authenticationToken) throws KapuaException {
+
+        if (currentSubject != null) {
+            currentSubject.logout();
+        }
+
+        KapuaAuthenticationException kae;
+
+        if (se instanceof UnknownAccountException) {
+            kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.UNKNOWN_LOGIN_CREDENTIAL, se, authenticationToken.getPrincipal());
+        } else if (se instanceof LockedAccountException) {
+            kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.LOCKED_LOGIN_CREDENTIAL, se, authenticationToken.getPrincipal());
+        } else if (se instanceof DisabledAccountException) {
+            kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.DISABLED_LOGIN_CREDENTIAL, se, authenticationToken.getPrincipal());
+        } else if (se instanceof IncorrectCredentialsException) {
+            kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS, se, authenticationToken.getPrincipal());
+        } else if (se instanceof ExpiredCredentialsException) {
+            kae = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.EXPIRED_LOGIN_CREDENTIALS, se, authenticationToken.getPrincipal());
+        } else {
+            throw KapuaException.internalError(se);
+        }
+
+        return kae;
     }
 
     /**

--- a/test/src/main/java/org/eclipse/kapua/test/authentication/AuthenticationServiceMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/authentication/AuthenticationServiceMock.java
@@ -33,8 +33,7 @@ public class AuthenticationServiceMock implements AuthenticationService {
     }
 
     @Override
-    public AccessToken login(LoginCredentials authenticationToken)
-            throws KapuaException {
+    public AccessToken login(LoginCredentials authenticationToken) throws KapuaException {
         if (!(authenticationToken instanceof UsernamePasswordCredentialsMock)) {
             throw KapuaException.internalError("Unmanaged credentials type");
         }
@@ -58,28 +57,20 @@ public class AuthenticationServiceMock implements AuthenticationService {
     }
 
     @Override
-    public AccessToken findAccessToken(String tokenId)
-            throws KapuaException {
-        // TODO Auto-generated method stub
+    public AccessToken findAccessToken(String tokenId) throws KapuaException {
         return null;
     }
 
     @Override
     public void authenticate(SessionCredentials sessionCredentials) throws KapuaException {
-        // TODO Auto-generated method stub
-
     }
 
     @Override
     public AccessToken refreshAccessToken(String tokenId, String refreshToken) throws KapuaException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    public boolean verifyCredentials(LoginCredentials loginCredentials) throws KapuaException {
-        // TODO Auto-generated method stub
-        return false;
+    public void verifyCredentials(LoginCredentials loginCredentials) throws KapuaException {
     }
-
 }


### PR DESCRIPTION
This PR fixes #1397 .

The Shiro `.login(..)` was invoked from the current `Subject`. 
This was causing the current session to be replaced with the one created from the `.login(...)` with the credentials to verify. 
I've changed to use a `Subject` on the fly, on which call `.login(...)` and then logout to avoid leave opened sessions.

I've also changed the `AuthenticationService.verify(...)` signature because it was set to always return `true` if no exception was risen. It makes more sense to have a `void` return value and throw an exception if validation fails.