### PR TITLE
Fixing issue with refresh button on entity grids

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -186,6 +186,7 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     }
 
     public void refresh() {
+        entityCRUDToolbar.getRefreshEntityButton().setEnabled(false);
         entityLoader.load();
     }
 
@@ -228,4 +229,11 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     public abstract GwtQuery getFilterQuery();
 
     public abstract void setFilterQuery(GwtQuery filterQuery);
+
+    /**
+     * Method is called when grid is loaded.
+     */
+    public void loaded() {
+        entityCRUDToolbar.getRefreshEntityButton().setEnabled(true);
+    }
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridLoadListener.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridLoadListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -41,6 +41,13 @@ public class EntityGridLoadListener<M extends GwtEntityModel> extends KapuaLoadL
                 }
             }
         }
+        entityGrid.loaded();
+    }
+
+    @Override
+    public void loaderLoadException(LoadEvent le) {
+        entityGrid.loaded();
+        super.loaderLoadException(le);
     }
 
 }


### PR DESCRIPTION
This solves issues that are present on all entity grids.
Now when refresh button is clicked and refresh method called on EntityGrid,
that button is disabled and enabled back only when load is finished or
exception is raised.

This solves issues:
- 1256
- 1257
- 1258
- 1259
- 1260
- 1261
- 1262
- 1263

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>