### PR TITLE
Minor fix for device groups

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
@@ -114,6 +114,7 @@ public class GroupSubjectGrid extends EntityGrid<GwtDevice> {
             selectedGroup = gwtGroup;
             GwtDeviceQueryPredicates predicates = new GwtDeviceQueryPredicates();
             predicates.setGroupId(selectedGroup.getId());
+            predicates.setGroupDevice("ANY");
             query.setPredicates(predicates);
         }
         refresh();


### PR DESCRIPTION
There was change to device service query mapper that broke mapping of
groupId parameter. It is fixed by adding additional ANY for grouping
of devices.

This solves issue #1563 

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>