### PR TITLE
Fixing issue with adding duplicate role to user

### DIFF
--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -20,6 +20,7 @@ import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
@@ -95,7 +96,13 @@ public class AccessRoleAddDialog extends EntityAddEditDialog {
                 status.hide();
 
                 exitStatus = false;
-                exitMessage = MSGS.dialogAddError(MSGS.dialogAddRoleError(cause.getLocalizedMessage()));
+                switch (((GwtKapuaException) cause).getCode()) {
+                case DUPLICATE_NAME:
+                    exitMessage = MSGS.dialogAddRoleDuplicateError();
+                    break;
+                default:
+                    exitMessage = MSGS.dialogAddError(MSGS.dialogAddRoleError(cause.getLocalizedMessage()));
+                }
 
                 hide();
             }

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
@@ -147,6 +147,7 @@ dialogAddRoleInfo=Select a Role to assign to the User
 dialogAddRoleComboName=Role
 dialogAddRoleError=Error assigning role: {0}
 dialogAddRoleErrorAccessInfo=Error retrieving AccessInfo: {0}
+dialogAddRoleDuplicateError=Error when associating role: An entity with the same value for field already exists.
 
 #
 # User view - Delete role dialog


### PR DESCRIPTION
Before role is added to user, check is made if user already has
this role and if it does, it reports duplicate role error and not
generic duplicate entity error during persistence operation.

This solves issue #1110.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>