### PR TITLE
Dropped 'eclipse-hudson' profile which was no longer needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1569,40 +1569,6 @@
                 </plugins>
             </build>
         </profile>
-
-        <profile>
-            <id>eclipse-hudson</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <jacoco.version>0.7.4.201502262128</jacoco.version>
-                <jacoco.extras.skip>true</jacoco.extras.skip>
-            </properties>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <!-- this is a workaround for a bug in Hudson breaking SLF4J with checkstyle -->
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-checkstyle-plugin</artifactId>
-                            <dependencies>
-                                <dependency>
-                                    <groupId>org.slf4j</groupId>
-                                    <artifactId>jcl-over-slf4j</artifactId>
-                                    <version>1.7.21</version>
-                                </dependency>
-                                <dependency>
-                                    <groupId>org.slf4j</groupId>
-                                    <artifactId>slf4j-jdk14</artifactId>
-                                    <version>1.7.21</version>
-                                </dependency>
-                            </dependencies>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
     </profiles>
 
     <licenses>


### PR DESCRIPTION
This PR fixes the Jenkins build.

After build https://hudson.eclipse.org/kapua/view/Branches/job/develop/111/ on Feb 19, 2018 3:32:07 AM, builds started to fail with error:

```
ERROR: Step ‘Record JaCoCo coverage report’ aborted due to exception: 
org.jacoco.core.data.IncompatibleExecDataVersionException: Cannot read execution data version 0x1006. This version of JaCoCo uses execution data version 0x1007.
	at org.jacoco.core.data.ExecutionDataReader.readHeader(ExecutionDataReader.java:129)
	at org.jacoco.core.data.ExecutionDataReader.readBlock(ExecutionDataReader.java:109)
	at org.jacoco.core.data.ExecutionDataReader.read(ExecutionDataReader.java:92)
	at hudson.plugins.jacoco.ExecutionFileLoader.loadExecutionData(ExecutionFileLoader.java:95)
Caused: java.io.IOException: While reading execution data-file: /home/hudson/genie.kapua/.jenkins/jobs/develop/builds/112/jacoco/execFiles/exec0/jacoco.exec
	at hudson.plugins.jacoco.ExecutionFileLoader.loadExecutionData(ExecutionFileLoader.java:98)
	at hudson.plugins.jacoco.ExecutionFileLoader.loadBundleCoverage(ExecutionFileLoader.java:136)
	at hudson.plugins.jacoco.JacocoReportDir.parse(JacocoReportDir.java:110)
	at hudson.plugins.jacoco.JacocoBuildAction.loadRatios(JacocoBuildAction.java:339)
	at hudson.plugins.jacoco.JacocoBuildAction.load(JacocoBuildAction.java:326)
	at hudson.plugins.jacoco.JacocoPublisher.perform(JacocoPublisher.java:631)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:690)
	at hudson.model.Build$BuildExecution.post2(Build.java:186)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:635)
	at hudson.model.Run.execute(Run.java:1749)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
```

Building without the profile `eclipse-hudson` has fixed the build as shown in build https://hudson.eclipse.org/kapua/view/Branches/job/develop/140/.

So we can drop the profile as it is no longer used.
