### PR TITLE
User Tests Fixes

### DIFF
--- a/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/UserServiceSteps.java
+++ b/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/UserServiceSteps.java
@@ -167,21 +167,23 @@ public class UserServiceSteps extends AbstractKapuaSteps {
                 } catch (KapuaException e) {
                     // skip
                 }
-                bind(AuthorizationService.class).toInstance(mockedAuthorization);
+
+                MockedLocator mockedLocator = (MockedLocator)locator;
+
+                mockedLocator.setMockedService(AuthorizationService.class, mockedAuthorization);
                 // Inject mocked Permission Factory
                 PermissionFactory mockedPermissionFactory = mock(PermissionFactory.class);
-                bind(PermissionFactory.class).toInstance(mockedPermissionFactory);
+                mockedLocator.setMockedFactory(PermissionFactory.class, mockedPermissionFactory);
                 // Set KapuaMetatypeFactory for Metatype configuration
                 KapuaMetatypeFactory metaFactory = new KapuaMetatypeFactoryImpl();
-                bind(KapuaMetatypeFactory.class).toInstance(metaFactory);
-
+                mockedLocator.setMockedFactory(KapuaMetatypeFactory.class, metaFactory);
                 // Inject actual implementation of UserService
                 UserEntityManagerFactory userEntityManagerFactory = (UserEntityManagerFactory) UserEntityManagerFactory.getInstance();
                 bind(UserEntityManagerFactory.class).toInstance(userEntityManagerFactory);
                 UserService userService = new UserServiceImpl();
-                bind(UserService.class).toInstance(userService);
+                mockedLocator.setMockedService(UserService.class, userService);
                 UserFactory userFactory = new UserFactoryImpl();
-                bind(UserFactory.class).toInstance(userFactory);
+                mockedLocator.setMockedFactory(UserFactory.class, userFactory);
             }
         };
 

--- a/service/user/internal/src/test/resources/locator.xml
+++ b/service/user/internal/src/test/resources/locator.xml
@@ -29,6 +29,7 @@
         <package>org.eclipse.kapua.service.user.internal</package>
         <package>org.eclipse.kapua.service.generator.id.sequence</package>
         <package>org.eclipse.kapua.test.steps</package>
-        <package>org.eclipse.kapua.test.auth</package>
+        <package>org.eclipse.kapua.test.authentication</package>
+        <package>org.eclipse.kapua.test.authorization</package>
     </packages>
 </locator-config>


### PR DESCRIPTION
Since commit 3e99d6febc8a2475c1a48657faaee9371a0ae73a removed `@Inject` notation from `UserServiceImpl`, tests are now failing. This PR fixes mocked service location in `UserServiceSteps` so that they are all passing again. Probably we want to plan a final refactoring of `@Inject` everywhere since this notation has been deprecated.