### PR TITLE
Fixed wildcard scopeId parsing with misconfigured shiro.ini

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/RestApiErrorCodes.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/RestApiErrorCodes.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources.exception;
+
+import org.eclipse.kapua.KapuaErrorCode;
+
+public enum RestApiErrorCodes implements KapuaErrorCode {
+    /**
+     * When a resource receive a request, but the {@link org.eclipse.kapua.commons.security.KapuaSession} is not populated.
+     * This is likely to happen when the `shiro.ini` does not map the `kapuaAuthcAccessToken` as a request filter chain.
+     */
+    SESSION_NOT_POPULATED
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/RestApiRuntimeException.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/RestApiRuntimeException.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources.exception;
+
+import org.eclipse.kapua.KapuaRuntimeException;
+
+public class RestApiRuntimeException extends KapuaRuntimeException {
+
+    /**
+     * Constructor
+     *
+     * @param message
+     * @param throwable
+     */
+    private RestApiRuntimeException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    /**
+     * Builds a new {@link RestApiRuntimeException} instance based on the supplied {@link RestApiErrorCodes}.
+     *
+     * @param code
+     */
+    public RestApiRuntimeException(RestApiErrorCodes code) {
+        this(code, (Object[]) null);
+    }
+
+    /**
+     * Builds a new {@link RestApiRuntimeException} instance based on the supplied {@link RestApiErrorCodes}
+     * and optional arguments for the associated exception message.
+     *
+     * @param code
+     * @param arguments
+     */
+    public RestApiRuntimeException(RestApiErrorCodes code, Object... arguments) {
+        this(code, null, arguments);
+    }
+
+    /**
+     * Builds a new {@link KapuaRuntimeException} instance based on the supplied {@link RestApiErrorCodes},
+     * an Throwable cause, and optional arguments for the associated exception message.
+     *
+     * @param code
+     * @param cause
+     * @param arguments
+     */
+    public RestApiRuntimeException(RestApiErrorCodes code, Throwable cause, Object... arguments) {
+        super(cause);
+        this.code = code;
+        args = arguments;
+    }
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/SessionNotPopulatedException.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/SessionNotPopulatedException.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources.exception;
+
+public class SessionNotPopulatedException extends RestApiRuntimeException {
+
+    public SessionNotPopulatedException() {
+        super(RestApiErrorCodes.SESSION_NOT_POPULATED);
+    }
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ScopeId.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ScopeId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,16 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources.model;
 
-import java.math.BigInteger;
-import java.util.Base64;
-
-import javax.ws.rs.PathParam;
-
 import org.eclipse.kapua.app.api.core.settings.KapuaApiSetting;
 import org.eclipse.kapua.app.api.core.settings.KapuaApiSettingKeys;
+import org.eclipse.kapua.app.api.resources.v1.resources.exception.SessionNotPopulatedException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.model.id.KapuaId;
+
+import javax.ws.rs.PathParam;
+import java.math.BigInteger;
+import java.util.Base64;
 
 /**
  * {@link KapuaId} implementation to be used on REST API to parse the {@link PathParam} scopeId.
@@ -49,6 +49,11 @@ public class ScopeId implements KapuaId {
 
         if (SCOPE_ID_WILDCARD.equals(compactScopeId)) {
             KapuaSession session = KapuaSecurityUtils.getSession();
+
+            if (session == null) {
+                throw new SessionNotPopulatedException();
+            }
+
             setId(session.getScopeId().getId());
         } else {
             byte[] bytes = Base64.getUrlDecoder().decode(compactScopeId);

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaRuntimeException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaRuntimeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,20 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.StringJoiner;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Kapua runtime exception.
  *
  * @since 1.0
- *
  */
 public class KapuaRuntimeException extends RuntimeException {
 
@@ -41,7 +40,6 @@ public class KapuaRuntimeException extends RuntimeException {
     /**
      * Constructor
      */
-    @SuppressWarnings("unused")
     private KapuaRuntimeException() {
         super();
     }
@@ -51,8 +49,7 @@ public class KapuaRuntimeException extends RuntimeException {
      *
      * @param message
      */
-    @SuppressWarnings("unused")
-    private KapuaRuntimeException(String message) {
+    protected KapuaRuntimeException(String message) {
         this(message, null);
     }
 
@@ -61,8 +58,7 @@ public class KapuaRuntimeException extends RuntimeException {
      *
      * @param throwable
      */
-    @SuppressWarnings("unused")
-    private KapuaRuntimeException(Throwable throwable) {
+    protected KapuaRuntimeException(Throwable throwable) {
         this(null, throwable);
     }
 
@@ -72,7 +68,7 @@ public class KapuaRuntimeException extends RuntimeException {
      * @param message
      * @param throwable
      */
-    private KapuaRuntimeException(String message, Throwable throwable) {
+    protected KapuaRuntimeException(String message, Throwable throwable) {
         super(message, throwable);
     }
 


### PR DESCRIPTION
This PR fixes #1348 

Introduced Rest API application specific runtime exceptions. 
Not instead of `throw`ing `NullPointerException` it `throws` a more specific exception.