### PR TITLE
Fix correctly throw internal error

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigImpl.java
@@ -90,7 +90,7 @@ public class ServiceConfigImpl extends AbstractKapuaUpdatableEntity implements S
             try {
                 props.load(new StringReader(configurations));
             } catch (IOException e) {
-                KapuaException.internalError(e);
+                throw KapuaException.internalError(e);
             }
         }
         return props;
@@ -105,7 +105,7 @@ public class ServiceConfigImpl extends AbstractKapuaUpdatableEntity implements S
                 props.store(writer, null);
                 configurations = writer.toString();
             } catch (IOException e) {
-                KapuaException.internalError(e);
+                throw KapuaException.internalError(e);
             }
         }
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
@@ -92,7 +92,7 @@ public class ServiceInspector {
                                     try {
                                         listenerMethod.invoke(aService, new Object[] { serviceEvent });
                                     } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-                                        KapuaException.internalError(e, String.format("Error invoking method %s", method.getName()));
+                                        throw KapuaException.internalError(e, String.format("Error invoking method %s", method.getName()));
                                     }
                                 }));
                 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
@@ -161,7 +161,7 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
             try {
                 props.load(new StringReader(attributes));
             } catch (IOException e) {
-                KapuaException.internalError(e);
+                throw KapuaException.internalError(e);
             }
         }
         return props;
@@ -176,7 +176,7 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
                 props.store(writer, null);
                 attributes = writer.toString();
             } catch (IOException e) {
-                KapuaException.internalError(e);
+                throw KapuaException.internalError(e);
             }
         }
     }
@@ -195,7 +195,7 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
             try {
                 props.load(new StringReader(properties));
             } catch (IOException e) {
-                KapuaException.internalError(e);
+                throw KapuaException.internalError(e);
             }
         }
         return props;
@@ -210,7 +210,7 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
                 props.store(writer, null);
                 properties = writer.toString();
             } catch (IOException e) {
-                KapuaException.internalError(e);
+                throw KapuaException.internalError(e);
             }
         }
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -725,7 +725,7 @@ public class ServiceDAO {
      * @since 1.0.0
      */
     @SuppressWarnings("rawtypes")
-    protected static void handleKapuaQueryGroupPredicate(KapuaQuery query, Domain domain, String groupPredicateName) {
+    protected static void handleKapuaQueryGroupPredicate(KapuaQuery query, Domain domain, String groupPredicateName) throws KapuaException {
 
         if (ACCESS_INFO_FACTORY != null) {
             KapuaSession kapuaSession = KapuaSecurityUtils.getSession();
@@ -799,7 +799,7 @@ public class ServiceDAO {
 
                     query.setPredicate(andPredicate);
                 } catch (Exception e) {
-                    KapuaException.internalError(e, "Error while grouping!");
+                    throw KapuaException.internalError(e, "Error while grouping!");
                 }
             }
         } else {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporter.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaListResult;
 import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 
@@ -54,7 +55,7 @@ public abstract class DeviceEventExporter {
     }
 
     public abstract void init(String account)
-            throws ServletException, IOException;
+            throws ServletException, IOException, KapuaException;
 
     public abstract void append(KapuaListResult<DeviceEvent> messages)
             throws ServletException, IOException;

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterCsv.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterCsv.java
@@ -49,7 +49,7 @@ public class DeviceEventExporterCsv extends DeviceEventExporter {
 
     @Override
     public void init(final String scopeId)
-            throws ServletException, IOException {
+            throws ServletException, IOException, KapuaException {
         this.scopeId = scopeId;
 
         final AccountService accountService = KapuaLocator.getInstance().getService(AccountService.class);
@@ -64,7 +64,7 @@ public class DeviceEventExporterCsv extends DeviceEventExporter {
             });
             accountName = account.getName();
         } catch (KapuaException e) {
-            KapuaException.internalError(e);
+            throw KapuaException.internalError(e);
         }
 
         dateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss.SSS");

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterExcel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterExcel.java
@@ -57,7 +57,7 @@ public class DeviceEventExporterExcel extends DeviceEventExporter {
 
     @Override
     public void init(final String scopeId)
-            throws ServletException, IOException {
+            throws ServletException, IOException, KapuaException {
         this.scopeId = scopeId;
 
         final AccountService accountService = KapuaLocator.getInstance().getService(AccountService.class);
@@ -72,7 +72,7 @@ public class DeviceEventExporterExcel extends DeviceEventExporter {
             });
             accountName = account.getName();
         } catch (KapuaException e) {
-            KapuaException.internalError(e);
+            throw KapuaException.internalError(e);
         }
 
         // workbook

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporter.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaListResult;
 import org.eclipse.kapua.service.device.registry.Device;
 
@@ -70,7 +71,7 @@ public abstract class DeviceExporter {
             throws ServletException, IOException;
 
     public abstract void append(KapuaListResult<Device> messages)
-            throws ServletException, IOException;
+            throws ServletException, IOException, KapuaException;
 
     public abstract void close()
             throws ServletException, IOException;

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporterCsv.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporterCsv.java
@@ -61,14 +61,14 @@ public class DeviceExporterCsv extends DeviceExporter {
 
     @Override
     public void append(KapuaListResult<Device> devices)
-            throws ServletException, IOException {
+            throws ServletException, IOException, KapuaException {
 
         AccountService accountService = KapuaLocator.getInstance().getService(AccountService.class);
         Account account = null;
         try {
             account = accountService.find(KapuaEid.parseCompactId(this.account));
         } catch (KapuaException e) {
-            KapuaException.internalError(e);
+            throw KapuaException.internalError(e);
         }
 
         for (Device device : devices.getItems()) {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporterExcel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporterExcel.java
@@ -76,14 +76,14 @@ public class DeviceExporterExcel extends DeviceExporter {
 
     @Override
     public void append(KapuaListResult<Device> devices)
-            throws ServletException, IOException {
+            throws ServletException, IOException, KapuaException {
 
         AccountService accountService = KapuaLocator.getInstance().getService(AccountService.class);
         Account account = null;
         try {
             account = accountService.find(KapuaEid.parseCompactId(this.account));
         } catch (KapuaException e) {
-            KapuaException.internalError(e);
+            throw KapuaException.internalError(e);
         }
 
         Row row;


### PR DESCRIPTION
Hi all,

There were some pieces of code where we were instantiating `KapuaException`s with `KapuaException.internalError()`, but then not throwing them. This led to a situation where some exception were expected to be thrown, but they were not actually. This PR aims at fixing these lines.