### PR TITLE
Fix issue with account deletion permission

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
@@ -29,7 +29,7 @@ public class AccountGridToolbar extends EntityCRUDToolbar<GwtAccount> {
         super.onRender(target, index);
         super.getEditEntityButton().disable();
         super.getDeleteEntityButton().disable();
-        getAddEntityButton().setEnabled(currentSession.hasPermission(AccountSessionPermission.delete()));
+        getAddEntityButton().setEnabled(currentSession.hasPermission(AccountSessionPermission.write()));
     }
 
     @Override


### PR DESCRIPTION
This issue was already resolved but I found new one. User was not able
to add Account.
Solution is based on implementation that disables delete button is user
has no privilege for deletion. Wrong permission was connected to Add button.

This fixes issue #1073

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>