### PR TITLE
Fix Message Export with queries having more than 10000 results

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSettingKeys.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSettingKeys.java
@@ -36,7 +36,9 @@ public enum ConsoleSettingKeys implements SettingKey {
 
     SSO_REDIRECT_URI("console.sso.redirect.uri"), //
     SITE_HOME_URI("site.home.uri"), //
-    ;
+
+    EXPORT_MAX_PAGES("console.export.max.pages"),
+    EXPORT_MAX_PAGE_SIZE("console.export.max.pagesize");
 
     private String key;
 

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
@@ -324,17 +324,6 @@ public class ResultsTable extends LayoutContainer {
             sbUrl.append("&endDate=").append(endDate.getTime());
         }
 
-        String sortField = resultsGrid.getStore().getSortField();
-        if (sortField != null && !sortField.trim().equals("")) {
-            sbUrl.append("&sortField=").append(resultsGrid.getStore().getSortField());
-
-            if (resultsGrid.getStore().getSortDir() == SortDir.ASC) {
-                sbUrl.append("&sortDir=").append(SortDir.ASC.toString());
-            } else {
-                sbUrl.append("&sortDir=").append(SortDir.DESC.toString());
-            }
-        }
-
         Window.open(sbUrl.toString(), "_blank", "location=no");
     }
 

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
@@ -167,7 +167,7 @@ public class ResultsTable extends LayoutContainer {
                 }
             }
         });
-        loader.setSortField("timestamp");
+        loader.setSortField("timestampFormatted");
         loader.setSortDir(SortDir.DESC);
         loader.setRemoteSort(true);
 

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
@@ -336,7 +336,9 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
         if (!StringUtils.isEmpty(loadConfig.getSortField())) {
             String sortField = loadConfig.getSortField();
             if (sortField.equals("timestampFormatted")) {
-                sortField = "timestamp";
+                sortField = MessageField.TIMESTAMP.field();
+            } else if (sortField.equals("clientId")) {
+                sortField = MessageField.CLIENT_ID.field();
             }
             query.setSortFields(Collections.singletonList(SortField.of(SortDirection.valueOf(loadConfig.getSortDir().name()), sortField)));
         }

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporter.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporter.java
@@ -43,6 +43,8 @@ public abstract class DataExporter {
     public abstract void append(List<DatastoreMessage> messages)
             throws ServletException, IOException;
 
+    public abstract void append(String message);
+
     public abstract void close()
             throws ServletException, IOException;
 

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterCsv.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterCsv.java
@@ -83,6 +83,11 @@ public class DataExporterCsv extends DataExporter {
     }
 
     @Override
+    public void append(String message) {
+        writer.writeNext(new String[]{ message });
+    }
+
+    @Override
     public void close() throws ServletException, IOException {
         writer.flush();
         writer.close();

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterExcel.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterExcel.java
@@ -115,6 +115,13 @@ public class DataExporterExcel extends DataExporter {
     }
 
     @Override
+    public void append(String message) {
+        Row row = sheet.createRow(rowCount++);
+        Cell cell = row.createCell(0);
+        cell.setCellValue(message);
+    }
+
+    @Override
     public void close() throws ServletException, IOException {
         response.setContentType("application/vnd.ms-excel");
         response.setHeader("Content-Disposition", "attachment; filename=" + URLEncoder.encode(topicOrDevice, "UTF-8") + "_data.xls");

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterExcel.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterExcel.java
@@ -38,7 +38,7 @@ public class DataExporterExcel extends DataExporter {
     private Workbook workbook;
     private Sheet sheet;
     private CellStyle dateStyle;
-    private short rowCount;
+    private int rowCount;
     private String topicOrDevice;
 
     private static final int MAX_ROWS = 65535;

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterServlet.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterServlet.java
@@ -19,9 +19,11 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.DatastoreObjectFactory;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
+import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.AndPredicate;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
+import org.eclipse.kapua.service.datastore.model.query.RangePredicate;
 import org.eclipse.kapua.service.datastore.model.query.SortDirection;
 import org.eclipse.kapua.service.datastore.model.query.SortField;
 import org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory;
@@ -47,6 +49,10 @@ public class DataExporterServlet extends HttpServlet {
 
     private static final StorablePredicateFactory STORABLE_PREDICATE_FACTORY = LOCATOR.getFactory(StorablePredicateFactory.class);
 
+    private static final MessageStoreService MESSAGE_STORE_SERVICE = LOCATOR.getService(MessageStoreService.class);
+
+    private static final int QUERY_PAGE = 250;
+
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String reqPathInfo = request.getPathInfo();
@@ -68,8 +74,8 @@ public class DataExporterServlet extends HttpServlet {
             String[] headers = request.getParameterValues("headers");
             String startDate = request.getParameter("startDate");
             String endDate = request.getParameter("endDate");
-            String sortField = request.getParameter("sortField");
-            String sortDir = request.getParameter("sortDir");
+            String sortField = "timestamp";
+            String sortDir = "ASC";
             String topicOrDevice;
 
             AndPredicate predicate = STORABLE_PREDICATE_FACTORY.newAndPredicate();
@@ -107,12 +113,11 @@ public class DataExporterServlet extends HttpServlet {
                 throw new IllegalArgumentException("format");
             }
             dataExporter.init(headers);
-            KapuaLocator locator = KapuaLocator.getInstance();
-            MessageStoreService messageService = locator.getService(MessageStoreService.class);
             MessageQuery query = DATASTORE_FACTORY.newDatastoreMessageQuery(GwtKapuaCommonsModelConverter.convertKapuaId(scopeIdString));
             Date start = new Date(Long.valueOf(startDate));
             Date end = new Date(Long.valueOf(endDate));
-            predicate.getPredicates().add(STORABLE_PREDICATE_FACTORY.newRangePredicate(MessageField.TIMESTAMP.field(), start, end));
+            RangePredicate datePredicate = STORABLE_PREDICATE_FACTORY.newRangePredicate(MessageField.TIMESTAMP.field(), start, end);
+            predicate.getPredicates().add(datePredicate);
 
             if (sortField != null && sortDir != null) {
                 query.setSortFields(Collections.singletonList(SortField.of(SortDirection.valueOf(sortDir), sortField)));
@@ -120,14 +125,27 @@ public class DataExporterServlet extends HttpServlet {
 
             query.setPredicate(predicate);
             MessageListResult result;
-            int offset = 0;
-            query.setLimit(250);
+
+            long totalCount = MESSAGE_STORE_SERVICE.count(query);
+            long totalOffset = 0;
             do {
-                query.setOffset(offset);
-                result = messageService.query(query);
-                dataExporter.append(result.getItems());
-                offset += result.getSize();
-            } while (!result.isEmpty());
+                int internalOffset = 0;
+                query.setLimit(250);
+                do {
+                    query.setOffset(internalOffset);
+                    result = MESSAGE_STORE_SERVICE.query(query);
+                    dataExporter.append(result.getItems());
+                    internalOffset += result.getSize();
+                } while (internalOffset < 10000 && !result.isEmpty());
+                totalOffset += internalOffset;
+                if (!result.isEmpty()) {
+                    DatastoreMessage lastMessage = result.getItems().get(result.getSize() - 1);
+                    Date lastMessageDate = lastMessage.getTimestamp();
+                    predicate.getPredicates().remove(datePredicate);
+                    datePredicate = STORABLE_PREDICATE_FACTORY.newRangePredicate(MessageField.TIMESTAMP.field(), lastMessageDate, end);
+                    predicate.getPredicates().add(datePredicate);
+                }
+            } while (totalOffset < totalCount);
             dataExporter.close();
         } catch (IllegalArgumentException iae) {
             response.sendError(400, "Illegal value for query parameter(s): " + iae.getMessage());

--- a/console/web/src/main/resources/console-setting.properties
+++ b/console/web/src/main/resources/console-setting.properties
@@ -39,3 +39,6 @@ console.sso.openid.client.id=console
 console.sso.openid.redirect.uri=http://localhost:8889/sso/callback
 
 console.skin.resource.dir=
+
+console.export.max.pages=10
+console.export.max.pagesize=10000

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaExceptionMapper.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.app.api.core.exception.model.KapuaExceptionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class KapuaExceptionMapper implements ExceptionMapper<KapuaException> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KapuaExceptionMapper.class);
+
+    @Override
+    public Response toResponse(KapuaException kapuaException) {
+        LOG.error("Generic Kapua exception!", kapuaException);
+        return Response
+                .status(Status.UNAUTHORIZED)
+                .entity(new KapuaExceptionInfo(Status.INTERNAL_SERVER_ERROR, kapuaException.getCode(), kapuaException))
+                .build();
+    }
+
+}

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfo.java
@@ -25,7 +25,7 @@ import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 @XmlRootElement(name = "entityNotFoundExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class EntityNotFoundExceptionInfo extends AbstractInfo {
+public class EntityNotFoundExceptionInfo extends KapuaExceptionInfo {
 
     @XmlElement(name = "entityType")
     private String entityType;
@@ -40,7 +40,7 @@ public class EntityNotFoundExceptionInfo extends AbstractInfo {
     }
 
     public EntityNotFoundExceptionInfo(Status httpStatus, KapuaEntityNotFoundException kapuaException) {
-        super(httpStatus, kapuaException.getCode());
+        super(httpStatus, kapuaException.getCode(), kapuaException);
 
         setEntityType(kapuaException.getEntityType());
         setEntityId(kapuaException.getEntityId());

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfo.java
@@ -21,7 +21,7 @@ import org.eclipse.kapua.KapuaIllegalArgumentException;
 
 @XmlRootElement(name = "illegalArgumentExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class IllegalArgumentExceptionInfo extends AbstractInfo {
+public class IllegalArgumentExceptionInfo extends KapuaExceptionInfo {
 
     @XmlElement(name = "argumentName")
     private String argumentName;
@@ -34,7 +34,7 @@ public class IllegalArgumentExceptionInfo extends AbstractInfo {
     }
 
     public IllegalArgumentExceptionInfo(Status httpStatus, KapuaIllegalArgumentException kapuaException) {
-        super(httpStatus, kapuaException.getCode());
+        super(httpStatus, kapuaException.getCode(), kapuaException);
 
         setArgumentName(kapuaException.getArgumentName());
         setArgumentValue(kapuaException.getArgumentValue());

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfo.java
@@ -21,7 +21,7 @@ import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 
 @XmlRootElement(name = "illegalNullArgumentExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class IllegalNullArgumentExceptionInfo extends AbstractInfo {
+public class IllegalNullArgumentExceptionInfo extends KapuaExceptionInfo {
 
     @XmlElement(name = "argumentName")
     private String argumentName;
@@ -31,7 +31,7 @@ public class IllegalNullArgumentExceptionInfo extends AbstractInfo {
     }
 
     public IllegalNullArgumentExceptionInfo(Status httpStatus, KapuaIllegalNullArgumentException kapuaException) {
-        super(httpStatus, kapuaException.getCode());
+        super(httpStatus, kapuaException.getCode(), kapuaException);
 
         setArgumentName(kapuaException.getArgumentName());
     }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/KapuaExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/KapuaExceptionInfo.java
@@ -15,30 +15,21 @@ import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.annotation.XmlElement;
 
 import org.eclipse.kapua.KapuaErrorCode;
+import org.eclipse.kapua.KapuaException;
 
-public abstract class AbstractInfo {
+public class KapuaExceptionInfo extends ThrowableInfo {
 
-    private int httpErrorCode;
+    @XmlElement(name = "kapuaErrorCode")
     private String kapuaErrorCode;
 
-    public AbstractInfo() {
+    public KapuaExceptionInfo() {
     }
 
-    public AbstractInfo(Status httpStatus, KapuaErrorCode kapuaErrorCode) {
-        setHttpErrorCode(httpStatus);
+    public KapuaExceptionInfo(Status httpStatus, KapuaErrorCode kapuaErrorCode, KapuaException exception) {
+        super(httpStatus, exception);
         setKapuaErrorCode(kapuaErrorCode);
     }
 
-    @XmlElement(name = "httpErrorCode")
-    public int getHttpErrorCode() {
-        return httpErrorCode;
-    }
-
-    private void setHttpErrorCode(Status httpErrorCode) {
-        this.httpErrorCode = httpErrorCode.getStatusCode();
-    }
-
-    @XmlElement(name = "kapuaErrorCode")
     public String getKapuaErrorCode() {
         return kapuaErrorCode;
     }
@@ -46,5 +37,4 @@ public abstract class AbstractInfo {
     private void setKapuaErrorCode(KapuaErrorCode kapuaErrorCode) {
         this.kapuaErrorCode = kapuaErrorCode.name();
     }
-
 }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfo.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "subjectUnauthorizedExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class SubjectUnauthorizedExceptionInfo extends AbstractInfo {
+public class SubjectUnauthorizedExceptionInfo extends KapuaExceptionInfo {
 
     @XmlElement(name = "permission")
     private Permission permission;
@@ -32,7 +32,7 @@ public class SubjectUnauthorizedExceptionInfo extends AbstractInfo {
     }
 
     public SubjectUnauthorizedExceptionInfo(Status httpStatus, SubjectUnauthorizedException kapuaException) {
-        super(httpStatus, kapuaException.getCode());
+        super(httpStatus, kapuaException.getCode(), kapuaException);
 
         setPermission(kapuaException.getPermission());
     }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfo.java
@@ -19,27 +19,57 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 
-import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.app.api.core.settings.KapuaApiSetting;
+import org.eclipse.kapua.app.api.core.settings.KapuaApiSettingKeys;
 
 @XmlRootElement(name = "throwableInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class ThrowableInfo extends AbstractInfo {
+public class ThrowableInfo {
+
+    @XmlElement(name = "httpErrorCode")
+    private int httpErrorCode;
+
+    @XmlElement(name = "message")
+    private String message;
 
     @XmlElement(name = "stackTrace")
     private String stackTrace;
+
+    @XmlTransient
+    private final boolean showStacktrace = KapuaApiSetting.getInstance().getBoolean(KapuaApiSettingKeys.API_EXCEPTION_STACKTRACE_SHOW, false);
 
     protected ThrowableInfo() {
         super();
     }
 
     public ThrowableInfo(Status httpStatus, Throwable throwable) {
-        super(httpStatus, KapuaErrorCodes.SEVERE_INTERNAL_ERROR);
-
+        this.httpErrorCode = httpStatus.getStatusCode();
+        this.message = throwable.getMessage();
         // Print stack trace
-        StringWriter stringWriter = new StringWriter();
-        throwable.printStackTrace(new PrintWriter(stringWriter));
-        setStackTrace(stringWriter.toString());
+        if (showStacktrace) {
+            StringWriter stringWriter = new StringWriter();
+            throwable.printStackTrace(new PrintWriter(stringWriter));
+            setStackTrace(stringWriter.toString());
+        }
+
+    }
+
+    public int getHttpErrorCode() {
+        return httpErrorCode;
+    }
+
+    public void setHttpErrorCode(Status httpErrorCode) {
+        this.httpErrorCode = httpErrorCode.getStatusCode();
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
     }
 
     public String getStackTrace() {

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSettingKeys.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSettingKeys.java
@@ -20,7 +20,8 @@ import org.eclipse.kapua.commons.setting.SettingKey;
  */
 public enum KapuaApiSettingKeys implements SettingKey {
     API_KEY("api.key"), //
-    API_PATH_PARAM_SCOPEID_WILDCARD("api.path.param.scopeId.wildcard"),;
+    API_PATH_PARAM_SCOPEID_WILDCARD("api.path.param.scopeId.wildcard"),
+    API_EXCEPTION_STACKTRACE_SHOW("api.exception.stacktrace.show");
 
     private String key;
 

--- a/rest-api/web/src/main/resources/kapua-api-settings.properties
+++ b/rest-api/web/src/main/resources/kapua-api-settings.properties
@@ -1,12 +1,14 @@
-/*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *     Eurotech - initial API and implementation
- *******************************************************************************/
+###############################################################################
+# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
 api.path.param.scopeId.wildcard=_
+api.exception.stacktrace.show=false

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -192,7 +192,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         try {
             return messageStoreFacade.query(query);
         } catch (Exception e) {
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getCause().getMessage());
         }
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreErrorCodes.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreErrorCodes.java
@@ -35,5 +35,5 @@ public enum DatastoreErrorCodes implements KapuaErrorCode {
     /**
      * Generic internal error
      */
-    INTERNAL_ERROR;
+    INTERNAL_ERROR
 }


### PR DESCRIPTION
Hi all,

This PR aims at fixing #1534, so that the `DataExportServlet` doesn't crash anymore due to Elasticsearch result set limit to 10000 rows. However, in order to achieve this, we have to specify data sorting as Timestamp Ascendent, ignoring any other sort setting selected in the Data View.

While I was there I also fixed a couple of issues in the Data View (default sorting was not visible, sort by device id was not working) and refactored a bit exception displayed from REST APIs.