### PR TITLE
Added message delay for failed login

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDelayUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDelayUtil.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.util;
+
+public class KapuaDelayUtil {
+
+    public static void executeDelay(){
+            try {
+                Thread.sleep((long) (Math.random()*1000));
+            } catch (InterruptedException e) {
+                //Restore the interupted status
+                Thread.currentThread().interrupt();
+            }
+        }
+
+    private KapuaDelayUtil() {
+        super();
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +33,7 @@ import org.eclipse.kapua.commons.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.commons.util.KapuaDelayUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.authentication.AuthenticationService;
@@ -357,6 +358,7 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             throw KapuaException.internalError(se);
         }
 
+        KapuaDelayUtil.executeDelay();
         return kae;
     }
 


### PR DESCRIPTION
Kapua Implicitly Exposes Which Users Exist in Database And Which Do Not #1303

- added random delay between 600 and 800 ms when displaying error message in case of login with non- existing username

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>