### PR TITLE
Enabled setting device status at device creation

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -110,7 +110,6 @@ public class DeviceAddDialog extends EntityAddEditDialog {
 
         // hide fields used for edit
         clientIdLabel.hide();
-        statusCombo.hide();
     }
 
     protected void generateBody() {
@@ -161,8 +160,9 @@ public class DeviceAddDialog extends EntityAddEditDialog {
 
         // Device Status
         statusCombo = new SimpleComboBox<GwtDeviceQueryPredicates.GwtDeviceStatus>();
+        statusCombo.setAllowBlank(false);
         statusCombo.setName("status");
-        statusCombo.setFieldLabel(DEVICE_MSGS.deviceFormStatus());
+        statusCombo.setFieldLabel("* " + DEVICE_MSGS.deviceFormStatus());
         statusCombo.setEditable(false);
         statusCombo.setTriggerAction(TriggerAction.ALL);
 
@@ -271,6 +271,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
             gwtDeviceCreator.setGroupId(groupCombo.getValue().getId());
         }
         gwtDeviceCreator.setDisplayName(displayNameField.getValue());
+        gwtDeviceCreator.setDeviceStatus(statusCombo.getSimpleValue().name());
 
         // Custom attributes
         gwtDeviceCreator.setCustomAttribute1(KapuaSafeHtmlUtils.htmlUnescape(customAttribute1Field.getValue()));

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceServiceImpl.java
@@ -362,6 +362,7 @@ public class GwtDeviceServiceImpl extends KapuaRemoteServiceServlet implements G
             DeviceCreator deviceCreator = deviceFactory.newCreator(scopeId, gwtDeviceCreator.getClientId());
             deviceCreator.setDisplayName(gwtDeviceCreator.getDisplayName());
             deviceCreator.setGroupId(GwtKapuaCommonsModelConverter.convertKapuaId(gwtDeviceCreator.getGroupId()));
+            deviceCreator.setStatus((DeviceStatus.valueOf(gwtDeviceCreator.getDeviceStatus())));
 
             // FIXME One day it will be specified from the form. In the meantime, defaults to LOOSE
             // deviceCreator.setCredentialsMode(DeviceCredentialsMode.LOOSE);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceCreator.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,6 +25,7 @@ public class GwtDeviceCreator extends KapuaBaseModel implements Serializable {
     private String groupId;
     private String clientId;
     private String displayName;
+    private String deviceStatus;
 
     // Security options
     private GwtConnectionUserCouplingMode gwtCredentialsTight;
@@ -90,6 +91,14 @@ public class GwtDeviceCreator extends KapuaBaseModel implements Serializable {
 
     public void setGwtPreferredUserId(String gwtPreferredUserId) {
         this.gwtPreferredUserId = gwtPreferredUserId;
+    }
+
+    public String getDeviceStatus() {
+        return deviceStatus;
+    }
+
+    public void setDeviceStatus(String deviceStatus) {
+        this.deviceStatus = deviceStatus;
     }
 
     public String getCustomAttribute1() {

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -352,4 +352,4 @@ dialogDeviceDeleteError=Error when deleting device: {0}
 
 deviceConnectionError=Selected device not connected. Please refresh device list.
 
-dialogDeviceAddInfoMessage=Create a new device providing Client ID and Access Group.
+dialogDeviceAddInfoMessage=Create a new device providing Client ID, Display Name, Access Group and Device Status.


### PR DESCRIPTION
The device status is now a mandatory field at the DeviceAddDialog. It's set
using GwtDeviceCreator class, which now has additional deviceStatus
field. There was also a change on the service side in the createDevice
method of GwtDeviceServiceImpl class when setting the status. The
dialogDeviceAddInfoMessage was also updated.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>