### PR TITLE
Fix adding same Permission to User

### DIFF
--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -22,6 +22,8 @@ import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
@@ -126,7 +128,12 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                 status.hide();
 
                 exitStatus = false;
-                exitMessage = MSGS.dialogAddError(MSGS.dialogAddPermissionError(cause.getLocalizedMessage()));
+                if ((cause instanceof GwtKapuaException) &&
+                    (GwtKapuaErrorCode.ENTITY_ALREADY_EXISTS.equals(((GwtKapuaException)cause).getCode()))) {
+                        exitMessage = MSGS.dialogAddPermissionAlreadyExists();
+                } else {
+                    exitMessage = MSGS.dialogAddError(MSGS.dialogAddPermissionError(cause.getLocalizedMessage()));
+                }
 
                 hide();
             }

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
@@ -120,6 +120,7 @@ dialogAddPermissionErrorGroups=Error retrieving groups: {0}
 dialogAddPermissionConfirmation=Permission association successfully granted.
 dialogAddPermissionError=Error granting permission: {0}
 dialogAddPermissionLoading=Loading...
+dialogAddPermissionAlreadyExists=Permission already granted.
 
 #
 # Delete permission dialog


### PR DESCRIPTION
Before permission is added to user it is checked if it already exists and
if so it displays error message explaining that.
Query is made on access permission with same attributes as permission is
created with.

This fixes issue #1002

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>