### PR TITLE
Fixed account organization info self edit

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -290,10 +290,9 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
         checkXSRFToken(xsrfToken);
 
         GwtAccount gwtAccountUpdated = null;
-        KapuaId scopeId = gwtAccount.getScopeId() != null ? KapuaEid.parseCompactId(gwtAccount.getScopeId()) : null;
         KapuaId accountId = KapuaEid.parseCompactId(gwtAccount.getId());
         try {
-            Account account = scopeId != null ? ACCOUNT_SERVICE.find(scopeId, accountId) : ACCOUNT_SERVICE.find(accountId);
+            Account account = ACCOUNT_SERVICE.find(accountId);
 
             account.getOrganization().setName(gwtAccount.getGwtOrganization().getName());
             account.getOrganization().setPersonName(gwtAccount.getGwtOrganization().getPersonName());


### PR DESCRIPTION
This PR fixes #1215 

Just changed the way the account is fetched for retrieve the original entity. This can be safely done since the `.update(...)` method then will perform the appropriate checks