### PR TITLE
Added filter panel to Batch Job grid

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import com.extjs.gxt.ui.client.event.ComponentEvent;
 import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.extjs.gxt.ui.client.widget.Component;
 import com.extjs.gxt.ui.client.widget.button.ToggleButton;
 import com.extjs.gxt.ui.client.widget.grid.GridSelectionModel;
 import com.extjs.gxt.ui.client.widget.toolbar.FillToolItem;
@@ -36,6 +37,8 @@ import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPane
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtEntityModel;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+
+import java.util.List;
 
 public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
 
@@ -67,6 +70,8 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
     protected EntityFilterPanel<M> filterPanel;
 
     protected M selectedEntity;
+
+    private List<Component> extraButtons;
 
     public EntityCRUDToolbar(GwtSession currentSession) {
         this (currentSession, false);
@@ -104,8 +109,13 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
             add(refreshEntityButton);
         }
 
+        if ((extraButtons != null) && (extraButtons.size() > 0)) {
+            for (Component button : extraButtons) {
+                add(button);
+            }
+        }
+
         if (filterButtonShow && filterPanel != null) {
-            //FIXME when providing additional buttons and also the filter button it will probably display weird
             add(new FillToolItem());
             filterButton = new ToggleButton(MSGS.deviceTableToolbarCloseFilter(), new SelectionListener<ButtonEvent>() {
 
@@ -126,6 +136,10 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
         }
 
         updateButtonEnablement();
+    }
+
+    protected void addExtraButtons(List<Component> buttons) {
+        extraButtons = buttons;
     }
 
     //

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobFilterPanel.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobFilterPanel.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.client;
+
+import com.extjs.gxt.ui.client.widget.Label;
+import com.extjs.gxt.ui.client.widget.VerticalPanel;
+import com.google.gwt.core.client.GWT;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
+import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobQuery;
+
+public class JobFilterPanel extends EntityFilterPanel<GwtJob> {
+
+    private final static ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
+    private final static int WIDTH = 193;
+    private static final int MAX_LEN = 255;
+
+    private final EntityGrid<GwtJob> entityGrid;
+    private final GwtSession currentSession;
+
+    private final KapuaTextField<String> jobNameField;
+
+    public JobFilterPanel(AbstractEntityView<GwtJob> entityView, GwtSession currentSession) {
+        super(entityView, currentSession);
+
+        entityGrid = entityView.getEntityGrid(entityView, currentSession);
+        this.currentSession = currentSession;
+
+        setHeading(JOB_MSGS.filterHeader());
+
+        VerticalPanel fieldsPanel = getFieldsPanel();
+
+        Label jobNameLabel = new Label(JOB_MSGS.filterFieldJobNameLabel());
+        jobNameLabel.setWidth(WIDTH);
+        jobNameLabel.setStyleAttribute("margin", "5px");
+
+        fieldsPanel.add(jobNameLabel);
+
+        jobNameField = new KapuaTextField<String>();
+        jobNameField.setName("name");
+        jobNameField.setWidth(WIDTH);
+        jobNameField.setMaxLength(MAX_LEN);
+        jobNameField.setStyleAttribute("margin-top", "0px");
+        jobNameField.setStyleAttribute("margin-left", "5px");
+        jobNameField.setStyleAttribute("margin-right", "5px");
+        jobNameField.setStyleAttribute("margin-bottom", "10px");
+        fieldsPanel.add(jobNameField);
+    }
+
+    @Override
+    public void resetFields() {
+        jobNameField.setValue(null);
+        GwtJobQuery query = new GwtJobQuery();
+        query.setScopeId(currentSession.getSelectedAccountId());
+        entityGrid.refresh(query);
+    }
+
+    @Override
+    public void doFilter() {
+        GwtJobQuery query = new GwtJobQuery();
+        query.setName(jobNameField.getValue());
+        query.setScopeId(currentSession.getSelectedAccountId());
+        entityGrid.refresh(query);
+    }
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@ package org.eclipse.kapua.app.console.module.job.client;
 
 import com.extjs.gxt.ui.client.event.ButtonEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.extjs.gxt.ui.client.widget.Component;
 import com.extjs.gxt.ui.client.widget.menu.SeparatorMenuItem;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
@@ -27,6 +28,9 @@ import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessag
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobEngineService;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobEngineServiceAsync;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
 
@@ -45,11 +49,8 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
 
     @Override
     protected void onRender(Element target, int index) {
-        super.onRender(target, index);
-        getEditEntityButton().disable();
-        getDeleteEntityButton().disable();
-
-        add(new SeparatorMenuItem());
+        List<Component> extraButtons = new ArrayList<Component>();
+        extraButtons.add(new SeparatorMenuItem());
         startJobButton = new Button(JOB_MSGS.startJobButton(), new KapuaIcon(IconSet.PLAY), new SelectionListener<ButtonEvent>() {
 
             @Override
@@ -59,7 +60,11 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
             }
         });
         startJobButton.disable();
-        add(startJobButton);
+        extraButtons.add(startJobButton);
+        addExtraButtons(extraButtons);
+        super.onRender(target, index);
+        getEditEntityButton().disable();
+        getDeleteEntityButton().disable();
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobView.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,6 +21,8 @@ import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
 
 public class JobView extends AbstractEntityView<GwtJob> {
 
+    private JobGrid jobGrid;
+
     public JobView(GwtSession currentSession) {
         super(currentSession);
     }
@@ -33,12 +35,16 @@ public class JobView extends AbstractEntityView<GwtJob> {
 
     @Override
     public EntityGrid<GwtJob> getEntityGrid(AbstractEntityView<GwtJob> entityView, GwtSession currentSession) {
-        return new JobGrid(entityView, currentSession);
+        if (jobGrid == null ) {
+            jobGrid = new JobGrid(entityView, currentSession);
+        }
+
+        return jobGrid;
     }
 
     @Override
-    public EntityFilterPanel<GwtJob> getEntityFilterPanel(AbstractEntityView<GwtJob> entityView, GwtSession currentSession2) {
-        return null;
+    public EntityFilterPanel<GwtJob> getEntityFilterPanel(AbstractEntityView<GwtJob> entityView, GwtSession currentSession) {
+        return new JobFilterPanel(this, currentSession);
     }
 
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -64,10 +64,10 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
             JobService jobService = locator.getService(JobService.class);
 
             // Convert from GWT entity
-            JobQuery userQuery = GwtKapuaJobModelConverter.convertJobQuery(gwtJobQuery, loadConfig);
+            JobQuery jobQuery = GwtKapuaJobModelConverter.convertJobQuery(gwtJobQuery, loadConfig);
 
             // query
-            JobListResult jobs = jobService.query(userQuery);
+            JobListResult jobs = jobService.query(jobQuery);
 
             // If there are results
             if (!jobs.isEmpty()) {
@@ -85,7 +85,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
                     usernameMap.put(user.getId().toCompactId(), user.getName());
                 }
                 // count
-                totalLength = Long.valueOf(jobService.count(userQuery)).intValue();
+                totalLength = Long.valueOf(jobService.count(jobQuery)).intValue();
 
                 // Converto to GWT entity
                 for (Job j : jobs.getItems()) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,4 +15,13 @@ import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
 
 public class GwtJobQuery extends GwtQuery {
 
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,7 @@ import org.eclipse.kapua.commons.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.predicate.KapuaAttributePredicate.Operator;
 import org.eclipse.kapua.service.job.Job;
 import org.eclipse.kapua.service.job.JobFactory;
 import org.eclipse.kapua.service.job.JobPredicates;
@@ -118,18 +119,23 @@ public class GwtKapuaJobModelConverter {
     }
 
     public static JobQuery convertJobQuery(GwtJobQuery gwtJobQuery, PagingLoadConfig loadConfig) {
+
+        AndPredicate predicate = new AndPredicate();
+        // Convert query
         JobQuery jobQuery = JOB_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobQuery.getScopeId()));
+        if (gwtJobQuery.getName() != null && !gwtJobQuery.getName().isEmpty()) {
+            predicate.and(new AttributePredicate<String>(JobPredicates.NAME, gwtJobQuery.getName(), Operator.LIKE));
+        }
         jobQuery.setLimit(loadConfig.getLimit());
         jobQuery.setOffset(loadConfig.getOffset());
-
         String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? JobPredicates.NAME : loadConfig.getSortField();
         if (sortField.equals("jobName")) {
             sortField = JobPredicates.NAME;
         }
-
         SortOrder sortOrder = loadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
         FieldSortCriteria sortCriteria = new FieldSortCriteria(sortField, sortOrder);
         jobQuery.setSortCriteria(sortCriteria);
+        jobQuery.setPredicate(predicate);
 
         return jobQuery;
     }

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -145,3 +145,8 @@ gridJobTabExecutionsLabel=Executions
 gridJobExecutionColumnHeaderStatus=Status
 gridJobExecutionsColumnHeaderStartedOnFormatted=Started on
 gridJobExecutionsColumnHeaderEndedOnFormatted=Ended on
+
+#
+# Job Filter
+filterHeader=Job Filter
+filterFieldJobNameLabel=Name


### PR DESCRIPTION
Standard filter panel was added to Batch Job grid.
Filter includes just job name.

Additionally EntityCRUDToolbar was fixed. As Jobs grid had additional
button in Start that was wrongly positioned when filter button was added.
This is now fixed and also closes FIXME comment in same part of code.

This fixes issue #1086.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>