### PR TITLE
Fixing button behaviour for webkit and gecko browsers - same look

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserTab.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,9 @@ import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
 
 public class AccountChildUserTab extends KapuaTabItem<GwtAccount> {
 
@@ -46,6 +48,13 @@ public class AccountChildUserTab extends KapuaTabItem<GwtAccount> {
     protected void onRender(Element parent, int index) {
         super.onRender(parent, index);
         this.add(userGrid);
+        EntityCRUDToolbar<GwtUser> toolBar = userGrid.getToolbar();
+
+        layout(true);
+        toolBar.setStyleAttribute("border-top", "0px none");
+        toolBar.setStyleAttribute("border-left", "0px none");
+        toolBar.setStyleAttribute("border-right", "0px none");
+        toolBar.setStyleAttribute("border-bottom", "1px solid rgb(208, 208, 208)");
     }
 
     @Override

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
@@ -127,9 +127,11 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
                         if (filterButton.getText().equals(MSGS.deviceTableToolbarOpenFilter())) {
                             filterPanel.show();
                             filterButton.setText(MSGS.deviceTableToolbarCloseFilter());
+                            filterButton.toggle(false);
                         } else {
                             filterPanel.hide();
                             filterButton.setText(MSGS.deviceTableToolbarOpenFilter());
+                            filterButton.toggle(false);
                         }
                     } else {
                         filterPanel.hide();
@@ -138,7 +140,7 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
 
                 }
             });
-            filterButton.toggle(true);
+            filterButton.toggle(false);
             add(filterButton);
         }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -317,11 +317,7 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
             public void componentSelected(ButtonEvent ce) {
                 if (!resetProcess) {
                     resetProcess = true;
-                    resetButton.setEnabled(false);
-
                     formPanel.reset();
-
-                    resetButton.setEnabled(true);
                     resetProcess = false;
                 }
             }

--- a/console/web/src/main/webapp/css/console.css
+++ b/console/web/src/main/webapp/css/console.css
@@ -215,3 +215,46 @@ table#header-button td, table#header-button button {
     left: 1px;
     top: 4px;
 }
+
+/** Removal of mozilla borders around button text. */
+button::-moz-focus-inner, button::-moz-focus-outer, button:-moz-focusring, button:focus
+{
+    border: none;
+}
+
+/** Added to sync behaviour of webkit and gecko based browsers for buttons. */
+.x-btn-focus .x-btn-tl{
+    background-position: -6px 0;
+}
+
+.x-btn-focus .x-btn-tr{
+    background-position: -9px 0;
+}
+
+.x-btn-focus .x-btn-tc{
+    background-position: 0 -9px;
+}
+
+.x-btn-focus .x-btn-ml{
+    background-position: -6px -24px;
+}
+
+.x-btn-focus .x-btn-mr{
+    background-position: -9px -24px;
+}
+
+.x-btn-focus .x-btn-mc{
+    background-position: 0 -2168px;
+}
+
+.x-btn-focus .x-btn-bl{
+    background-position: -6px -3px;
+}
+
+.x-btn-focus .x-btn-br{
+    background-position: -9px -3px;
+}
+
+.x-btn-focus .x-btn-bc{
+    background-position: 0 -18px;
+}


### PR DESCRIPTION
Changed behaviour of buttons so that they behave same on webkit based and
mozilla browser.

Buttons in mozilla are changed so that they don't have border when they are in
focus. Also mozilla buttons are now blue when in focus, same as with chrome
and other webkit browsers.

Filter button is now not blue when not selected.

This fixes issue #1276

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>