### PR TITLE
Proposal for fixing long text in paging toolbar

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaPagingToolBar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaPagingToolBar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,8 +19,17 @@ public class KapuaPagingToolBar extends PagingToolBar {
 
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
 
+    /**
+     * Max length of user input field for page number.
+     */
+    public static final String MAX_TEXT_LEN = "4";
+
     public KapuaPagingToolBar(int pageSize) {
         super(pageSize);
+        this.pageText.setMaxLength(Integer.parseInt(MAX_TEXT_LEN));
+        if (rendered) {
+            this.pageText.getElement().setAttribute("maxLength", MAX_TEXT_LEN);
+        }
 
         PagingToolBarMessages pagingToolbarMessages = getMessages();
         pagingToolbarMessages.setBeforePageText(MSGS.pagingToolbarPage());

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaPagingToolBar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaPagingToolBar.java
@@ -22,13 +22,13 @@ public class KapuaPagingToolBar extends PagingToolBar {
     /**
      * Max length of user input field for page number.
      */
-    public static final String MAX_TEXT_LEN = "4";
+    public static final int MAX_TEXT_LEN = 4;
 
     public KapuaPagingToolBar(int pageSize) {
         super(pageSize);
-        this.pageText.setMaxLength(Integer.parseInt(MAX_TEXT_LEN));
+        this.pageText.setMaxLength(MAX_TEXT_LEN);
         if (rendered) {
-            this.pageText.getElement().setAttribute("maxLength", MAX_TEXT_LEN);
+            this.pageText.getElement().setAttribute("maxLength", String.valueOf(MAX_TEXT_LEN));
         }
 
         PagingToolBarMessages pagingToolbarMessages = getMessages();


### PR DESCRIPTION
This is possible solution to paging toolbar, where user can enter arbitrarily long
text for page number.

We already have KapuaPagingToolbar where I tested it and it works.

This fixes issue #1225.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>