### PR TITLE
Execute permission added to Job Service

### DIFF
--- a/service/job/internal/src/main/resources/liquibase/1.0.0/changelog-job-1.0.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.0.0/changelog-job-1.0.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-1.0.0.xml">
+
+    <include relativeToChangelogFile="true" file="./job-domain.xml"/>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.0.0/job-domain.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.0.0/job-domain.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-1.0.0.xml">
+
+    <property name="selectJobDomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'job')"/>
+
+    <changeSet id="changelog-job-domain-1.0.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_domain"/>
+                <tableExists tableName="athz_domain_actions"/>
+            </and>
+        </preConditions>
+
+        <!-- Seed values -->
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectJobDomainQuery}"/>
+            <column name="action" value="execute"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -16,5 +16,6 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-job-0.3.0.xml" />
+    <include relativeToChangelogFile="true" file="./1.0.0/changelog-job-1.0.0.xml" />
 
 </databaseChangeLog>


### PR DESCRIPTION
Job domain was lacking execute permission which could be assigned to user.
Now (1.0.0 liquibase change) it has it and can be assigned to user and
that user can execute job.

This fixes issue #1075.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>