### PR TITLE
Data tab's bottom window fix

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -27,6 +27,7 @@ import com.extjs.gxt.ui.client.widget.layout.TableData;
 import com.extjs.gxt.ui.client.widget.layout.TableLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Window;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
@@ -127,7 +128,7 @@ public class AssetTabItem extends TabItem {
         tables.add(metricsTable, channelLayout);
 
         BorderLayoutData queryButtonLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.1f);
-        queryButtonLayout.setMargins(new Margins(5));
+        queryButtonLayout.setMargins(new Margins(5, 5, 15, 5));
         queryButton = new Button(MSGS.assetTabItemQueryButtonText(), new KapuaIcon(IconSet.SEARCH), new SelectionListener<ButtonEvent>() {
 
             @Override
@@ -146,6 +147,7 @@ public class AssetTabItem extends TabItem {
 
         BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.5f);
         resultsLayout.setSplit(true);
+        resultsLayout.setMaxSize(Window.getClientHeight()/2);
 
         TabPanel resultsTabPanel = new TabPanel();
         resultsTabPanel.setPlain(true);

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
@@ -27,6 +27,7 @@ import com.extjs.gxt.ui.client.widget.layout.TableData;
 import com.extjs.gxt.ui.client.widget.layout.TableLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Window;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
@@ -107,7 +108,7 @@ public class DeviceTabItem extends TabItem {
         tables.add(metricsTable, metricLayout);
 
         BorderLayoutData queryButtonLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.1f);
-        queryButtonLayout.setMargins(new Margins(5));
+        queryButtonLayout.setMargins(new Margins(5, 5, 15, 5));
         queryButton = new Button(MSGS.deviceTabItemQueryButtonText(), new KapuaIcon(IconSet.SEARCH), new SelectionListener<ButtonEvent>() {
 
             @Override
@@ -127,6 +128,7 @@ public class DeviceTabItem extends TabItem {
 
         BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.5f);
         resultsLayout.setSplit(true);
+        resultsLayout.setMaxSize(Window.getClientHeight()/2);
 
         TabPanel resultsTabPanel = new TabPanel();
         resultsTabPanel.setPlain(true);

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
@@ -27,6 +27,7 @@ import com.extjs.gxt.ui.client.widget.layout.TableData;
 import com.extjs.gxt.ui.client.widget.layout.TableLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Window;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
@@ -106,7 +107,7 @@ public class TopicsTabItem extends TabItem {
         tables.add(metricsTable, metricLayout);
 
         BorderLayoutData queryButtonLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.1f);
-        queryButtonLayout.setMargins(new Margins(5));
+        queryButtonLayout.setMargins(new Margins(5, 5, 15, 5));
         queryButton = new Button(MSGS.topicTabItemQueryButtonText(), new KapuaIcon(IconSet.SEARCH), new SelectionListener<ButtonEvent>() {
 
             @Override
@@ -124,6 +125,7 @@ public class TopicsTabItem extends TabItem {
 
         BorderLayoutData resultsLayout = new BorderLayoutData(LayoutRegion.SOUTH, 0.5f);
         resultsLayout.setSplit(true);
+        resultsLayout.setMaxSize(Window.getClientHeight()/2);
 
         TabPanel resultsTabPanel = new TabPanel();
         resultsTabPanel.setPlain(true);


### PR DESCRIPTION
Solves issue: Bottom Window Can Cover Refresh Buttons in Data Tab #1143 
- set maxSize for resultsLayout
- changed bottom margin for queryButtonLayout to prevent overlapping on small windows
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>