### PR TITLE
Fix find child jwt certificate

### DIFF
--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
@@ -24,4 +25,8 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(factoryClass = CertificateXmlRegistry.class, factoryMethod = "newQuery")
 public interface CertificateQuery extends KapuaQuery<Certificate> {
 
+    @XmlElement(name = "includeInherited")
+    public Boolean getIncludeInherited();
+
+    public void setIncludeInherited(Boolean includeInherited);
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
@@ -30,7 +30,11 @@ public interface CertificateService extends KapuaEntityService<Certificate, Cert
 
     Certificate findByName(String var1) throws KapuaException;
 
-    CertificateListResult query(KapuaQuery<Certificate> var1) throws KapuaException;
+    CertificateListResult query(KapuaQuery<Certificate> query) throws KapuaException;
+
+    CertificateListResult query(KapuaQuery<Certificate> query, boolean includeAncestorAccounts) throws KapuaException;
+
+    long count(KapuaQuery<Certificate> query, boolean includeAncestorAccounts) throws KapuaException;
 
     Certificate generate(CertificateGenerator generator) throws KapuaException;
 

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
@@ -32,10 +32,6 @@ public interface CertificateService extends KapuaEntityService<Certificate, Cert
 
     CertificateListResult query(KapuaQuery<Certificate> query) throws KapuaException;
 
-    CertificateListResult query(KapuaQuery<Certificate> query, boolean includeAncestorAccounts) throws KapuaException;
-
-    long count(KapuaQuery<Certificate> query, boolean includeAncestorAccounts) throws KapuaException;
-
     Certificate generate(CertificateGenerator generator) throws KapuaException;
 
     List<Certificate> findAncestorsCertificates(KapuaId scopeId, CertificateUsage usage) throws KapuaException;

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateQueryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateQueryImpl.java
@@ -18,6 +18,8 @@ import org.eclipse.kapua.service.certificate.CertificateQuery;
 
 public class CertificateQueryImpl extends AbstractKapuaQuery<Certificate> implements CertificateQuery {
 
+    private Boolean includeInherited = Boolean.FALSE;
+
     /**
      * Constructor
      */
@@ -35,4 +37,13 @@ public class CertificateQueryImpl extends AbstractKapuaQuery<Certificate> implem
         setScopeId(scopeId);
     }
 
+    @Override
+    public Boolean getIncludeInherited() {
+        return includeInherited;
+    }
+
+    @Override
+    public void setIncludeInherited(Boolean includeInherited) {
+        this.includeInherited = includeInherited;
+    }
 }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
@@ -83,11 +83,6 @@ public class CertificateServiceImpl implements CertificateService {
 
     @Override
     public CertificateListResult query(KapuaQuery<Certificate> query) throws KapuaException {
-        return query(query, false);
-    }
-
-    @Override
-    public CertificateListResult query(KapuaQuery<Certificate> query, boolean includeAncestorAccounts) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(query, "query");
@@ -120,11 +115,6 @@ public class CertificateServiceImpl implements CertificateService {
 
     @Override
     public long count(KapuaQuery<Certificate> query) throws KapuaException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public long count(KapuaQuery<Certificate> query, boolean includeAncestorAccounts) throws KapuaException {
         throw new UnsupportedOperationException();
     }
 

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
@@ -83,6 +83,11 @@ public class CertificateServiceImpl implements CertificateService {
 
     @Override
     public CertificateListResult query(KapuaQuery<Certificate> query) throws KapuaException {
+        return query(query, false);
+    }
+
+    @Override
+    public CertificateListResult query(KapuaQuery<Certificate> query, boolean includeAncestorAccounts) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(query, "query");
@@ -100,7 +105,7 @@ public class CertificateServiceImpl implements CertificateService {
 
         KapuaCertificateSetting setting = KapuaCertificateSetting.getInstance();
 
-        Certificate kapuaCertificate = new CertificateImpl(query.getScopeId());
+        Certificate kapuaCertificate = new CertificateImpl(KapuaId.ONE);
         kapuaCertificate.setPrivateKey(privateKey);
         kapuaCertificate.setCertificate(certificate);
         kapuaCertificate.getKeyUsageSettings().add(keyUsageSetting);
@@ -115,6 +120,11 @@ public class CertificateServiceImpl implements CertificateService {
 
     @Override
     public long count(KapuaQuery<Certificate> query) throws KapuaException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long count(KapuaQuery<Certificate> query, boolean includeAncestorAccounts) throws KapuaException {
         throw new UnsupportedOperationException();
     }
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -457,9 +457,10 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             certificateQuery.setPredicate(new AndPredicate()
                     .and(new AttributePredicate<>(CertificatePredicates.USAGE_NAME, "JWT"))
                     .and(new AttributePredicate<>(CertificatePredicates.STATUS, CertificateStatus.VALID)));
+            certificateQuery.setIncludeInherited(true);
             certificateQuery.setLimit(1);
 
-            Certificate certificate = KapuaSecurityUtils.doPrivileged(() -> certificateService.query(certificateQuery, true)).getFirstItem();
+            Certificate certificate = KapuaSecurityUtils.doPrivileged(() -> certificateService.query(certificateQuery)).getFirstItem();
 
             JsonWebSignature jws = new JsonWebSignature();
             jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -35,7 +35,6 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
-import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.AuthenticationService;
 import org.eclipse.kapua.service.authentication.LoginCredentials;
 import org.eclipse.kapua.service.authentication.SessionCredentials;
@@ -454,13 +453,13 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             KapuaLocator locator = KapuaLocator.getInstance();
             CertificateService certificateService = locator.getService(CertificateService.class);
             CertificateFactory certificateFactory = locator.getFactory(CertificateFactory.class);
-            CertificateQuery certificateQuery = certificateFactory.newQuery(KapuaId.ONE);
+            CertificateQuery certificateQuery = certificateFactory.newQuery(scopeId);
             certificateQuery.setPredicate(new AndPredicate()
                     .and(new AttributePredicate<>(CertificatePredicates.USAGE_NAME, "JWT"))
                     .and(new AttributePredicate<>(CertificatePredicates.STATUS, CertificateStatus.VALID)));
             certificateQuery.setLimit(1);
 
-            Certificate certificate = KapuaSecurityUtils.doPrivileged(() -> certificateService.query(certificateQuery)).getItem(0);
+            Certificate certificate = KapuaSecurityUtils.doPrivileged(() -> certificateService.query(certificateQuery, true)).getFirstItem();
 
             JsonWebSignature jws = new JsonWebSignature();
             jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.RSA_USING_SHA256);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenCredentialsMatcher.java
@@ -81,7 +81,7 @@ public class AccessTokenCredentialsMatcher implements CredentialsMatcher {
                 certificateQuery.setSortCriteria(new FieldSortCriteria(CertificatePredicates.CREATED_BY, FieldSortCriteria.SortOrder.DESCENDING));
                 certificateQuery.setLimit(1);
 
-                Certificate certificate = KapuaSecurityUtils.doPrivileged(() -> CERTIFICATE_SERVICE.query(certificateQuery)).getFirstItem();
+                Certificate certificate = KapuaSecurityUtils.doPrivileged(() -> CERTIFICATE_SERVICE.query(certificateQuery, true)).getFirstItem();
 
                 if (certificate == null) {
                     throw new JwtCertificateNotFoundException();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenCredentialsMatcher.java
@@ -79,9 +79,10 @@ public class AccessTokenCredentialsMatcher implements CredentialsMatcher {
                         )
                 );
                 certificateQuery.setSortCriteria(new FieldSortCriteria(CertificatePredicates.CREATED_BY, FieldSortCriteria.SortOrder.DESCENDING));
+                certificateQuery.setIncludeInherited(true);
                 certificateQuery.setLimit(1);
 
-                Certificate certificate = KapuaSecurityUtils.doPrivileged(() -> CERTIFICATE_SERVICE.query(certificateQuery, true)).getFirstItem();
+                Certificate certificate = KapuaSecurityUtils.doPrivileged(() -> CERTIFICATE_SERVICE.query(certificateQuery)).getFirstItem();
 
                 if (certificate == null) {
                     throw new JwtCertificateNotFoundException();


### PR DESCRIPTION
Hi all,

This PR allows for looking for JWT signing Certificates in ancestors account, escalating the query up until the root account, instead of looking for it in the root account only. This way any account in the hierarchy can have its own JWT signing Certificate, not relying only on the root account one.