### PR TITLE
Convert Account.childAccounts to List to keep children sorting

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccount.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccount.java
@@ -12,7 +12,7 @@
 package org.eclipse.kapua.app.console.module.account.shared.model;
 
 import java.io.Serializable;
-import java.util.Set;
+import java.util.List;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityModel;
@@ -98,11 +98,11 @@ public class GwtAccount extends GwtUpdatableEntityModel implements Serializable 
         return (String) get("parentAccountId");
     }
 
-    public Set<GwtAccount> getChildAccounts() {
+    public List<GwtAccount> getChildAccounts() {
         return get("childAccounts");
     }
 
-    public void setChildAccounts(Set<GwtAccount> childAccounts) {
+    public void setChildAccounts(List<GwtAccount> childAccounts) {
         set("childAccounts", childAccounts);
     }
 }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/KapuaGwtAccountModelConverter.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/KapuaGwtAccountModelConverter.java
@@ -11,8 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.account.shared.util;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.kapua.app.console.module.api.shared.util.KapuaGwtCommonsModelConverter;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
@@ -53,12 +53,12 @@ public class KapuaGwtAccountModelConverter {
         return gwtAccount;
     }
 
-    private static Set<GwtAccount> convertChildAccounts(Set<Account> childAccounts) {
-        Set<GwtAccount> accountSet = new HashSet<GwtAccount>();
+    private static List<GwtAccount> convertChildAccounts(List<Account> childAccounts) {
+        List<GwtAccount> accountList = new ArrayList<GwtAccount>();
         for (Account account : childAccounts) {
-            accountSet.add(KapuaGwtAccountModelConverter.convertAccount(account));
+            accountList.add(KapuaGwtAccountModelConverter.convertAccount(account));
         }
-        return accountSet;
+        return accountList;
     }
 
     /**

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
@@ -17,7 +17,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import java.util.Set;
+import java.util.List;
 
 import org.eclipse.kapua.model.KapuaNamedEntity;
 
@@ -71,5 +71,5 @@ public interface Account extends KapuaNamedEntity {
      */
     public void setParentAccountPath(String parentAccountPath);
 
-    public Set<Account> getChildAccounts();
+    public List<Account> getChildAccounts();
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
@@ -22,10 +22,11 @@ import javax.persistence.JoinColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -70,7 +71,8 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "scope_id", referencedColumnName = "id", insertable = false, updatable = false)
-    private Set<AccountImpl> childAccounts;
+    @OrderBy("name ASC")
+    private List<AccountImpl> childAccounts;
 
     /**
      * Constructor
@@ -121,8 +123,10 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
     }
 
     @Override
-    public Set<Account> getChildAccounts() {
-        return new HashSet<>(childAccounts);
+    public List<Account> getChildAccounts() {
+        List<Account> list = new ArrayList<>();
+        list.addAll(childAccounts);
+        return list;
     }
 
 }

--- a/test/src/main/java/org/eclipse/kapua/test/account/AccountMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/account/AccountMock.java
@@ -13,8 +13,8 @@ package org.eclipse.kapua.test.account;
 
 import java.math.BigInteger;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
@@ -152,7 +152,7 @@ public class AccountMock implements Account {
     }
 
     @Override
-    public Set<Account> getChildAccounts() {
+    public List<Account> getChildAccounts() {
         return null;
     }
 


### PR DESCRIPTION
Hi all,

this PR refactors `Account.getChildAccounts` to return a `List` instead of a `Set` so that Child Accounts are consistently returned when clicking on the Account change menu.

Fixes #866