### PR TITLE
Fixed DeviceConnection status check

### DIFF
--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallExecutor.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallExecutor.java
@@ -28,6 +28,7 @@ import org.eclipse.kapua.service.device.management.message.request.KapuaRequestP
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionStatus;
 import org.eclipse.kapua.translator.Translator;
 
 /**
@@ -84,6 +85,18 @@ public class DeviceCallExecutor<C extends KapuaRequestChannel, P extends KapuaRe
         Device device = DEVICE_REGISTRY_SERVICE.find(requestMessage.getScopeId(), requestMessage.getDeviceId());
         if (device == null) {
             throw new KapuaEntityNotFoundException(Device.TYPE, requestMessage.getDeviceId());
+        }
+
+        //
+        // Check Device Connection
+        if (device.getConnection() == null) {
+            throw new DeviceManagementException(DeviceManagementErrorCodes.DEVICE_NEVER_CONNECTED, device.getScopeId(), device.getId());
+        }
+
+        //
+        // Check Device Connection status
+        if (!DeviceConnectionStatus.CONNECTED.equals(device.getConnection().getStatus())) {
+            throw new DeviceManagementException(DeviceManagementErrorCodes.DEVICE_NOT_CONNECTED, device.getScopeId(), device.getId(), device.getConnection().getStatus());
         }
 
         //

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementErrorCodes.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementErrorCodes.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.service.device.management.commons.exception;
 
 import org.eclipse.kapua.KapuaErrorCode;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 
 /**
  * Device management error codes.
@@ -20,9 +21,21 @@ import org.eclipse.kapua.KapuaErrorCode;
  */
 public enum DeviceManagementErrorCodes implements KapuaErrorCode {
     /**
+     * The {@link org.eclipse.kapua.service.device.registry.Device} has {@code null} {@link org.eclipse.kapua.service.device.registry.connection.DeviceConnection}
+     */
+    DEVICE_NEVER_CONNECTED,
+
+    /**
+     * The {@link org.eclipse.kapua.service.device.registry.Device} has {@link DeviceConnection#getStatus()} not equals to
+     * {@link org.eclipse.kapua.service.device.registry.connection.DeviceConnectionStatus#CONNECTED}
+     */
+    DEVICE_NOT_CONNECTED,
+
+    /**
      * Request exception
      */
     REQUEST_EXCEPTION,
+
     /**
      * Bad request method
      */
@@ -37,12 +50,14 @@ public enum DeviceManagementErrorCodes implements KapuaErrorCode {
      * Bad request
      */
     RESPONSE_BAD_REQUEST,
+
     /**
      * Response not found
      */
     RESPONSE_NOT_FOUND,
+
     /**
      * Response internal error
      */
-    RESPONSE_INTERNAL_ERROR;
+    RESPONSE_INTERNAL_ERROR
 }


### PR DESCRIPTION
This PR fixes #1579 .

Added check on the `DeviceConnection` of the selected `Device`.

 This PR is based on #1582 so requires the other PR to be merged first.