### PR TITLE
Set Device Display Name as a mandatory field at device creation

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -152,9 +152,9 @@ public class DeviceAddDialog extends EntityAddEditDialog {
 
         // Display name
         displayNameField = new KapuaTextField<String>();
-        displayNameField.setAllowBlank(true);
+        displayNameField.setAllowBlank(false);
         displayNameField.setName("displayName");
-        displayNameField.setFieldLabel(DEVICE_MSGS.deviceFormDisplayName());
+        displayNameField.setFieldLabel("* " + DEVICE_MSGS.deviceFormDisplayName());
         displayNameField.setWidth(225);
         displayNameField.setMaxLength(255);
         fieldSet.add(displayNameField, formData);


### PR DESCRIPTION
Solves: Problem With Adding Targets When Device Do Not Have Display Name #1598
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>