### PR TITLE
Proposal for Entity Grid auto refresh

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -54,7 +54,12 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     /**
      * Used for checks if data on grid query has changed from last refresh.
      */
-    protected int lastOptlockSum;
+    protected boolean lastChanged;
+    /**
+     * List of entity changed flags.
+     */
+    protected int[] lastChange = new int[ENTITY_PAGE_SIZE];
+
 
     private EntityCRUDToolbar<M> entityCRUDToolbar;
     private boolean entityGridConfigured;

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -26,6 +26,7 @@ import com.extjs.gxt.ui.client.widget.layout.FitLayout;
 import com.extjs.gxt.ui.client.widget.toolbar.PagingToolBar;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Timer;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.ContentPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
@@ -46,6 +47,14 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
 
     protected GwtSession currentSession;
     private AbstractEntityView<M> parentEntityView;
+    /**
+     * Timer that when enabled (not null) refreshes the grid.
+     */
+    private Timer refreshTimer;
+    /**
+     * Used for checks if data on grid query has changed from last refresh.
+     */
+    protected int lastOptlockSum;
 
     private EntityCRUDToolbar<M> entityCRUDToolbar;
     private boolean entityGridConfigured;
@@ -180,6 +189,27 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     }
 
     protected abstract List<ColumnConfig> getColumns();
+
+    /**
+     * Enable refresh of data grid when data changes.
+     *
+     * @param refreshMillis milli seconds refresh interval
+     * @param timer timer that executes refresh if necessary
+     */
+    protected void enableRefreshTimer(int refreshMillis, Timer timer) {
+        refreshTimer = timer;
+        refreshTimer.scheduleRepeating(refreshMillis);
+    }
+
+    /**
+     * Disable periodic refresh of data grid.
+     */
+    protected void disableRefreshTimer() {
+        if (refreshTimer != null) {
+            refreshTimer.cancel();
+            refreshTimer = null;
+        }
+    }
 
     public void clearGridElement() {
         entityStore.removeAll();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGrid.java
@@ -46,6 +46,7 @@ import java.util.List;
 public class DeviceGrid extends EntityGrid<GwtDevice> {
 
     private GwtDeviceQuery query;
+    private PagingLoadConfig lastLoadConfig;
     private DeviceGridToolbar toolbar;
 
     private static final GwtDeviceServiceAsync GWT_DEVICE_SERVICE = GWT.create(GwtDeviceService.class);
@@ -65,7 +66,7 @@ public class DeviceGrid extends EntityGrid<GwtDevice> {
 
             @Override
             public void run() {
-                GWT_DEVICE_SERVICE.query(query, new AsyncCallback<List<GwtDevice>>() {
+                GWT_DEVICE_SERVICE.query(lastLoadConfig, query, new AsyncCallback<PagingLoadResult<GwtDevice>>() {
 
                     @Override
                     public void onFailure(Throwable caught) {
@@ -73,13 +74,18 @@ public class DeviceGrid extends EntityGrid<GwtDevice> {
                     }
 
                     @Override
-                    public void onSuccess(List<GwtDevice> results) {
-                        int optlockSum = 0;
-                        for (GwtDevice result : results) {
-                            optlockSum += result.getOptlock();
+                    public void onSuccess(PagingLoadResult<GwtDevice> results) {
+                        boolean changed = false;
+                        List<GwtDevice> data = results.getData();
+                        for (int i = 0; i < data.size(); i++) {
+                            GwtDevice result = data.get(i);
+                            int newStatus = result.getGwtDeviceConnectionStatusEnum().ordinal();
+                            if (newStatus != lastChange[i]) {
+                                changed = true;
+                            }
+                            lastChange[i] = newStatus;
                         }
-                        if (optlockSum != lastOptlockSum) {
-                            lastOptlockSum = optlockSum;
+                        if (changed) {
                             refresh();
                         }
                     }
@@ -101,6 +107,7 @@ public class DeviceGrid extends EntityGrid<GwtDevice> {
 
             @Override
             protected void load(Object loadConfig, AsyncCallback<PagingLoadResult<GwtDevice>> callback) {
+                lastLoadConfig = (PagingLoadConfig) loadConfig;
                 GWT_DEVICE_SERVICE.query((PagingLoadConfig) loadConfig,
                         query,
                         callback);


### PR DESCRIPTION
This is an example of automatic refresh of Entity grids.
Example is based on DeviceGrid, where it is useful to have dynamic
refresh of device status.

Implementation is based on client side timer that executes pull for
data and checks if data that is displayed in grid has changed. If data
changed it issues refresh of grid, if not it stays as it is. This prevents
unnecessary blinking of UI.

Data change is checked on check of optlock fields sum of displayed records.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>