### PR TITLE
Fixing issue with leaving dirty input forms

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
@@ -104,6 +104,8 @@ public class AccountConfigComponents extends LayoutContainer {
 
     private boolean applyProcess;
 
+    private GwtSession gwtSession;
+
     private final AsyncCallback<Void> applyConfigCallback = new AsyncCallback<Void>() {
 
         @Override
@@ -126,6 +128,7 @@ public class AccountConfigComponents extends LayoutContainer {
         this.tabConfig = tabConfig;
         dirty = false;
         initialized = false;
+        gwtSession = currentSession;
     }
 
     public void setAccount(GwtAccount selectedAccount) {
@@ -175,6 +178,7 @@ public class AccountConfigComponents extends LayoutContainer {
 
                     refreshButton.setEnabled(true);
                     refreshProcess = false;
+                    gwtSession.setFormDirty(false);
                 }
             }
         });
@@ -195,6 +199,7 @@ public class AccountConfigComponents extends LayoutContainer {
 
                     apply.setEnabled(true);
                     applyProcess = false;
+                    gwtSession.setFormDirty(false);
                 }
             }
         });
@@ -211,12 +216,14 @@ public class AccountConfigComponents extends LayoutContainer {
 
                     reset.setEnabled(true);
                     resetProcess = false;
+                    gwtSession.setFormDirty(false);
                 }
             }
         });
 
         apply.setEnabled(false);
         reset.setEnabled(false);
+        gwtSession.setFormDirty(false);
 
         toolBar.add(apply);
         toolBar.add(new SeparatorToolItem());
@@ -344,6 +351,7 @@ public class AccountConfigComponents extends LayoutContainer {
             apply.setEnabled(false);
             reset.setEnabled(false);
             refreshButton.setEnabled(false);
+            gwtSession.setFormDirty(false);
 
             treeStore.removeAll();
 
@@ -362,6 +370,7 @@ public class AccountConfigComponents extends LayoutContainer {
     private void refreshConfigPanel(GwtConfigComponent configComponent) {
         apply.setEnabled(false);
         reset.setEnabled(false);
+        gwtSession.setFormDirty(false);
 
         if (devConfPanel != null) {
             devConfPanel.removeFromParent();
@@ -375,6 +384,7 @@ public class AccountConfigComponents extends LayoutContainer {
                 public void handleEvent(BaseEvent be) {
                     apply.setEnabled(true);
                     reset.setEnabled(true);
+                    gwtSession.setFormDirty(true);
                 }
             });
             configPanel.add(devConfPanel, centerData);
@@ -415,6 +425,7 @@ public class AccountConfigComponents extends LayoutContainer {
                             apply.setEnabled(false);
                             reset.setEnabled(false);
                             refreshButton.setEnabled(false);
+                            gwtSession.setFormDirty(false);
 
                             //
                             // Getting XSRF token

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaTextArea.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaTextArea.java
@@ -14,12 +14,12 @@ package org.eclipse.kapua.app.console.module.api.client.ui.widget;
 import com.extjs.gxt.ui.client.event.ComponentEvent;
 import com.extjs.gxt.ui.client.event.PreviewEvent;
 import com.extjs.gxt.ui.client.util.BaseEventPreview;
-import com.extjs.gxt.ui.client.widget.form.TextField;
+import com.extjs.gxt.ui.client.widget.form.TextArea;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.DeferredCommand;
 import com.google.gwt.user.client.Element;
 
-public class KapuaTextField<T> extends TextField<T> {
+public class KapuaTextArea extends TextArea {
     protected BaseEventPreview focusEventPreview;
     protected boolean mimicing;
 
@@ -45,7 +45,7 @@ public class KapuaTextField<T> extends TextField<T> {
         this.focusEventPreview = new BaseEventPreview() {
             protected boolean onAutoHide(PreviewEvent ce) {
                 if (ce.getEventTypeInt() == 4) {
-                    KapuaTextField.this.mimicBlur(ce, ce.getTarget());
+                    KapuaTextArea.this.mimicBlur(ce, ce.getTarget());
                 }
 
                 return false;
@@ -65,12 +65,11 @@ public class KapuaTextField<T> extends TextField<T> {
     protected void triggerBlur(ComponentEvent ce) {
         DeferredCommand.addCommand(new Command() {
             public void execute() {
-                KapuaTextField.this.getFocusEl().blur();
+                KapuaTextArea.this.getFocusEl().blur();
             }
         });
         this.mimicing = false;
         this.focusEventPreview.remove();
         super.onBlur(ce);
     }
-
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSession.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -43,6 +43,11 @@ public class GwtSession extends KapuaBaseModel implements Serializable {
 
     private List<GwtSessionPermission> sessionPermissions = new ArrayList<GwtSessionPermission>();
     private Map<GwtSessionPermission, Boolean> checkedPermissionsCache = new HashMap<GwtSessionPermission, Boolean>();
+
+    /**
+     * Is UI form dirty and needs save.
+     */
+    private boolean formDirty;
 
     public GwtSession() {
     }
@@ -193,6 +198,24 @@ public class GwtSession extends KapuaBaseModel implements Serializable {
 
         // Return it
         return permitted;
+    }
+
+    /**
+     * Is UI form dirty and needs confirmation to switch menu.
+     *
+     * @return true if user needs to confirm menu change.
+     */
+    public boolean isFormDirty() {
+        return formDirty;
+    }
+
+    /**
+     * Set user interface into dirty state.
+     *
+     * @param formDirty true if user will need to confirm menu change.
+     */
+    public void setFormDirty(boolean formDirty) {
+        this.formDirty = formDirty;
     }
 
     /**

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -163,6 +163,7 @@ packageDeleteButton=Uninstall
 exportToExcel=Export to Excel
 exportToCSV=Export to CSV
 validateButton=Validate
+unsavedChanges=There are unsaved changes. Do you want to discard them and continue?
 
 loginCode=2FA code
 login2FA=On this user you choose to enable the two factor authentication system to increase your security.

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -104,11 +104,14 @@ public class DeviceConfigComponents extends LayoutContainer {
 
     protected boolean applyProcess;
 
+    private GwtSession gwtSession;
+
     public DeviceConfigComponents(GwtSession currentSession,
             DeviceTabConfiguration tabConfig) {
         this.tabConfig = tabConfig;
         dirty = false;
         initialized = false;
+        gwtSession = currentSession;
     }
 
     public void setDevice(GwtDevice selectedDevice) {
@@ -157,6 +160,7 @@ public class DeviceConfigComponents extends LayoutContainer {
                     refresh();
                     refreshProcess = false;
                     refreshButton.setEnabled(true);
+                    gwtSession.setFormDirty(false);
                 }
             }
         });
@@ -173,6 +177,7 @@ public class DeviceConfigComponents extends LayoutContainer {
 
                     apply.setEnabled(true);
                     applyProcess = false;
+                    gwtSession.setFormDirty(false);
                 }
             }
         });
@@ -189,12 +194,14 @@ public class DeviceConfigComponents extends LayoutContainer {
 
                     reset.setEnabled(true);
                     resetProcess = false;
+                    gwtSession.setFormDirty(false);
                 }
             }
         });
 
         apply.setEnabled(false);
         reset.setEnabled(false);
+        gwtSession.setFormDirty(false);
         if (selectedDevice == null) {
             refreshButton.setEnabled(false);
         } else {
@@ -399,6 +406,7 @@ public class DeviceConfigComponents extends LayoutContainer {
             // clear the tree and disable the toolbar
             apply.setEnabled(false);
             reset.setEnabled(false);
+            gwtSession.setFormDirty(false);
 
             treeStore.removeAll();
 
@@ -417,6 +425,7 @@ public class DeviceConfigComponents extends LayoutContainer {
     public void refreshConfigPanel(GwtConfigComponent configComponent) {
         apply.setEnabled(false);
         reset.setEnabled(false);
+        gwtSession.setFormDirty(false);
 
         if (devConfPanel != null) {
             devConfPanel.removeFromParent();
@@ -430,6 +439,7 @@ public class DeviceConfigComponents extends LayoutContainer {
                 public void handleEvent(BaseEvent be) {
                     apply.setEnabled(true);
                     reset.setEnabled(true);
+                    gwtSession.setFormDirty(true);
                 }
             });
             configPanel.add(devConfPanel, centerData);
@@ -478,6 +488,7 @@ public class DeviceConfigComponents extends LayoutContainer {
                             apply.setEnabled(false);
                             reset.setEnabled(false);
                             refreshButton.setEnabled(false);
+                            gwtSession.setFormDirty(false);
 
                             //
                             // Getting XSRF token

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextArea;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.api.client.util.Constants;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
@@ -51,7 +53,6 @@ import com.extjs.gxt.ui.client.widget.form.Radio;
 import com.extjs.gxt.ui.client.widget.form.RadioGroup;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboValue;
-import com.extjs.gxt.ui.client.widget.form.TextArea;
 import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.extjs.gxt.ui.client.widget.form.Validator;
 import com.extjs.gxt.ui.client.widget.layout.BorderLayout;
@@ -727,9 +728,9 @@ public class DeviceConfigPanel extends LayoutContainer {
     private static TextField<String> createTextFieldOrArea(GwtConfigParameter param) {
         String[] desc = splitDescription(param);
         if (desc != null && desc.length > 1 && desc[1].equals("TextArea")) {
-            return new TextArea();
+            return new KapuaTextArea();
         }
-        return new TextField<String>();
+        return new KapuaTextField<String>();
     }
 
     private static class IntegerValidator implements Validator {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -461,7 +461,7 @@ public class DeviceConfigPanel extends LayoutContainer {
     }
 
     private Field<?> paintPasswordConfigParameter(GwtConfigParameter param) {
-        TextField<String> field = new TextField<String>();
+        TextField<String> field = new KapuaTextField<String>();
         field.setName(param.getId());
         field.setValue((String) param.getValue());
         field.setAllowBlank(true);


### PR DESCRIPTION
There are forms on UI that can be left in dirty state by using main
menu - West menu.
This was solved by adding dirty form flag on gwtSession object and
when user uses West menu it is notified that changes will be lost and
can decide if this is ok or not.

Changes were required to WestNavigationView and that could break unexpected
functionality of UI. It was tested but not overall UI tested.

This fixes issue #1137.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>