### PR TITLE
Fixing multi select checkbox on selecting Targets for Job

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridCheckBoxSelectionModel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridCheckBoxSelectionModel.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.api.client.ui.grid;
+
+import com.extjs.gxt.ui.client.data.ModelData;
+import com.extjs.gxt.ui.client.event.GridEvent;
+import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
+import com.google.gwt.user.client.Event;
+
+/**
+ * This is extension of CheckBoxSelectionModel that fixes issues with
+ * multiple select not working properly on GridView that uses checkboxes.
+ *
+ * @param <M> data model type used in grid view
+ */
+public class EntityGridCheckBoxSelectionModel<M extends ModelData> extends CheckBoxSelectionModel<M> {
+
+    @Override
+    protected void handleMouseDown(GridEvent<M> e) {
+      if (e.getEvent().getButton() == Event.BUTTON_LEFT) {
+        M m = listStore.getAt(e.getRowIndex());
+        if (m != null) {
+          if (isSelected(m)) {
+            deselect(m);
+          } else {
+            select(m, true);
+          }
+        }
+      } else {
+        super.handleMouseDown(e);
+      }
+    }
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -125,15 +125,12 @@ public class JobTabTargetsGrid extends EntityGrid<GwtJobTarget> {
                 if (result.getJobXmlDefinition() == null) {
                     JobTabTargetsGrid.this.toolbar.getAddEntityButton().enable();
                     if (selectedItem == null) {
-                        JobTabTargetsGrid.this.toolbar.getEditEntityButton().disable();
                         JobTabTargetsGrid.this.toolbar.getDeleteEntityButton().disable();
                     } else {
-                        JobTabTargetsGrid.this.toolbar.getEditEntityButton().enable();
                         JobTabTargetsGrid.this.toolbar.getDeleteEntityButton().enable();
                     }
                 } else {
                     JobTabTargetsGrid.this.toolbar.getAddEntityButton().disable();
-                    JobTabTargetsGrid.this.toolbar.getEditEntityButton().disable();
                     JobTabTargetsGrid.this.toolbar.getDeleteEntityButton().disable();
                 }
             }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.targets;
 
+import com.extjs.gxt.ui.client.Style.SelectionMode;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
@@ -21,6 +22,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGridCheckBoxSelectionModel;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingToolBar;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtSession;
@@ -39,7 +41,7 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     private static final GwtDeviceServiceAsync GWT_DEVICE_SERVICE = GWT.create(GwtDeviceService.class);
     private static final ConsoleDeviceMessages DVC_MSGS = GWT.create(ConsoleDeviceMessages.class);
 
-    private final CheckBoxSelectionModel<GwtDevice> selectionModel = new CheckBoxSelectionModel<GwtDevice>();
+    private final EntityGridCheckBoxSelectionModel<GwtDevice> selectionModel = new EntityGridCheckBoxSelectionModel<GwtDevice>();
 
     private static final int ENTITY_PAGE_SIZE = 10;
 
@@ -91,9 +93,10 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     protected List<ColumnConfig> getColumns() {
         List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
 
-        columnConfigs.add(selectionModel.getColumn());
+        ColumnConfig column = selectionModel.getColumn();
+        columnConfigs.add(column);
 
-        ColumnConfig column = new ColumnConfig("clientId", DVC_MSGS.deviceTableClientID(), 175);
+        column = new ColumnConfig("clientId", DVC_MSGS.deviceTableClientID(), 175);
         column.setSortable(true);
         columnConfigs.add(column);
 
@@ -106,10 +109,11 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
 
     @Override
     protected void onRender(Element target, int index) {
-        super.onRender(target, index);
-
+        configureEntityGrid(SelectionMode.SIMPLE);
         entityGrid.addPlugin(selectionModel);
         entityGrid.setSelectionModel(selectionModel);
+
+        super.onRender(target, index);
     }
 
     @Override


### PR DESCRIPTION
Changes were needed on EntityGrid because implementation was not
according to GXT rules. Setting of grid was moved before onRender
method.

This was done in a manner that should leave existing usage of EntityGrid
in tact. Test of this fix should be extended to other girds not only
on this single one.

This fixes issue #1357

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>