### PR TITLE
Credential Toolbar looks disabled fix

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
@@ -120,7 +120,6 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
 
     private void showUnlockDialog(GwtCredential selectedCredential) {
         CredentialUnlockDialog dialog = new CredentialUnlockDialog(selectedCredential);
-        thisToolbar.disable();
         dialog.addListener(Events.Hide, getHideDialogListener());
         dialog.show();
     }


### PR DESCRIPTION
Removed tolbar disable() method from the showUnlockDialog()
function.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>