### PR TITLE
New User window size fix

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -83,8 +83,8 @@ public class UserAddDialog extends EntityAddEditDialog {
         userFormPanel.setHeaderVisible(false);
         userFormPanel.setPadding(0);
 
-        FormData subFieldsetFormData = new FormData("-11");
-        FormData subFormData = new FormData("0");
+        FormData subFieldsetFormData = new FormData();
+        FormData subFormData = new FormData();
 
         //
         // User info tab


### PR DESCRIPTION
Removed values passed to FormData constructor in UserAddDialog, because
of the difference in behaviour of specific browsers.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>