### PR TITLE
Improved KapuaStepContextImpl to support KapuaId and Enums as primive types

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -55,7 +55,13 @@ import java.util.List;
 
 public class JobStepAddDialog extends EntityAddEditDialog {
 
+    /**
+     * This identifies the KapuaId fully qualified name since it is treated as a primitive type, and therefore its input is rendered as a {@link TextField}
+     */
+    protected static final String KAPUA_ID_CLASS_NAME = "org.eclipse.kapua.model.id.KapuaId";
+
     private final String jobId;
+
     protected int jobStepIndex;
 
     protected final TextField<String> jobStepName;
@@ -200,7 +206,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
 
         for (GwtJobStepProperty property : gwtJobStepDefinition.getStepProperties()) {
             String propertyType = property.getPropertyType();
-            if (propertyType.equals(String.class.getName())) {
+            if (propertyType.equals(String.class.getName()) || property.isEnum() || KAPUA_ID_CLASS_NAME.equals(propertyType)) {
                 TextField<String> textField = new TextField<String>();
                 textField.setFieldLabel(property.getPropertyName());
                 textField.setEmptyText(KapuaSafeHtmlUtils.htmlUnescape(property.getPropertyValue()));

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepDefinitionServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepDefinitionServiceImpl.java
@@ -42,8 +42,13 @@ public class GwtJobStepDefinitionServiceImpl extends KapuaRemoteServiceServlet i
             JobStepDefinitionFactory jobStepDefinitionFactory = locator.getFactory(JobStepDefinitionFactory.class);
             JobStepDefinitionListResult result = jobStepDefinitionService.query(jobStepDefinitionFactory.newQuery(KapuaId.ONE));
             for (JobStepDefinition jsd : result.getItems()) {
-                gwtJobStepDefinitionList.add(KapuaGwtJobModelConverter.convertJobStepDefinition(jsd));
+                GwtJobStepDefinition gwtJobStepDefinition = KapuaGwtJobModelConverter.convertJobStepDefinition(jsd);
+
+                setEnumOnJobStepProperty(gwtJobStepDefinition.getStepProperties());
+
+                gwtJobStepDefinitionList.add(gwtJobStepDefinition);
             }
+
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
         }
@@ -61,6 +66,8 @@ public class GwtJobStepDefinitionServiceImpl extends KapuaRemoteServiceServlet i
             JobStepDefinition jobStepDefinition = jobStepDefinitionService.find(null, jobStepDefinitionId);
             if (jobStepDefinition != null) {
                 gwtJobStepDefinition = KapuaGwtJobModelConverter.convertJobStepDefinition(jobStepDefinition);
+
+                setEnumOnJobStepProperty(gwtJobStepDefinition.getStepProperties());
             }
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
@@ -72,6 +79,19 @@ public class GwtJobStepDefinitionServiceImpl extends KapuaRemoteServiceServlet i
     @Override
     public GwtJobStepProperty trickGwt() {
         return null;
+    }
+
+    /**
+     * Set the {@link GwtJobStepProperty#isEnum()} property.
+     * This cannot be performed in *.shared.* packages (entity converters are in that package), since `Class.forName` is not present in the JRE Emulation library.
+     *
+     * @param jobStepProperties
+     * @throws ClassNotFoundException
+     */
+    private void setEnumOnJobStepProperty(List<GwtJobStepProperty> jobStepProperties) throws ClassNotFoundException {
+        for (GwtJobStepProperty gjsp : jobStepProperties) {
+            gjsp.setEnum(Class.forName(gjsp.getPropertyType()).isEnum());
+        }
     }
 
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
@@ -70,6 +70,9 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
                     JobStepDefinition jobStepDefinition = jobStepDefinitionService
                             .find(GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobStep.getScopeId()), GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobStep.getJobStepDefinitionId()));
                     gwtJobStep.setJobStepDefinitionName(jobStepDefinition.getName());
+
+                    setEnumOnJobStepProperty(gwtJobStep.getStepProperties());
+
                     gwtJobStepList.add(gwtJobStep);
                 }
             }
@@ -114,6 +117,7 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
             // Convert
             gwtJobStep = KapuaGwtJobModelConverter.convertJobStep(jobStep);
 
+            setEnumOnJobStepProperty(gwtJobStep.getStepProperties());
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
         }
@@ -151,6 +155,8 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
             JobStep jobStep = gwtJobStepService.find(scopeId, jobStepId);
             if (jobStep != null) {
                 gwtJobStep = KapuaGwtJobModelConverter.convertJobStep(jobStep);
+
+                setEnumOnJobStepProperty(gwtJobStep.getStepProperties());
             }
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
@@ -208,11 +214,26 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
                 // convert to GwtAccount and return
                 // reload the user as we want to load all its permissions
                 gwtJobStepUpdated = KapuaGwtJobModelConverter.convertJobStep(jobStepUpdated);
+
+                setEnumOnJobStepProperty(gwtJobStep.getStepProperties());
             }
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
         }
         return gwtJobStepUpdated;
+    }
+
+    /**
+     * Set the {@link GwtJobStepProperty#isEnum()} property.
+     * This cannot be performed in *.shared.* packages (entity converters are in that package), since `Class.forName` is not present in the JRE Emulation library.
+     *
+     * @param jobStepProperties
+     * @throws ClassNotFoundException
+     */
+    private void setEnumOnJobStepProperty(List<GwtJobStepProperty> jobStepProperties) throws ClassNotFoundException {
+        for (GwtJobStepProperty gjsp : jobStepProperties) {
+            gjsp.setEnum(Class.forName(gjsp.getPropertyType()).isEnum());
+        }
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
@@ -39,4 +39,12 @@ public class GwtJobStepProperty extends KapuaBaseModel {
         set("propertyValue", propertyValue, false);
     }
 
+    public boolean isEnum() {
+        return get("isEnum");
+    }
+
+    public void setEnum(boolean isEnum) {
+        set("isEnum", isEnum);
+    }
+
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/context/internal/KapuaStepContextImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/context/internal/KapuaStepContextImpl.java
@@ -12,7 +12,9 @@
 package org.eclipse.kapua.service.job.context.internal;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.context.KapuaStepContext;
 import org.eclipse.kapua.service.job.context.StepContextPropertyNames;
 import org.xml.sax.SAXException;
@@ -70,6 +72,16 @@ public class KapuaStepContextImpl implements KapuaStepContext {
                 stepProperty = (T) Boolean.valueOf(stepPropertyString);
             } else if (type == byte[].class || type == Byte[].class) {
                 stepProperty = (T) DatatypeConverter.parseBase64Binary(stepPropertyString);
+            } else if (type == KapuaId.class) {
+                stepProperty = (T) KapuaEid.parseCompactId(stepPropertyString);
+            } else if (type.isEnum()) {
+                Class<? extends Enum> enumType = (Class<? extends Enum>) type;
+
+                try {
+                    stepProperty = (T) Enum.valueOf(enumType, stepPropertyString);
+                } catch (IllegalArgumentException iae) {
+                    throw new KapuaIllegalArgumentException(stepPropertyName, stepPropertyString);
+                }
             } else {
                 try {
                     stepProperty = XmlUtil.unmarshal(stepPropertyString, type);


### PR DESCRIPTION
This PR closes #1271 

Now `KapuaId` and enums properties can be specified as "primitive" types (like Long, Integer, Strings, etc) without the requirement to use the XML serialized equivalent.

Console Job view has been updated to support this changes