### PR TITLE
Feature that checks size of browser window

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/InfoPopup.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/InfoPopup.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.core.client;
+
+import com.extjs.gxt.ui.client.Style;
+import com.extjs.gxt.ui.client.widget.ContentPanel;
+import com.extjs.gxt.ui.client.widget.Text;
+import com.extjs.gxt.ui.client.widget.layout.TableData;
+import com.extjs.gxt.ui.client.widget.layout.TableLayout;
+import com.google.gwt.user.client.ui.PopupPanel;
+
+/**
+ * Info pop-up panel that blocks UI and displays message to user.
+ * Show and hide functionality should be handled by PopupInfo creator.
+ */
+public class InfoPopup extends PopupPanel {
+
+    private ContentPanel infoPanel;
+
+    public InfoPopup(String message) {
+        // Popup auto-hide is set to false, user can not close this popup.
+        super(false, true);
+        setGlassEnabled(true);
+        setStylePrimaryName("kapua-popupPanel");
+
+        // Info setup
+        infoPanel = new ContentPanel();
+        infoPanel.setBorders(false);
+        infoPanel.setBodyBorder(false);
+        infoPanel.setHeaderVisible(false);
+        infoPanel.setLayout(new TableLayout(2));
+        infoPanel.setStyleAttribute("background-color", "#F0F0F0");
+        infoPanel.setBodyStyle("background-color: #F0F0F0");
+        setWidget(infoPanel);
+        // Message
+        TableData tableData = new TableData();
+        tableData.setHorizontalAlign(Style.HorizontalAlignment.LEFT);
+        tableData.setVerticalAlign(Style.VerticalAlignment.MIDDLE);
+        Text infoText = new Text(message);
+        infoText.setStyleName("kapua-info-text");
+        infoText.setStyleAttribute("padding", "5px");
+        infoPanel.add(infoText, tableData);
+    }
+
+}

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaCloudConsole.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaCloudConsole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -158,7 +158,7 @@ public class KapuaCloudConsole implements EntryPoint {
     private void render(GwtSession gwtSession) {
         BorderLayout borderLayout = new BorderLayout();
 
-        viewport = new Viewport();
+        viewport = new KapuaViewport();
         viewport.setLayout(borderLayout);
 
         // Set class name based on account. This allows for styling based on account

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaViewport.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaViewport.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.core.client;
+
+import com.extjs.gxt.ui.client.widget.Viewport;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Window;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+
+/**
+ * Extension of basic Viewport that monitors browser window resize and reacts
+ * with displaying message when window is too small. It also disables user
+ * interaction with UI if too small for usage.
+ */
+public class KapuaViewport extends Viewport {
+
+    protected static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
+
+    /**
+     * Minimum width of browser window.
+     */
+    public static final int MIN_CLIENT_WIDTH = 900;
+
+    /**
+     * Minimum height of browser window.
+     */
+    public static final int MIN_CLIENT_HEIGHT = 530;
+
+    private InfoPopup infoPopup;
+
+    public KapuaViewport() {
+        super();
+
+        setMonitorWindowResize(true);
+        infoPopup = new InfoPopup(MSGS.browserWindowTooSmall());
+        int clientHeight = Window.getClientHeight();
+        int clientWidth = Window.getClientWidth();
+        // React at browser size at login, before any resize is made
+        if ((clientHeight < MIN_CLIENT_HEIGHT) || (clientWidth < MIN_CLIENT_WIDTH)) {
+            infoPopup.center();
+            infoPopup.show();
+        }
+    }
+
+    @Override
+    protected void onWindowResize(final int width, final int height) {
+        if ((width < MIN_CLIENT_WIDTH) || (height < MIN_CLIENT_HEIGHT)) {
+            infoPopup.center();
+            infoPopup.show();
+        } else {
+            if (infoPopup != null) {
+                infoPopup.hide();
+            }
+        }
+
+        super.onWindowResize(width, height);
+    }
+
+}

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -36,9 +36,11 @@ ssoWaitDialog.title=Please wait\u2026
 ssoWaitDialog.text=SSO in progress
 
 popupInfo=Info
- popupAlert=Alert
- popupError=Error
- 
+popupAlert=Alert
+popupError=Error
+
+browserWindowTooSmall=Browser Window is too small for accurate UI display.
+
  #
  # Entity Grid labels
  gridEmptyResult=No result found

--- a/console/web/src/main/webapp/css/console.css
+++ b/console/web/src/main/webapp/css/console.css
@@ -33,6 +33,11 @@ h1 {
     margin: 5px;
 }
 
+.kapua-popupPanel {
+    border: 3px solid #F0F0F0;
+    padding: 3px;
+    background: #F0F0F0;
+}
 .serverResponseLabelError {
     color: red;
 }


### PR DESCRIPTION
This feature is added to console when console is created. Listener is
registered that reacts on browser window resizing.
Minimum window width and height are set and if window is too small UI
is blocked with dialog that informs user of that issue.

This could solve multiple issues that are based on UI being to small to
work correctly or issues when layout of UI changes when browser is resized
and is smaller than minSize set for UI components.

Min size is now set to 900 x 530 based on empirical UI usage observations.
It could be made even less if scroll bars would be introducet to tabbed
panels.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>