### PR TITLE
stealing link fix on device disconnection

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -503,8 +503,16 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
                 loginRemoveConnectionTimeContext.stop();
                 authenticationService.logout();
                 if (kcc != null && kcc.getFullClientId() != null) {
-                    // cleanup stealing link detection map
-                    CONNECTION_MAP.remove(kcc.getFullClientId());
+                    if (info.getConnectionId().getValue().equals(CONNECTION_MAP.get(kcc.getFullClientId()))) {
+                        // cleanup stealing link detection map
+                        CONNECTION_MAP.remove(kcc.getFullClientId());
+                    }
+                    else {
+                        logger.info("Cannot find client id in the connection map. May be it's due to a stealing link. ({})", kcc.getFullClientId());
+                    }
+                }
+                else {
+                    logger.warn("Cannot find Kapua connection context or client id is null");
                 }
             }
         }


### PR DESCRIPTION
Check the connection id before removing it from the map on device disconnection.
Otherwise, if a stealing link occurred, the client id is wrongly removed from the connected client ids map, then we could have more that one device with the same client id connected at the same time.

Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>