### PR TITLE
Added list of devices assigned to group

### DIFF
--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
@@ -52,4 +52,5 @@ filterFieldGroupNameLabel=Name
 # Access Groups - Assigned Devices tab
 groupTabSubjectGridTitle=Assigned Devices
 gridGroupSubjectColumnHeaderId=Id
-gridGroupSubjectColumnHeaderName=Name
+gridGroupSubjectColumnHeaderClientId=Client ID
+gridGroupSubjectColumnHeaderDisplayName=Display Name

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
@@ -47,3 +47,9 @@ dialogDeleteError=Access Group delete failed: {0}
 # Group Filter
 filterHeader=Access Groups Filter
 filterFieldGroupNameLabel=Name
+
+#
+# Access Groups - Assigned Devices tab
+groupTabSubjectGridTitle=Assigned Devices
+gridGroupSubjectColumnHeaderId=Id
+gridGroupSubjectColumnHeaderName=Name

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/DevicesGroupTabItem.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/DevicesGroupTabItem.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.client.device.group;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Element;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsoleGroupMessages;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
+
+public class DevicesGroupTabItem extends KapuaTabItem<GwtGroup> {
+
+    private static final ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
+    GroupSubjectGrid groupDeviceGrid;
+
+    public DevicesGroupTabItem(GwtSession currentSession) {
+        super(currentSession, MSGS.groupTabSubjectGridTitle(), new KapuaIcon(IconSet.SUPPORT));
+        groupDeviceGrid = new GroupSubjectGrid(null, currentSession);
+        groupDeviceGrid.setRefreshOnRender(false);
+        setEnabled(false);
+    }
+
+    @Override
+    protected void doRefresh() {
+        if (selectedEntity != null) {
+            groupDeviceGrid.refresh();
+        }
+    }
+
+    @Override
+    public void setEntity(GwtGroup t) {
+        super.setEntity(t);
+        if (t != null) {
+            setEnabled(true);
+        } else {
+            setEnabled(false);
+        }
+        groupDeviceGrid.setEntity(t);
+
+    }
+
+    @Override
+    protected void onRender(Element parent, int index) {
+        super.onRender(parent, index);
+        setBorders(false);
+        add(groupDeviceGrid);
+    }
+
+}

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/DevicesGroupTabItemDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/DevicesGroupTabItemDescriptor.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.client.device.group;
+
+import org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.AbstractEntityTabDescriptor;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.authorization.client.group.GroupView;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
+import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceSessionPermission;
+
+public class DevicesGroupTabItemDescriptor extends AbstractEntityTabDescriptor<GwtGroup, DevicesGroupTabItem, GroupView> {
+
+    @Override
+    public String getViewId() {
+        return "group.devices";
+    }
+
+    @Override
+    public Integer getOrder() {
+        return 200;
+    }
+
+    @Override
+    public DevicesGroupTabItem getTabViewInstance(GroupView view, GwtSession currentSession) {
+        return new DevicesGroupTabItem(currentSession);
+    }
+
+    @Override
+    public Boolean isEnabled(GwtSession currentSession) {
+        return currentSession.hasPermission(DeviceSessionPermission.read()) && currentSession.hasPermission(AccessInfoSessionPermission.read());
+    }
+}

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.client.device.group;
+
+import com.extjs.gxt.ui.client.data.BasePagingLoadResult;
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
+import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsoleGroupMessages;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
+import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQuery;
+import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQueryPredicates;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceService;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceServiceAsync;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GroupSubjectGrid extends EntityGrid<GwtDevice> {
+
+    private GwtGroup selectedGroup;
+    private static final GwtDeviceServiceAsync DEVICE_SERVICE = GWT.create(GwtDeviceService.class);
+    private static final ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
+    private GwtDeviceQuery query;
+
+    GroupSubjectGrid(AbstractEntityView<GwtDevice> entityView, GwtSession currentSession) {
+        super(entityView, currentSession);
+        query = new GwtDeviceQuery();
+        query.setScopeId(currentSession.getSelectedAccountId());
+
+    }
+
+    @Override
+    protected RpcProxy<PagingLoadResult<GwtDevice>> getDataProxy() {
+        return new RpcProxy<PagingLoadResult<GwtDevice>>() {
+
+            @Override
+            protected void load(Object loadConfig,
+                    AsyncCallback<PagingLoadResult<GwtDevice>> callback) {
+                if (selectedGroup != null) {
+                    DEVICE_SERVICE.query((PagingLoadConfig) loadConfig, query, callback);
+                } else {
+                    callback.onSuccess(new BasePagingLoadResult<GwtDevice>(new ArrayList<GwtDevice>(), 0, 0));
+                }
+            }
+
+        };
+    }
+
+    @Override
+    protected List<ColumnConfig> getColumns() {
+        List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
+
+        ColumnConfig columnConfig = new ColumnConfig("id", MSGS.gridGroupSubjectColumnHeaderId(), 100);
+        columnConfig.setHidden(true);
+        columnConfig.setSortable(false);
+        columnConfigs.add(columnConfig);
+
+        columnConfig = new ColumnConfig("displayName", MSGS.gridGroupSubjectColumnHeaderName(), 100);
+        columnConfig.setSortable(false);
+        columnConfigs.add(columnConfig);
+
+        return columnConfigs;
+    }
+
+    @Override
+    public GwtQuery getFilterQuery() {
+        return query;
+    }
+
+    @Override
+    public void setFilterQuery(GwtQuery filterQuery) {
+        this.query = (GwtDeviceQuery) filterQuery;
+
+    }
+
+    @Override
+    protected EntityCRUDToolbar<GwtDevice> getToolbar() {
+        EntityCRUDToolbar<GwtDevice> toolbar = super.getToolbar();
+        toolbar.setRefreshButtonVisible(true);
+        toolbar.setAddButtonVisible(false);
+        toolbar.setEditButtonVisible(false);
+        toolbar.setDeleteButtonVisible(false);
+        toolbar.setFilterButtonVisible(false);
+        toolbar.setBorders(true);
+
+        return toolbar;
+    }
+
+    public void setEntity(GwtGroup gwtGroup) {
+        if (gwtGroup != null) {
+            selectedGroup = gwtGroup;
+            GwtDeviceQueryPredicates predicates = new GwtDeviceQueryPredicates();
+            predicates.setGroupId(selectedGroup.getId());
+            query.setPredicates(predicates);
+        }
+        refresh();
+    }
+
+    @Override
+    public void refresh() {
+        if (super.rendered) {
+            super.refresh();
+        }
+    }
+
+}

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
@@ -74,8 +74,12 @@ public class GroupSubjectGrid extends EntityGrid<GwtDevice> {
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
-        columnConfig = new ColumnConfig("displayName", MSGS.gridGroupSubjectColumnHeaderName(), 100);
-        columnConfig.setSortable(false);
+        columnConfig = new ColumnConfig("clientId", MSGS.gridGroupSubjectColumnHeaderClientId(), 50);
+        columnConfig.setSortable(true);
+        columnConfigs.add(columnConfig);
+
+        columnConfig = new ColumnConfig("displayName", MSGS.gridGroupSubjectColumnHeaderDisplayName(), 50);
+        columnConfig.setSortable(true);
         columnConfigs.add(columnConfig);
 
         return columnConfigs;

--- a/console/web/src/main/resources/org/eclipse/kapua/app/console/view-descriptors.json
+++ b/console/web/src/main/resources/org/eclipse/kapua/app/console/view-descriptors.json
@@ -49,7 +49,8 @@
     "descriptor": "org.eclipse.kapua.app.console.module.authorization.client.group.GroupViewDescriptor",
     "view": "org.eclipse.kapua.app.console.module.authorization.client.group.GroupView",
     "tabs": [
-      "org.eclipse.kapua.app.console.module.authorization.client.group.GroupTabDescriptionDescriptor"
+      "org.eclipse.kapua.app.console.module.authorization.client.group.GroupTabDescriptionDescriptor",
+      "org.eclipse.kapua.app.console.module.device.client.device.group.DevicesGroupTabItemDescriptor"
     ]
   },
   {


### PR DESCRIPTION
Additional tab was added to Access Groups where for selected group, all
the devices belonging to that group are shown in paged grid.

This functionality was replicated by user-role principle as it is the same
in principle.

More extensive testing should be performed on this functionality.

This fixes issue #1089

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>