### PR TITLE
Fixed a bunch of redundant modifiers issue reported by Sonar

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
@@ -12,13 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.converter;
 
-import java.util.Base64;
-import java.util.Date;
-
-import javax.jms.BytesMessage;
-import javax.jms.JMSException;
-import javax.jms.Message;
-
+import com.codahale.metrics.Counter;
 import org.apache.camel.Converter;
 import org.apache.camel.Exchange;
 import org.apache.camel.component.jms.JmsMessage;
@@ -37,7 +31,11 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.codahale.metrics.Counter;
+import javax.jms.BytesMessage;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import java.util.Base64;
+import java.util.Date;
 
 /**
  * Kapua message converter reference implementation used to convert from Camel incoming messages ({@link JmsMessage}) to a platform specific message type.
@@ -49,8 +47,8 @@ public abstract class AbstractKapuaConverter {
     public static final Logger logger = LoggerFactory.getLogger(AbstractKapuaConverter.class);
 
     // metrics
-    protected final static String METRIC_COMPONENT_NAME = "converter";
-    protected final static MetricsService METRICS_SERVICE = MetricServiceFactory.getInstance();
+    protected static final String METRIC_COMPONENT_NAME = "converter";
+    protected static final MetricsService METRICS_SERVICE = MetricServiceFactory.getInstance();
 
     private final Counter metricConverterJmsMessage;
     private final Counter metricConverterJmsErrorMessage;
@@ -70,11 +68,9 @@ public abstract class AbstractKapuaConverter {
      *
      * @param exchange
      * @param value
-     * @param messageType
-     *            expected incoming message type
+     * @param messageType expected incoming message type
      * @return Message container that contains message of asked type
-     * @throws KapuaException
-     *             if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
+     * @throws KapuaException if incoming message does not contain a javax.jms.BytesMessage or an error during conversion occurred
      */
     protected CamelKapuaMessage<?> convertTo(Exchange exchange, Object value, MessageType messageType) throws KapuaException {
         // assume that the message is a Camel Jms message
@@ -104,8 +100,7 @@ public abstract class AbstractKapuaConverter {
      * @param exchange
      * @param value
      * @return jms Message
-     * @throws KapuaException
-     *             if incoming message does not contain a javax.jms.BytesMessage
+     * @throws KapuaException if incoming message does not contain a javax.jms.BytesMessage
      */
     @Converter
     public Message convertToJmsMessage(Exchange exchange, Object value) throws KapuaException {

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaCamelFilter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaCamelFilter.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.converter;
 
-import java.util.Base64;
-
 import org.apache.camel.Exchange;
 import org.apache.commons.lang.SerializationException;
 import org.apache.commons.lang3.SerializationUtils;
@@ -25,13 +23,14 @@ import org.eclipse.kapua.commons.security.KapuaSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Base64;
+
 /**
  * Kapua Camel session filter used to bind/unbind Kapua session to the thread context
- *
  */
 public class KapuaCamelFilter extends AbstractListener {
 
-    private final static Logger logger = LoggerFactory.getLogger(KapuaCamelFilter.class);
+    private static final Logger logger = LoggerFactory.getLogger(KapuaCamelFilter.class);
 
     public KapuaCamelFilter() {
         super("filter");
@@ -39,7 +38,7 @@ public class KapuaCamelFilter extends AbstractListener {
 
     /**
      * Bind the Kapua session retrieved from the message header (with key {@link MessageConstants#HEADER_KAPUA_SESSION}) to the current thread context.
-     * 
+     *
      * @param exchange
      * @param value
      * @throws KapuaException
@@ -60,7 +59,7 @@ public class KapuaCamelFilter extends AbstractListener {
 
     /**
      * Unbind the Kapua session from the current thread context.
-     * 
+     *
      * @param exchange
      * @param value
      * @throws KapuaException
@@ -71,7 +70,7 @@ public class KapuaCamelFilter extends AbstractListener {
 
     /**
      * Bridge the error condition putting the in the JmsMessage header (At the present only the Exception raised is handled by this method)
-     * 
+     *
      * @param exchange
      * @param value
      */
@@ -83,8 +82,7 @@ public class KapuaCamelFilter extends AbstractListener {
         } else if (exchange.getException() != null) {
             exchange.getIn().setHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION,
                     Base64.getEncoder().encodeToString(SerializationUtils.serialize(exchange.getException())));
-        }
-        else {
+        } else {
             logger.debug("Cannot serialize exception since it is null!");
         }
     }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractListener.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractListener.java
@@ -11,11 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.listener;
 
-import org.eclipse.kapua.commons.metric.MetricServiceFactory;
-import org.eclipse.kapua.commons.metric.MetricsService;
-
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
+import org.eclipse.kapua.commons.metric.MetricServiceFactory;
+import org.eclipse.kapua.commons.metric.MetricsService;
 
 /**
  * Default camel pojo endpoint listener.
@@ -26,16 +25,15 @@ public abstract class AbstractListener {
 
     // metrics
     private String metricComponentName = "listener";
-    private final static MetricsService METRICS_SERVICE = MetricServiceFactory.getInstance();
+    private static final MetricsService METRICS_SERVICE = MetricServiceFactory.getInstance();
 
     protected String name;
 
     /**
      * Create a listener with the specific name.<BR>
      * The "listener" constant will be used as metricComponentName.
-     * 
-     * @param name
-     *            First level name to categorize the metrics inside the listener
+     *
+     * @param name First level name to categorize the metrics inside the listener
      */
     protected AbstractListener(String name) {
         this.name = name;
@@ -43,11 +41,9 @@ public abstract class AbstractListener {
 
     /**
      * Create a listener with the specific metricComponentName and name
-     * 
-     * @param metricComponentName
-     *            Root name to categorize the metrics inside the listener
-     * @param name
-     *            First level name to categorize the metrics inside the listener
+     *
+     * @param metricComponentName Root name to categorize the metrics inside the listener
+     * @param name                First level name to categorize the metrics inside the listener
      */
     protected AbstractListener(String metricComponentName, String name) {
         this(name);
@@ -57,7 +53,7 @@ public abstract class AbstractListener {
     /**
      * Register a Counter with the specified names as suffix.<BR>
      * The prefix is described by a combination of constructor parameters name and metricComponentName depending on which constructor will be used.
-     * 
+     *
      * @param names
      * @return
      */
@@ -68,7 +64,7 @@ public abstract class AbstractListener {
     /**
      * Register a Timer with the specified names as suffix.<BR>
      * The prefix is described by a combination of constructor parameters name and metricComponentName depending on which constructor will be used.
-     * 
+     *
      * @param names
      * @return
      */

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceMessageListener.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceMessageListener.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.listener;
 
+import com.codahale.metrics.Counter;
 import org.apache.camel.spi.UriEndpoint;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.message.CamelKapuaMessage;
@@ -24,8 +25,6 @@ import org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedMessage;
 import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.codahale.metrics.Counter;
 
 /**
  * Device messages listener (device life cycle).<br>
@@ -64,7 +63,7 @@ public class DeviceMessageListener extends AbstractListener {
 
     /**
      * Process a birth message.
-     * 
+     *
      * @param birthMessage
      */
     public void processBirthMessage(CamelKapuaMessage<KapuaBirthMessage> birthMessage) {
@@ -94,19 +93,18 @@ public class DeviceMessageListener extends AbstractListener {
             // return;
             // }
             // catch (Throwable t) {
-            // logger.warn("Cannot send birth life cycle message {}! {}", new Object[]{birthMessage.getMessage().getChannel().toString(), t.getMessage()}, t);
+            // logger.warn("Cannot send birth life cycle message {}! {}", birthMessage.getMessage().getChannel().toString(), t.getMessage(), t);
             // return;
             // }
         } catch (KapuaException e) {
             metricDeviceErrorMessage.inc();
             logger.error("Error while processing device birth life-cycle event", e);
-            return;
         }
     }
 
     /**
      * Process a disconnect message.
-     * 
+     *
      * @param disconnectMessage
      */
     public void processDisconnectMessage(CamelKapuaMessage<KapuaDisconnectMessage> disconnectMessage) {
@@ -116,13 +114,12 @@ public class DeviceMessageListener extends AbstractListener {
         } catch (KapuaException e) {
             metricDeviceErrorMessage.inc();
             logger.error("Error while processing device disconnect life-cycle event", e);
-            return;
         }
     }
 
     /**
      * Process an application message.
-     * 
+     *
      * @param appsMessage
      */
     public void processAppsMessage(CamelKapuaMessage<KapuaAppsMessage> appsMessage) {
@@ -132,13 +129,12 @@ public class DeviceMessageListener extends AbstractListener {
         } catch (KapuaException e) {
             metricDeviceErrorMessage.inc();
             logger.error("Error while processing device apps life-cycle event", e);
-            return;
         }
     }
 
     /**
      * Process a missing message.
-     * 
+     *
      * @param missingMessage
      */
     public void processMissingMessage(CamelKapuaMessage<KapuaMissingMessage> missingMessage) {
@@ -148,29 +144,26 @@ public class DeviceMessageListener extends AbstractListener {
         } catch (KapuaException e) {
             metricDeviceErrorMessage.inc();
             logger.error("Error while processing device missing life-cycle event", e);
-            return;
         }
     }
 
     /**
      * Process a notify message.
-     * 
+     *
      * @param notifyMessage
      */
     public void processNotifyMessage(CamelKapuaMessage<KapuaNotifyMessage> notifyMessage) {
-        logger.info("Received notify message from device channel: {}",
-                new Object[] { notifyMessage.getMessage().getChannel().toString() });
+        logger.info("Received notify message from device channel: {}", notifyMessage.getMessage().getChannel());
         metricDeviceNotifyMessage.inc();
     }
 
     /**
      * Process a unmatched message.
-     * 
+     *
      * @param unmatchedMessage
      */
     public void processUnmatchedMessage(CamelKapuaMessage<KapuaUnmatchedMessage> unmatchedMessage) {
-        logger.info("Received unmatched message from device channel: {}",
-                new Object[] { unmatchedMessage.getMessage().getChannel().toString() });
+        logger.info("Received unmatched message from device channel: {}", unmatchedMessage.getMessage().getChannel());
         metricDeviceUnmatchedMessage.inc();
     }
 

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListener.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListener.java
@@ -11,8 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.listener;
 
-import java.util.Base64;
-
+import com.codahale.metrics.Counter;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.UriEndpoint;
 import org.apache.commons.lang3.SerializationUtils;
@@ -21,19 +20,19 @@ import org.eclipse.kapua.broker.core.message.MessageConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.codahale.metrics.Counter;
+import java.util.Base64;
 
 @UriEndpoint(title = "error message processor", syntax = "bean:errorMessageListener", scheme = "bean")
 /**
  * Error message listener endpoint.
- * 
+ *
  * @since 1.0
  */
 public class ErrorMessageListener extends AbstractListener {
 
-    public final static String NO_EXCEPTION_FOUND_MESSAGE = "NO EXCEPTION FOUND!";
-
     private static final Logger logger = LoggerFactory.getLogger(ErrorMessageListener.class);
+
+    private static final String NO_EXCEPTION_FOUND_MESSAGE = "NO EXCEPTION FOUND!";
 
     private Counter metricError;
     private Counter metricErrorLifeCycleMessage;
@@ -46,7 +45,7 @@ public class ErrorMessageListener extends AbstractListener {
 
     /**
      * Process an error condition for an elaboration of a generic message
-     * 
+     *
      * @param exchange
      * @param message
      * @throws KapuaException
@@ -58,7 +57,7 @@ public class ErrorMessageListener extends AbstractListener {
 
     /**
      * Process an error condition for an elaboration of a life cycle message
-     * 
+     *
      * @param exchange
      * @param message
      * @throws KapuaException
@@ -70,7 +69,7 @@ public class ErrorMessageListener extends AbstractListener {
 
     /**
      * Process an error condition for an elaboration of a camel routing unmatched message
-     * 
+     *
      * @param exchange
      * @param message
      * @throws KapuaException
@@ -86,8 +85,7 @@ public class ErrorMessageListener extends AbstractListener {
         String encodedException = exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class);
         if (encodedException != null) {
             t = (Throwable) SerializationUtils.deserialize(Base64.getDecoder().decode(exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)));
-        }
-        else {
+        } else {
             // otherwise fallback to the exchange property or the exchange exception
             t = ((Throwable) exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION));
             if (t == null) {

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListener.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListener.java
@@ -30,7 +30,7 @@ import java.util.Base64;
  */
 public class ErrorMessageListener extends AbstractListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(ErrorMessageListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ErrorMessageListener.class);
 
     private static final String NO_EXCEPTION_FOUND_MESSAGE = "NO EXCEPTION FOUND!";
 
@@ -84,7 +84,7 @@ public class ErrorMessageListener extends AbstractListener {
         // looking at the property filled by the KapuaCamelFilter#bridgeError)
         String encodedException = exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class);
         if (encodedException != null) {
-            t = (Throwable) SerializationUtils.deserialize(Base64.getDecoder().decode(exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)));
+            t = SerializationUtils.deserialize(Base64.getDecoder().decode(exchange.getIn().getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)));
         } else {
             // otherwise fallback to the exchange property or the exchange exception
             t = ((Throwable) exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION));
@@ -92,21 +92,19 @@ public class ErrorMessageListener extends AbstractListener {
                 t = exchange.getException();
             }
         }
-        logger.warn("Processing error message for service {}... Message type {} - Endpoint {} - Error message {}",
-                new Object[] {
-                        serviceName,
-                        (message != null ? message.getClass().getName() : null),
-                        exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_ENDPOINT),
-                        t != null ? t.getMessage() : NO_EXCEPTION_FOUND_MESSAGE });
-        logger.warn("Exception: ", t);
+        LOG.warn("Processing error message for service {}... Message type {} - Endpoint {} - Error message {}",
+                serviceName,
+                (message != null ? message.getClass().getName() : null),
+                exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_ENDPOINT),
+                t != null ? t.getMessage() : NO_EXCEPTION_FOUND_MESSAGE);
+        LOG.warn("Exception: ", t);
     }
 
     private void logUnmatched(Exchange exchange, Object message, String serviceName) {
-        logger.warn("Processing unmatched message for service {}... Message type {} - Endpoint {}",
-                new Object[] {
-                        serviceName,
-                        (message != null ? message.getClass().getName() : null),
-                        exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_ENDPOINT) });
+        LOG.warn("Processing unmatched message for service {}... Message type {} - Endpoint {}",
+                serviceName,
+                (message != null ? message.getClass().getName() : null),
+                exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_ENDPOINT));
     }
 
 }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/MessageConstants.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/MessageConstants.java
@@ -26,8 +26,8 @@ public class MessageConstants {
     public static final String METRIC_ACCOUNT = "account";
     public static final String METRIC_CLIENT_ID = "clientId";
     public static final String METRIC_IP = "ip";
-    public final static String PROPERTY_ORIGINAL_TOPIC = "originalTopic";
-    public final static String PROPERTY_ENQUEUED_TIMESTAMP = "enqueuedTimestamp";
+    public static final String PROPERTY_ORIGINAL_TOPIC = "originalTopic";
+    public static final String PROPERTY_ENQUEUED_TIMESTAMP = "enqueuedTimestamp";
     public static final String PROPERTY_BROKER_ID = "brokerId";
     public static final String PROPERTY_CLIENT_ID = "clientId";
     public static final String PROPERTY_SCOPE_ID = "scopeId";

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/system/DefaultSystemMessageCreator.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/message/system/DefaultSystemMessageCreator.java
@@ -20,7 +20,7 @@ import org.eclipse.kapua.broker.core.plugin.KapuaConnectionContext;
  */
 public class DefaultSystemMessageCreator implements SystemMessageCreator {
 
-    private final static String CONNECT_MESSAGE_TEMPLATE = "Device: [%s] - connected by user: [%s]";
+    private static final String CONNECT_MESSAGE_TEMPLATE = "Device: [%s] - connected by user: [%s]";
 
     @Override
     public String createMessage(SystemMessageType systemMessageType, KapuaConnectionContext kbc) {

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIpResolver.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIpResolver.java
@@ -24,7 +24,7 @@ import org.eclipse.kapua.broker.core.setting.BrokerSettingKey;
  */
 public class DefaultBrokerIpResolver implements BrokerIpResolver {
 
-    private final static String CANNOT_FIND_IP_ERROR_MSG = "Cannot find the ip. Please check the configuration!";
+    private static final String CANNOT_FIND_IP_ERROR_MSG = "Cannot find the ip. Please check the configuration!";
     private String brokerIpOrHostName;
 
     public DefaultBrokerIpResolver() throws KapuaException {

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaApplicationBrokerFilter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaApplicationBrokerFilter.java
@@ -21,17 +21,17 @@ import org.slf4j.LoggerFactory;
 /**
  * ActiveMQ application filter plugin implementation (application context lifecycle filter).<br>
  * <br>
- * 
+ * <p>
  * Filter to startup/shutdown proprly the application context.<br>
  * <br>
- * 
+ * <p>
  * This filter is added inside ActiveMQ filter chain plugin by {@link org.eclipse.kapua.broker.core.KapuaBrokerApplicationPlugin}
- * 
+ *
  * @since 1.0
  */
 public class KapuaApplicationBrokerFilter extends BrokerFilter {
 
-    private final static Logger logger = LoggerFactory.getLogger(KapuaApplicationBrokerFilter.class);
+    private static final Logger logger = LoggerFactory.getLogger(KapuaApplicationBrokerFilter.class);
 
     // The following line must be done before any invocation of KapuaLocator.getInstance()
     private static ServiceModuleBundle application;
@@ -44,9 +44,11 @@ public class KapuaApplicationBrokerFilter extends BrokerFilter {
     public void start()
             throws Exception {
         logger.info(">>> Application broker filter: calling start...");
-        synchronized(KapuaApplicationBrokerFilter.class) {
+        synchronized (KapuaApplicationBrokerFilter.class) {
             if (application == null) {
-                application = new ServiceModuleBundle() {};
+                application = new ServiceModuleBundle() {
+
+                };
             }
             application.startup();
         }
@@ -59,7 +61,7 @@ public class KapuaApplicationBrokerFilter extends BrokerFilter {
             throws Exception {
         logger.info(">>> Application broker filter: calling stop...");
         super.stop();
-        synchronized(KapuaApplicationBrokerFilter.class) {
+        synchronized (KapuaApplicationBrokerFilter.class) {
             if (application != null) {
                 application.shutdown();
             }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaConnectionContext.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaConnectionContext.java
@@ -11,10 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin;
 
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.activemq.command.ConnectionInfo;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.KapuaPrincipal;
@@ -23,14 +19,18 @@ import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Connection information container
- * 
+ *
  * @since 1.0
  */
 public class KapuaConnectionContext {
 
-    protected final static Logger logger = LoggerFactory.getLogger(KapuaConnectionContext.class);
+    protected static final Logger logger = LoggerFactory.getLogger(KapuaConnectionContext.class);
 
     private String brokerId;
     private KapuaPrincipal principal;

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -246,12 +246,12 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
                 } catch (JMSException e1) {
                     // ignore it
                 }
-                logger.debug("Received connect message topic: '{}' - message id: '{}'", new Object[] { destination, messageId });
+                logger.debug("Received connect message topic: '{}' - message id: '{}'", destination, messageId);
                 String messageBrokerId;
                 try {
                     messageBrokerId = message.getStringProperty(MessageConstants.PROPERTY_BROKER_ID);
                     if (!brokerId.equals(messageBrokerId)) {
-                        logger.debug("Received connect message from another broker id: '{}' topic: '{}' - message id: '{}'", new Object[] { messageBrokerId, destination, messageId });
+                        logger.debug("Received connect message from another broker id: '{}' topic: '{}' - message id: '{}'", messageBrokerId, destination, messageId);
                         KapuaConnectionContext kcc = null;
                         // try parsing from message context (if the message is coming from other brokers it has these fields evaluated)
                         try {
@@ -263,7 +263,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
                             kcc = parseTopicInfo(message);
                         }
                         if (CONNECTION_MAP.get(kcc.getFullClientId()) != null) {
-                            logger.debug("Stealing link detected - broker id: '{}' topic: '{}' - message id: '{}'", new Object[] { messageBrokerId, destination, messageId });
+                            logger.debug("Stealing link detected - broker id: '{}' topic: '{}' - message id: '{}'", messageBrokerId, destination, messageId);
                             // iterate over all connected clients
                             for (Connection conn : getClients()) {
                                 logger.debug("Checking if {} equals {}", kcc.getFullClientId(), conn.getConnectionId());
@@ -287,7 +287,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
             private KapuaConnectionContext parseMessageSession(javax.jms.Message message) throws JMSException, KapuaException {
                 Long scopeId = message.propertyExists(MessageConstants.PROPERTY_SCOPE_ID) ? message.getLongProperty(MessageConstants.PROPERTY_SCOPE_ID) : null;
                 String clientId = message.getStringProperty(MessageConstants.PROPERTY_CLIENT_ID);
-                if (scopeId == null || scopeId.longValue() <= 0 || StringUtils.isEmpty(clientId)) {
+                if (scopeId == null || scopeId <= 0 || StringUtils.isEmpty(clientId)) {
                     logger.debug("Invalid message context. Try parsing the topic.");
                     throw new KapuaException(KapuaErrorCodes.ILLEGAL_ARGUMENT, "Invalid message context");
                 }
@@ -540,9 +540,8 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
 
     private void internalSend(ProducerBrokerExchange producerExchange, Message messageSend)
             throws Exception {
-        if (!StringUtils.containsNone(messageSend.getDestination().getPhysicalName(), new char[] { '+', '#' })) {
-            String message = MessageFormat.format("The caracters '+' and '#' cannot be included in a topic! Destination: {}",
-                    messageSend.getDestination());
+        if (!StringUtils.containsNone(messageSend.getDestination().getPhysicalName(), '+', '#')) {
+            String message = MessageFormat.format("The caracters '+' and '#' cannot be included in a topic! Destination: {0}", messageSend.getDestination());
             throw new SecurityException(message);
         }
         if (!isBrokerContext(producerExchange.getConnectionContext())) {

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthenticationLogic.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthenticationLogic.java
@@ -51,9 +51,9 @@ import java.util.Map;
  */
 public abstract class AuthenticationLogic {
 
-    protected final static Logger logger = LoggerFactory.getLogger(AuthenticationLogic.class);
+    protected static final Logger logger = LoggerFactory.getLogger(AuthenticationLogic.class);
 
-    protected final static String PERMISSION_LOG = "{0}/{1}/{2} - {3}";
+    protected static final String PERMISSION_LOG = "{0}/{1}/{2} - {3}";
 
     protected String aclHash;
     protected String aclAdvisory;

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/DefaultAuthenticator.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/DefaultAuthenticator.java
@@ -40,9 +40,9 @@ import java.util.Map;
  */
 public class DefaultAuthenticator implements Authenticator {
 
-    protected final static Logger logger = LoggerFactory.getLogger(DefaultAuthenticator.class);
+    protected static final Logger logger = LoggerFactory.getLogger(DefaultAuthenticator.class);
 
-    private final static String SYSTEM_MESSAGE_CREATOR_CLASS_NAME;
+    private static final String SYSTEM_MESSAGE_CREATOR_CLASS_NAME;
 
     static {
         SYSTEM_MESSAGE_CREATOR_CLASS_NAME = BrokerSetting.getInstance().getString(BrokerSettingKey.SYSTEM_MESSAGE_CREATOR_CLASS_NAME);

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/ClientMetric.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/ClientMetric.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin.metric;
 
+import com.codahale.metrics.Counter;
 import org.eclipse.kapua.commons.metric.MetricServiceFactory;
 import org.eclipse.kapua.commons.metric.MetricsService;
 
-import com.codahale.metrics.Counter;
-
 public class ClientMetric {
 
-    private final static ClientMetric CLIENT_METRIC = new ClientMetric();
+    private static final ClientMetric CLIENT_METRIC = new ClientMetric();
 
     private Counter connectedClient;
     private Counter connectedKapuasys;

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetric.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetric.java
@@ -11,15 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin.metric;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
 import org.eclipse.kapua.commons.metric.MetricServiceFactory;
 import org.eclipse.kapua.commons.metric.MetricsService;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Timer;
-
 public class LoginMetric {
 
-    private final static LoginMetric LOGIN_METRIC = new LoginMetric();
+    private static final LoginMetric LOGIN_METRIC = new LoginMetric();
 
     private Counter success;
     private Counter failure;

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/PublishMetric.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/PublishMetric.java
@@ -11,16 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin.metric;
 
-import org.eclipse.kapua.commons.metric.MetricServiceFactory;
-import org.eclipse.kapua.commons.metric.MetricsService;
-
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
+import org.eclipse.kapua.commons.metric.MetricServiceFactory;
+import org.eclipse.kapua.commons.metric.MetricsService;
 
 public class PublishMetric {
 
-    private final static PublishMetric PUBLISH_METRIC = new PublishMetric();
+    private static final PublishMetric PUBLISH_METRIC = new PublishMetric();
 
     private Counter allowedMessages;
     private Counter notAllowedMessages;

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/SubscribeMetric.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/SubscribeMetric.java
@@ -11,15 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin.metric;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
 import org.eclipse.kapua.commons.metric.MetricServiceFactory;
 import org.eclipse.kapua.commons.metric.MetricsService;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Timer;
-
 public class SubscribeMetric {
 
-    private final static SubscribeMetric SUBSCRIBE_METRIC = new SubscribeMetric();
+    private static final SubscribeMetric SUBSCRIBE_METRIC = new SubscribeMetric();
 
     private Counter allowedMessages;
     private Counter notAllowedMessages;

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/CamelKapuaDefaultRouter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/CamelKapuaDefaultRouter.java
@@ -11,15 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.router;
 
-import java.io.FileReader;
-import java.io.IOException;
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.stream.XMLStreamException;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Header;
 import org.apache.camel.Properties;
@@ -37,14 +28,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
+import javax.xml.bind.JAXBException;
+import javax.xml.stream.XMLStreamException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Default message router
- * 
+ *
  * @since 1.0
  */
 public class CamelKapuaDefaultRouter {
 
-    private final static Logger logger = LoggerFactory.getLogger(CamelKapuaDefaultRouter.class);
+    private static final Logger logger = LoggerFactory.getLogger(CamelKapuaDefaultRouter.class);
 
     private EndPointContainer endPointContainer;
 

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/CamelKapuaDefaultRouter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/CamelKapuaDefaultRouter.java
@@ -43,7 +43,7 @@ import java.util.Map;
  */
 public class CamelKapuaDefaultRouter {
 
-    private static final Logger logger = LoggerFactory.getLogger(CamelKapuaDefaultRouter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CamelKapuaDefaultRouter.class);
 
     private EndPointContainer endPointContainer;
 
@@ -55,13 +55,13 @@ public class CamelKapuaDefaultRouter {
         } catch (KapuaSettingException e) {
             throw new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, e, "Cannot find configuration file!");
         }
-        logger.info("Default Camel routing... Loading configuration from file {}", url.getFile());
+        LOG.info("Default Camel routing... Loading configuration from file {}", url.getFile());
         FileReader configurationFileReader = null;
         try {
             XmlUtil.setContextProvider(new BrokerJAXBContextProvider());
             configurationFileReader = new FileReader(url.getFile());
             endPointContainer = XmlUtil.unmarshal(configurationFileReader, EndPointContainer.class);
-            logger.info("Default Camel routing... Loading configuration from file {} Found {} parent endpoints in the route", configurationFileName,
+            LOG.info("Default Camel routing... Loading configuration from file {} Found {} parent endpoints in the route", configurationFileName,
                     (endPointContainer.getEndPoints() != null ? endPointContainer.getEndPoints().size() : 0));
             logLoadedEndPoints(endPointContainer.getEndPoints());
         } catch (XMLStreamException | JAXBException | SAXException | IOException e) {
@@ -71,17 +71,18 @@ public class CamelKapuaDefaultRouter {
                 try {
                     configurationFileReader.close();
                 } catch (IOException e) {
-                    logger.warn("Cannot close configuration file '{}'!", configurationFileName, e);
+                    LOG.warn("Cannot close configuration file '{}'!", configurationFileName, e);
                 }
             }
         }
-        logger.info("Default Camel routing... Loading configuration '{}' from file '{}' DONE", configurationFileName, url.getFile());
+        LOG.info("Default Camel routing... Loading configuration '{}' from file '{}' DONE", configurationFileName, url.getFile());
     }
 
     public String defaultRoute(Exchange exchange, Object value, @Header(Exchange.SLIP_ENDPOINT) String previous, @Properties Map<String, Object> properties) {
-        logger.trace("Received message on topic {} - Previous slip endpoint {} - id {}",
-                new Object[] { exchange.getIn().getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class), previous,
-                        exchange.getIn().getHeader(CamelConstants.JMS_CORRELATION_ID) });
+        LOG.trace("Received message on topic {} - Previous slip endpoint {} - id {}",
+                exchange.getIn().getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class),
+                previous,
+                exchange.getIn().getHeader(CamelConstants.JMS_CORRELATION_ID));
         for (EndPoint endPoint : endPointContainer.getEndPoints()) {
             if (endPoint.matches(exchange, value, previous, properties)) {
                 return endPoint.getEndpoint(exchange, value, previous, properties);
@@ -96,7 +97,7 @@ public class CamelKapuaDefaultRouter {
         for (EndPoint endPoint : endPoints) {
             endPoint.toLog(buffer, "");
         }
-        logger.info(buffer.toString());
+        LOG.info(buffer.toString());
     }
 
 }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointAdapter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointAdapter.java
@@ -11,19 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.router;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.dom.DOMSource;
-
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaRuntimeException;
@@ -36,15 +23,26 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.dom.DOMSource;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * {@link CamelKapuaDefaultRouter} {@link EndPoint} adapter
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class EndPointAdapter extends XmlAdapter<Element, List<EndPoint>> {
 
-    private final static Logger logger = LoggerFactory.getLogger(EndPointAdapter.class);
+    private static final Logger logger = LoggerFactory.getLogger(EndPointAdapter.class);
 
     public EndPointAdapter() {
     }

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/PlaceholderReplacer.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/PlaceholderReplacer.java
@@ -11,14 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.router;
 
-import java.util.HashMap;
-
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 
+import java.util.HashMap;
+
 public class PlaceholderReplacer {
 
-    private final static String REGEX_REPLACEMENT_CHARS = "([\\\\\\.\\)\\]\\}\\(‌​\\[\\{\\*\\+\\?\\^\\$\\|])";
+    private static final String REGEX_REPLACEMENT_CHARS = "([\\\\\\.\\)\\]\\}\\(‌​\\[\\{\\*\\+\\?\\^\\$\\|])";
 
     enum CAMEL_ROUTER_PLACEHOLDER {
         CLASSIFIER

--- a/broker-core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
+++ b/broker-core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
@@ -11,23 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.plugin;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.broker.core.setting.BrokerSetting;
 import org.eclipse.kapua.broker.core.setting.BrokerSettingKey;
-
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ConnectorDescriptorTest {
 
-    private final static String BROKER_IP_RESOLVER_CLASS_NAME;
+    private static final String BROKER_IP_RESOLVER_CLASS_NAME;
 
     static {
         BrokerSetting config = BrokerSetting.getInstance();
@@ -215,9 +214,9 @@ public class ConnectorDescriptorTest {
     /**
      * Code reused form KapuaSecurityBrokerFilter for instantiating broker ip resolver class.
      *
-     * @param clazz class that instantiates broker ip resolver
+     * @param clazz           class that instantiates broker ip resolver
      * @param defaultInstance default instance of class
-     * @param <T> generic type
+     * @param <T>             generic type
      * @return instance of ip resolver
      * @throws KapuaException
      */
@@ -226,7 +225,6 @@ public class ConnectorDescriptorTest {
         // lazy synchronization
         try {
             if (!StringUtils.isEmpty(clazz)) {
-                @SuppressWarnings("unchecked")
                 Class<T> clazzToInstantiate = (Class<T>) Class.forName(clazz);
                 instance = clazzToInstantiate.newInstance();
             } else {

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ValueTokenizer.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ValueTokenizer.java
@@ -12,16 +12,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration;
 
+import org.eclipse.kapua.commons.configuration.metatype.TscalarImpl;
+import org.eclipse.kapua.model.config.metatype.KapuaTad;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
-import org.eclipse.kapua.commons.configuration.metatype.TscalarImpl;
-import org.eclipse.kapua.model.config.metatype.KapuaTad;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The implementation of this class is inspired from the org.eclipse.equinox.metatype.impl.ValueTokenizer class
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ValueTokenizer {
 
-    private static final Logger logger = LoggerFactory.getLogger(ValueTokenizer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ValueTokenizer.class);
 
     private static final String VALUE_INVALID = "Value is invalid";
     private static final String NULL_VALUE_INVALID = "Null cannot be validated";
@@ -85,7 +85,7 @@ public class ValueTokenizer {
                 } else {
                     // If the ESCAPE character occurs as the last character
                     // of the string, log the error and ignore it.
-                    logger.error(VALUE_INVALID);
+                    LOG.error(VALUE_INVALID);
                 }
                 break;
             default:
@@ -154,7 +154,8 @@ public class ValueTokenizer {
         if (values.isEmpty()) {
             return null;
         }
-        return values.toArray(new String[values.size()]);
+
+        return values.toArray(new String[0]);
     }
 
     /**
@@ -166,15 +167,17 @@ public class ValueTokenizer {
         if (values.isEmpty()) {
             return null;
         }
+
         if (values.size() == 1) {
             return values.get(0);
         }
-        StringBuffer buffer = new StringBuffer(values.get(0));
+
+        StringBuilder builder = new StringBuilder(values.get(0));
         for (int i = 1; i < values.size(); i++) {
-            buffer.append(',');
-            buffer.append(values.get(i));
+            builder.append(',')
+                    .append(values.get(i));
         }
-        return buffer.toString();
+        return builder.toString();
     }
 
     /**
@@ -194,17 +197,17 @@ public class ValueTokenizer {
             // If the cardinality is zero, the value must contain one and only one token.
             if (cardinality == 0) {
                 if (values.size() != 1) {
-                    return MessageFormat.format(CARDINALITY_VIOLATION, new Object[] { getValuesAsString(), values.size(), 1, 1 });
+                    return MessageFormat.format(CARDINALITY_VIOLATION, getValuesAsString(), values.size(), 1, 1);
                 }
             }
             // Otherwise, the number of tokens must be between 0 and cardinality, inclusive.
             else if (values.size() > cardinality) {
-                return MessageFormat.format(CARDINALITY_VIOLATION, new Object[] { getValuesAsString(), values.size(), 0, cardinality });
+                return MessageFormat.format(CARDINALITY_VIOLATION, getValuesAsString(), values.size(), 0, cardinality);
             }
             // Now inspect each token.
             for (String s : values) {
                 // If options were declared and the value does not match one of them, the value is not valid.
-                if (!ad.getOption().isEmpty() && ad.getOption().stream().filter( option -> s.equals(option.getValue()) ).count() == 0) {
+                if (!ad.getOption().isEmpty() && ad.getOption().stream().filter(option -> s.equals(option.getValue())).count() == 0) {
                     return MessageFormat.format(VALUE_OUT_OF_OPTION, s);
                 }
                 // Check the type. Also check the range if min or max were declared.
@@ -258,9 +261,9 @@ public class ValueTokenizer {
                     // Seems unnecessary to impose any further restrictions.
                     break;
                 case CHAR:
-                    minVal = ad.getMin() == null ? null : Character.valueOf(ad.getMin().charAt(0));
-                    maxVal = ad.getMax() == null ? null : Character.valueOf(ad.getMax().charAt(0));
-                    Character charVal = Character.valueOf(s.charAt(0));
+                    minVal = ad.getMin() == null ? null : ad.getMin().charAt(0);
+                    maxVal = ad.getMax() == null ? null : ad.getMax().charAt(0);
+                    Character charVal = s.charAt(0);
                     if (minVal != null && charVal.compareTo((Character) minVal) < 0) {
                         rangeError = true;
                     } else if (maxVal != null && charVal.compareTo((Character) maxVal) > 0) {
@@ -308,7 +311,7 @@ public class ValueTokenizer {
             return ""; //$NON-NLS-1$
         } catch (Throwable t) {
             String message = MessageFormat.format(INTERNAL_ERROR, t.getMessage());
-            logger.debug(message, t);
+            LOG.debug(message, t);
             return message;
         }
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImpl.java
@@ -26,7 +26,7 @@ import javax.xml.namespace.QName;
 @XmlRegistry
 public class ObjectFactoryImpl {
 
-    private final static QName _MetaData_QNAME = new QName("http://www.osgi.org/xmlns/metatype/v1.2.0", "MetaData");
+    private static final QName _MetaData_QNAME = new QName("http://www.osgi.org/xmlns/metatype/v1.2.0", "MetaData");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes.
@@ -95,7 +95,7 @@ public class ObjectFactoryImpl {
      */
     @XmlElementDecl(namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0", name = "MetaData")
     public JAXBElement<TmetadataImpl> createMetaData(TmetadataImpl value) {
-        return new JAXBElement<TmetadataImpl>(_MetaData_QNAME, TmetadataImpl.class, null, value);
+        return new JAXBElement<>(_MetaData_QNAME, TmetadataImpl.class, null, value);
     }
 
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleBundle.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleBundle.java
@@ -11,17 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.core;
 
-import java.util.Set;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.event.ServiceEventBusManager;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Set;
+
 public class ServiceModuleBundle {
 
-    private final static Logger logger = LoggerFactory.getLogger(ServiceModuleBundle.class);
+    private static final Logger logger = LoggerFactory.getLogger(ServiceModuleBundle.class);
 
     public ServiceModuleBundle() {
         // Initialize the kapua locator

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/JsonServiceEventMarshaler.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/JsonServiceEventMarshaler.java
@@ -11,26 +11,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.event;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.stream.FactoryConfigurationError;
-import javax.xml.stream.XMLStreamException;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.event.ServiceEventBusException;
-
 import org.xml.sax.SAXException;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLStreamException;
 
 /**
  * Xml event bus marshaller implementation
- * 
+ *
  * @since 1.0
- * 
  */
 public class JsonServiceEventMarshaler implements ServiceEventMarshaler {
 
-    public final static String CONTENT_TYPE_JSON = "application/json";
+    public static final String CONTENT_TYPE_JSON = "application/json";
 
     @Override
     public String getContentType() {

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventBusManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventBusManager.java
@@ -11,25 +11,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.event;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.ServiceLoader;
-
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.event.ServiceEventBus;
 import org.eclipse.kapua.event.ServiceEventBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
 /**
  * Service event bus manager. It handles the service event bus life cycle
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class ServiceEventBusManager {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(ServiceEventBusManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceEventBusManager.class);
 
     public static final String JMS_20_EVENT_BUS = "JMS_20_EVENT_BUS";
 
@@ -61,7 +60,7 @@ public class ServiceEventBusManager {
 
     /**
      * Get the event bus instance
-     * 
+     *
      * @return
      * @throws ServiceEventBusException
      */
@@ -81,7 +80,7 @@ public class ServiceEventBusManager {
 
     /**
      * Start the event bus
-     * 
+     *
      * @throws ServiceEventBusException
      */
     public static void start() throws ServiceEventBusException {
@@ -93,7 +92,7 @@ public class ServiceEventBusManager {
 
     /**
      * Stop the event bus
-     * 
+     *
      * @throws ServiceEventBusException
      */
     public static void stop() throws ServiceEventBusException {

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventHousekeeper.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventHousekeeper.java
@@ -141,7 +141,11 @@ public class ServiceEventHousekeeper implements Runnable {
         if (!unsentMessagesList.isEmpty()) {
             for (EventStoreRecord kapuaEvent : unsentMessagesList.getItems()) {
                 try {
-                    LOGGER.info("publish event: service '{}' - operation '{}' - id '{}'", new Object[] { kapuaEvent.getService(), kapuaEvent.getOperation(), kapuaEvent.getContextId() });
+                    LOGGER.info("publish event: service '{}' - operation '{}' - id '{}'",
+                            kapuaEvent.getService(),
+                            kapuaEvent.getOperation(),
+                            kapuaEvent.getContextId());
+
                     eventbus.publish(serviceInternalEventAddress, ServiceEventUtil.toServiceEventBus(kapuaEvent));
                     //if message was sent successfully then confirm the event in the event table
                     //if something goes wrong during this update the event message may be raised twice (but this condition should happens rarely and it is compliant to the contract of the service events)

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventMarshaler.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventMarshaler.java
@@ -21,30 +21,30 @@ import org.eclipse.kapua.event.ServiceEvent;
  */
 public interface ServiceEventMarshaler {
 
-    public final static String CONTENT_TYPE_KEY = "ContentType";
+    String CONTENT_TYPE_KEY = "ContentType";
 
     /**
      * Return the encoded content type
-     * 
+     *
      * @return
      */
-    public String getContentType();
+    String getContentType();
 
     /**
      * Unmarshal the message received from the bus
-     * 
+     *
      * @param message
      * @return
      * @throws KapuaException
      */
-    public ServiceEvent unmarshal(String message) throws KapuaException;
+    ServiceEvent unmarshal(String message) throws KapuaException;
 
     /**
      * Marshal the message to the service event bus
-     * 
+     *
      * @param kapuaEvent
      * @throws KapuaException
      */
-    public String marshal(ServiceEvent kapuaEvent) throws KapuaException;
+    String marshal(ServiceEvent kapuaEvent) throws KapuaException;
 
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceMap.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceMap.java
@@ -11,18 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.event;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Utility class used to handle the mapping between services and address used to republish events.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class ServiceMap {
 
@@ -31,14 +30,14 @@ public class ServiceMap {
     //no need to have a concurrent map since:
     //if a service is not available (due to register process in progress) no event is sent
     //if a service is going to be deregistered may some event is still fired and will remain in the queue until the service consuming these events will come available later
-    private final static Map<String, String> AVAILABLE_SERVICES = new HashMap<>();
+    private static final Map<String, String> AVAILABLE_SERVICES = new HashMap<>();
 
     private ServiceMap() {
     }
 
     /**
      * Register the list of services to the provided address
-     * 
+     *
      * @param serviceAddress
      * @param servicesNames
      */
@@ -46,16 +45,14 @@ public class ServiceMap {
         for (String serviceName : servicesNames) {
             //register service name
             String tmpServiceName = AVAILABLE_SERVICES.get(serviceName);
-            if (tmpServiceName==null) {
+            if (tmpServiceName == null) {
                 AVAILABLE_SERVICES.put(serviceName, serviceAddress);
                 LOGGER.info("Bound service '{}' to address '{}'",
                         new Object[] { serviceName, serviceAddress });
-            }
-            else if (!serviceAddress.equals(tmpServiceName)) {
+            } else if (!serviceAddress.equals(tmpServiceName)) {
                 LOGGER.warn("The service '{}' is already registered with a different address (old '{}' - new '{}'). No change will be made",
                         new Object[] { serviceName, tmpServiceName, serviceAddress });
-            }
-            else {
+            } else {
                 LOGGER.info("The service '{}' is already registered with address '{}'",
                         new Object[] { serviceName, serviceAddress });
             }
@@ -64,7 +61,7 @@ public class ServiceMap {
 
     /**
      * Unregister the provided services from the addess map
-     * 
+     *
      * @param servicesNames
      */
     public static synchronized void unregisterServices(List<String> servicesNames) {
@@ -83,7 +80,7 @@ public class ServiceMap {
 
     /**
      * Get the address associated to the specific service
-     * 
+     *
      * @param serviceName
      * @return
      */

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceMap.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceMap.java
@@ -25,7 +25,7 @@ import java.util.Map;
  */
 public class ServiceMap {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceMap.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceMap.class);
 
     //no need to have a concurrent map since:
     //if a service is not available (due to register process in progress) no event is sent
@@ -47,14 +47,11 @@ public class ServiceMap {
             String tmpServiceName = AVAILABLE_SERVICES.get(serviceName);
             if (tmpServiceName == null) {
                 AVAILABLE_SERVICES.put(serviceName, serviceAddress);
-                LOGGER.info("Bound service '{}' to address '{}'",
-                        new Object[] { serviceName, serviceAddress });
+                LOG.info("Bound service '{}' to address '{}'", serviceName, serviceAddress);
             } else if (!serviceAddress.equals(tmpServiceName)) {
-                LOGGER.warn("The service '{}' is already registered with a different address (old '{}' - new '{}'). No change will be made",
-                        new Object[] { serviceName, tmpServiceName, serviceAddress });
+                LOG.warn("The service '{}' is already registered with a different address (old '{}' - new '{}'). No change will be made", serviceName, tmpServiceName, serviceAddress);
             } else {
-                LOGGER.info("The service '{}' is already registered with address '{}'",
-                        new Object[] { serviceName, serviceAddress });
+                LOG.info("The service '{}' is already registered with address '{}'", serviceName, serviceAddress);
             }
         }
     }
@@ -69,10 +66,9 @@ public class ServiceMap {
             for (String serviceName : servicesNames) {
                 String tmpServiceName = AVAILABLE_SERVICES.remove(serviceName);
                 if (tmpServiceName == null) {
-                    LOGGER.warn("Cannot deregister service '{}'. The service wasn't registered!", serviceName);
+                    LOG.warn("Cannot deregister service '{}'. The service wasn't registered!", serviceName);
                 } else {
-                    LOGGER.info("Deregistered service '{}' from address '{}'",
-                            new Object[] { serviceName, tmpServiceName });
+                    LOG.info("Deregistered service '{}' from address '{}'", serviceName, tmpServiceName);
                 }
             }
         }

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/XmlServiceEventMarshaler.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/XmlServiceEventMarshaler.java
@@ -11,26 +11,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.event;
 
-import javax.xml.bind.JAXBException;
-import javax.xml.stream.FactoryConfigurationError;
-import javax.xml.stream.XMLStreamException;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.event.ServiceEventBusException;
-
 import org.xml.sax.SAXException;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLStreamException;
 
 /**
  * Xml event bus marshaller implementation
- * 
+ *
  * @since 1.0
- * 
  */
 public class XmlServiceEventMarshaler implements ServiceEventMarshaler {
 
-    public final static String CONTENT_TYPE_XML = "application/xml";
+    public static final String CONTENT_TYPE_XML = "application/xml";
 
     @Override
     public String getContentType() {

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
@@ -11,27 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.event.jms;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.ExceptionListener;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageListener;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.jms.Topic;
-import javax.naming.Context;
-import javax.naming.NamingException;
-
 import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
@@ -55,22 +34,42 @@ import org.eclipse.kapua.event.ServiceEventBusListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
 /**
  * JMS event bus implementation
- * 
+ *
  * @since 1.0
  */
 public class JMSServiceEventBus implements ServiceEventBus, ServiceEventBusDriver, ExceptionListener {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(JMSServiceEventBus.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(JMSServiceEventBus.class);
 
-    private final static int PRODUCER_POOL_MIN_SIZE = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_PRODUCER_POOL_MIN_SIZE);
-    private final static int PRODUCER_POOL_MAX_SIZE = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_PRODUCER_POOL_MAX_SIZE);
-    private final static int PRODUCER_POOL_BORROW_WAIT = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_PRODUCER_POOL_BORROW_WAIT_MAX);
-    private final static int PRODUCER_POOL_EVICTION_INTERVAL = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_PRODUCER_EVICTION_INTERVAL);
-    private final static int CONSUMER_POOL_SIZE = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_CONSUMER_POOL_SIZE);
-    private final static String MESSAGE_SERIALIZER = SystemSetting.getInstance().getString(SystemSettingKey.EVENT_BUS_MESSAGE_SERIALIZER);
-    private final static String TRANSPORT_USE_EPOLL = SystemSetting.getInstance().getString(SystemSettingKey.EVENT_BUS_TRANSPORT_USE_EPOLL);
+    private static final int PRODUCER_POOL_MIN_SIZE = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_PRODUCER_POOL_MIN_SIZE);
+    private static final int PRODUCER_POOL_MAX_SIZE = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_PRODUCER_POOL_MAX_SIZE);
+    private static final int PRODUCER_POOL_BORROW_WAIT = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_PRODUCER_POOL_BORROW_WAIT_MAX);
+    private static final int PRODUCER_POOL_EVICTION_INTERVAL = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_PRODUCER_EVICTION_INTERVAL);
+    private static final int CONSUMER_POOL_SIZE = SystemSetting.getInstance().getInt(SystemSettingKey.EVENT_BUS_CONSUMER_POOL_SIZE);
+    private static final String MESSAGE_SERIALIZER = SystemSetting.getInstance().getString(SystemSettingKey.EVENT_BUS_MESSAGE_SERIALIZER);
+    private static final String TRANSPORT_USE_EPOLL = SystemSetting.getInstance().getString(SystemSettingKey.EVENT_BUS_TRANSPORT_USE_EPOLL);
 
     private List<Subscription> subscriptionList = new ArrayList<>();
     private EventBusJMSConnectionBridge eventBusJMSConnectionBridge;
@@ -78,7 +77,7 @@ public class JMSServiceEventBus implements ServiceEventBus, ServiceEventBusDrive
 
     /**
      * Default constructor
-     * 
+     *
      * @throws JMSException
      * @throws NamingException
      */
@@ -100,7 +99,7 @@ public class JMSServiceEventBus implements ServiceEventBus, ServiceEventBusDrive
 
     /**
      * Start the event bus
-     * 
+     *
      * @throws ServiceEventBusException
      */
     @Override
@@ -138,13 +137,13 @@ public class JMSServiceEventBus implements ServiceEventBus, ServiceEventBusDrive
         }
     }
 
-    private final void setSession(ServiceEvent kapuaEvent) {
+    private void setSession(ServiceEvent kapuaEvent) {
         KapuaSession.createFrom(kapuaEvent.getScopeId(), kapuaEvent.getUserId());
     }
 
     /**
      * Stop the event bus
-     * 
+     *
      * @throws ServiceEventBusException
      */
     @Override

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerSession.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerSession.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.jpa;
 
-import javax.persistence.PersistenceException;
-
 import org.eclipse.kapua.KapuaEntityExistsException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.event.ServiceEventScope;
@@ -26,6 +24,8 @@ import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.persistence.PersistenceException;
 
 /**
  * Entity manager session reference implementation.
@@ -259,7 +259,7 @@ public class EntityManagerSession {
                         logger.debug("Kapua event - update entity id to '{}'", ((KapuaEntity) instance).getId());
                         serviceEventBus.setEntityId(((KapuaEntity) instance).getId());
                     }
-                    logger.info("Entity '{}' with id '{}' found!", new Object[]{instance.getClass().getName(), ((KapuaEntity) instance).getId()});
+                    logger.info("Entity '{}' with id '{}' found!", instance.getClass().getName(), ((KapuaEntity) instance).getId());
                 }
 
                 //insert the kapua event only if it's a new entity

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
@@ -124,7 +124,7 @@ public class MetricsServiceImpl implements MetricsService {
      * @return
      */
     private String getMetricName(String module, String component, String... metricsName) {
-        return MessageFormat.format(METRICS_NAME_FORMAT, new Object[] { module, component, convertToDotNotation(metricsName) });
+        return MessageFormat.format(METRICS_NAME_FORMAT, module, component, convertToDotNotation(metricsName));
     }
 
     /**

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
@@ -11,15 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.metric;
 
-import java.text.MessageFormat;
-import java.util.concurrent.TimeUnit;
-
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.setting.system.SystemSetting;
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
@@ -27,6 +18,14 @@ import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.JmxReporter.Builder;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.MessageFormat;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Metric report exporter handler.
@@ -36,9 +35,9 @@ import com.codahale.metrics.Timer;
  */
 public class MetricsServiceImpl implements MetricsService {
 
-    private static Logger logger = LoggerFactory.getLogger(MetricsServiceImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(MetricsServiceImpl.class);
 
-    public final static String METRICS_NAME_FORMAT = "{0}.{1}.{2}";
+    public static final String METRICS_NAME_FORMAT = "{0}.{1}.{2}";
 
     private final MetricRegistry metricRegistry;
 
@@ -152,7 +151,7 @@ public class MetricsServiceImpl implements MetricsService {
      * <p>
      * The default is that JMX support is enabled
      * </p>
-     * 
+     *
      * @return {@code true} JMX should be enabled, {@code false} otherwise
      */
     private static boolean isJmxEnabled() {

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/IdGenerator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/IdGenerator.java
@@ -11,22 +11,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model.id;
 
-import java.math.BigInteger;
-import java.security.SecureRandom;
-
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
 
 /**
  * Generates random identifier
  *
  * @since 1.0
- *
  */
 public class IdGenerator {
 
-    private final static SecureRandom SECURE_RANDOM = new SecureRandom();
-    private final static int ID_SIZE = SystemSetting.getInstance().getInt(SystemSettingKey.KAPUA_KEY_SIZE);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int ID_SIZE = SystemSetting.getInstance().getInt(SystemSettingKey.KAPUA_KEY_SIZE);
 
     private IdGenerator() {
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSession.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSession.java
@@ -11,14 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.security;
 
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.KapuaPrincipal;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+
 import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authentication.KapuaPrincipal;
-import org.eclipse.kapua.service.authentication.token.AccessToken;
 
 /**
  * Kapua session
@@ -29,7 +29,7 @@ public class KapuaSession implements Serializable {
 
     private static final long serialVersionUID = -3831904230950408142L;
 
-    public final static String KAPUA_SESSION_KEY = "KapuaSession";
+    public static final String KAPUA_SESSION_KEY = "KapuaSession";
 
     private static final List<String> TRUSTED_CLASSES = new ArrayList<>();
     private static final String TRUST_CLASS_METHOD_PATTERN = "{0}.{1}";
@@ -115,7 +115,7 @@ public class KapuaSession implements Serializable {
      *
      * @return
      */
-    private final static boolean isCallerClassTrusted() {
+    private static boolean isCallerClassTrusted() {
         // the stack trace should be like
         // 0 ---> Thread
         // 1 ---> KapuaSession -> isCallerClassTrusted()
@@ -147,7 +147,7 @@ public class KapuaSession implements Serializable {
 
     /**
      * Constructs a {@link KapuaSession} with given parameter
-     * 
+     *
      * @param principal
      */
     public KapuaSession(KapuaPrincipal principal) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSetting.java
@@ -29,7 +29,7 @@ public class SystemSetting extends AbstractKapuaSetting<SystemSettingKey> {
     private static final String CONFIG_RESOURCE_NAME = "kapua-environment-setting.properties";
 
     private static final SystemSetting INSTANCE = new SystemSetting();
-    private final static String COMMONS_CONTROL_MESSAGE_CLASSIFIER = "commons.control_message.classifier";
+    private static final String COMMONS_CONTROL_MESSAGE_CLASSIFIER = "commons.control_message.classifier";
 
     // Constructors
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ClassUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ClassUtil.java
@@ -11,34 +11,33 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.util;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
 /**
  * Utility class to instantiate object through reflection
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class ClassUtil {
 
-    protected final static Logger logger = LoggerFactory.getLogger(ClassUtil.class);
+    protected static final Logger logger = LoggerFactory.getLogger(ClassUtil.class);
 
-    private final static String CANNOT_LOAD_INSTANCE_ERROR_MSG = "Cannot load instance %s for %s. Please check the configuration file!";
-    private final static String PARAMETER_ERROR_MSG = "Invalid parameters. Parameters types and values differ!";
+    private static final String CANNOT_LOAD_INSTANCE_ERROR_MSG = "Cannot load instance %s for %s. Please check the configuration file!";
+    private static final String PARAMETER_ERROR_MSG = "Invalid parameters. Parameters types and values differ!";
 
     private ClassUtil() {
     }
 
     /**
      * Create a class new instance (fallback to the default instance if something goes wrong)
-     * 
+     *
      * @param clazz
      * @param defaultInstance
      * @return
@@ -48,16 +47,13 @@ public class ClassUtil {
         return newInstance(clazz, defaultInstance, null, null);
     }
 
-    @SuppressWarnings("unchecked")
     /**
      * Create a class new instance by invoking the proper constructor (fallback to the default instance if something goes wrong)
-     * 
+     *
      * @param clazz
      * @param defaultInstance
-     * @param parameterTypes
-     *            constructor parameters type
-     * @param parameters
-     *            constructor parameters value
+     * @param parameterTypes  constructor parameters type
+     * @param parameters      constructor parameters value
      * @return
      * @throws KapuaException
      */
@@ -73,8 +69,7 @@ public class ClassUtil {
             } catch (ClassNotFoundException e) {
                 throw new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, e, String.format(CANNOT_LOAD_INSTANCE_ERROR_MSG, clazz, clazzToInstantiate));
             }
-        }
-        else {
+        } else {
             logger.info("Initializing instance of. Instantiate default instance {} ...", defaultInstance);
         }
         if (parameterTypes == null || parameterTypes.length <= 0) {
@@ -83,8 +78,7 @@ public class ClassUtil {
             } catch (InstantiationException | IllegalAccessException e) {
                 throw new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, e, String.format(CANNOT_LOAD_INSTANCE_ERROR_MSG, clazz, clazzToInstantiate));
             }
-        }
-        else {
+        } else {
             if (parameters == null || parameters.length != parameterTypes.length) {
                 throw new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, PARAMETER_ERROR_MSG);
             }

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ValidationRegex.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ValidationRegex.java
@@ -15,5 +15,5 @@ import java.util.regex.Pattern;
 
 public interface ValidationRegex {
 
-    public Pattern getPattern();
+    Pattern getPattern();
 }

--- a/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
@@ -88,7 +88,7 @@ public class KapuaDoPrivilegeTest {
         List<ScheduledFuture<Void>> doPrivilegeList = new ArrayList<>();
         for (int i = 0; i < CONCURRENT_THREAD; i++) {
             long delay = (long) (Math.random() * 200d);
-            logger.debug("Delay: ", new Object[] { delay });
+            logger.debug("Delay: ", delay);
             doPrivilegeList.add(es.schedule(new DoPrivilegeCallable("nosync_random_wait_" + i), delay, TimeUnit.MILLISECONDS));
         }
         waitForTermination(doPrivilegeList, executionTimeOut);
@@ -100,7 +100,7 @@ public class KapuaDoPrivilegeTest {
         doPrivilegeList.clear();
         for (int i = 0; i < CONCURRENT_THREAD; i++) {
             long delay = (long) (Math.random() * 100d);
-            logger.debug("Delay: ", new Object[] { delay });
+            logger.debug("Delay: ", delay);
             doPrivilegeList.add(es.schedule(new DoPrivilegeCallable("nosync_no_random_wait_" + i), delay, TimeUnit.MILLISECONDS));
         }
         waitForTermination(doPrivilegeList, executionTimeOut);
@@ -156,7 +156,7 @@ public class KapuaDoPrivilegeTest {
 
             if (executionProgress < MAX_EXECUTION) {
                 long wait = (long) (Math.random() * maxRandomWait);
-                logger.debug(callableName + " Wait: ", new Object[] { wait });
+                logger.debug(callableName + " Wait: ", wait);
                 Thread.sleep(wait);
                 KapuaSecurityUtils.doPrivileged(() -> doPrivilegeCode(Integer.valueOf(executionProgress.intValue() + 1)));
             }
@@ -164,9 +164,13 @@ public class KapuaDoPrivilegeTest {
             String kapuaSessionId = getKapuaSessionId();
 
             logger.debug("Execution: {} - KapuaSession object ID before {} - and after {} the nested DoPriviledge call",
-                    new Object[] { executionProgress.intValue(), originalKapuaSessionId, kapuaSessionId });
+                    executionProgress.intValue(),
+                    originalKapuaSessionId,
+                    kapuaSessionId);
+
             Assert.assertEquals("Wrong session ID!!! The do priledge method corrupted the KapuaSession", kapuaSessionId, originalKapuaSessionId);
-            return (Void) null;
+
+            return null;
         }
 
     }

--- a/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
@@ -11,6 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.security;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -19,24 +24,18 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Test the correctness of the doPrivilege calls.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class KapuaDoPrivilegeTest {
 
     private static Logger logger = LoggerFactory.getLogger(KapuaDoPrivilegeTest.class);
 
-    private final static int MAX_EXECUTION = 10;
-    private final static int CONCURRENT_THREAD = 20;
-    private final static int FIX_WAIT_TIME_FOR_EXECUTION_END = 30000;
+    private static final int MAX_EXECUTION = 10;
+    private static final int CONCURRENT_THREAD = 20;
+    private static final int FIX_WAIT_TIME_FOR_EXECUTION_END = 30000;
 
     private static long maxRandomWait;
 
@@ -60,7 +59,7 @@ public class KapuaDoPrivilegeTest {
         maxRandomWait = 100;
         ScheduledExecutorService es = Executors.newScheduledThreadPool(CONCURRENT_THREAD);
         long executionTimeOut = MAX_EXECUTION * maxRandomWait + FIX_WAIT_TIME_FOR_EXECUTION_END;
-        List<ScheduledFuture<Void>> doPrivilegeList = new ArrayList<ScheduledFuture<Void>>();
+        List<ScheduledFuture<Void>> doPrivilegeList = new ArrayList<>();
         for (int i = 0; i < CONCURRENT_THREAD; i++) {
             doPrivilegeList.add(es.schedule(new DoPrivilegeCallable("sync_random_wait_" + i), 0, TimeUnit.MILLISECONDS));
         }
@@ -86,7 +85,7 @@ public class KapuaDoPrivilegeTest {
         maxRandomWait = 100;
         ScheduledExecutorService es = Executors.newScheduledThreadPool(CONCURRENT_THREAD);
         long executionTimeOut = MAX_EXECUTION * maxRandomWait + FIX_WAIT_TIME_FOR_EXECUTION_END;
-        List<ScheduledFuture<Void>> doPrivilegeList = new ArrayList<ScheduledFuture<Void>>();
+        List<ScheduledFuture<Void>> doPrivilegeList = new ArrayList<>();
         for (int i = 0; i < CONCURRENT_THREAD; i++) {
             long delay = (long) (Math.random() * 200d);
             logger.debug("Delay: ", new Object[] { delay });

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlUtilTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlUtilTest.java
@@ -11,13 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.util.xml;
 
-import java.lang.reflect.Constructor;
-import org.eclipse.kapua.commons.util.xml.XmlUtil;
-
-import javax.xml.bind.JAXBException;
-
 import org.junit.Assert;
 import org.junit.Test;
+
+import javax.xml.bind.JAXBException;
+import java.lang.reflect.Constructor;
 
 public class XmlUtilTest extends Assert {
 
@@ -32,14 +30,13 @@ public class XmlUtilTest extends Assert {
     public void testSetContextProvider() {
         JAXBContextProvider provider = null;
         XmlUtil.setContextProvider(provider);
-
     }
 
     @Test
     public void testMarshal() throws Exception {
         Object[] jaxbElements = new Object[] { 123, "string", "s" };
         int sizeOfjaxbElements = jaxbElements.length;
-        Object[] jaxbElementsFalse = new Object[] {null};
+        Object[] jaxbElementsFalse = new Object[] { null };
         int sizeOfjaxbElementsFalse = jaxbElementsFalse.length;
         // JAXBException
         for (int i = 0; i < sizeOfjaxbElements; i++) {
@@ -63,7 +60,7 @@ public class XmlUtilTest extends Assert {
 
     @Test
     public void testUnmarshal() throws JAXBException {
-        String[] listOfStrings = new String[] {"string",null};
+        String[] listOfStrings = new String[] { "string", null };
         int sizeOfList = listOfStrings.length;
         for (int i = 0; i < sizeOfList; i++) {
             try {

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/UploadRequest.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/UploadRequest.java
@@ -69,7 +69,11 @@ class UploadRequest extends ServletFileUpload {
                 long sizeInBytes = item.getSize();
 
                 logger.debug("File upload item name: {}, fileName: {}, contentType: {}, isInMemory: {}, size: {}",
-                        new Object[] { fieldName, fileName, contentType, isInMemory, sizeInBytes });
+                        fieldName,
+                        fileName,
+                        contentType,
+                        isInMemory,
+                        sizeInBytes);
 
                 fileItems.add(item);
             }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
@@ -42,9 +42,9 @@ import java.util.List;
 
 public class AccountChildUserGrid extends EntityGrid<GwtUser> {
 
-    private static final GwtUserServiceAsync GWT_USER_SERVICE = GWT.create(GwtUserService.class);
+    private static final ConsoleUserMessages MSGS = GWT.create(ConsoleUserMessages.class);
 
-    private final static ConsoleUserMessages MSGS = GWT.create(ConsoleUserMessages.class);
+    private static final GwtUserServiceAsync GWT_USER_SERVICE = GWT.create(GwtUserService.class);
 
     private GwtUserQuery query;
     private AccountChildUserToolbar toolbar;

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/GwtKapuaException.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/GwtKapuaException.java
@@ -11,10 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.api.client;
 
-import java.util.MissingResourceException;
-
 import com.google.gwt.core.client.GWT;
 import org.eclipse.kapua.app.console.module.api.client.messages.ValidationMessages;
+
+import java.util.MissingResourceException;
 
 /**
  * The GwtKapuaException class is the superclass of all GWT errors and exceptions in the Kapua project. It extends the JDK Exception class by requesting its invokers to provide an error code
@@ -23,7 +23,6 @@ import org.eclipse.kapua.app.console.module.api.client.messages.ValidationMessag
  * exception messages to be reported. Exceptions messages are stored in the KapuaExceptionMessagesBundle Properties Bundle and they are keyed on the exception code.
  *
  * @author mcarrer
- *
  */
 public class GwtKapuaException extends Exception {
 
@@ -33,7 +32,6 @@ public class GwtKapuaException extends Exception {
     protected String[] arguments;
     protected Integer remainingLoginAttempts;
 
-    @SuppressWarnings("unused")
     private GwtKapuaException() {
         super();
     }
@@ -42,12 +40,10 @@ public class GwtKapuaException extends Exception {
         super(message);
     }
 
-    @SuppressWarnings("unused")
     private GwtKapuaException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    @SuppressWarnings("unused")
     private GwtKapuaException(Throwable t) {
         super(t);
     }
@@ -96,10 +92,12 @@ public class GwtKapuaException extends Exception {
         return errorCode;
     }
 
+    @Override
     public String getMessage() {
         return getLocalizedMessage();
     }
 
+    @Override
     public String getLocalizedMessage() {
 
         String msg = errorCode.toString();

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
@@ -44,7 +44,7 @@ import java.util.List;
 
 public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
 
-    private final static ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
+    private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
 
     protected GwtSession currentSession;
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
@@ -31,8 +31,9 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGrou
 
 public class GroupAddDialog extends EntityAddEditDialog {
 
-    private final static GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
-    private final static ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
+    private static final ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
+
+    private static final GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
 
     protected KapuaTextField<String> groupNameField;
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupDeleteDialog.java
@@ -11,23 +11,23 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authorization.client.group;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityDeleteDialog;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsoleGroupMessages;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGroupService;
-
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGroupServiceAsync;
 
 public class GroupDeleteDialog extends EntityDeleteDialog {
 
-    private static final GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
-    private GwtGroup gwtGroup;
-    private final static ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
+    private static final ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
 
+    private static final GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
+
+    private GwtGroup gwtGroup;
 
     public GroupDeleteDialog(GwtGroup gwtGroup) {
         this.gwtGroup = gwtGroup;

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
@@ -24,8 +24,10 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGrou
 
 public class GroupEditDialog extends GroupAddDialog {
 
-    private final static GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
-    private final static ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
+    private static final ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
+
+    private static final GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
+
     private GwtGroup selectedGroup;
 
     public GroupEditDialog(GwtSession currentSession, GwtGroup selectedGroup) {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
@@ -25,8 +25,8 @@ import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRoleQu
 
 public class RoleFilterPanel extends EntityFilterPanel<GwtRole> {
 
-    private final static ConsoleRoleMessages ROLE_MSGS = GWT.create(ConsoleRoleMessages.class);
-    private final static int WIDTH = 193;
+    private static final ConsoleRoleMessages ROLE_MSGS = GWT.create(ConsoleRoleMessages.class);
+    private static final int WIDTH = 193;
     private static final int MAX_LEN = 255;
 
     private final EntityGrid<GwtRole> entityGrid;

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 public class RoleGrid extends EntityGrid<GwtRole> {
 
-    private final static ConsoleRoleMessages ROLE_MSGS = GWT.create(ConsoleRoleMessages.class);
+    private static final ConsoleRoleMessages ROLE_MSGS = GWT.create(ConsoleRoleMessages.class);
 
     private static final GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
@@ -31,9 +31,9 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRole
 
 public class RoleAddDialog extends EntityAddEditDialog {
 
-    private final static ConsoleRoleMessages MSGS = GWT.create(ConsoleRoleMessages.class);
+    private static final ConsoleRoleMessages MSGS = GWT.create(ConsoleRoleMessages.class);
 
-    private final static GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
+    private static final GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
 
     protected KapuaTextField<String> roleNameField;
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
@@ -25,9 +25,9 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRole
 
 public class RoleEditDialog extends RoleAddDialog {
 
-    private final static ConsoleRoleMessages MSGS = GWT.create(ConsoleRoleMessages.class);
+    private static final ConsoleRoleMessages MSGS = GWT.create(ConsoleRoleMessages.class);
 
-    private final static GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
+    private static final GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
 
     private GwtRole selectedRole;
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
@@ -47,10 +47,11 @@ import java.util.List;
 
 public class RolePermissionAddDialog extends EntityAddEditDialog {
 
-    private final static ConsolePermissionMessages MSGS = GWT.create(ConsolePermissionMessages.class);
-    private final static GwtDomainRegistryServiceAsync DOMAIN_SERVICE = GWT.create(GwtDomainRegistryService.class);
-    private final static GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
-    private final static GwtDomainRegistryServiceAsync GWT_DOMAIN_SERVICE = GWT.create(GwtDomainRegistryService.class);
+    private static final ConsolePermissionMessages MSGS = GWT.create(ConsolePermissionMessages.class);
+
+    private static final GwtDomainRegistryServiceAsync DOMAIN_SERVICE = GWT.create(GwtDomainRegistryService.class);
+    private static final GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
+    private static final GwtDomainRegistryServiceAsync GWT_DOMAIN_SERVICE = GWT.create(GwtDomainRegistryService.class);
 
     private ComboBox<GwtDomain> domainsCombo;
     private SimpleComboBox<GwtAction> actionsCombo;

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -49,12 +49,12 @@ import java.util.List;
 
 public class PermissionAddDialog extends EntityAddEditDialog {
 
-    private final static ConsolePermissionMessages MSGS = GWT.create(ConsolePermissionMessages.class);
+    private static final ConsolePermissionMessages MSGS = GWT.create(ConsolePermissionMessages.class);
 
-    private final static GwtDomainRegistryServiceAsync GWT_DOMAIN_SERVICE = GWT.create(GwtDomainRegistryService.class);
-    private final static GwtAccessPermissionServiceAsync GWT_ACCESS_PERMISSION_SERVICE = GWT.create(GwtAccessPermissionService.class);
-    private final static GwtAccessInfoServiceAsync GWT_ACCESS_INFO_SERVICE = GWT.create(GwtAccessInfoService.class);
-    private final static GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
+    private static final GwtDomainRegistryServiceAsync GWT_DOMAIN_SERVICE = GWT.create(GwtDomainRegistryService.class);
+    private static final GwtAccessPermissionServiceAsync GWT_ACCESS_PERMISSION_SERVICE = GWT.create(GwtAccessPermissionService.class);
+    private static final GwtAccessInfoServiceAsync GWT_ACCESS_INFO_SERVICE = GWT.create(GwtAccessInfoService.class);
+    private static final GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
 
     private ComboBox<GwtDomain> domainsCombo;
     private SimpleComboBox<GwtAction> actionsCombo;
@@ -98,9 +98,9 @@ public class PermissionAddDialog extends EntityAddEditDialog {
     protected void onRender(Element parent, int pos) {
         super.onRender(parent, pos);
         submitButton.disable();
-            }
+    }
 
-            @Override
+    @Override
     public void createBody() {
         FormPanel permissionFormPanel = new FormPanel(FORM_LABEL_WIDTH);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -39,11 +39,12 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRole
 
 public class AccessRoleAddDialog extends EntityAddEditDialog {
 
-    private final static GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
-    private final static GwtAccessRoleServiceAsync GWT_ACCESS_ROLE_SERVICE = GWT.create(GwtAccessRoleService.class);
-    private final static GwtAccessInfoServiceAsync GWT_ACCESS_INFO_SERVICE = GWT.create(GwtAccessInfoService.class);
-
     private static final ConsolePermissionMessages MSGS = GWT.create(ConsolePermissionMessages.class);
+
+    private static final GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
+    private static final GwtAccessRoleServiceAsync GWT_ACCESS_ROLE_SERVICE = GWT.create(GwtAccessRoleService.class);
+    private static final GwtAccessInfoServiceAsync GWT_ACCESS_INFO_SERVICE = GWT.create(GwtAccessInfoService.class);
+
     private ComboBox<GwtRole> rolesCombo;
     private String accessInfoId;
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
@@ -34,9 +34,9 @@ import java.util.List;
 
 public class UserTabAccessRoleGrid extends EntityGrid<GwtAccessRole> {
 
-    private static final GwtAccessRoleServiceAsync GWT_ACCESS_ROLE_SERVICE = GWT.create(GwtAccessRoleService.class);
+    private static final ConsoleRoleMessages MSGS = GWT.create(ConsoleRoleMessages.class);
 
-    private final static ConsoleRoleMessages MSGS = GWT.create(ConsoleRoleMessages.class);
+    private static final GwtAccessRoleServiceAsync GWT_ACCESS_ROLE_SERVICE = GWT.create(GwtAccessRoleService.class);
 
     private String userId;
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -33,16 +33,16 @@ import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceConnect
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceConnectionOption;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceConnectionOptionService;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceConnectionOptionServiceAsync;
-import org.eclipse.kapua.app.console.module.user.shared.model.permission.UserSessionPermission;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
+import org.eclipse.kapua.app.console.module.user.shared.model.permission.UserSessionPermission;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserService;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserServiceAsync;
 
 public class ConnectionEditDialog extends EntityAddEditDialog {
 
-    private final static GwtUserServiceAsync GWT_USER_SERVICE = GWT.create(GwtUserService.class);
-    private final static GwtDeviceConnectionOptionServiceAsync GWT_CONNECTION_OPTION_SERVICE = GWT.create(GwtDeviceConnectionOptionService.class);
-    private final static ConsoleConnectionMessages MSGS = GWT.create(ConsoleConnectionMessages.class);
+    private static final GwtUserServiceAsync GWT_USER_SERVICE = GWT.create(GwtUserService.class);
+    private static final GwtDeviceConnectionOptionServiceAsync GWT_CONNECTION_OPTION_SERVICE = GWT.create(GwtDeviceConnectionOptionService.class);
+    private static final ConsoleConnectionMessages MSGS = GWT.create(ConsoleConnectionMessages.class);
 
     private GwtDeviceConnection selectedDeviceConnection;
     // Security Options fields

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -62,9 +62,9 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private static final ConsoleDeviceMessages DEVICE_MSGS = GWT.create(ConsoleDeviceMessages.class);
 
-    private final static String SERVLET_URL = "file/command";
+    private static final String SERVLET_URL = "file/command";
 
-    private final static int COMMAND_TIMEOUT_SECS = 60;
+    private static final int COMMAND_TIMEOUT_SECS = 60;
 
     // XSRF
     private final GwtSecurityTokenServiceAsync gwtXSRFService = GWT.create(GwtSecurityTokenService.class);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -33,10 +33,10 @@ import java.util.List;
 
 public class DeviceTagAddDialog extends EntityAddEditDialog {
 
-    private final static ConsoleDeviceMessages MSGS = GWT.create(ConsoleDeviceMessages.class);
+    private static final ConsoleDeviceMessages MSGS = GWT.create(ConsoleDeviceMessages.class);
 
-    private final static GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
-    private final static GwtDeviceServiceAsync GWT_DEVICE_SERVICE = GWT.create(GwtDeviceService.class);
+    private static final GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
+    private static final GwtDeviceServiceAsync GWT_DEVICE_SERVICE = GWT.create(GwtDeviceService.class);
 
     private ComboBox<GwtTag> tagsCombo;
 

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
@@ -32,8 +32,8 @@ import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointS
 
 public class EndpointAddDialog extends EntityAddEditDialog {
 
-    private final static GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
-    private final static ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
+    private static final GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
+    private static final ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
 
     protected KapuaTextField<String> endpointSchemaField;
     protected KapuaTextField<String> endpointDnsField;

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointDeleteDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointDeleteDialog.java
@@ -23,9 +23,11 @@ import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointS
 
 public class EndpointDeleteDialog extends EntityDeleteDialog {
 
+    private static final ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
+
     private static final GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
+
     private GwtEndpoint gwtEndpoint;
-    private final static ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
 
     public EndpointDeleteDialog(GwtEndpoint gwtEndpoint) {
         this.gwtEndpoint = gwtEndpoint;

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointEditDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointEditDialog.java
@@ -22,8 +22,8 @@ import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointS
 
 public class EndpointEditDialog extends EndpointAddDialog {
 
-    private final static GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
-    private final static ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
+    private static final GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
+    private static final ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
     private GwtEndpoint selectedEndpoint;
 
     public EndpointEditDialog(GwtSession currentSession, GwtEndpoint selectedEndpoint) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobFilterPanel.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobFilterPanel.java
@@ -25,8 +25,8 @@ import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobQuery;
 
 public class JobFilterPanel extends EntityFilterPanel<GwtJob> {
 
-    private final static ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
-    private final static int WIDTH = 193;
+    private static final ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
+    private static final int WIDTH = 193;
     private static final int MAX_LEN = 255;
 
     private final EntityGrid<GwtJob> entityGrid;

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
@@ -31,8 +31,9 @@ import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagServiceAsyn
 
 public class TagAddDialog extends EntityAddEditDialog {
 
-    private final static GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
-    private final static ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
+    private static final ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
+
+    private static final GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
 
     protected KapuaTextField<String> tagNameField;
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagDeleteDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagDeleteDialog.java
@@ -11,12 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.tag.client;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityDeleteDialog;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
-
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.tag.client.messages.ConsoleTagMessages;
 import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
 import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagService;
@@ -24,9 +23,11 @@ import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagServiceAsyn
 
 public class TagDeleteDialog extends EntityDeleteDialog {
 
+    private static final ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
+
     private static final GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
+
     private GwtTag gwtTag;
-    private final static ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
 
     public TagDeleteDialog(GwtTag gwtTag) {
         this.gwtTag = gwtTag;

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagEditDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagEditDialog.java
@@ -24,8 +24,8 @@ import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagServiceAsyn
 
 public class TagEditDialog extends TagAddDialog {
 
-    private final static GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
-    private final static ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
+    private static final GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
+    private static final ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
     private GwtTag selectedTag;
 
     public TagEditDialog(GwtSession currentSession, GwtTag selectedTag) {

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserFilterPanel.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserFilterPanel.java
@@ -27,8 +27,8 @@ import org.eclipse.kapua.app.console.module.user.shared.model.GwtUserQuery;
 
 public class UserFilterPanel extends EntityFilterPanel<GwtUser> {
 
-    private final static ConsoleUserMessages USER_MSGS = GWT.create(ConsoleUserMessages.class);
-    private final static int WIDTH = 193;
+    private static final ConsoleUserMessages USER_MSGS = GWT.create(ConsoleUserMessages.class);
+    private static final int WIDTH = 193;
     private static final int MAX_LEN = 255;
 
     private final EntityGrid<GwtUser> entityGrid;

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGrid.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGrid.java
@@ -32,9 +32,9 @@ import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolb
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.user.client.messages.ConsoleUserMessages;
-import org.eclipse.kapua.app.console.module.user.shared.model.permission.UserSessionPermission;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUserQuery;
+import org.eclipse.kapua.app.console.module.user.shared.model.permission.UserSessionPermission;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserService;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserServiceAsync;
 
@@ -48,8 +48,8 @@ public class UserGrid extends EntityGrid<GwtUser> {
 
     private static final GwtUserServiceAsync GWT_USER_SERVICE = GWT.create(GwtUserService.class);
 
-    private final static ConsoleUserMessages USER_MSGS = GWT.create(ConsoleUserMessages.class);
-    private final static ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
+    private static final ConsoleUserMessages USER_MSGS = GWT.create(ConsoleUserMessages.class);
+    private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
 
     public UserGrid(AbstractEntityView<GwtUser> entityView, GwtSession currentSession) {
         super(entityView, currentSession);

--- a/console/web/src/main/java/org/eclipse/kapua/app/console/server/util/ConsoleListener.java
+++ b/console/web/src/main/java/org/eclipse/kapua/app/console/server/util/ConsoleListener.java
@@ -11,42 +11,39 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.server.util;
 
-import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-
-import java.util.Optional;
-
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-
+import com.google.common.base.MoreObjects;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.ConsoleJAXBContextProvider;
 import org.eclipse.kapua.commons.core.ServiceModuleBundle;
+import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
 import org.eclipse.kapua.service.scheduler.quartz.SchedulerServiceInit;
-
-import com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.util.Optional;
+
 public class ConsoleListener implements ServletContextListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(ConsoleListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConsoleListener.class);
 
     private ServiceModuleBundle moduleBundle;
 
     @Override
     public void contextInitialized(final ServletContextEvent event) {
-        logger.info("Initialize Console JABContext Provider");
+        LOG.info("Initialize Console JABContext Provider");
         JAXBContextProvider consoleProvider = new ConsoleJAXBContextProvider();
         XmlUtil.setContextProvider(consoleProvider);
 
         SystemSetting config = SystemSetting.getInstance();
         if (config.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
-            logger.info("Initialize Liquibase embedded client.");
+            LOG.info("Initialize Liquibase embedded client.");
             String dbUsername = config.getString(SystemSettingKey.DB_USERNAME);
             String dbPassword = config.getString(SystemSettingKey.DB_PASSWORD);
             String schema = MoreObjects.firstNonNull(config.getString(SystemSettingKey.DB_SCHEMA_ENV), config.getString(SystemSettingKey.DB_SCHEMA));
@@ -55,32 +52,32 @@ public class ConsoleListener implements ServletContextListener {
             try {
                 Class.forName(config.getString(SystemSettingKey.DB_JDBC_DRIVER));
             } catch (ClassNotFoundException e) {
-                logger.warn("Could not find jdbc driver: {}", config.getString(SystemSettingKey.DB_JDBC_DRIVER));
+                LOG.warn("Could not find jdbc driver: {}", config.getString(SystemSettingKey.DB_JDBC_DRIVER));
             }
 
-            logger.debug("Starting Liquibase embedded client update - URL: {}, user/pass: {}/{}", new Object[] { JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword });
+            LOG.debug("Starting Liquibase embedded client update - URL: {}, user/pass: {}/{}", JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword);
             new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, Optional.of(schema)).update();
         }
 
         // start quarz scheduler
-        logger.info("Starting job scheduler...");
+        LOG.info("Starting job scheduler...");
         try {
             SchedulerServiceInit.initialize();
         } catch (KapuaException e) {
-            logger.error("Cannot start scheduler service: {}", e.getMessage(), e);
+            LOG.error("Cannot start scheduler service: {}", e.getMessage(), e);
         }
-        logger.info("Starting job scheduler... DONE");
+        LOG.info("Starting job scheduler... DONE");
 
         // Start service modules
         try {
-            logger.info("Starting service modules...");
+            LOG.info("Starting service modules...");
             if (moduleBundle == null) {
                 moduleBundle = new ServiceModuleBundle();
             }
             moduleBundle.startup();
-            logger.info("Starting service modules...DONE");
+            LOG.info("Starting service modules...DONE");
         } catch (KapuaException e) {
-            logger.error("Cannot start service modules: {}", e.getMessage(), e);
+            LOG.error("Cannot start service modules: {}", e.getMessage(), e);
         }
     }
 
@@ -88,20 +85,20 @@ public class ConsoleListener implements ServletContextListener {
     public void contextDestroyed(final ServletContextEvent event) {
         // stop event modules
         try {
-            logger.info("Stopping service modules...");
+            LOG.info("Stopping service modules...");
             if (moduleBundle != null) {
-                moduleBundle.shutdown();;
+                moduleBundle.shutdown();
                 moduleBundle = null;
             }
-            logger.info("Stopping service modules...DONE");
+            LOG.info("Stopping service modules...DONE");
         } catch (KapuaException e) {
-            logger.error("Cannot stop service modules: {}", e.getMessage(), e);
-        }       
+            LOG.error("Cannot stop service modules: {}", e.getMessage(), e);
+        }
 
         // stop quarz scheduler
-        logger.info("Stopping job scheduler...");
+        LOG.info("Stopping job scheduler...");
         SchedulerServiceInit.close();
-        logger.info("Stopping job scheduler... DONE");
+        LOG.info("Stopping job scheduler... DONE");
     }
 
 }

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,10 +19,10 @@ import org.eclipse.kapua.service.job.JobDomain;
 
 public interface JobEngineService extends KapuaService, KapuaDomainService<JobDomain> {
 
-    public static final JobDomain JOB_DOMAIN = new JobDomain();
+    JobDomain JOB_DOMAIN = new JobDomain();
 
     @Override
-    public default JobDomain getServiceDomain() {
+    default JobDomain getServiceDomain() {
         return JOB_DOMAIN;
     }
 
@@ -34,7 +34,7 @@ public interface JobEngineService extends KapuaService, KapuaDomainService<JobDo
      * @throws KapuaException if something goes bad when starting the job
      * @since 1.0.0
      */
-    public void startJob(KapuaId scopeId, KapuaId jobId) throws KapuaException;
+    void startJob(KapuaId scopeId, KapuaId jobId) throws KapuaException;
 
     /**
      * Starts the {@link org.eclipse.kapua.service.job.Job} with the given {@link JobStartOptions}.
@@ -45,7 +45,7 @@ public interface JobEngineService extends KapuaService, KapuaDomainService<JobDo
      * @throws KapuaException if something goes bad when starting the job
      * @since 1.0.0
      */
-    public void startJob(KapuaId scopeId, KapuaId jobId, JobStartOptions jobStartOptions) throws KapuaException;
+    void startJob(KapuaId scopeId, KapuaId jobId, JobStartOptions jobStartOptions) throws KapuaException;
 
     /**
      * Checks whether or not the {@link org.eclipse.kapua.service.job.Job} is running.
@@ -56,7 +56,7 @@ public interface JobEngineService extends KapuaService, KapuaDomainService<JobDo
      * @throws KapuaException if something goes bad when checking the status of the job
      * @since 1.0.0
      */
-    public boolean isRunning(KapuaId scopeId, KapuaId jobId) throws KapuaException;
+    boolean isRunning(KapuaId scopeId, KapuaId jobId) throws KapuaException;
 
     /**
      * Stops the {@link org.eclipse.kapua.service.job.Job}.
@@ -72,6 +72,6 @@ public interface JobEngineService extends KapuaService, KapuaDomainService<JobDo
      * @throws KapuaException if something goes bad when checking the status of the job
      * @since 1.0.0
      */
-    public void stopJob(KapuaId scopeId, KapuaId jobId) throws KapuaException;
+    void stopJob(KapuaId scopeId, KapuaId jobId) throws KapuaException;
 
 }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
@@ -49,7 +49,7 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
     public void beforeJob() throws Exception {
         JobContextWrapper jobContextWrapper = new JobContextWrapper(jobContext);
 
-        LOG.info("JOB {} - {} - Running before job...", new Object[] { jobContextWrapper.getJobId(), jobContextWrapper.getJobName() });
+        LOG.info("JOB {} - {} - Running before job...", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());
 
         JobExecutionCreator jobExecutionCreator = JOB_EXECUTION_FACTORY.newCreator(jobContextWrapper.getScopeId());
 
@@ -68,14 +68,14 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
             throw new KapuaIllegalStateException(String.format("Cannot start job [%s]. Another instance of this job is running.", jobContextWrapper.getJobName()));
         }
 
-        LOG.info("JOB {} - {} - Running before job... DONE!", new Object[] { jobContextWrapper.getJobId(), jobContextWrapper.getJobName() });
+        LOG.info("JOB {} - {} - Running before job... DONE!", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());
     }
 
     @Override
     public void afterJob() throws Exception {
         JobContextWrapper jobContextWrapper = new JobContextWrapper(jobContext);
 
-        LOG.info("JOB {} - {} - Running after job...", new Object[] { jobContextWrapper.getJobId(), jobContextWrapper.getJobName() });
+        LOG.info("JOB {} - {} - Running after job...", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());
 
         KapuaId kapuaExecutionId = jobContextWrapper.getKapuaExecutionId();
         if (kapuaExecutionId == null) {
@@ -90,6 +90,6 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
 
         KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.update(jobExecution));
 
-        LOG.info("JOB {} - {} - Running after job... DONE!", new Object[] { jobContextWrapper.getJobId(), jobContextWrapper.getJobName() });
+        LOG.info("JOB {} - {} - Running after job... DONE!", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());
     }
 }

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
@@ -12,17 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.guice;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.multibindings.Multibinder;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaRuntimeException;
@@ -37,14 +34,16 @@ import org.eclipse.kapua.service.KapuaService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.reflect.ClassPath;
-import com.google.common.reflect.ClassPath.ClassInfo;
-import com.google.inject.AbstractModule;
-import com.google.inject.Singleton;
-import com.google.inject.matcher.Matcher;
-import com.google.inject.matcher.Matchers;
-import com.google.inject.multibindings.Multibinder;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class KapuaModule extends AbstractModule {
 
@@ -176,14 +175,13 @@ public class KapuaModule extends AbstractModule {
             // Bind service modules
             logger.info("Binding service modules ..");
             //cast is safe by design
-            multibinders.put(ServiceModule.class, (Multibinder<Class<?>>) Multibinder.newSetBinder(binder(), (Class<?>)ServiceModule.class));
+            multibinders.put(ServiceModule.class, (Multibinder<Class<?>>) Multibinder.newSetBinder(binder(), (Class<?>) ServiceModule.class));
             for (Class<?> clazz : providers) {
                 if (ServiceModule.class.isAssignableFrom(clazz)) {
-                    @SuppressWarnings("rawtypes")
                     ComponentResolver resolver = ComponentResolver.newInstance(ServiceModule.class, clazz);
                     //cast is safe by design
                     if (resolver.getProvidedClass().isAssignableFrom(clazz)) {
-                        logger.info("Assignable from {}", new Object[]{resolver.getProvidedClass(), clazz});
+                        logger.info("Assignable from {}", resolver.getProvidedClass(), clazz);
                         multibinders.get(resolver.getProvidedClass()).addBinding().to(resolver.getImplementationClass());
                     }
                     continue;

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiListener.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiListener.java
@@ -11,33 +11,31 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.web;
 
-import java.util.Optional;
-
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-
+import com.google.common.base.MoreObjects;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.core.ServiceModuleBundle;
 import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
-
-import com.google.common.base.MoreObjects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import java.util.Optional;
+
 public class RestApiListener implements ServletContextListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(RestApiListener.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RestApiListener.class);
 
     private ServiceModuleBundle moduleBundle;
 
     @Override
     public void contextInitialized(final ServletContextEvent event) {
         SystemSetting config = SystemSetting.getInstance();
-        if(config.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
-            logger.info("Initialize Liquibase embedded client.");
+        if (config.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
+            LOG.info("Initialize Liquibase embedded client.");
             String dbUsername = config.getString(SystemSettingKey.DB_USERNAME);
             String dbPassword = config.getString(SystemSettingKey.DB_PASSWORD);
             String schema = MoreObjects.firstNonNull(config.getString(SystemSettingKey.DB_SCHEMA_ENV), config.getString(SystemSettingKey.DB_SCHEMA));
@@ -46,23 +44,24 @@ public class RestApiListener implements ServletContextListener {
             try {
                 Class.forName(config.getString(SystemSettingKey.DB_JDBC_DRIVER));
             } catch (ClassNotFoundException e) {
-                logger.warn("Could not find jdbc driver: {}", config.getString(SystemSettingKey.DB_JDBC_DRIVER));
+                LOG.warn("Could not find jdbc driver: {}", config.getString(SystemSettingKey.DB_JDBC_DRIVER));
             }
 
-            logger.debug("Starting Liquibase embedded client update - URL: {}, user/pass: {}/{}", new Object[]{JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword});
+            LOG.debug("Starting Liquibase embedded client update - URL: {}, user/pass: {}/{}", JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword);
+
             new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, Optional.of(schema)).update();
         }
 
         // Start service modules
         try {
-            logger.info("Starting service modules...");
+            LOG.info("Starting service modules...");
             if (moduleBundle == null) {
                 moduleBundle = new ServiceModuleBundle();
             }
             moduleBundle.startup();
-            logger.info("Starting service modules...DONE");
+            LOG.info("Starting service modules...DONE");
         } catch (KapuaException e) {
-            logger.error("Cannot start service modules: {}", e.getMessage(), e);
+            LOG.error("Cannot start service modules: {}", e.getMessage(), e);
         }
     }
 
@@ -70,15 +69,15 @@ public class RestApiListener implements ServletContextListener {
     public void contextDestroyed(final ServletContextEvent event) {
         // stop event modules
         try {
-            logger.info("Stopping service modules...");
+            LOG.info("Stopping service modules...");
             if (moduleBundle != null) {
                 moduleBundle.shutdown();
                 moduleBundle = null;
             }
-            logger.info("Stopping service modules...DONE");
+            LOG.info("Stopping service modules...DONE");
         } catch (KapuaException e) {
-            logger.error("Cannot stop service modules: {}", e.getMessage(), e);
-        }       
+            LOG.error("Cannot stop service modules: {}", e.getMessage(), e);
+        }
     }
 
 }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
@@ -11,65 +11,63 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account;
 
+import org.eclipse.kapua.model.KapuaNamedEntity;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
 import java.util.List;
 
-import org.eclipse.kapua.model.KapuaNamedEntity;
-
 /**
- * User account entity.
- * 
- * @since 1.0
+ * {@link Account} {@link org.eclipse.kapua.model.KapuaEntity}.
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "account")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "organization",
-        "parentAccountPath" }, factoryClass = AccountXmlRegistry.class, factoryMethod = "newAccount")
+@XmlType(factoryClass = AccountXmlRegistry.class, factoryMethod = "newAccount")
 public interface Account extends KapuaNamedEntity {
 
-    public static final String TYPE = "account";
+    String TYPE = "account";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Get the account's organization
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organization")
-    public Organization getOrganization();
+    Organization getOrganization();
 
     /**
      * Set the account's organization
-     * 
+     *
      * @param organization
      */
-    public void setOrganization(Organization organization);
+    void setOrganization(Organization organization);
 
     /**
      * Return the parent account path.<br>
      * The account path is a '/' separated list of the parents account identifiers in reverse order (so it should be read from right to left).<br>
      * e.g. The parent account path 7/14/15 mens that the current account has 15 as parent, then 15 has 14 as parent and 14 has 7 as parent.
-     * 
+     *
      * @return
      */
     @XmlElement(name = "parentAccountPath")
-    public String getParentAccountPath();
+    String getParentAccountPath();
 
     /**
      * Set the parent account path.
-     * 
+     *
      * @param parentAccountPath
      */
-    public void setParentAccountPath(String parentAccountPath);
+    void setParentAccountPath(String parentAccountPath);
 
-    public List<Account> getChildAccounts();
+    List<Account> getChildAccounts();
 }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
@@ -11,20 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account;
 
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.KapuaNamedEntityCreator;
-
 /**
  * AccountCreator encapsulates all the information needed to create a new Account in the system.<br>
  * The data provided will be used to seed the new Account and its related information such as the associated organization and users.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "accountCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -42,151 +41,151 @@ public interface AccountCreator extends KapuaNamedEntityCreator<Account> {
 
     /**
      * Get the organization name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationName")
-    public String getOrganizationName();
+    String getOrganizationName();
 
     /**
      * Set the organization name
-     * 
+     *
      * @param organizationName
      */
-    public void setOrganizationName(String organizationName);
+    void setOrganizationName(String organizationName);
 
     /**
      * Get organization referent name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationPersonName")
-    public String getOrganizationPersonName();
+    String getOrganizationPersonName();
 
     /**
      * Set organization referent name
-     * 
+     *
      * @param organizationPersonName
      */
-    public void setOrganizationPersonName(String organizationPersonName);
+    void setOrganizationPersonName(String organizationPersonName);
 
     /**
      * Get the organization email
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationEmail")
-    public String getOrganizationEmail();
+    String getOrganizationEmail();
 
     /**
      * Set the organization email
-     * 
+     *
      * @param organizationEmail
      */
-    public void setOrganizationEmail(String organizationEmail);
+    void setOrganizationEmail(String organizationEmail);
 
     /**
      * Get the organization phone number
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationPhoneNumber")
-    public String getOrganizationPhoneNumber();
+    String getOrganizationPhoneNumber();
 
     /**
      * Set the organization phone number
-     * 
+     *
      * @param organizationPhoneNumber
      */
-    public void setOrganizationPhoneNumber(String organizationPhoneNumber);
+    void setOrganizationPhoneNumber(String organizationPhoneNumber);
 
     /**
      * Get organization address (first line)
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationAddressLine1")
-    public String getOrganizationAddressLine1();
+    String getOrganizationAddressLine1();
 
     /**
      * Set organization address (first line)
-     * 
+     *
      * @param organizationAddressLine1
      */
-    public void setOrganizationAddressLine1(String organizationAddressLine1);
+    void setOrganizationAddressLine1(String organizationAddressLine1);
 
     /**
      * Get organization address (second line)
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationAddressLine2")
-    public String getOrganizationAddressLine2();
+    String getOrganizationAddressLine2();
 
     /**
      * Set organization address (second line)
-     * 
+     *
      * @param organizationAddressLine2
      */
-    public void setOrganizationAddressLine2(String organizationAddressLine2);
+    void setOrganizationAddressLine2(String organizationAddressLine2);
 
     /**
      * Get the organization city
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationCity")
-    public String getOrganizationCity();
+    String getOrganizationCity();
 
     /**
      * Set the organization city
-     * 
+     *
      * @param organizationCity
      */
-    public void setOrganizationCity(String organizationCity);
+    void setOrganizationCity(String organizationCity);
 
     /**
      * Get organization postal zip code
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationZipPostCode")
-    public String getOrganizationZipPostCode();
+    String getOrganizationZipPostCode();
 
     /**
      * Set organization postal zip code
-     * 
+     *
      * @param organizationZipPostCode
      */
-    public void setOrganizationZipPostCode(String organizationZipPostCode);
+    void setOrganizationZipPostCode(String organizationZipPostCode);
 
     /**
      * Get organization province or state (if it is a federal state) within a country
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationStateProvinceCounty")
-    public String getOrganizationStateProvinceCounty();
+    String getOrganizationStateProvinceCounty();
 
     /**
      * Set organization province or state (if it is a federal state) within a country
-     * 
+     *
      * @param organizationStateProvinceCounty
      */
-    public void setOrganizationStateProvinceCounty(String organizationStateProvinceCounty);
+    void setOrganizationStateProvinceCounty(String organizationStateProvinceCounty);
 
     /**
      * Get the organization country
-     * 
+     *
      * @return
      */
     @XmlElement(name = "organizationCountry")
-    public String getOrganizationCountry();
+    String getOrganizationCountry();
 
     /**
      * Set the organization country
-     * 
+     *
      * @param organizationCountry
      */
-    public void setOrganizationCountry(String organizationCountry);
+    void setOrganizationCountry(String organizationCountry);
 }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountFactory.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountFactory.java
@@ -16,26 +16,25 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * Account factory service definition.
- * 
+ *
  * @since 1.0
- * 
  */
 public interface AccountFactory extends KapuaEntityFactory<Account, AccountCreator, AccountQuery, AccountListResult> {
 
     /**
      * Creates a new {@link AccountCreator} for the specified name
-     * 
+     *
      * @param scopeId
      * @param name
      * @return
      */
-    public AccountCreator newCreator(KapuaId scopeId, String name);
+    AccountCreator newCreator(KapuaId scopeId, String name);
 
     /**
      * Creates a new organization entity
-     * 
+     *
      * @return
      */
-    public Organization newOrganization();
+    Organization newOrganization();
 
 }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountPredicates.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountPredicates.java
@@ -15,9 +15,6 @@ import org.eclipse.kapua.model.KapuaNamedEntityPredicates;
 
 public interface AccountPredicates extends KapuaNamedEntityPredicates {
 
-    /**
-     * The {@link Account} name.
-     */
     String PARENT_ACCOUNT_PATH = "parentAccountPath";
 
     String CHILD_ACCOUNTS = "childAccounts";

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountService.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountService.java
@@ -33,10 +33,10 @@ public interface AccountService extends KapuaEntityService<Account, AccountCreat
         KapuaDomainService<AccountDomain>,
         KapuaConfigurableService {
 
-    public static final AccountDomain ACCOUNT_DOMAIN = new AccountDomain();
+    AccountDomain ACCOUNT_DOMAIN = new AccountDomain();
 
     @Override
-    public default AccountDomain getServiceDomain() {
+    default AccountDomain getServiceDomain() {
         return ACCOUNT_DOMAIN;
     }
 
@@ -47,8 +47,7 @@ public interface AccountService extends KapuaEntityService<Account, AccountCreat
      * @return
      * @throws KapuaException
      */
-    public Account find(KapuaId id)
-            throws KapuaException;
+    Account find(KapuaId id) throws KapuaException;
 
     /**
      * Returns the {@link AccountListResult} with elements matching the provided query.
@@ -59,8 +58,7 @@ public interface AccountService extends KapuaEntityService<Account, AccountCreat
      * @since 1.0.0
      */
     @Override
-    public AccountListResult query(KapuaQuery<Account> query)
-            throws KapuaException;
+    AccountListResult query(KapuaQuery<Account> query) throws KapuaException;
 
     /**
      * Returns a List of direct child account of the provided account identifier
@@ -69,6 +67,5 @@ public interface AccountService extends KapuaEntityService<Account, AccountCreat
      * @return List of direct child account of an account
      * @throws KapuaException
      */
-    public AccountListResult findChildsRecursively(KapuaId accountId)
-            throws KapuaException;
+    AccountListResult findChildsRecursively(KapuaId accountId) throws KapuaException;
 }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/Organization.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/Organization.java
@@ -17,9 +17,8 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Organization entity
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = AccountXmlRegistry.class, factoryMethod = "newOrganization")
@@ -27,141 +26,141 @@ public interface Organization {
 
     /**
      * Get the organization name
-     * 
+     *
      * @return
      */
-    public String getName();
+    String getName();
 
     /**
      * Set the organization name
-     * 
+     *
      * @param name
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get organization referent name
-     * 
+     *
      * @return
      */
-    public String getPersonName();
+    String getPersonName();
 
     /**
      * Set organization referent name
-     * 
+     *
      * @param name
      */
-    public void setPersonName(String name);
+    void setPersonName(String name);
 
     /**
      * Get the organization email
-     * 
+     *
      * @return
      */
-    public String getEmail();
+    String getEmail();
 
     /**
      * Set the organization email
-     * 
+     *
      * @param email
      */
-    public void setEmail(String email);
+    void setEmail(String email);
 
     /**
      * Get the organization phone number
-     * 
+     *
      * @return
      */
-    public String getPhoneNumber();
+    String getPhoneNumber();
 
     /**
      * Set the organization phone number
-     * 
+     *
      * @param phoneNumber
      */
-    public void setPhoneNumber(String phoneNumber);
+    void setPhoneNumber(String phoneNumber);
 
     /**
      * Get organization address (first line)
-     * 
+     *
      * @return
      */
-    public String getAddressLine1();
+    String getAddressLine1();
 
     /**
      * Set organization address (first line)
-     * 
+     *
      * @param addressLine1
      */
-    public void setAddressLine1(String addressLine1);
+    void setAddressLine1(String addressLine1);
 
     /**
      * Get organization address (second line)
-     * 
+     *
      * @return
      */
-    public String getAddressLine2();
+    String getAddressLine2();
 
     /**
      * Set organization address (second line)
-     * 
+     *
      * @param addressLine2
      */
-    public void setAddressLine2(String addressLine2);
+    void setAddressLine2(String addressLine2);
 
     /**
      * Get organization postal zip code
-     * 
+     *
      * @return
      */
-    public String getZipPostCode();
+    String getZipPostCode();
 
     /**
      * Set organization postal zip code
-     * 
+     *
      * @param zipPostalCode
      */
-    public void setZipPostCode(String zipPostalCode);
+    void setZipPostCode(String zipPostalCode);
 
     /**
      * Get the organization city
-     * 
+     *
      * @return
      */
-    public String getCity();
+    String getCity();
 
     /**
      * Set the organization city
-     * 
+     *
      * @param city
      */
-    public void setCity(String city);
+    void setCity(String city);
 
     /**
      * Get organization province or state (if it is a federal state) within a country
-     * 
+     *
      * @return
      */
-    public String getStateProvinceCounty();
+    String getStateProvinceCounty();
 
     /**
      * Set organization province or state (if it is a federal state) within a country
-     * 
+     *
      * @param stateProvinceCounty
      */
-    public void setStateProvinceCounty(String stateProvinceCounty);
+    void setStateProvinceCounty(String stateProvinceCounty);
 
     /**
      * Get the organization country
-     * 
+     *
      * @return
      */
-    public String getCountry();
+    String getCountry();
 
     /**
      * Set the organization country
-     * 
+     *
      * @param country
      */
-    public void setCountry(String country);
+    void setCountry(String country);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEntityNotFoundException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEntityNotFoundException.java
@@ -15,9 +15,8 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * {@link KapuaEntityNotFoundException} is thrown when an entity could not be loaded from the database.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class KapuaEntityNotFoundException extends KapuaException {
 
@@ -29,12 +28,12 @@ public class KapuaEntityNotFoundException extends KapuaException {
 
     /**
      * Constructor with entity name not found
-     * 
+     *
      * @param entityType
      * @param entityName
      */
     public KapuaEntityNotFoundException(String entityType, String entityName) {
-        super(KapuaErrorCodes.ENTITY_NOT_FOUND, new Object[] { entityType, entityName });
+        super(KapuaErrorCodes.ENTITY_NOT_FOUND, entityType, entityName);
 
         this.entityType = entityType;
         this.entityName = entityName;
@@ -42,12 +41,12 @@ public class KapuaEntityNotFoundException extends KapuaException {
 
     /**
      * Constructor with entity identifier not found.
-     * 
+     *
      * @param entityType
      * @param entityId
      */
     public KapuaEntityNotFoundException(String entityType, KapuaId entityId) {
-        super(KapuaErrorCodes.ENTITY_NOT_FOUND, new Object[] { entityType, entityId.getId() });
+        super(KapuaErrorCodes.ENTITY_NOT_FOUND, entityType, entityId.getId());
 
         this.entityType = entityType;
         this.entityId = entityId;

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaErrorCode.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaErrorCode.java
@@ -15,14 +15,13 @@ package org.eclipse.kapua;
  * Kapua error code definition.
  *
  * @since 1.0
- *
  */
 public interface KapuaErrorCode {
 
     /**
      * Get the error code name
-     * 
+     *
      * @return
      */
-    public String name();
+    String name();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBus.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBus.java
@@ -13,32 +13,27 @@ package org.eclipse.kapua.event;
 
 /**
  * Service event bus definition.
- * 
+ *
  * @since 1.0
  */
 public interface ServiceEventBus {
 
     /**
      * Publish the event to the bus
-     * 
-     * @param address
-     *            address in which to publish the event
-     * @param event
-     *            event to publish
+     *
+     * @param address address in which to publish the event
+     * @param event   event to publish
      * @throws ServiceEventBusException
      */
-    public void publish(String address, ServiceEvent event) throws ServiceEventBusException;
+    void publish(String address, ServiceEvent event) throws ServiceEventBusException;
 
     /**
      * Subscribe for a specific address event
-     * 
-     * @param address
-     *            address to listen for events
-     * @param name
-     *            subscriber name. It's used to share events between multiple instances of the same consumer.
-     * @param eventListener
-     *            listener to invoke when an event is received
+     *
+     * @param address       address to listen for events
+     * @param name          subscriber name. It's used to share events between multiple instances of the same consumer.
+     * @param eventListener listener to invoke when an event is received
      * @throws ServiceEventBusException
      */
-    public void subscribe(String address, String name, ServiceEventBusListener eventListener) throws ServiceEventBusException;
+    void subscribe(String address, String name, ServiceEventBusListener eventListener) throws ServiceEventBusException;
 }

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBusListener.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBusListener.java
@@ -15,7 +15,7 @@ import org.eclipse.kapua.KapuaException;
 
 /**
  * Event bus listener definition
- * 
+ *
  * @since 1.0
  */
 public interface ServiceEventBusListener {
@@ -23,9 +23,9 @@ public interface ServiceEventBusListener {
     /**
      * Process the on event business logic<BR>
      * <B>NOTE: This method implementation must be thread safe!</B>
-     * 
+     *
      * @param kapuaEvent
      * @throws KapuaException
      */
-    public void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException;
+    void onKapuaEvent(ServiceEvent kapuaEvent) throws KapuaException;
 }

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaServiceLoader.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaServiceLoader.java
@@ -12,46 +12,41 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator;
 
-import java.util.List;
-
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.model.KapuaObjectFactory;
 import org.eclipse.kapua.service.KapuaService;
 
+import java.util.List;
+
 /**
  * Kapua service loader definition.<br>
  * Each service loader must provide the proper implementation for these methods.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface KapuaServiceLoader {
 
     /**
      * Returns an instance of a KapuaService implementing the provided KapuaService class.
-     * 
-     * @param serviceClass
-     *            - class of the service whose instance is required.
-     * @throws KapuaRuntimeException
-     *             with KapuaLocatorErrorCodes.SERVICE_UNAVAILABLE code if service is not available
+     *
+     * @param serviceClass - class of the service whose instance is required.
      * @return service instance
+     * @throws KapuaRuntimeException with KapuaLocatorErrorCodes.SERVICE_UNAVAILABLE code if service is not available
      */
-    public <S extends KapuaService> S getService(Class<S> serviceClass);
+    <S extends KapuaService> S getService(Class<S> serviceClass);
 
     /**
      * Returns an instance of a KapuaEntityFactory implementing the provided KapuaFactory class.
-     * 
-     * @param factoryClass
-     *            - class of the factory whose instance is required.
+     *
+     * @param factoryClass - class of the factory whose instance is required.
      * @return
      */
-    public <F extends KapuaObjectFactory> F getFactory(Class<F> factoryClass);
+    <F extends KapuaObjectFactory> F getFactory(Class<F> factoryClass);
 
     /**
      * Returns a list of all the classes implementing KapuaServices
      *
      * @return a list of all the classes implementing KapuaServices
      */
-    public List<KapuaService> getServices();
-
+    List<KapuaService> getServices();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
@@ -11,23 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.model;
 
-import java.util.Date;
-
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.KapuaSerializable;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Date;
+
 /**
  * Kapua base entity definition.<br>
  * All the Kapua entities will be an extension of this entity.
- * 
+ *
  * @since 1.0.0
  */
 @XmlType(propOrder = { //
@@ -38,65 +37,64 @@ import org.eclipse.kapua.model.xml.DateXmlAdapter;
 public interface KapuaEntity extends KapuaSerializable {
 
     @XmlTransient
-    public String getType();
+    String getType();
 
     /**
      * Get the Kapua identifier for the entity
-     * 
+     *
      * @return
      * @since 1.0.0
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getId();
+    KapuaId getId();
 
     /**
      * Set the Kapua identifier for the entity
-     * 
+     *
      * @param id
      * @since 1.0.0
      */
-    public void setId(KapuaId id);
+    void setId(KapuaId id);
 
     /**
      * Get the Kapua scope identifier for the entity
-     * 
+     *
      * @return
      * @since 1.0.0
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Set the Kapua scope identifier for the entity.
-     * 
-     * @param scopeId
-     *            The Kapua scope identifier to set.
+     *
+     * @param scopeId The Kapua scope identifier to set.
      * @since 1.0.0
      */
-    public void setScopeId(KapuaId scopeId);
+    void setScopeId(KapuaId scopeId);
 
     /**
      * Get the created on date
-     * 
+     *
      * @return
      * @since 1.0.0
      */
     @XmlElement(name = "createdOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getCreatedOn();
+    Date getCreatedOn();
 
     /**
      * Set the created by Kapua identifier
-     * 
+     *
      * @return
      * @since 1.0.0
      */
     @XmlElement(name = "createdBy")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getCreatedBy();
+    KapuaId getCreatedBy();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityCreator.java
@@ -11,41 +11,38 @@
  *******************************************************************************/
 package org.eclipse.kapua.model;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * Kapua entity base creator service definition.<br>
  * All the Kapua entities base creator service will be an extension of this entity.
  *
- * @param <E>
- *            entity type
- * 
+ * @param <E> entity type
  * @since 1.0.0
- * 
  */
 @XmlType(propOrder = { "scopeId" })
 public interface KapuaEntityCreator<E extends KapuaEntity> {
 
     /**
      * Get the Kapua scope identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Set the Kapua scope identifier
-     * 
+     *
      * @param scopeId
      */
-    public void setScopeId(KapuaId scopeId);
+    void setScopeId(KapuaId scopeId);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityFactory.java
@@ -17,11 +17,11 @@ import org.eclipse.kapua.model.query.KapuaQuery;
 
 public interface KapuaEntityFactory<E extends KapuaEntity, C extends KapuaEntityCreator<E>, Q extends KapuaQuery<E>, L extends KapuaListResult<E>> extends KapuaObjectFactory {
 
-    public E newEntity(KapuaId scopeId);
+    E newEntity(KapuaId scopeId);
 
-    public C newCreator(KapuaId scopeId);
+    C newCreator(KapuaId scopeId);
 
-    public Q newQuery(KapuaId scopeId);
+    Q newQuery(KapuaId scopeId);
 
-    public L newListResult();
+    L newListResult();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntity.java
@@ -16,25 +16,24 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kapua named entity definition.
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlType(propOrder = { "name" })
 public interface KapuaNamedEntity extends KapuaUpdatableEntity {
 
     /**
      * Get the entity name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the entity name
-     * 
+     *
      * @param name
      */
-    public void setName(String name);
+    void setName(String name);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityCreator.java
@@ -17,27 +17,24 @@ import javax.xml.bind.annotation.XmlType;
 /**
  * Kapua named entity creator service definition.
  *
- * @param <E>
- *            entity type
- * 
+ * @param <E> entity type
  * @since 1.0
- * 
  */
 @XmlType(propOrder = { "name" })
 public interface KapuaNamedEntityCreator<E extends KapuaEntity> extends KapuaUpdatableEntityCreator<E> {
 
     /**
      * Get the entity name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the entity name
-     * 
+     *
      * @param name
      */
-    public void setName(String name);
+    void setName(String name);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
@@ -11,25 +11,23 @@
  *******************************************************************************/
 package org.eclipse.kapua.model;
 
-import java.util.Date;
-import java.util.Properties;
-
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Date;
+import java.util.Properties;
+
 /**
  * Kapua updatable entity definition.
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlType(propOrder = { //
         "modifiedOn", //
@@ -40,73 +38,73 @@ public interface KapuaUpdatableEntity extends KapuaEntity {
 
     /**
      * Get modified on date
-     * 
+     *
      * @return
      */
     @XmlElement(name = "modifiedOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getModifiedOn();
+    Date getModifiedOn();
 
     /**
      * Get modified by kapua identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "modifiedBy")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getModifiedBy();
+    KapuaId getModifiedBy();
 
     /**
      * Get optlock
-     * 
+     *
      * @return
      */
     @XmlElement(name = "optlock")
-    public int getOptlock();
+    int getOptlock();
 
     /**
      * Set optlock
-     * 
+     *
      * @param optlock
      */
-    public void setOptlock(int optlock);
+    void setOptlock(int optlock);
 
     /**
      * Get entity attributes
-     * 
+     *
      * @return
      * @throws KapuaException
      */
     @XmlTransient
-    public Properties getEntityAttributes()
+    Properties getEntityAttributes()
             throws KapuaException;
 
     /**
      * Set entity attributes
-     * 
+     *
      * @param props
      * @throws KapuaException
      */
-    public void setEntityAttributes(Properties props)
+    void setEntityAttributes(Properties props)
             throws KapuaException;
 
     /**
      * Get the property entities
-     * 
+     *
      * @return
      * @throws KapuaException
      */
     @XmlTransient
-    public Properties getEntityProperties()
+    Properties getEntityProperties()
             throws KapuaException;
 
     /**
      * Set the property entities
-     * 
+     *
      * @param props
      * @throws KapuaException
      */
-    public void setEntityProperties(Properties props)
+    void setEntityProperties(Properties props)
             throws KapuaException;
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityCreator.java
@@ -11,23 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.model;
 
-import java.util.Properties;
-
 import org.eclipse.kapua.KapuaException;
+
+import java.util.Properties;
 
 /**
  * Kapua updateable entity creator service definition.
  *
- * @param <E>
- *            entity type
- * 
+ * @param <E> entity type
  * @since 1.0
- * 
  */
 public interface KapuaUpdatableEntityCreator<E extends KapuaEntity> extends KapuaEntityCreator<E> {
 
-    public Properties getEntityAttributes() throws KapuaException;
+    Properties getEntityAttributes() throws KapuaException;
 
-    public void setEntityAttributes(Properties entityAttributes) throws KapuaException;
+    void setEntityAttributes(Properties entityAttributes) throws KapuaException;
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityPredicates.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityPredicates.java
@@ -13,20 +13,19 @@ package org.eclipse.kapua.model;
 
 /**
  * {@link KapuaUpdatableEntity} query predicates.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 public interface KapuaUpdatableEntityPredicates extends KapuaEntityPredicates {
 
     /**
      * {@link KapuaUpdatableEntity} modified on date.
      */
-    public static final String MODIFIED_ON = "modifiedOn";
+    String MODIFIED_ON = "modifiedOn";
 
     /**
      * {@link KapuaUpdatableEntity} modified by id.
      */
-    public static final String MODIFIED_BY = "modifiedBy";
+    String MODIFIED_BY = "modifiedBy";
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaMetatypeFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaMetatypeFactory.java
@@ -16,68 +16,66 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
 /**
  * Kapua metatype objects factory service definition.<br>
  * This class provides, through locator and factory service, a factory for few objects types.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
-public interface KapuaMetatypeFactory extends KapuaObjectFactory{
+public interface KapuaMetatypeFactory extends KapuaObjectFactory {
 
     /**
      * Returns a {@link KapuaTocd} instance
-     * 
+     *
      * @return
      */
-    public KapuaTocd newKapuaTocd();
+    KapuaTocd newKapuaTocd();
 
     /**
      * Returns a {@link KapuaTad} instance
-     * 
+     *
      * @return
      */
-    public KapuaTad newKapuaTad();
+    KapuaTad newKapuaTad();
 
     /**
      * Returns a {@link KapuaTscalar} instance
-     * 
+     *
      * @param type
-     * 
      * @return
      */
-    public KapuaTscalar newKapuaTscalar(String type);
+    KapuaTscalar newKapuaTscalar(String type);
 
     /**
      * Returns a {@link KapuaToption} instance
-     * 
+     *
      * @return
      */
-    public KapuaToption newKapuaToption();
+    KapuaToption newKapuaToption();
 
     /**
      * Returns a {@link KapuaTicon} instance
-     * 
+     *
      * @return
      */
-    public KapuaTicon newKapuaTicon();
+    KapuaTicon newKapuaTicon();
 
     /**
      * Returns a {@link KapuaTmetadata} instance
-     * 
+     *
      * @return
      */
-    public KapuaTmetadata newKapuaTmetadata();
+    KapuaTmetadata newKapuaTmetadata();
 
     /**
      * Returns a {@link KapuaTdesignate} instance
-     * 
+     *
      * @return
      */
-    public KapuaTdesignate newKapuaTdesignate();
+    KapuaTdesignate newKapuaTdesignate();
 
     /**
      * Returns a {@link KapuaTobject} instance
-     * 
+     *
      * @return
      */
-    public KapuaTobject newKapuaTobject();
+    KapuaTobject newKapuaTobject();
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTad.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTad.java
@@ -11,9 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
-import java.util.List;
-import java.util.Map;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyAttribute;
@@ -24,11 +21,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.namespace.QName;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
  * Java class for Tad complex type.
- *
  * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
@@ -56,7 +54,6 @@ import javax.xml.namespace.QName;
  * </pre>
  *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "AD", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -68,265 +65,192 @@ public interface KapuaTad {
 
     /**
      * Gets the value of the option property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the option property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getOption().add(newItem);
      * </pre>
-     *
-     *
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link KapuaToption }
-     *
-     *
      */
     @XmlElement(name = "Option", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
-    public List<KapuaToption> getOption();
+    List<KapuaToption> getOption();
 
-    public void setOption(List<KapuaToption> option);
+    void setOption(List<KapuaToption> option);
 
     /**
      * Gets the value of the any property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAny().add(newItem);
      * </pre>
-     *
-     *
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link Object }
-     *
-     *
      */
     @XmlAnyElement(lax = true)
-    public List<Object> getAny();
+    List<Object> getAny();
 
-    public void setAny(List<Object> any);
+    void setAny(List<Object> any);
 
     /**
      * Gets the value of the name property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String}
      */
     @XmlAttribute(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Sets the value of the name property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setName(String value);
+    void setName(String value);
 
     /**
      * Gets the value of the description property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "description")
-    public String getDescription();
+    String getDescription();
 
     /**
      * Sets the value of the description property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setDescription(String value);
+    void setDescription(String value);
 
     /**
      * Gets the value of the id property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String}
      */
     @XmlAttribute(name = "id", required = true)
-    public String getId();
+    String getId();
 
     /**
      * Sets the value of the id property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setId(String value);
+    void setId(String value);
 
     /**
      * Gets the value of the type property.
      *
-     * @return
-     *         possible object is
-     *         {@link KapuaTscalar }
-     *
+     * @return possible object is {@link KapuaTscalar }
      */
     @XmlAttribute(name = "type", required = true)
     @XmlJavaTypeAdapter(KapuaTscalarAdapter.class)
-    public KapuaTscalar getType();
+    KapuaTscalar getType();
 
     /**
      * Sets the value of the type property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link KapuaTscalar }
-     *
+     * @param value allowed object is {@link KapuaTscalar }
      */
-    public void setType(KapuaTscalar value);
+    void setType(KapuaTscalar value);
 
     /**
      * Gets the value of the cardinality property.
      *
-     * @return
-     *         possible object is
-     *         {@link Integer }
-     *
+     * @return possible object is {@link Integer }
      */
     @XmlAttribute(name = "cardinality")
-    public Integer getCardinality();
+    Integer getCardinality();
 
     /**
      * Sets the value of the cardinality property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link Integer }
-     *
+     * @param value allowed object is {@link Integer }
      */
-    public void setCardinality(Integer value);
+    void setCardinality(Integer value);
 
     /**
      * Gets the value of the min property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is  {@link String }
      */
     @XmlAttribute(name = "min")
-    public String getMin();
+    String getMin();
 
     /**
      * Sets the value of the min property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setMin(String value);
+    void setMin(String value);
 
     /**
      * Gets the value of the max property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "max")
-    public String getMax();
+    String getMax();
 
     /**
      * Sets the value of the max property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is  {@link String }
      */
-    public void setMax(String value);
+    void setMax(String value);
 
     /**
      * Gets the value of the default property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "default")
-    public String getDefault();
+    String getDefault();
 
     /**
      * Sets the value of the default property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setDefault(String value);
+    void setDefault(String value);
 
     /**
      * Gets the value of the required property.
      *
-     * @return
-     *         possible object is
-     *         {@link Boolean }
-     *
+     * @return possible object is {@link Boolean }
      */
     @XmlAttribute(name = "required")
-    public Boolean isRequired();
+    Boolean isRequired();
 
     /**
      * Sets the value of the required property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link Boolean }
-     *
+     * @param value allowed object is  {@link Boolean }
      */
-    public void setRequired(Boolean value);
+    void setRequired(Boolean value);
 
     /**
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     *
      * <p>
      * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     *
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
      *
-     *
-     * @return
-     *         always non-null
+     * @return always non-null
      */
     @XmlAnyAttribute
-    public Map<QName, String> getOtherAttributes();
+    Map<QName, String> getOtherAttributes();
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
@@ -11,17 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
+import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Map;
-
-import javax.xml.namespace.QName;
-
-import org.w3c.dom.Element;
 
 /**
  * <p>
  * Java class for Tattribute complex type.
- *
  * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
@@ -42,114 +38,81 @@ import org.w3c.dom.Element;
  * </pre>
  *
  * @since 1.0
- *
  */
 public interface KapuaTattribute {
 
     /**
      * Gets the value of the value property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the value property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getValue().add(newItem);
      * </pre>
-     *
-     *
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link String }
-     *
-     *
      */
-    public List<String> getValue();
+    List<String> getValue();
 
     /**
      * Gets the value of the any property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAny().add(newItem);
      * </pre>
-     *
-     *
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link Element }
-     * {@link Object }
-     *
-     *
      */
-    public List<Object> getAny();
+    List<Object> getAny();
 
     /**
      * Gets the value of the adref property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
-    public String getAdref();
+    String getAdref();
 
     /**
      * Sets the value of the adref property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setAdref(String value);
+    void setAdref(String value);
 
     /**
      * Gets the value of the content property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
-    public String getContent();
+    String getContent();
 
     /**
      * Sets the value of the content property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setContent(String value);
+    void setContent(String value);
 
     /**
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     *
      * <p>
      * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     *
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
      *
-     *
-     * @return
-     *         always non-null
+     * @return always non-null
      */
-    public Map<QName, String> getOtherAttributes();
+    Map<QName, String> getOtherAttributes();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTdesignate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTdesignate.java
@@ -11,9 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
-import java.util.List;
-import java.util.Map;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyAttribute;
@@ -23,13 +20,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-
-import org.w3c.dom.Element;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
  * Java class for Tdesignate complex type.
- *
  * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
@@ -51,8 +47,6 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent&gt;
  * &lt;/complexType&gt;
  * </pre>
- *
- *
  */
 @XmlRootElement(name = "Designate", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -71,175 +65,127 @@ public interface KapuaTdesignate {
     /**
      * Gets the value of the object property.
      *
-     * @return
-     *         possible object is
-     *         {@link KapuaTobject }
-     *
+     * @return possible object is {@link KapuaTobject }
      */
     @XmlElement(name = "Object", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0", required = true)
-    public KapuaTobject getObject();
+    KapuaTobject getObject();
 
     /**
      * Sets the value of the object property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link KapuaTobject }
-     *
+     * @param value allowed object is   {@link KapuaTobject }
      */
-    public void setObject(KapuaTobject value);
+    void setObject(KapuaTobject value);
 
     /**
      * Gets the value of the any property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAny().add(newItem);
      * </pre>
-     *
-     *
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link Element }
-     * {@link Object }
-     *
-     *
      */
     @XmlAnyElement(lax = true)
-    public List<Object> getAny();
+    List<Object> getAny();
 
-    public void setAny(List<Object> any);
+    void setAny(List<Object> any);
 
     /**
      * Gets the value of the pid property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "pid")
-    public String getPid();
+    String getPid();
 
     /**
      * Sets the value of the pid property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setPid(String value);
+    void setPid(String value);
 
     /**
      * Gets the value of the factoryPid property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "factoryPid")
-    public String getFactoryPid();
+    String getFactoryPid();
 
     /**
      * Sets the value of the factoryPid property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setFactoryPid(String value);
+    void setFactoryPid(String value);
 
     /**
      * Gets the value of the bundle property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "bundle")
-    public String getBundle();
+    String getBundle();
 
     /**
      * Sets the value of the bundle property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setBundle(String value);
+    void setBundle(String value);
 
     /**
      * Gets the value of the optional property.
      *
-     * @return
-     *         possible object is
-     *         {@link Boolean }
-     *
+     * @return possible object is {@link Boolean }
      */
     @XmlAttribute(name = "optional")
-    public Boolean isOptional();
+    Boolean isOptional();
 
     /**
      * Sets the value of the optional property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link Boolean }
-     *
+     * @param value allowed object is {@link Boolean }
      */
-    public void setOptional(Boolean value);
+    void setOptional(Boolean value);
 
     /**
      * Gets the value of the merge property.
      *
-     * @return
-     *         possible object is
-     *         {@link Boolean }
-     *
+     * @return possible object is {@link Boolean }
      */
     @XmlAttribute(name = "merge")
-    public Boolean isMerge();
+    Boolean isMerge();
 
     /**
      * Sets the value of the merge property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link Boolean }
-     *
+     * @param value allowed object is {@link Boolean }
      */
-    public void setMerge(Boolean value);
+    void setMerge(Boolean value);
 
     /**
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     *
      * <p>
      * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     *
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
      *
-     *
-     * @return
-     *         always non-null
+     * @return always non-null
      */
     @XmlAnyAttribute
-    public Map<QName, String> getOtherAttributes();
+    Map<QName, String> getOtherAttributes();
 
-    public void setOtherAttributes(Map<QName, String> otherAttributes);
+    void setOtherAttributes(Map<QName, String> otherAttributes);
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTicon.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTicon.java
@@ -11,10 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
-import java.math.BigInteger;
-import java.util.List;
-import java.util.Map;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyAttribute;
@@ -24,13 +20,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-
-import org.w3c.dom.Element;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
  * Java class for Ticon complex type.
- *
  * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
@@ -50,7 +46,6 @@ import org.w3c.dom.Element;
  * </pre>
  *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "Icon", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -59,89 +54,64 @@ public interface KapuaTicon {
 
     /**
      * Gets the value of the any property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAny().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link Element }
-     * {@link Object }
-     *
-     *
      */
     @XmlAnyElement(lax = true)
-    public List<Object> getAny();
+    List<Object> getAny();
 
     /**
      * Gets the value of the resource property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "resource", required = true)
-    public String getResource();
+    String getResource();
 
     /**
      * Sets the value of the resource property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setResource(String value);
+    void setResource(String value);
 
     /**
      * Gets the value of the size property.
      *
-     * @return
-     *         possible object is
-     *         {@link BigInteger }
-     *
+     * @return possible object is {@link BigInteger }
      */
     @XmlAttribute(name = "size", required = true)
     @XmlSchemaType(name = "positiveInteger")
-    public BigInteger getSize();
+    BigInteger getSize();
 
     /**
      * Sets the value of the size property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link BigInteger }
-     *
+     * @param value allowed object is {@link BigInteger }
      */
-    public void setSize(BigInteger value);
+    void setSize(BigInteger value);
 
     /**
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     *
-     * <p>
+     * <p></p>
      * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     *
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
      *
-     *
-     * @return
-     *         always non-null
+     * @return always non-null
      */
     @XmlAnyAttribute
-    public Map<QName, String> getOtherAttributes();
+    Map<QName, String> getOtherAttributes();
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTmetadata.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTmetadata.java
@@ -11,9 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
-import java.util.List;
-import java.util.Map;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyAttribute;
@@ -23,14 +20,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-
-import org.w3c.dom.Element;
-
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
  * Java class for Tmetadata complex type.
- *
  * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
@@ -49,139 +44,100 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent&gt;
  * &lt;/complexType&gt;
  * </pre>
- *
- *
  */
 @XmlRootElement(name = "MetaData", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(name = "Tmetadata", propOrder = {
-                                           "OCD",
-                                           "designate",
-                                           "any",
-                                           "localization",
-                                           "otherAttributes"
+        "OCD",
+        "designate",
+        "any",
+        "localization",
+        "otherAttributes"
 }, factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTmetadata")
 public interface KapuaTmetadata {
 
     /**
      * Gets the value of the ocd property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the ocd property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getOCD().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link KapuaTocd }
-     *
-     *
      */
     @XmlElement(name = "OCD", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
-    public List<KapuaTocd> getOCD();
+    List<KapuaTocd> getOCD();
 
-    public void setOCD(List<KapuaTocd> ocd);
+    void setOCD(List<KapuaTocd> ocd);
 
     /**
      * Gets the value of the designate property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the designate property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getDesignate().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link KapuaTdesignate }
-     *
-     *
      */
     @XmlElement(name = "Designate", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
-    public List<KapuaTdesignate> getDesignate();
+    List<KapuaTdesignate> getDesignate();
 
-    public void setDesignate(List<KapuaTdesignate> designate);
+    void setDesignate(List<KapuaTdesignate> designate);
 
     /**
      * Gets the value of the any property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getAny().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link Element }
-     * {@link Object }
-     *
-     *
      */
     @XmlAnyElement(lax = true)
-    public List<Object> getAny();
+    List<Object> getAny();
 
-    public void setAny(List<Object> any);
+    void setAny(List<Object> any);
 
     /**
      * Gets the value of the localization property.
      *
-     * @return
-     *     possible object is
-     *     {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "localization")
-    public String getLocalization();
+    String getLocalization();
 
     /**
      * Sets the value of the localization property.
      *
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setLocalization(String value);
+    void setLocalization(String value);
 
     /**
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     *
      * <p>
      * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     *
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
      *
-     *
-     * @return
-     *     always non-null
+     * @return always non-null
      */
     @XmlAnyAttribute
-    public Map<QName, String> getOtherAttributes();
+    Map<QName, String> getOtherAttributes();
 
-    public void setOtherAttributes(Map<QName, String> otherAttributes);
+    void setOtherAttributes(Map<QName, String> otherAttributes);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTobject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTobject.java
@@ -11,9 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
-import java.util.List;
-import java.util.Map;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyAttribute;
@@ -23,13 +20,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
-
-import org.w3c.dom.Element;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
  * Java class for Tobject complex type.
- *
  * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
@@ -47,8 +43,6 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent&gt;
  * &lt;/complexType&gt;
  * </pre>
- *
- *
  */
 @XmlRootElement(name = "Object", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -60,93 +54,66 @@ public interface KapuaTobject {
 
     /**
      * Gets the value of the attribute property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the attribute property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAttribute().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link KapuaTattribute }
-     *
-     *
      */
     @XmlElement(name = "Attribute", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
-    public List<KapuaTattribute> getAttribute();
+    List<KapuaTattribute> getAttribute();
 
     /**
      * Gets the value of the any property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAny().add(newItem);
      * </pre>
-     *
-     *
      * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link Element }
-     * {@link Object }
-     *
-     *
      */
     @XmlAnyElement(lax = true)
-    public List<Object> getAny();
+    List<Object> getAny();
 
     /**
      * Gets the value of the ocdref property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "ocdref", required = true)
-    public String getOcdref();
+    String getOcdref();
 
     /**
      * Sets the value of the ocdref property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setOcdref(String value);
+    void setOcdref(String value);
 
     /**
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     *
      * <p>
      * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     *
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
      *
-     *
-     * @return
-     *         always non-null
+     * @return always non-null
      */
     @XmlAnyAttribute
-    public Map<QName, String> getOtherAttributes();
+    Map<QName, String> getOtherAttributes();
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTocd.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTocd.java
@@ -11,9 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
-import java.util.List;
-import java.util.Map;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyAttribute;
@@ -23,11 +20,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
  * Java class for Tocd complex type.
- *
  * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
@@ -50,7 +48,6 @@ import javax.xml.namespace.QName;
  * </pre>
  *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "OCD", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -59,169 +56,120 @@ public interface KapuaTocd {
 
     /**
      * Gets the value of the ad property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the ad property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAD().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link KapuaTad }
-     *
-     *
      */
     @XmlElement(name = "AD", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0", required = true)
-    public List<KapuaTad> getAD();
+    List<KapuaTad> getAD();
 
-    public void setAD(List<? extends KapuaTad> icon);
+    void setAD(List<? extends KapuaTad> icon);
 
     /**
      * Gets the value of the icon property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the icon property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getIcon().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link KapuaTicon }
-     *
-     *
      */
     @XmlElement(name = "Icon", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
-    public List<KapuaTicon> getIcon();
+    List<KapuaTicon> getIcon();
 
-    public void setIcon(List<? extends KapuaTicon> icon);
+    void setIcon(List<? extends KapuaTicon> icon);
 
     /**
      * Gets the value of the any property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAny().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     *
-     * {@link Object }
-     *
-     *
      */
     @XmlAnyElement(lax = true)
-    public List<Object> getAny();
+    List<Object> getAny();
 
-    public void setAny(List<Object> any);
+    void setAny(List<Object> any);
 
     /**
      * Gets the value of the name property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "name", required = true)
-    public String getName();
+    String getName();
 
     /**
      * Sets the value of the name property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setName(String value);
+    void setName(String value);
 
     /**
      * Gets the value of the description property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "description")
-    public String getDescription();
+    String getDescription();
 
     /**
      * Sets the value of the description property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setDescription(String value);
+    void setDescription(String value);
 
     /**
      * Gets the value of the id property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "id", required = true)
-    public String getId();
+    String getId();
 
     /**
      * Sets the value of the id property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setId(String value);
+    void setId(String value);
 
     /**
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     *
      * <p>
      * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     *
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
      *
-     *
-     * @return
-     *         always non-null
+     * @return always non-null
      */
     @XmlAnyAttribute
-    public Map<QName, String> getOtherAttributes();
+    Map<QName, String> getOtherAttributes();
 
-    public void setOtherAttributes(Map<QName, String> otherAttributes);
+    void setOtherAttributes(Map<QName, String> otherAttributes);
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaToption.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaToption.java
@@ -11,9 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
-import java.util.List;
-import java.util.Map;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyAttribute;
@@ -22,11 +19,12 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
  * Java class for Toption complex type.
- *
  * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
@@ -46,7 +44,6 @@ import javax.xml.namespace.QName;
  * </pre>
  *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "Option", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -57,87 +54,63 @@ public interface KapuaToption {
 
     /**
      * Gets the value of the any property.
-     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the any property.
-     *
      * <p>
      * For example, to add a new item, do as follows:
-     * 
+     *
      * <pre>
      * getAny().add(newItem);
      * </pre>
-     *
-     *
-     * <p>
-     * Objects of the following type(s) are allowed in the list
-     * {@link Object }
-     *
-     *
      */
     @XmlAnyElement(lax = true)
-    public List<Object> getAny();
+    List<Object> getAny();
 
     /**
      * Gets the value of the label property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "label", required = true)
-    public String getLabel();
+    String getLabel();
 
     /**
      * Sets the value of the label property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setLabel(String value);
+    void setLabel(String value);
 
     /**
      * Gets the value of the value property.
      *
-     * @return
-     *         possible object is
-     *         {@link String }
-     *
+     * @return possible object is {@link String }
      */
     @XmlAttribute(name = "value", required = true)
-    public String getValue();
+    String getValue();
 
     /**
      * Sets the value of the value property.
      *
-     * @param value
-     *            allowed object is
-     *            {@link String }
-     *
+     * @param value allowed object is {@link String }
      */
-    public void setValue(String value);
+    void setValue(String value);
 
     /**
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     *
      * <p>
      * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     *
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
      *
-     *
-     * @return
-     *         always non-null
+     * @return always non-null
      */
     @XmlAnyAttribute
-    public Map<QName, String> getOtherAttributes();
+    Map<QName, String> getOtherAttributes();
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalar.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalar.java
@@ -10,10 +10,11 @@
  *     Eurotech - initial API and implementation
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
+
 /**
  * <p>
  * Java class for Tscalar complex type.
- *
+ * <p>
  * The following schema fragment specifies the expected content contained within this class.
  *
  * <pre>
@@ -34,7 +35,6 @@ package org.eclipse.kapua.model.config.metatype;
  * </pre>
  *
  * @since 1.0
- * 
  */
 public interface KapuaTscalar {
 
@@ -42,7 +42,6 @@ public interface KapuaTscalar {
      * Gets the value property.
      *
      * @return possible object is {@link String } with restricted values
-     *
      */
-    public String value();
+    String value();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalarAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalarAdapter.java
@@ -11,23 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 public class KapuaTscalarAdapter extends XmlAdapter<String, KapuaTscalar> {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final KapuaMetatypeFactory metatypeFactory = locator.getFactory(KapuaMetatypeFactory.class);
-
-    @Override
-    public KapuaTscalar unmarshal(String v) throws Exception {
-        return metatypeFactory.newKapuaTscalar(v);
-    }
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final KapuaMetatypeFactory METATYPE_FACTORY = LOCATOR.getFactory(KapuaMetatypeFactory.class);
 
     @Override
     public String marshal(KapuaTscalar v) throws Exception {
         return v.value();
     }
 
+    @Override
+    public KapuaTscalar unmarshal(String v) throws Exception {
+        return METATYPE_FACTORY.newKapuaTscalar(v);
+    }
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/MetatypeXmlRegistry.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/MetatypeXmlRegistry.java
@@ -16,9 +16,8 @@ import org.eclipse.kapua.locator.KapuaLocator;
 /**
  * Xml factory class.<br>
  * This class provides, through locator and factory service, a factory for few objects types.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class MetatypeXmlRegistry {
 
@@ -34,7 +33,7 @@ public class MetatypeXmlRegistry {
 
     /**
      * Returns a {@link KapuaTocd} instance
-     * 
+     *
      * @return
      */
     public KapuaTocd newKapuaTocd() {
@@ -43,7 +42,7 @@ public class MetatypeXmlRegistry {
 
     /**
      * Returns a {@link KapuaTad} instance
-     * 
+     *
      * @return
      */
     public KapuaTad newKapuaTad() {
@@ -52,26 +51,16 @@ public class MetatypeXmlRegistry {
 
     /**
      * Returns a {@link KapuaTicon} instance
-     * 
+     *
      * @return
      */
     public KapuaTicon newKapuaTicon() {
         return factory.newKapuaTicon();
     }
 
-    // /**
-    // * Returns a {@link KapuaTscalar} instance
-    // *
-    // * @return
-    // */
-    // public KapuaTscalar newKapuaTscalar()
-    // {
-    // return factory.newKapuaTscalar();
-    // }
-
     /**
      * Returns a {@link KapuaToption} instance
-     * 
+     *
      * @return
      */
     public KapuaToption newKapuaToption() {
@@ -80,7 +69,7 @@ public class MetatypeXmlRegistry {
 
     /**
      * Returns a {@link KapuaTmetadata} instance
-     * 
+     *
      * @return
      */
     public KapuaTmetadata newKapuaTmetadata() {
@@ -89,7 +78,7 @@ public class MetatypeXmlRegistry {
 
     /**
      * Returns a {@link KapuaTdesignate} instance
-     * 
+     *
      * @return
      */
     public KapuaTdesignate newKapuaTdesignate() {
@@ -98,7 +87,7 @@ public class MetatypeXmlRegistry {
 
     /**
      * Returns a {@link KapuaTobject} instance
-     * 
+     *
      * @return
      */
     public KapuaTobject newKapuaTobject() {

--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/Domain.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/Domain.java
@@ -26,7 +26,7 @@ public interface Domain {
      * @return The {@link Domain} name.
      * @since 1.0.0
      */
-    public String getName();
+    String getName();
 
     /**
      * Gets the {@link org.eclipse.kapua.service.KapuaService} name that use this {@link Domain}.<br>
@@ -35,7 +35,7 @@ public interface Domain {
      * @return The {@link org.eclipse.kapua.service.KapuaService} that use this {@link Domain}.<br>
      * @since 1.0.0
      */
-    public String getServiceName();
+    String getServiceName();
 
     /**
      * Gets the set of {@link Actions} available in this {@link Domain}.<br>
@@ -44,7 +44,7 @@ public interface Domain {
      * @return The set of {@link Actions}.
      * @since 1.0.0
      */
-    public Set<Actions> getActions();
+    Set<Actions> getActions();
 
     /**
      * Gets whether or not this {@link Domain} is group-able or not.
@@ -52,5 +52,5 @@ public interface Domain {
      * @return {@code true} if the KapuaEntity is group-able or not, {@code false} otherwise.
      * @since 1.0.0
      */
-    public boolean getGroupable();
+    boolean getGroupable();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaId.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaId.java
@@ -11,56 +11,51 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.id;
 
+import javax.xml.bind.annotation.XmlTransient;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Base64;
-
-import javax.xml.bind.annotation.XmlTransient;
 
 /**
  * Kapua identifier object.<br>
  * This object it's used to identify each entity.<br>
  * <b>It should be unique within the same entity.</b>
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 public interface KapuaId extends Serializable {
 
     @XmlTransient
-    public static final KapuaId ANY = new KapuaIdStatic(BigInteger.ONE.negate());
+    KapuaId ANY = new KapuaIdStatic(BigInteger.ONE.negate());
 
     @XmlTransient
-    public static final KapuaId ONE = new KapuaIdStatic(BigInteger.ONE);
+    KapuaId ONE = new KapuaIdStatic(BigInteger.ONE);
 
     /**
      * Get the identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public BigInteger getId();
+    BigInteger getId();
 
     /**
      * Get the identifier Base64 URL encoded formatted.
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public default String toCompactId() {
+    default String toCompactId() {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(getId().toByteArray());
     }
 
     /**
      * Get the identifier numeric String formatted.
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public default String toStringId() {
+    default String toStringId() {
         return getId().toString();
     }
 

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdAdapter.java
@@ -11,27 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.id;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * Kapua identifier adapter. It marshal and unmarshal the Kapua identifier in a proper way.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class KapuaIdAdapter extends XmlAdapter<String, KapuaId> {
 
-    /**
-     * Locator instance
-     */
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-
-    /**
-     * Meta type factory instance
-     */
-    private final KapuaIdFactory kapuaIdFactory = locator.getFactory(KapuaIdFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final KapuaIdFactory KAPUA_ID_FACTORY = LOCATOR.getFactory(KapuaIdFactory.class);
 
     @Override
     public String marshal(KapuaId v) throws Exception {
@@ -40,7 +32,6 @@ public class KapuaIdAdapter extends XmlAdapter<String, KapuaId> {
 
     @Override
     public KapuaId unmarshal(String v) throws Exception {
-        return v != null ? kapuaIdFactory.newKapuaId(v) : null;
+        return v != null ? KAPUA_ID_FACTORY.newKapuaId(v) : null;
     }
-
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdFactory.java
@@ -12,13 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.id;
 
-import java.math.BigInteger;
-
 import org.eclipse.kapua.model.KapuaObjectFactory;
+
+import java.math.BigInteger;
 
 /**
  * {@link KapuaId} factory definition.
- * 
+ *
  * @since 1.0.0
  */
 public interface KapuaIdFactory extends KapuaObjectFactory {
@@ -28,7 +28,7 @@ public interface KapuaIdFactory extends KapuaObjectFactory {
      * <p>
      * <b>Note:</b> This operation must be the inverse function of {@link KapuaId#toCompactId()} so, in other word, this code should't fail:
      * </p>
-     * 
+     *
      * <pre>{@code
      * KapuaIdFactory kapuaIdFactory = KapuaLocator.getInstance().getService(KapuaIdFactory.class);
      * String shortId = "some well formed encoded short id";
@@ -36,22 +36,19 @@ public interface KapuaIdFactory extends KapuaObjectFactory {
      * String shortIdConverted = id.getShortId();
      * AssertTrue(shortId.equals(shortIdConverted));
      * }</pre>
-     * 
-     * @param shortId
-     *            The {@link KapuaId} short id to parse.
+     *
+     * @param shortId The {@link KapuaId} short id to parse.
      * @return The {@link KapuaId} parsed from its short representation.
      * @since 1.0.0
      */
-    public KapuaId newKapuaId(String shortId);
+    KapuaId newKapuaId(String shortId);
 
     /**
      * Creates a new {@link KapuaId} form the {@link BigInteger} parameter.
-     * 
-     * @param bigInteger
-     *            The {@link BigInteger} from which create the {@link KapuaId}.
+     *
+     * @param bigInteger The {@link BigInteger} from which create the {@link KapuaId}.
      * @return The new {@link KapuaId}
      * @since 1.0.0
      */
-    public KapuaId newKapuaId(BigInteger bigInteger);
-
+    KapuaId newKapuaId(BigInteger bigInteger);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
@@ -11,9 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.query;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
+import org.eclipse.kapua.KapuaSerializable;
+import org.eclipse.kapua.model.KapuaEntity;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -21,18 +20,15 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.KapuaSerializable;
-import org.eclipse.kapua.model.KapuaEntity;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * Query list result definition.
- * 
- * @param <E>
- *            query entity domain
- * 
+ *
+ * @param <E> query entity domain
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "result")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -41,77 +37,75 @@ public interface KapuaListResult<E extends KapuaEntity> extends KapuaSerializabl
 
     /**
      * Get the limit exceeded flag
-     * 
+     *
      * @return
      */
     @XmlElement(name = "limitExceeded")
-    public boolean isLimitExceeded();
+    boolean isLimitExceeded();
 
     /**
      * Set the limit exceeded flag
-     * 
-     * @param limitExceeded
-     *            true if the query matching elements are more than {@link KapuaQuery#setLimit(Integer)} value
+     *
+     * @param limitExceeded true if the query matching elements are more than {@link KapuaQuery#setLimit(Integer)} value
      */
-    public void setLimitExceeded(boolean limitExceeded);
+    void setLimitExceeded(boolean limitExceeded);
 
     /**
      * Return the result list
-     * 
+     *
      * @return
      */
     @XmlElementWrapper(name = "items")
     @XmlElement(name = "item")
-    public List<E> getItems();
+    List<E> getItems();
 
     /**
      * Return the element at i position (zero based)
-     * 
+     *
      * @param i
      * @return
      */
-    public E getItem(int i);
+    E getItem(int i);
 
     /**
      * Returns the first element in the {@link KapuaListResult}.<br>
      * It returns {@code null} if first element does not exist.
-     * 
+     *
      * @return The first element in the {@link KapuaListResult} or {@code null} if not present.
      */
-    public E getFirstItem();
+    E getFirstItem();
 
     /**
      * Return the result list size
-     * 
+     *
      * @return
      */
     @XmlElement(name = "size")
-    public int getSize();
+    int getSize();
 
     /**
      * Check if the result list is empty
-     * 
+     *
      * @return
      */
-    public boolean isEmpty();
+    boolean isEmpty();
 
     /**
      * Add items to the result list
-     * 
+     *
      * @param items
      */
-    public void addItems(Collection<? extends E> items);
+    void addItems(Collection<? extends E> items);
 
     /**
      * Clear item result list
      */
-    public void clearItems();
+    void clearItems();
 
     /**
      * Sorts the list result according to the given {@link Comparator}.
-     * 
-     * @param comparator
-     *            The {@link Comparator} used to compare items.
+     *
+     * @param comparator The {@link Comparator} used to compare items.
      */
-    public void sort(Comparator<E> comparator);
+    void sort(Comparator<E> comparator);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResultAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResultAdapter.java
@@ -11,29 +11,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.query;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdFactory;
 
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
 /**
  * Kapua result list adapter. It marshal and unmarshal the Kapua result list in a proper way.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class KapuaListResultAdapter extends XmlAdapter<String, KapuaId> {
 
-    /**
-     * Locator instance
-     */
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-
-    /**
-     * Meta type factory instance
-     */
-    private final KapuaIdFactory kapuaIdFactory = locator.getFactory(KapuaIdFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final KapuaIdFactory KAPUA_ID_FACTORY = LOCATOR.getFactory(KapuaIdFactory.class);
 
     @Override
     public String marshal(KapuaId v) throws Exception {
@@ -42,7 +34,7 @@ public class KapuaListResultAdapter extends XmlAdapter<String, KapuaId> {
 
     @Override
     public KapuaId unmarshal(String v) throws Exception {
-        return kapuaIdFactory.newKapuaId(v);
+        return KAPUA_ID_FACTORY.newKapuaId(v);
     }
 
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
@@ -11,13 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.query;
 
-import java.util.List;
-
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -26,140 +19,138 @@ import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.model.query.predicate.QueryPredicate;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.List;
+
 /**
  * {@link KapuaQuery} definition.
  *
- * @param <E>
- *            query entity domain
+ * @param <E> query entity domain
  */
 public interface KapuaQuery<E extends KapuaEntity> {
 
     /**
      * Gets the fetch attribute names list.
-     * 
+     *
      * @return The fetch attribute names list.
      */
     @XmlElementWrapper(name = "fetchAttributeName")
     @XmlElement(name = "fetchAttributeName")
-    public List<String> getFetchAttributes();
+    List<String> getFetchAttributes();
 
     /**
      * Adds an attribute to the fetch attribute names list
-     * 
-     * @param fetchAttribute
-     *            The fetch attribute to add to the list.
+     *
+     * @param fetchAttribute The fetch attribute to add to the list.
      * @since 1.0.0
      */
-    public void addFetchAttributes(String fetchAttribute);
+    void addFetchAttributes(String fetchAttribute);
 
     /**
      * Sets the fetch attribute names list.<br>
      * This list is a list of optional attributes of a {@link KapuaEntity} that can be fetched when querying.
-     * 
-     * @param fetchAttributeNames
-     *            The fetch attribute names list.
+     *
+     * @param fetchAttributeNames The fetch attribute names list.
      * @since 1.0.0
      */
-    public void setFetchAttributes(List<String> fetchAttributeNames);
+    void setFetchAttributes(List<String> fetchAttributeNames);
 
     /**
      * Get the scope {@link KapuaId} in which to query.
-     * 
+     *
      * @return The scope {@link KapuaId} in which to query.
      * @since 1.0.0
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Set the scope {@link KapuaId} in which to query.
-     * 
-     * @param scopeId
-     *            The scope {@link KapuaId} in which to query.
+     *
+     * @param scopeId The scope {@link KapuaId} in which to query.
      * @since 1.0.0
      */
-    public void setScopeId(KapuaId scopeId);
+    void setScopeId(KapuaId scopeId);
 
     /**
      * Gets the {@link KapuaQuery} {@link QueryPredicate}s.
-     * 
+     *
      * @return The {@link KapuaQuery} {@link QueryPredicate}s.
      * @since 1.0.0
      */
     @XmlTransient
     // @XmlElement(name = "predicate")
-    public QueryPredicate getPredicate();
+    QueryPredicate getPredicate();
 
     /**
      * Sets the {@link KapuaQuery} {@link QueryPredicate}s.<br>
      * The {@link QueryPredicate} can be a simple {@link AttributePredicate} or a combination
      * of them by using the {@link AndPredicate}
-     * 
-     * @param queryPredicate
-     *            The {@link KapuaQuery} {@link QueryPredicate}s.
+     *
+     * @param queryPredicate The {@link KapuaQuery} {@link QueryPredicate}s.
      * @since 1.0.0
      */
-    public void setPredicate(QueryPredicate queryPredicate);
+    void setPredicate(QueryPredicate queryPredicate);
 
     /**
      * Gets the {@link KapuaQuery} {@link KapuaSortCriteria}
-     * 
+     *
      * @return The {@link KapuaQuery} {@link KapuaSortCriteria}
      * @since 1.0.0
      */
     @XmlTransient
     // @XmlElement(name = "sortCriteria")
-    public KapuaSortCriteria getSortCriteria();
+    KapuaSortCriteria getSortCriteria();
 
     /**
      * Sets the {@link KapuaQuery} {@link KapuaSortCriteria}.
-     * 
-     * @param sortCriteria
-     *            The {@link KapuaQuery} {@link KapuaSortCriteria}.
+     *
+     * @param sortCriteria The {@link KapuaQuery} {@link KapuaSortCriteria}.
      * @since 1.0.0
      */
-    public void setSortCriteria(KapuaSortCriteria sortCriteria);
+    void setSortCriteria(KapuaSortCriteria sortCriteria);
 
     /**
      * Gets the {@link KapuaQuery} offset.
-     * 
+     *
      * @return The {@link KapuaQuery} offset.
      * @since 1.0.0
      */
     @XmlElement(name = "offset")
-    public Integer getOffset();
+    Integer getOffset();
 
     /**
      * Set the {@link KapuaQuery} offset in the result set from which start query.<br>
      * If set to {@code null} the {@link KapuaQuery} will start from the first result found.
      * This also mean that {@link #setOffset(Integer)} with {@code 0} or {@code null} will produce the same result.<br>
      * This method and {@link #setLimit(Integer)} are meant to be used to paginate through the result set.
-     * 
-     * @param offset
-     *            The {@link KapuaQuery} offset.
+     *
+     * @param offset The {@link KapuaQuery} offset.
      * @since 1.0.0
      */
-    public void setOffset(Integer offset);
+    void setOffset(Integer offset);
 
     /**
      * Gets the {@link KapuaQuery} limit.
-     * 
+     *
      * @return The {@link KapuaQuery} limit.
      * @since 1.0.0
      */
     @XmlElement(name = "limit")
-    public Integer getLimit();
+    Integer getLimit();
 
     /**
      * Sets max number of result that will be fetched by this {@link KapuaEntity}.<br>
      * If set to {@code null} the {@link KapuaQuery} will be unlimited.<br>
      * This method and {@link #setOffset(Integer)} are meant to be used to paginate through the result set.
-     * 
-     * @param limit
-     *            The max number of result that will be fetched by this {@link KapuaEntity}.
+     *
+     * @param limit The max number of result that will be fetched by this {@link KapuaEntity}.
      * @since 1.0.0
      */
-    public void setLimit(Integer limit);
+    void setLimit(Integer limit);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/AndPredicate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/AndPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,25 +14,24 @@ package org.eclipse.kapua.model.query.predicate;
 import java.util.List;
 
 /**
- * Kapua sql and predicate definition.
- * 
+ * Kapua sql {@link AndPredicate} definition.
+ *
  * @since 1.0
- * 
  */
 public interface AndPredicate extends QueryPredicate {
 
     /**
      * Creates an "and predicate" from a generic predicate
-     * 
+     *
      * @param predicate
      * @return
      */
-    public AndPredicate and(QueryPredicate predicate);
+    AndPredicate and(QueryPredicate predicate);
 
     /**
      * Returns a list of predicates
-     * 
+     *
      * @return
      */
-    public List<QueryPredicate> getPredicates();
+    List<QueryPredicate> getPredicates();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/DateXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/DateXmlAdapter.java
@@ -11,27 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.xml;
 
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
-
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 public class DateXmlAdapter extends XmlAdapter<String, Date> {
 
     public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
     public static final String TIME_ZONE_UTC = "UTC";
-
-    @Override
-    public Date unmarshal(String v) {
-        if (v == null || v.isEmpty()) {
-            return null;
-        }
-
-        return DatatypeConverter.parseDateTime(v).getTime();
-    }
 
     @Override
     public String marshal(Date v) throws Exception {
@@ -42,5 +32,14 @@ public class DateXmlAdapter extends XmlAdapter<String, Date> {
         SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
         format.setTimeZone(TimeZone.getTimeZone(TIME_ZONE_UTC));
         return format.format(v);
+    }
+
+    @Override
+    public Date unmarshal(String v) {
+        if (v == null || v.isEmpty()) {
+            return null;
+        }
+
+        return DatatypeConverter.parseDateTime(v).getTime();
     }
 }

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaDomainService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaDomainService.java
@@ -20,5 +20,5 @@ import org.eclipse.kapua.model.domain.Domain;
  */
 public interface KapuaDomainService<D extends Domain> extends KapuaService {
 
-    public D getServiceDomain();
+    D getServiceDomain();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaEntityService.java
@@ -21,64 +21,55 @@ import org.eclipse.kapua.model.query.KapuaQuery;
 /**
  * Common interface for all KapuaService that are managing identifiable entities.
  *
- * @param <E>
- *            - Class of the KapuaEntity being managed by this Service
- * @param <C>
- *            - Creator Class of the KapuaEntity being managed by this Service
- * 
+ * @param <E> - Class of the KapuaEntity being managed by this Service
+ * @param <C> - Creator Class of the KapuaEntity being managed by this Service
  * @since 1.0
- * 
  */
 public interface KapuaEntityService<E extends KapuaEntity, C extends KapuaEntityCreator<E>> extends KapuaService {
 
     /**
      * Creates the entity using information provided via entity creator
-     * 
+     *
      * @param creator
      * @return
      * @throws KapuaException
      */
-    public E create(C creator)
-            throws KapuaException;
+    E create(C creator) throws KapuaException;
 
     /**
      * Find the entity identified by entity and scope identifiers
-     * 
+     *
      * @param scopeId
      * @param entityId
      * @return
      * @throws KapuaException
      */
-    public E find(KapuaId scopeId, KapuaId entityId)
-            throws KapuaException;
+    E find(KapuaId scopeId, KapuaId entityId) throws KapuaException;
 
     /**
      * Returns the entity list matching the provided query
-     * 
+     *
      * @param query
      * @return
      * @throws KapuaException
      */
-    public KapuaListResult<E> query(KapuaQuery<E> query)
-            throws KapuaException;
+    KapuaListResult<E> query(KapuaQuery<E> query) throws KapuaException;
 
     /**
      * Returns the entity count matching the provided query
-     * 
+     *
      * @param query
      * @return
      * @throws KapuaException
      */
-    public long count(KapuaQuery<E> query)
-            throws KapuaException;
+    long count(KapuaQuery<E> query) throws KapuaException;
 
     /**
      * Delete the entity identified by the entity and scope identifiers
-     * 
+     *
      * @param scopeId
      * @param entityId
      * @throws KapuaException
      */
-    public void delete(KapuaId scopeId, KapuaId entityId)
-            throws KapuaException;
+    void delete(KapuaId scopeId, KapuaId entityId) throws KapuaException;
 }

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaNamedEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaNamedEntityService.java
@@ -17,21 +17,17 @@ import org.eclipse.kapua.model.KapuaEntity;
 /**
  * Common interface for all KapuaService that are managing identifiable entities.
  *
- * @param <E>
- *            - Class of the KapuaEntity being managed by this Service
- * 
+ * @param <E> - Class of the KapuaEntity being managed by this Service
  * @since 1.0
- * 
  */
 public interface KapuaNamedEntityService<E extends KapuaEntity> extends KapuaService {
 
     /**
      * Find the entity by name
-     * 
+     *
      * @param name
      * @return
      * @throws KapuaException
      */
-    public E findByName(String name)
-            throws KapuaException;
+    E findByName(String name) throws KapuaException;
 }

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaUpdatableEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaUpdatableEntityService.java
@@ -17,21 +17,17 @@ import org.eclipse.kapua.model.KapuaEntity;
 /**
  * Common interface for all KapuaService that are managing identifiable entities.
  *
- * @param <E>
- *            - Class of the KapuaEntity being managed by this Service
- * 
+ * @param <E> - Class of the KapuaEntity being managed by this Service
  * @since 1.0
- * 
  */
 public interface KapuaUpdatableEntityService<E extends KapuaEntity> extends KapuaService {
 
     /**
      * Update the provided entity
-     * 
+     *
      * @param entity
      * @return
      * @throws KapuaException
      */
-    public E update(E entity)
-            throws KapuaException;
+    E update(E entity) throws KapuaException;
 }

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/KapuaConfigurableService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/KapuaConfigurableService.java
@@ -11,44 +11,43 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.config;
 
-import java.util.Map;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.id.KapuaId;
 
+import java.util.Map;
+
 /**
  * Configurable service definition
- * 
+ *
  * @since 1.0
- * 
  */
 public interface KapuaConfigurableService {
 
     /**
      * Return the service configuration metadata
-     * 
+     *
      * @return
      * @throws KapuaException
      */
-    public KapuaTocd getConfigMetadata() throws KapuaException;
+    KapuaTocd getConfigMetadata() throws KapuaException;
 
     /**
      * Return a map of configuration values associated with the provided scope id
-     * 
+     *
      * @param scopeId
      * @return
      * @throws KapuaException
      */
-    public Map<String, Object> getConfigValues(KapuaId scopeId) throws KapuaException;
+    Map<String, Object> getConfigValues(KapuaId scopeId) throws KapuaException;
 
     /**
      * Set the configuration values for the specified scope id
-     * 
+     *
      * @param scopeId
      * @param values
      * @throws KapuaException
      */
-    public void setConfigValues(KapuaId scopeId, KapuaId parentId, Map<String, Object> values) throws KapuaException;
+    void setConfigValues(KapuaId scopeId, KapuaId parentId, Map<String, Object> values) throws KapuaException;
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoRegistryService.java
@@ -39,8 +39,7 @@ public interface ChannelInfoRegistryService extends KapuaService,
      * @throws KapuaException
      * @since 1.0.0
      */
-    public ChannelInfo find(KapuaId scopeId, StorableId id)
-            throws KapuaException;
+    ChannelInfo find(KapuaId scopeId, StorableId id) throws KapuaException;
 
     /**
      * Query for channels informations objects matching the given query
@@ -50,8 +49,7 @@ public interface ChannelInfoRegistryService extends KapuaService,
      * @throws KapuaException
      * @since 1.0.0
      */
-    public ChannelInfoListResult query(ChannelInfoQuery query)
-            throws KapuaException;
+    ChannelInfoListResult query(ChannelInfoQuery query) throws KapuaException;
 
     /**
      * Get the channels informations count matching the given query
@@ -61,7 +59,5 @@ public interface ChannelInfoRegistryService extends KapuaService,
      * @throws KapuaException
      * @since 1.0.0
      */
-    public long count(ChannelInfoQuery query)
-            throws KapuaException;
-
+    long count(ChannelInfoQuery query) throws KapuaException;
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoXmlRegistry.java
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 /**
  * Channel information xml registry
@@ -25,24 +25,24 @@ import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
 @XmlRegistry
 public class ChannelInfoXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DatastoreObjectFactory factory = locator.getFactory(DatastoreObjectFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DatastoreObjectFactory DATASTORE_OBJECT_FACTORY = LOCATOR.getFactory(DatastoreObjectFactory.class);
 
     /**
      * Creates a {@link ChannelInfoListResult} instance
-     * 
+     *
      * @return
      */
     public ChannelInfoListResult newChannelInfoListResult() {
-        return factory.newChannelInfoListResult();
+        return DATASTORE_OBJECT_FACTORY.newChannelInfoListResult();
     }
 
     /**
      * Creates a {@link ChannelInfoQuery} instance.
-     * 
+     *
      * @return
      */
     public ChannelInfoQuery newQuery() {
-        return factory.newChannelInfoQuery(null);
+        return DATASTORE_OBJECT_FACTORY.newChannelInfoQuery(null);
     }
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoRegistryService.java
@@ -39,8 +39,7 @@ public interface ClientInfoRegistryService extends KapuaService,
      * @throws KapuaException
      * @since 1.0.0
      */
-    public ClientInfo find(KapuaId scopeId, StorableId id)
-            throws KapuaException;
+    ClientInfo find(KapuaId scopeId, StorableId id) throws KapuaException;
 
     /**
      * Query for clients informations objects matching the given query
@@ -50,8 +49,7 @@ public interface ClientInfoRegistryService extends KapuaService,
      * @throws KapuaException
      * @since 1.0.0
      */
-    public ClientInfoListResult query(ClientInfoQuery query)
-            throws KapuaException;
+    ClientInfoListResult query(ClientInfoQuery query) throws KapuaException;
 
     /**
      * Get the clients informations count matching the given query
@@ -61,7 +59,6 @@ public interface ClientInfoRegistryService extends KapuaService,
      * @throws KapuaException
      * @since 1.0.0
      */
-    public long count(ClientInfoQuery query)
-            throws KapuaException;
+    long count(ClientInfoQuery query) throws KapuaException;
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoXmlRegistry.java
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.model.ClientInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 /**
  * Client information xml registry
@@ -25,24 +25,24 @@ import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 @XmlRegistry
 public class ClientInfoXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DatastoreObjectFactory factory = locator.getFactory(DatastoreObjectFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DatastoreObjectFactory DATASTORE_OBJECT_FACTORY = LOCATOR.getFactory(DatastoreObjectFactory.class);
 
     /**
      * Creates a {@link ClientInfoListResult} instance
-     * 
+     *
      * @return
      */
     public ClientInfoListResult newClientInfoListResult() {
-        return factory.newClientInfoListResult();
+        return DATASTORE_OBJECT_FACTORY.newClientInfoListResult();
     }
 
     /**
      * Creates a {@link ClientInfoQuery} instance.
-     * 
+     *
      * @return
      */
     public ClientInfoQuery newQuery() {
-        return factory.newClientInfoQuery(null);
+        return DATASTORE_OBJECT_FACTORY.newClientInfoQuery(null);
     }
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreMessageXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreMessageXmlRegistry.java
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 /**
  * Datastore message xml registry
@@ -25,24 +25,24 @@ import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 @XmlRegistry
 public class DatastoreMessageXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DatastoreObjectFactory factory = locator.getFactory(DatastoreObjectFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DatastoreObjectFactory DATASTORE_OBJECT_FACTORY = LOCATOR.getFactory(DatastoreObjectFactory.class);
 
     /**
      * Creates a {@link MessageListResult} instance
-     * 
+     *
      * @return
      */
     public MessageListResult newDatastoreMessageListResult() {
-        return factory.newDatastoreMessageListResult();
+        return DATASTORE_OBJECT_FACTORY.newDatastoreMessageListResult();
     }
 
     /**
      * Creates a {@link MessageQuery} instance.
-     * 
+     *
      * @return
      */
     public MessageQuery newQuery() {
-        return factory.newDatastoreMessageQuery(null);
+        return DATASTORE_OBJECT_FACTORY.newDatastoreMessageQuery(null);
     }
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreObjectFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreObjectFactory.java
@@ -25,93 +25,86 @@ import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 
 /**
  * Datastore object factory definition
- * 
+ *
  * @since 1.0.0
  */
 public interface DatastoreObjectFactory extends KapuaObjectFactory {
 
     /**
      * Return a new channel information query
-     * 
+     *
      * @param scopeId
      * @return
-     * 
      * @since 1.0.0
      */
-    public ChannelInfoQuery newChannelInfoQuery(KapuaId scopeId);
+    ChannelInfoQuery newChannelInfoQuery(KapuaId scopeId);
 
     /**
      * Return a new channel information query
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public ChannelInfoListResult newChannelInfoListResult();
+    ChannelInfoListResult newChannelInfoListResult();
 
     /**
      * Return a new client information query
-     * 
+     *
      * @param scopeId
      * @return
-     * 
      * @since 1.0.0
      */
-    public ClientInfoQuery newClientInfoQuery(KapuaId scopeId);
+    ClientInfoQuery newClientInfoQuery(KapuaId scopeId);
 
     /**
      * Return a new client information query
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public ClientInfoListResult newClientInfoListResult();
+    ClientInfoListResult newClientInfoListResult();
 
     /**
      * Return a new datastore message query
-     * 
+     *
      * @param scopeId
      * @return
-     * 
      * @since 1.0.0
      */
-    public MessageQuery newDatastoreMessageQuery(KapuaId scopeId);
+    MessageQuery newDatastoreMessageQuery(KapuaId scopeId);
 
     /**
+     * s
      * Return a new metric information query
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public MessageListResult newDatastoreMessageListResult();
+    MessageListResult newDatastoreMessageListResult();
 
     /**
      * Return a new metric information query
-     * 
+     *
      * @param scopeId
      * @return
-     * 
      * @since 1.0.0
      */
-    public MetricInfoQuery newMetricInfoQuery(KapuaId scopeId);
+    MetricInfoQuery newMetricInfoQuery(KapuaId scopeId);
 
     /**
      * Return a new metric information query
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public MetricInfoListResult newMetricInfoListResult();
+    MetricInfoListResult newMetricInfoListResult();
 
     /**
      * Returns a new Metric instance
-     * 
+     *
      * @param name
      * @param value
      * @return
      */
-    public Metric<?> newMetric(String name, Object value);
+    Metric<?> newMetric(String name, Object value);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreService.java
@@ -16,10 +16,10 @@ import org.eclipse.kapua.service.KapuaService;
 
 public interface DatastoreService extends KapuaService, KapuaDomainService<DatastoreDomain> {
 
-    public static final DatastoreDomain DATASTORE_DOMAIN = new DatastoreDomain();
+    DatastoreDomain DATASTORE_DOMAIN = new DatastoreDomain();
 
     @Override
-    public default DatastoreDomain getServiceDomain() {
+    default DatastoreDomain getServiceDomain() {
         return DATASTORE_DOMAIN;
     }
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
@@ -37,8 +37,7 @@ public interface MessageStoreService extends KapuaService, DatastoreService, Kap
      * @throws KapuaException
      * @since 1.0.0
      */
-    StorableId store(KapuaMessage<?, ?> message)
-            throws KapuaException;
+    StorableId store(KapuaMessage<?, ?> message) throws KapuaException;
 
     /**
      * Store the message setting the provided datastoreId
@@ -48,8 +47,7 @@ public interface MessageStoreService extends KapuaService, DatastoreService, Kap
      * @return
      * @throws KapuaException
      */
-    StorableId store(KapuaMessage<?, ?> message, String datastoreId)
-            throws KapuaException;
+    StorableId store(KapuaMessage<?, ?> message, String datastoreId) throws KapuaException;
 
     /**
      * Find message by identifier
@@ -61,8 +59,7 @@ public interface MessageStoreService extends KapuaService, DatastoreService, Kap
      * @throws KapuaException
      * @since 1.0.0
      */
-    DatastoreMessage find(KapuaId scopeId, StorableId id, StorableFetchStyle fetchStyle)
-            throws KapuaException;
+    DatastoreMessage find(KapuaId scopeId, StorableId id, StorableFetchStyle fetchStyle) throws KapuaException;
 
     /**
      * Query for messages objects matching the given query
@@ -72,8 +69,7 @@ public interface MessageStoreService extends KapuaService, DatastoreService, Kap
      * @throws KapuaException
      * @since 1.0.0
      */
-    MessageListResult query(MessageQuery query)
-            throws KapuaException;
+    MessageListResult query(MessageQuery query) throws KapuaException;
 
     /**
      * Get messages count matching the given query
@@ -83,8 +79,7 @@ public interface MessageStoreService extends KapuaService, DatastoreService, Kap
      * @throws KapuaException
      * @since 1.0.0
      */
-    long count(MessageQuery query)
-            throws KapuaException;
+    long count(MessageQuery query) throws KapuaException;
 
     /**
      * Delete message by identifier
@@ -94,8 +89,7 @@ public interface MessageStoreService extends KapuaService, DatastoreService, Kap
      * @throws KapuaException
      * @since 1.0.0
      */
-    void delete(KapuaId scopeId, StorableId id)
-            throws KapuaException;
+    void delete(KapuaId scopeId, StorableId id) throws KapuaException;
 
     /**
      * Delete messages matching the given query
@@ -104,7 +98,5 @@ public interface MessageStoreService extends KapuaService, DatastoreService, Kap
      * @throws KapuaException
      * @since 1.0.0
      */
-    void delete(MessageQuery query)
-            throws KapuaException;
-
+    void delete(MessageQuery query) throws KapuaException;
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoRegistryService.java
@@ -38,8 +38,7 @@ public interface MetricInfoRegistryService extends KapuaService, DatastoreServic
      * @throws KapuaException
      * @since 1.0.0
      */
-    public MetricInfo find(KapuaId scopeId, StorableId id)
-            throws KapuaException;
+    MetricInfo find(KapuaId scopeId, StorableId id) throws KapuaException;
 
     /**
      * Query for metrics informations objects matching the given query
@@ -49,8 +48,7 @@ public interface MetricInfoRegistryService extends KapuaService, DatastoreServic
      * @throws KapuaException
      * @since 1.0.0
      */
-    public MetricInfoListResult query(MetricInfoQuery query)
-            throws KapuaException;
+    MetricInfoListResult query(MetricInfoQuery query) throws KapuaException;
 
     /**
      * Get the metrics informations count matching the given query
@@ -60,7 +58,6 @@ public interface MetricInfoRegistryService extends KapuaService, DatastoreServic
      * @throws KapuaException
      * @since 1.0.0
      */
-    public long count(MetricInfoQuery query)
-            throws KapuaException;
+    long count(MetricInfoQuery query) throws KapuaException;
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoXmlRegistry.java
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.datastore.model.MetricInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 /**
  * Metric information xml registry
@@ -25,24 +25,24 @@ import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 @XmlRegistry
 public class MetricInfoXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DatastoreObjectFactory factory = locator.getFactory(DatastoreObjectFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DatastoreObjectFactory DATASTORE_OBJECT_FACTORY = LOCATOR.getFactory(DatastoreObjectFactory.class);
 
     /**
      * Creates a {@link MetricInfoListResult} instance
-     * 
+     *
      * @return
      */
     public MetricInfoListResult newMetricInfoListResult() {
-        return factory.newMetricInfoListResult();
+        return DATASTORE_OBJECT_FACTORY.newMetricInfoListResult();
     }
 
     /**
      * Creates a {@link MetricInfoQuery} instance.
-     * 
+     *
      * @return
      */
     public MetricInfoQuery newQuery() {
-        return factory.newMetricInfoQuery(null);
+        return DATASTORE_OBJECT_FACTORY.newMetricInfoQuery(null);
     }
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import java.util.Date;
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -19,15 +22,11 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.model.xml.DateXmlAdapter;
+import java.util.Date;
 
 /**
  * Channel information schema definition
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "channel")
@@ -46,159 +45,143 @@ public interface ChannelInfo extends Storable {
 
     /**
      * Get the record identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getId();
+    StorableId getId();
 
     /**
      * Set the record identifier
-     * 
+     *
      * @param id
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public void setId(StorableId id);
+    void setId(StorableId id);
 
     /**
      * Get the scope id
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Get the client identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "clientId")
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set the client identifier
-     * 
+     *
      * @param clientId
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "clientId")
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the channel name
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the channel name
-     * 
+     *
      * @param name
-     * 
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the message identifier (of the first message published on this channel)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageId")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getFirstMessageId();
+    StorableId getFirstMessageId();
 
     /**
      * Set the message identifier (of the first message published on this channel)
-     * 
+     *
      * @param firstMessageId
-     * 
      * @since 1.0.0
      */
-    public void setFirstMessageId(StorableId firstMessageId);
+    void setFirstMessageId(StorableId firstMessageId);
 
     /**
      * Get the message timestamp (of the first message published on this channel)
-     * 
+     *
      * @return
-     * 
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getFirstMessageOn();
+    Date getFirstMessageOn();
 
     /**
      * Set the message timestamp (of the first message published on this channel)
-     * 
+     *
      * @param firstMessageOn
      */
-    public void setFirstMessageOn(Date firstMessageOn);
+    void setFirstMessageOn(Date firstMessageOn);
 
     /**
      * Get the message identifier of the last published message for this channel.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageId")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-
-    public StorableId getLastMessageId();
+    StorableId getLastMessageId();
 
     /**
      * Set the message identifier of the last published message for this channel.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
-     * 
+     *
      * @param lastMessageId
-     * 
      * @since 1.0.0
      */
-    public void setLastMessageId(StorableId lastMessageId);
+    void setLastMessageId(StorableId lastMessageId);
 
     /**
      * Get the timestamp of the last published message for this channel.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getLastMessageOn();
+    Date getLastMessageOn();
 
     /**
      * Set the timestamp of the last published message for this channel.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
-     * 
+     *
      * @param lastMessageOn
-     * 
      * @since 1.0.0
      */
-    public void setLastMessageOn(Date lastMessageOn);
+    void setLastMessageOn(Date lastMessageOn);
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoCreator.java
@@ -11,86 +11,78 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import java.util.Date;
-
 import org.eclipse.kapua.model.id.KapuaId;
+
+import java.util.Date;
 
 /**
  * Channel information schema creator definition
- * 
+ *
  * @since 1.0.0
  */
 public interface ChannelInfoCreator extends StorableCreator<ChannelInfo> {
 
     /**
      * Get the account
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Get the client identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public String getClientId();
+    String getClientId();
 
     /**
      * Get the name
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public String getName();
+    String getName();
 
     /**
      * Set the channel name
-     * 
+     *
      * @param name
-     * 
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the message identifier (of the first message published on this channel)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public StorableId getMessageId();
+    StorableId getMessageId();
 
     /**
      * Set the message identifier (of the first message published on this channel)
-     * 
+     *
      * @param messageId
-     * 
      * @since 1.0.0
      */
-    public void setMessageId(StorableId messageId);
+    void setMessageId(StorableId messageId);
 
     /**
      * Get the message timestamp (of the first message published on this channel)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public Date getMessageTimestamp();
+    Date getMessageTimestamp();
 
     /**
      * Set the message timestamp (of the first message published on this channel)
-     * 
+     *
      * @param messageTimestamp
-     * 
      * @since 1.0.0
      */
-    public void setMessageTimestamp(Date messageTimestamp);
+    void setMessageTimestamp(Date messageTimestamp);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoListResult.java
@@ -11,17 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
+import org.eclipse.kapua.service.datastore.ChannelInfoXmlRegistry;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.service.datastore.ChannelInfoXmlRegistry;
 
 /**
  * Channel information query result list definition.<br>
  * This object contains the list of the channel information objects retrieved by the search service.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "channelInfos")
 @XmlType(factoryClass = ChannelInfoXmlRegistry.class, factoryMethod = "newChannelInfoListResult")

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import java.util.Date;
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -19,15 +22,11 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.model.xml.DateXmlAdapter;
+import java.util.Date;
 
 /**
  * Client information schema definition
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "clientInfo")
@@ -45,138 +44,125 @@ public interface ClientInfo extends Storable {
 
     /**
      * Get the record identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getId();
+    StorableId getId();
 
     /**
      * Set the record identifier
-     * 
+     *
      * @param id
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public void setId(StorableId id);
+    void setId(StorableId id);
 
     /**
      * Get the scope id
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Get the client identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "clientId")
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set the client identifier
-     * 
+     *
      * @param clientId
-     * 
      * @since 1.0.0
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the message identifier (of the first message published by this client)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageId")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getFirstMessageId();
+    StorableId getFirstMessageId();
 
     /**
      * Set the message identifier (of the first message published by this client)
-     * 
+     *
      * @param firstMessageId
-     * 
      * @since 1.0.0
      */
-    public void setFirstMessageId(StorableId firstMessageId);
+    void setFirstMessageId(StorableId firstMessageId);
 
     /**
      * Get the message timestamp (of the first message published by this client)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getFirstMessageOn();
+    Date getFirstMessageOn();
 
     /**
      * Set the message timestamp (of the first message published by this client)
-     * 
+     *
      * @param firstMessageOn
-     * 
      * @since 1.0.0
      */
-    public void setFirstMessageOn(Date firstMessageOn);
+    void setFirstMessageOn(Date firstMessageOn);
 
     /**
      * Get the message identifier of the last published message for this client.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageId")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getLastMessageId();
+    StorableId getLastMessageId();
 
     /**
      * Set the message identifier of the last published message for this client.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
-     * 
+     *
      * @param lastMessageId
-     * 
      * @since 1.0.0
      */
-    public void setLastMessageId(StorableId lastMessageId);
+    void setLastMessageId(StorableId lastMessageId);
 
     /**
      * Get the identifier of the last published message for this client.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getLastMessageOn();
+    Date getLastMessageOn();
 
     /**
      * Set the timestamp of the last published message for this client.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
-     * 
+     *
      * @param lastMessageOn
-     * 
      * @since 1.0.0
      */
-    public void setLastMessageOn(Date lastMessageOn);
+    void setLastMessageOn(Date lastMessageOn);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoCreator.java
@@ -11,77 +11,70 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import java.util.Date;
-
 import org.eclipse.kapua.model.id.KapuaId;
+
+import java.util.Date;
 
 /**
  * Client information schema creator definition
- * 
+ *
  * @since 1.0.0
  */
 public interface ClientInfoCreator extends StorableCreator<ClientInfo> {
 
     /**
      * Get the account
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Get the client identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set the client identifier
-     * 
+     *
      * @param clientId
-     * 
      * @since 1.0.0
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the message identifier (of the first message published by this client)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public StorableId getMessageId();
+    StorableId getMessageId();
 
     /**
      * Set the message identifier (of the first message published by this client)
-     * 
+     *
      * @param messageId
-     * 
      * @since 1.0.0
      */
-    public void setMessageId(StorableId messageId);
+    void setMessageId(StorableId messageId);
 
     /**
      * Get the message timestamp (of the first message published by this client)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public Date getMessageTimestamp();
+    Date getMessageTimestamp();
 
     /**
      * Set the message timestamp (of the first message published by this client)
-     * 
+     *
      * @param messageTimestamp
-     * 
      * @since 1.0.0
      */
-    public void setMessageTimestamp(Date messageTimestamp);
+    void setMessageTimestamp(Date messageTimestamp);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoListResult.java
@@ -11,17 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
+import org.eclipse.kapua.service.datastore.ClientInfoXmlRegistry;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.service.datastore.ClientInfoXmlRegistry;
 
 /**
  * Client information query result list definition.<br>
  * This object contains the list of the client information objects retrieved by the search service.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "clientInfos")
 @XmlType(factoryClass = ClientInfoXmlRegistry.class, factoryMethod = "newClientInfoListResult")

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
@@ -11,16 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import java.util.Date;
-import java.util.UUID;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.message.KapuaChannel;
 import org.eclipse.kapua.message.KapuaPayload;
@@ -28,6 +18,15 @@ import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Date;
+import java.util.UUID;
 
 /**
  * Message returned by the data store find services
@@ -54,33 +53,29 @@ public interface DatastoreMessage extends Storable {
 
     /**
      * Stored message identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "datastoreId")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getDatastoreId();
+    StorableId getDatastoreId();
 
     /**
      * Stored message identifier
-     * 
      */
-    public void setDatastoreId(StorableId storableId);
+    void setDatastoreId(StorableId storableId);
 
     /**
      * Stored message timestamp
-     * 
+     *
      * @return
      */
-    public Date getTimestamp();
+    Date getTimestamp();
 
-    // TODO TOCHECK security for updates (the timestamp shouldn't updated outside datastore)
     /**
      * Stored message timestamp
-     * 
      */
-    public void setTimestamp(Date timestamp);
-
+    void setTimestamp(Date timestamp);
 
     /**
      * Get the message identifier
@@ -88,14 +83,14 @@ public interface DatastoreMessage extends Storable {
      * @return
      */
     @XmlElement(name = "id")
-    public UUID getId();
+    UUID getId();
 
     /**
      * Set the message identifier
      *
      * @param id
      */
-    public void setId(UUID id);
+    void setId(UUID id);
 
     /**
      * Get scope identifier
@@ -105,14 +100,14 @@ public interface DatastoreMessage extends Storable {
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Set scope identifier
      *
      * @param scopeId
      */
-    public void setScopeId(KapuaId scopeId);
+    void setScopeId(KapuaId scopeId);
 
     /**
      * Get client identifier
@@ -120,14 +115,14 @@ public interface DatastoreMessage extends Storable {
      * @return
      */
     @XmlElement(name = "clientId")
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set client identifier
      *
      * @param clientId
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get device identifier
@@ -136,14 +131,14 @@ public interface DatastoreMessage extends Storable {
      */
     @XmlElement(name = "deviceId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
-    public KapuaId getDeviceId();
+    KapuaId getDeviceId();
 
     /**
      * Set device identifier
      *
      * @param deviceId
      */
-    public void setDeviceId(KapuaId deviceId);
+    void setDeviceId(KapuaId deviceId);
 
     /**
      * Get the message received on date
@@ -152,14 +147,14 @@ public interface DatastoreMessage extends Storable {
      */
     @XmlElement(name = "receivedOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getReceivedOn();
+    Date getReceivedOn();
 
     /**
      * Set the message received on date
      *
      * @param receivedOn
      */
-    public void setReceivedOn(Date receivedOn);
+    void setReceivedOn(Date receivedOn);
 
     /**
      * Get the message sent on date
@@ -168,14 +163,14 @@ public interface DatastoreMessage extends Storable {
      */
     @XmlElement(name = "sentOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getSentOn();
+    Date getSentOn();
 
     /**
      * Set the message sent on date
      *
      * @param sentOn
      */
-    public void setSentOn(Date sentOn);
+    void setSentOn(Date sentOn);
 
     /**
      * Get the message captured on date
@@ -184,14 +179,14 @@ public interface DatastoreMessage extends Storable {
      */
     @XmlElement(name = "capturedOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getCapturedOn();
+    Date getCapturedOn();
 
     /**
      * Set the message captured on date
      *
      * @param capturedOn
      */
-    public void setCapturedOn(Date capturedOn);
+    void setCapturedOn(Date capturedOn);
 
     /**
      * Get the device position
@@ -199,14 +194,14 @@ public interface DatastoreMessage extends Storable {
      * @return
      */
     @XmlElement(name = "position")
-    public KapuaPosition getPosition();
+    KapuaPosition getPosition();
 
     /**
      * Set the device position
      *
      * @param position
      */
-    public void setPosition(KapuaPosition position);
+    void setPosition(KapuaPosition position);
 
     /**
      * Get the message channel
@@ -214,14 +209,14 @@ public interface DatastoreMessage extends Storable {
      * @return
      */
     @XmlElement(name = "channel")
-    public KapuaChannel getChannel();
+    KapuaChannel getChannel();
 
     /**
      * Set the message channel
      *
      * @param semanticChannel
      */
-    public void setChannel(KapuaChannel semanticChannel);
+    void setChannel(KapuaChannel semanticChannel);
 
     /**
      * Get the message payload
@@ -229,12 +224,12 @@ public interface DatastoreMessage extends Storable {
      * @return
      */
     @XmlElement(name = "payload")
-    public KapuaPayload getPayload();
+    KapuaPayload getPayload();
 
     /**
      * Set the message payload
      *
      * @param payload
      */
-    public void setPayload(KapuaPayload payload);
+    void setPayload(KapuaPayload payload);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MessageListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MessageListResult.java
@@ -11,17 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
+import org.eclipse.kapua.service.datastore.DatastoreMessageXmlRegistry;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.service.datastore.DatastoreMessageXmlRegistry;
 
 /**
  * Message information query result list definition.<br>
  * This object contains the list of the message objects retrieved by the search service.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "datastoreMessages")
 @XmlType(factoryClass = DatastoreMessageXmlRegistry.class, factoryMethod = "newDatastoreMessageListResult")

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Metric.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Metric.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
+import org.eclipse.persistence.oxm.annotations.XmlPath;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -18,14 +20,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.eclipse.persistence.oxm.annotations.XmlPath;
-
 /**
  * Metric definition
- * 
- * @since 1.0
  *
  * @param <T>
+ * @since 1.0
  */
 @XmlRootElement(name = "metric")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -36,60 +35,54 @@ public interface Metric<T> extends Comparable<T> {
 
     /**
      * Get the name
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the name
-     * 
+     *
      * @param name
-     * 
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the type
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "type")
     @XmlJavaTypeAdapter(MetricInfoTypeAdapter.class)
-    public Class<T> getType();
+    Class<T> getType();
 
     /**
      * Set the type
-     * 
+     *
      * @param type
-     * 
      * @since 1.0.0
      */
-    public void setType(Class<T> type);
+    void setType(Class<T> type);
 
     /**
      * Get the metric value
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "value")
     @XmlPath(".")
-    public T getValue();
+    T getValue();
 
     /**
      * Set the metric value
-     * 
+     *
      * @param value
-     * 
      * @since 1.0.0
      */
-    public void setValue(T value);
+    void setValue(T value);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import java.util.Date;
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -19,16 +22,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.model.xml.DateXmlAdapter;
+import java.util.Date;
 
 /**
  * Information about device metric value. Metric is an arbitrary named value. We usually
  * keep only the most recent value of the metric.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "metricInfo")
@@ -48,194 +47,176 @@ public interface MetricInfo extends Storable {
 
     /**
      * Get the record identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getId();
+    StorableId getId();
 
     /**
      * Set the record identifier
-     * 
+     *
      * @param id
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "id")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public void setId(StorableId id);
+    void setId(StorableId id);
 
     /**
      * Get the scope id
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Get the client identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "clientId")
-    public String getClientId();
+    String getClientId();
 
     /**
      * Sets the client identifier
-     * 
-     * @param clientId
-     *            The client identifier
-     * 
+     *
+     * @param clientId The client identifier
      * @since 1.0.0
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the channel
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "channel")
-    public String getChannel();
+    String getChannel();
 
     /**
      * Set the channel
-     * 
+     *
      * @param channel
-     * 
      * @since 1.0.0
      */
-    public void setChannel(String channel);
+    void setChannel(String channel);
 
     /**
      * Gets the metric name
-     * 
+     *
      * @return The metric name
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Sets the metric name
-     * 
-     * @param name
-     *            The metric name
+     *
+     * @param name The metric name
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the metric type
-     * 
+     *
      * @return The metric type
      * @since 1.0.0
      */
     @XmlElement(name = "metricType")
     @XmlJavaTypeAdapter(MetricInfoTypeAdapter.class)
-    public Class<?> getMetricType();
+    Class<?> getMetricType();
 
     /**
      * Sets the metric type
-     * 
-     * @param metricType
-     *            The metric type
+     *
+     * @param metricType The metric type
      */
-    public void setMetricType(Class<?> metricType);
+    void setMetricType(Class<?> metricType);
 
     /**
      * Get the message identifier (of the first message published that containing this metric)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageId")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getFirstMessageId();
+    StorableId getFirstMessageId();
 
     /**
      * Set the message identifier (of the first message published that containing this metric)
-     * 
+     *
      * @param firstMessageId
-     * 
      * @since 1.0.0
      */
-    public void setFirstMessageId(StorableId firstMessageId);
+    void setFirstMessageId(StorableId firstMessageId);
 
     /**
      * Get the message timestamp (of the first message published that containing this metric)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "firstMessageOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getFirstMessageOn();
+    Date getFirstMessageOn();
 
     /**
      * Set the message timestamp (of the first message published that containing this metric)
-     * 
+     *
      * @param firstMessageOn
-     * 
      * @since 1.0.0
      */
-    public void setFirstMessageOn(Date firstMessageOn);
+    void setFirstMessageOn(Date firstMessageOn);
 
     /**
      * Get the message identifier of the last published message for this metric.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageId")
     @XmlJavaTypeAdapter(StorableIdAdapter.class)
-    public StorableId getLastMessageId();
+    StorableId getLastMessageId();
 
     /**
      * Set the message identifier of the last published message for this metric.<br>
      * <b>Transient data field (the last publish message identifier should get from the message table by the find service)</b>
-     * 
+     *
      * @param lastMessageId
-     * 
      * @since 1.0.0
      */
-    public void setLastMessageId(StorableId lastMessageId);
+    void setLastMessageId(StorableId lastMessageId);
 
     /**
      * Get the timestamp of the last published message for this metric.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "lastMessageOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getLastMessageOn();
+    Date getLastMessageOn();
 
     /**
      * Set the timestamp of the last published message for this metric.<br>
      * <b>Transient data field (the last publish timestamp should get from the message table by the find service)</b>
-     * 
+     *
      * @param lastMessageOn
-     * 
      * @since 1.0.0
      */
-    public void setLastMessageOn(Date lastMessageOn);
+    void setLastMessageOn(Date lastMessageOn);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoCreator.java
@@ -11,132 +11,118 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import java.util.Date;
-
 import org.eclipse.kapua.model.id.KapuaId;
+
+import java.util.Date;
 
 /**
  * Metric information schema creator definition
- * 
+ *
  * @since 1.0.0
  */
 public interface MetricInfoCreator<T> extends StorableCreator<MetricInfo> {
 
     /**
      * Get the account
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Get the client identifier
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public String getClientId();
+    String getClientId();
 
     /**
      * Sets the client identifier
-     * 
-     * @param clientId
-     *            The client identifier
-     * 
+     *
+     * @param clientId The client identifier
      * @since 1.0.0
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the channel
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public String getChannel();
+    String getChannel();
 
     /**
      * Set the channel
-     * 
+     *
      * @param channel
-     * 
      * @since 1.0.0
      */
-    public void setChannel(String channel);
+    void setChannel(String channel);
 
     /**
      * Get the metric name
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public String getName();
+    String getName();
 
     /**
      * Set the metric name
-     * 
+     *
      * @param name
-     * 
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the metric type
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public Class<T> getMetricType();
+    Class<T> getMetricType();
 
     /**
      * Sets the metric type
-     * 
-     * @param metricType
-     *            The metric type
+     *
+     * @param metricType The metric type
      * @since 1.0.0
      */
-    public void setMetricType(Class<T> metricType);
+    void setMetricType(Class<T> metricType);
 
     /**
      * Get the message identifier (of the first message published that containing this metric)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public StorableId getMessageId();
+    StorableId getMessageId();
 
     /**
      * Set the message identifier (of the first message published that containing this metric)
-     * 
+     *
      * @param messageId
-     * 
      * @since 1.0.0
      */
-    public void setMessageId(StorableId messageId);
+    void setMessageId(StorableId messageId);
 
     /**
      * Get the message timestamp (of the first message published that containing this metric)
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public Date getMessageTimestamp();
+    Date getMessageTimestamp();
 
     /**
      * Set the message timestamp (of the first message published that containing this metric)
-     * 
+     *
      * @param messageTimestamp
-     * 
      * @since 1.0.0
      */
-    public void setMessageTimestamp(Date messageTimestamp);
+    void setMessageTimestamp(Date messageTimestamp);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoListResult.java
@@ -11,17 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
+import org.eclipse.kapua.service.datastore.MetricInfoXmlRegistry;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.service.datastore.MetricInfoXmlRegistry;
 
 /**
  * Metric information query result list definition.<br>
  * This object contains the list of the metric information objects retrieved by the search service.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "metricInfos")
 @XmlType(factoryClass = MetricInfoXmlRegistry.class, factoryMethod = "newMetricInfoListResult")

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoTypeAdapter.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoTypeAdapter.java
@@ -15,7 +15,7 @@ import org.eclipse.kapua.model.xml.ObjectTypeXmlAdapter;
 
 /**
  * Kapua identifier adapter. It marshal and unmarshal the Kapua identifier in a proper way.
- * 
+ *
  * @since 1.0.0
  */
 public class MetricInfoTypeAdapter extends ObjectTypeXmlAdapter {

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Storable.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Storable.java
@@ -15,7 +15,7 @@ import org.eclipse.kapua.KapuaSerializable;
 
 /**
  * Storable object definition
- * 
+ *
  * @since 1.0
  */
 public interface Storable extends KapuaSerializable {

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableCreator.java
@@ -13,10 +13,9 @@ package org.eclipse.kapua.service.datastore.model;
 
 /**
  * Storable object creator definition
- * 
- * @since 1.0
  *
  * @param <E>
+ * @since 1.0
  */
 public interface StorableCreator<E extends Storable> {
 

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableId.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableId.java
@@ -14,16 +14,16 @@ package org.eclipse.kapua.service.datastore.model;
 /**
  * Storable identifier definition.<br>
  * It defines the identifier of every object that can be stored in a datastore schema.
- * 
+ *
  * @since 1.0
- * 
  */
 public interface StorableId {
 
     /**
      * Return the storable identifier as a string
-     * 
+     *
      * @return
      */
-    public String toString();
+    @Override
+    String toString();
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdAdapter.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdAdapter.java
@@ -11,27 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * Kapua identifier adapter. It marshal and unmarshal the Kapua identifier in a proper way.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class StorableIdAdapter extends XmlAdapter<String, StorableId> {
 
-    /**
-     * Locator instance
-     */
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-
-    /**
-     * Meta type factory instance
-     */
-    private final StorableIdFactory storableIdFactory = locator.getFactory(StorableIdFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final StorableIdFactory STORABLE_ID_FACTORY = LOCATOR.getFactory(StorableIdFactory.class);
 
     @Override
     public String marshal(StorableId v) throws Exception {
@@ -40,7 +32,7 @@ public class StorableIdAdapter extends XmlAdapter<String, StorableId> {
 
     @Override
     public StorableId unmarshal(String v) throws Exception {
-        return storableIdFactory.newStorableId(v);
+        return STORABLE_ID_FACTORY.newStorableId(v);
     }
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdFactory.java
@@ -15,7 +15,7 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
 
 /**
  * {@link StorableId} factory definition.
- * 
+ *
  * @since 1.0.0
  */
 public interface StorableIdFactory extends KapuaObjectFactory {
@@ -24,7 +24,7 @@ public interface StorableIdFactory extends KapuaObjectFactory {
      * Creates a new {@link StorableId} starting the provided string identifier.<br>
      * <b>This operation must be the inverse function of {@link StorableId#toString()} so, in other word, this code should't fail:
      * </b>
-     * 
+     *
      * <pre>
      * {@code
      * StorableIdFactory storableIdFactory = KapuaLocator.getInstance().getService(StorableIdFactory.class);<br>
@@ -34,12 +34,11 @@ public interface StorableIdFactory extends KapuaObjectFactory {
      * AssertTrue(shortId.equals(shortIdConverted));
      * }
      * </pre>
-     * 
-     * @param stringId
-     *            The {@link StorableId} short id to parse.
+     *
+     * @param stringId The {@link StorableId} short id to parse.
      * @return The {@link StorableId} parsed from its short representation.
      * @since 1.0.0
      */
-    public StorableId newStorableId(String stringId);
+    StorableId newStorableId(String stringId);
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableListResult.java
@@ -11,8 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model;
 
-import java.util.Collection;
-import java.util.List;
+import org.eclipse.kapua.KapuaSerializable;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.model.query.KapuaQuery;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -20,17 +21,14 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.KapuaSerializable;
-import org.eclipse.kapua.model.query.KapuaListResult;
-import org.eclipse.kapua.model.query.KapuaQuery;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Storable object list definition
- * 
- * @since 1.0.0
  *
  * @param <E>
+ * @since 1.0.0
  */
 @XmlRootElement(name = "result")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -39,122 +37,110 @@ public interface StorableListResult<E extends Storable> extends KapuaSerializabl
 
     /**
      * Get the limit exceeded flag
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "limitExceeded")
-    public boolean isLimitExceeded();
+    boolean isLimitExceeded();
 
     /**
      * Set the limit exceeded flag
-     * 
-     * @param limitExceeded
-     *            true if the query matching elements are more than {@link KapuaQuery#setLimit(Integer)} value
-     * 
+     *
+     * @param limitExceeded true if the query matching elements are more than {@link KapuaQuery#setLimit(Integer)} value
      * @since 1.0.0
      */
-    public void setLimitExceeded(boolean limitExceeded);
+    void setLimitExceeded(boolean limitExceeded);
 
     /**
      * Return the result list
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElementWrapper(name = "items")
     @XmlElement(name = "item")
-    public List<E> getItems();
+    List<E> getItems();
 
     /**
      * Return the element at i position (zero based)
-     * 
+     *
      * @param i
      * @return
-     * 
      * @since 1.0.0
      */
-    public E getItem(int i);
+    E getItem(int i);
 
     /**
      * Returns the first element in the {@link KapuaListResult}.<br>
      * It returns {@code null} if first element does not exist.
-     * 
+     *
      * @return The first element in the {@link KapuaListResult} or {@code null} if not present.
-     * 
      * @since 1.0.0
      */
-    public E getFirstItem();
+    E getFirstItem();
 
     /**
      * Return the result list size
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "size")
-    public int getSize();
+    int getSize();
 
     /**
      * Check if the result list is empty
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
-    public boolean isEmpty();
+    boolean isEmpty();
 
     /**
      * Add items to the result list
-     * 
+     *
      * @param items
-     * 
      * @since 1.0.0
      */
-    public void addItems(Collection<? extends E> items);
+    void addItems(Collection<? extends E> items);
 
     /**
      * Clear item result list
-     * 
+     *
      * @since 1.0.0
      */
-    public void clearItems();
+    void clearItems();
 
     /**
      * Get the next key.<br>
      * If a limit is set into the query parameters (limit) and the messages count matching the query is higher than the limit, so the next key is the key of the first next object not included in the
      * result set.
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "nextKey")
-    public Object getNextKey();
+    Object getNextKey();
 
     /**
      * Get the total count.<br>
      * The total count may be higher that the result set since the extracted result set can be limited by the query (limit) parameter
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "totalCount")
-    public Long getTotalCount();
+    Long getTotalCount();
 
     /**
      * Set the total count.<br>
      * The total count may be higher that the result set since the extracted result set can be limited by the query (limit) parameter
-     * 
+     *
      * @param totalCount
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "totalCount")
-    public void setTotalCount(Long totalCount);
+    void setTotalCount(Long totalCount);
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/AndPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/AndPredicate.java
@@ -15,16 +15,15 @@ import java.util.List;
 
 /**
  * Query "and" aggregation definition
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface AndPredicate extends StorablePredicate {
 
     /**
      * Get the {@link StorablePredicate} list
-     * 
+     *
      * @return
      */
-    public List<StorablePredicate> getPredicates();
+    List<StorablePredicate> getPredicates();
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelInfoQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelInfoQuery.java
@@ -11,22 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model.query;
 
+import org.eclipse.kapua.service.datastore.ChannelInfoXmlRegistry;
+import org.eclipse.kapua.service.datastore.model.ChannelInfo;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.service.datastore.ChannelInfoXmlRegistry;
-import org.eclipse.kapua.service.datastore.model.ChannelInfo;
-
 /**
  * Channel information schema query definition
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = ChannelInfoXmlRegistry.class, factoryMethod = "newQuery")
 public interface ChannelInfoQuery extends StorableQuery<ChannelInfo> {
+
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelMatchPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelMatchPredicate.java
@@ -13,16 +13,15 @@ package org.eclipse.kapua.service.datastore.model.query;
 
 /**
  * Query predicate definition for matching the channel value
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface ChannelMatchPredicate extends StorablePredicate {
 
     /**
      * Get the channel expression (may use wildcard)
-     * 
+     *
      * @return
      */
-    public String getExpression();
+    String getExpression();
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ExistsPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ExistsPredicate.java
@@ -13,17 +13,16 @@ package org.eclipse.kapua.service.datastore.model.query;
 
 /**
  * Query predicate definition for checking if a field exists
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface ExistsPredicate extends StorablePredicate {
 
     /**
      * Returns the field name to check
-     * 
+     *
      * @return
      */
-    public String getName();
+    String getName();
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/IdsPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/IdsPredicate.java
@@ -11,30 +11,29 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model.query;
 
-import java.util.Set;
-
 import org.eclipse.kapua.service.datastore.model.StorableId;
+
+import java.util.Set;
 
 /**
  * Query predicate definition for matching identifier values fields
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface IdsPredicate extends StorablePredicate {
 
     /**
      * Get the identifier type
-     * 
+     *
      * @return
      */
-    public String getType();
+    String getType();
 
     /**
      * Get the identifier set.<br>
      * This set is used a comparison term by the query predicate.
-     * 
+     *
      * @return
      */
-    public Set<StorableId> getIdSet();
+    Set<StorableId> getIdSet();
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricPredicate.java
@@ -13,7 +13,7 @@ package org.eclipse.kapua.service.datastore.model.query;
 
 /**
  * Query predicate for matching range values on message metrics implementation
- * 
+ *
  * @since 1.0.0
  */
 public interface MetricPredicate extends RangePredicate {
@@ -21,21 +21,18 @@ public interface MetricPredicate extends RangePredicate {
     /**
      * Gets the metric type to search.
      * This is required because metric with the same name can have different types.
-     * 
+     *
      * @return The metric type
-     * 
      * @since 1.0.0
      */
-    public Class<?> getType();
+    Class<?> getType();
 
     /**
      * Sets the metric type so search.
-     * 
-     * @param type
-     *            The metric type to search.
-     * 
+     *
+     * @param type The metric type to search.
      * @since 1.0.0
      */
-    public void setType(Class<?> type);
+    void setType(Class<?> type);
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/RangePredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/RangePredicate.java
@@ -13,46 +13,45 @@ package org.eclipse.kapua.service.datastore.model.query;
 
 /**
  * Query predicate for matching range values implementation
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface RangePredicate extends StorablePredicate {
 
     /**
      * Get the field to be compared
-     * 
+     *
      * @return
      */
-    public String getField();
+    String getField();
 
     /**
      * Return the desired minimum value
-     * 
+     *
      * @return
      */
-    public Object getMinValue();
+    Object getMinValue();
 
     /**
      * Get the minimum value as {@link Comparable} (type)
-     * 
+     *
      * @param clazz
      * @return
      */
-    public <V extends Comparable<V>> V getMinValue(Class<V> clazz);
+    <V extends Comparable<V>> V getMinValue(Class<V> clazz);
 
     /**
      * Get the maximum value
-     * 
+     *
      * @return
      */
-    public Object getMaxValue();
+    Object getMaxValue();
 
     /**
      * Get the maximum value as {@link Comparable} (typed)
-     * 
+     *
      * @param clazz
      * @return
      */
-    public <V extends Comparable<V>> V getMaxValue(Class<V> clazz);
+    <V extends Comparable<V>> V getMaxValue(Class<V> clazz);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortDirection.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortDirection.java
@@ -13,17 +13,17 @@ package org.eclipse.kapua.service.datastore.model.query;
 
 /**
  * Query sort behavior
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public enum SortDirection {
     /**
      * Ascending
      */
     ASC,
+
     /**
      * Descending
      */
-    DESC;
+    DESC
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableFetchStyle.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableFetchStyle.java
@@ -13,21 +13,22 @@ package org.eclipse.kapua.service.datastore.model.query;
 
 /**
  * Fetch style behavior
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public enum StorableFetchStyle {
     /**
      * Only indexed fields
      */
     FIELDS,
+
     /**
      * Full document (except the message body)
      */
     SOURCE_SELECT,
+
     /**
      * Full document
      */
-    SOURCE_FULL;
+    SOURCE_FULL
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableField.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableField.java
@@ -13,16 +13,15 @@ package org.eclipse.kapua.service.datastore.model.query;
 
 /**
  * Storable field definition
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface StorableField {
 
     /**
      * Return the field name
-     * 
+     *
      * @return
      */
-    public String field();
+    String field();
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicate.java
@@ -11,24 +11,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model.query;
 
-import org.eclipse.kapua.service.datastore.client.DatamodelMappingException;
-
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.eclipse.kapua.service.datastore.client.DatamodelMappingException;
 
 /**
  * Storable query predicate definition
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface StorablePredicate {
 
     /**
      * Serialize the predicate to a Json object
-     * 
+     *
      * @return
      * @throws DatamodelMappingException
      */
-    public ObjectNode toSerializedMap() throws DatamodelMappingException;
-
+    ObjectNode toSerializedMap() throws DatamodelMappingException;
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
@@ -15,81 +15,66 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
 
 /**
  * {@link KapuaObjectFactory} for {@link StorablePredicate}s
- * 
+ *
  * @since 1.0.0
  */
 public interface StorablePredicateFactory extends KapuaObjectFactory {
 
     /**
      * Returns a new instance of {@link AndPredicate}.
-     * 
+     *
      * @return The newly instantiated {@link AndPredicate}.
      * @since 1.0.0
      */
-    public AndPredicate newAndPredicate();
+    AndPredicate newAndPredicate();
 
     /**
      * Returns a new instance of {@link ChannelMatchPredicate}.
-     * 
-     * @param expression
-     *            The expression to match with the channel name.
-     * 
+     *
+     * @param expression The expression to match with the channel name.
      * @return The newly instantiated {@link ChannelMatchPredicate}.
      * @since 1.0.0
      */
-    public ChannelMatchPredicate newChannelMatchPredicate(String expression);
+    ChannelMatchPredicate newChannelMatchPredicate(String expression);
 
     /**
      * Return a new instance of {@link RangePredicate}
-     * 
-     * @param fieldName
-     *            The field name to filter.
-     * @param minValue
-     *            The lower limit. Can be {@code null}.
-     * @param maxValue
-     *            The upper limit. Can be {@code null}.
+     *
+     * @param fieldName The field name to filter.
+     * @param minValue  The lower limit. Can be {@code null}.
+     * @param maxValue  The upper limit. Can be {@code null}.
      * @return The newly instantiated {@link RangePredicate}.
-     * 
      * @since 1.0.0
      */
-    public <V extends Comparable<V>> RangePredicate newRangePredicate(String fieldName, V minValue, V maxValue);
+    <V extends Comparable<V>> RangePredicate newRangePredicate(String fieldName, V minValue, V maxValue);
 
     /**
      * Return a new instance of {@link MetricPredicate}
-     * 
-     * @param fieldName
-     *            The metric name to filter.
-     * @param type
-     *            The type of the metric to filter
-     * @param minValue
-     *            The lower limit. Can be {@code null}.
-     * @param maxValue
-     *            The upper limit. Can be {@code null}.
+     *
+     * @param fieldName The metric name to filter.
+     * @param type      The type of the metric to filter
+     * @param minValue  The lower limit. Can be {@code null}.
+     * @param maxValue  The upper limit. Can be {@code null}.
      * @return The newly instantiated {@link MetricPredicate}.
-     * 
      * @since 1.0.0
      */
-    public <V extends Comparable<V>> MetricPredicate newMetricPredicate(String fieldName, Class<V> type, V minValue, V maxValue);
+    <V extends Comparable<V>> MetricPredicate newMetricPredicate(String fieldName, Class<V> type, V minValue, V maxValue);
 
     /**
      * Return a new instance of {@link TermPredicate}
-     * 
-     * @param field
-     *            The field name to filter
-     * @param value
-     *            The value to filter
+     *
+     * @param field The field name to filter
+     * @param value The value to filter
      * @return The newly instantiated {@link TermPredicate}.
-     * 
      * @since 1.0.0
      */
-    public <V> TermPredicate newTermPredicate(StorableField field, V value);
+    <V> TermPredicate newTermPredicate(StorableField field, V value);
 
     /**
      * Returns a new instance of {@link ExistsPredicate}.
-     * 
-     * @param fieldName
-     *            The field name to search.
+     *
+     * @param fieldName The field name to search.
      * @return The newly instantiated {@link ExistsPredicate}.
      */
-    public ExistsPredicate newExistsPredicate(String fieldName);
+    ExistsPredicate newExistsPredicate(String fieldName);
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableQuery.java
@@ -11,158 +11,141 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.model.query;
 
-import java.util.List;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import java.util.List;
 
 /**
  * Storable query definition.<br>
  * It defines the queries applicable to the persisted objects (such as messages, channeles information...)
- * 
- * @since 1.0.0
  *
- * @param <S>
- *            persisted object type (such as messages, channeles information...)
+ * @param <S> persisted object type (such as messages, channeles information...)
+ * @since 1.0.0
  */
 public interface StorableQuery<S extends Object> {
 
     /**
      * Gets the scope id
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
-    public KapuaId getScopeId();
+    KapuaId getScopeId();
 
     /**
      * Sets the scope id
-     * 
+     *
      * @param scopeId
-     * 
      * @since 1.0.0
      */
-    public void setScopeId(KapuaId scopeId);
+    void setScopeId(KapuaId scopeId);
 
     /**
      * Get the predicate
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlTransient
-    public StorablePredicate getPredicate();
+    StorablePredicate getPredicate();
 
     /**
      * Set the predicate
-     * 
+     *
      * @param predicate
-     * 
      * @since 1.0.0
      */
-    public void setPredicate(StorablePredicate predicate);
+    void setPredicate(StorablePredicate predicate);
 
     /**
      * Get the query result list offset
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "offset")
-    public Integer getOffset();
+    Integer getOffset();
 
     /**
      * Set the query result list offset
-     * 
+     *
      * @param offset
-     * 
      * @since 1.0.0
      */
-    public void setOffset(Integer offset);
+    void setOffset(Integer offset);
 
     /**
      * Get the result list limit count
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "limit")
-    public Integer getLimit();
+    Integer getLimit();
 
     /**
      * Set the result list limit count
-     * 
+     *
      * @param limit
-     * 
      * @since 1.0.0
      */
-    public void setLimit(Integer limit);
+    void setLimit(Integer limit);
 
     /**
      * Get the ask for the total count matching query objects
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "askTotalCount")
-    public boolean isAskTotalCount();
+    boolean isAskTotalCount();
 
     /**
      * Set the ask for the total count matching query objects
-     * 
+     *
      * @param askTotalCount
-     * 
      * @since 1.0.0
      */
-    public void setAskTotalCount(boolean askTotalCount);
+    void setAskTotalCount(boolean askTotalCount);
 
     /**
      * Get the fetch style
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlTransient
-    public StorableFetchStyle getFetchStyle();
+    StorableFetchStyle getFetchStyle();
 
     /**
      * Set the fetch style
-     * 
+     *
      * @param fetchStyle
-     * 
      * @since 1.0.0
      */
-    public void setFetchStyle(StorableFetchStyle fetchStyle);
+    void setFetchStyle(StorableFetchStyle fetchStyle);
 
     /**
      * Get the sort fields list
-     * 
+     *
      * @return
-     * 
      * @since 1.0.0
      */
     @XmlTransient
-    public List<SortField> getSortFields();
+    List<SortField> getSortFields();
 
     /**
      * Set the sort fields list
-     * 
+     *
      * @param sortFields
-     * 
      * @since 1.0.0
      */
-    public void setSortFields(List<SortField> sortFields);
+    void setSortFields(List<SortField> sortFields);
 
 }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/TermPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/TermPredicate.java
@@ -13,31 +13,30 @@ package org.eclipse.kapua.service.datastore.model.query;
 
 /**
  * Query predicate definition for matching field value
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface TermPredicate extends StorablePredicate {
 
     /**
      * Return the field
-     * 
+     *
      * @return
      */
-    public StorableField getField();
+    StorableField getField();
 
     /**
      * Return the value
-     * 
+     *
      * @return
      */
-    public Object getValue();
+    Object getValue();
 
     /**
      * Return the value (typed)
-     * 
+     *
      * @param clazz
      * @return
      */
-    public <V> V getValue(Class<V> clazz);
+    <V> V getValue(Class<V> clazz);
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorMessages.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorMessages.java
@@ -14,15 +14,13 @@ package org.eclipse.kapua.service.datastore.client;
 /**
  * Client error messages
  * TODO move to properties file
- * 
+ *
  * @since 1.0
  */
 public class ClientErrorMessages {
 
-    private ClientErrorMessages() {
-
-    }
-
     public final static String CRUD_INTERNAL_ERROR = "An error occurred on performing the operation: [%s]";
 
+    private ClientErrorMessages() {
+    }
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorMessages.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorMessages.java
@@ -19,7 +19,7 @@ package org.eclipse.kapua.service.datastore.client;
  */
 public class ClientErrorMessages {
 
-    public final static String CRUD_INTERNAL_ERROR = "An error occurred on performing the operation: [%s]";
+    public static final String CRUD_INTERNAL_ERROR = "An error occurred on performing the operation: [%s]";
 
     private ClientErrorMessages() {
     }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientProvider.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientProvider.java
@@ -14,10 +14,8 @@ package org.eclipse.kapua.service.datastore.client;
 /**
  * Datastore client wrapper definition.
  *
+ * @param <C> client type
  * @since 1.0
- *
- * @param <C>
- *            client type
  */
 public interface ClientProvider<C> {
 
@@ -26,6 +24,5 @@ public interface ClientProvider<C> {
      *
      * @return
      */
-    public C getClient();
-
+    C getClient();
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/DatastoreClient.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/DatastoreClient.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.kapua.service.datastore.client.model.BulkUpdateRequest;
 import org.eclipse.kapua.service.datastore.client.model.BulkUpdateResponse;
 import org.eclipse.kapua.service.datastore.client.model.IndexRequest;
@@ -22,27 +24,24 @@ import org.eclipse.kapua.service.datastore.client.model.TypeDescriptor;
 import org.eclipse.kapua.service.datastore.client.model.UpdateRequest;
 import org.eclipse.kapua.service.datastore.client.model.UpdateResponse;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * Datastore client definition. It defines the methods (crud and utilities) to be exposed to the caller.<br>
  * The datastore client implementation should provide a static init method and a static getInstance method that return the already initialized client instance.
- * 
+ *
  * @since 1.0
  */
 public interface DatastoreClient {
 
     /**
      * Close the underlying client resources (such as datastore client connection)
-     * 
+     *
      * @throws ClientException
      */
     void close() throws ClientException;
 
     /**
      * Insert
-     * 
+     *
      * @param insertRequest
      * @return
      * @throws ClientException
@@ -51,7 +50,7 @@ public interface DatastoreClient {
 
     /**
      * Upsert
-     * 
+     *
      * @param updateRequest
      * @return
      * @throws ClientException
@@ -60,7 +59,7 @@ public interface DatastoreClient {
 
     /**
      * Bulk upsert
-     * 
+     *
      * @param bulkUpdateRequest
      * @return
      * @throws ClientException
@@ -69,7 +68,7 @@ public interface DatastoreClient {
 
     /**
      * Find by query (this method returns the first result found that matches the quesy)
-     * 
+     *
      * @param typeDescriptor
      * @param query
      * @param clazz
@@ -80,7 +79,7 @@ public interface DatastoreClient {
 
     /**
      * Find by query criteria
-     * 
+     *
      * @param typeDescriptor
      * @param query
      * @param clazz
@@ -91,7 +90,7 @@ public interface DatastoreClient {
 
     /**
      * Count by query criteria
-     * 
+     *
      * @param typeDescriptor
      * @param query
      * @return
@@ -101,7 +100,7 @@ public interface DatastoreClient {
 
     /**
      * Delete by id
-     * 
+     *
      * @param typeDescriptor
      * @param id
      * @throws ClientException
@@ -110,7 +109,7 @@ public interface DatastoreClient {
 
     /**
      * Delete by query criteria
-     * 
+     *
      * @param typeDescriptor
      * @param query
      * @throws ClientException
@@ -121,7 +120,7 @@ public interface DatastoreClient {
 
     /**
      * Check if the index exists
-     * 
+     *
      * @param indexRequest
      * @return
      * @throws ClientException
@@ -130,7 +129,7 @@ public interface DatastoreClient {
 
     /**
      * Create the index
-     * 
+     *
      * @param indexName
      * @param indexSettings
      * @throws ClientException
@@ -139,7 +138,7 @@ public interface DatastoreClient {
 
     /**
      * Check if the mapping exists
-     * 
+     *
      * @param typeDescriptor
      * @return
      * @throws ClientException
@@ -148,7 +147,7 @@ public interface DatastoreClient {
 
     /**
      * Put the mapping
-     * 
+     *
      * @param typeDescriptor
      * @param mapping
      * @throws ClientException
@@ -157,7 +156,7 @@ public interface DatastoreClient {
 
     /**
      * Force the datastore to refresh the indexes.
-     * 
+     *
      * @throws ClientException
      */
     void refreshAllIndexes() throws ClientException;
@@ -177,33 +176,33 @@ public interface DatastoreClient {
      * Once dropped the indexes cannot be restored!<br>
      * Be careful using it! :)
      * </b>
-     * 
+     *
      * @param indexes
      * @throws ClientException
      */
-    public void deleteIndexes(String... indexes) throws ClientException;
+    void deleteIndexes(String... indexes) throws ClientException;
 
     /**
      * Find indexes by prefix.
-     * 
+     *
      * @param indexRequest
      * @return
      * @throws ClientException
      */
-    public IndexResponse findIndexes(IndexRequest indexRequest) throws ClientException;
+    IndexResponse findIndexes(IndexRequest indexRequest) throws ClientException;
 
     // ModelContext
 
     /**
      * Set the model context
-     * 
+     *
      * @param modelContext
      */
     void setModelContext(ModelContext modelContext);
 
     /**
      * Set the query converter
-     * 
+     *
      * @param queryConverter
      */
     void setQueryConverter(QueryConverter queryConverter);

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ModelContext.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ModelContext.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 /**
  * Model context definition. This object is responsible for translating datastore model objects from/to client objects
- * 
+ *
  * @since 1.0
  */
 public interface ModelContext {
@@ -23,30 +23,29 @@ public interface ModelContext {
     /**
      * Type descriptor key
      */
-    public String TYPE_DESCRIPTOR_KEY = "type_descriptor";
+    String TYPE_DESCRIPTOR_KEY = "type_descriptor";
     /**
      * Datastore object id descriptor key
      */
-    public String DATASTORE_ID_KEY = "datastore_id";
+    String DATASTORE_ID_KEY = "datastore_id";
 
     /**
      * Convert the serialized object (from client domain) to the specific datastore object.
-     * 
-     * @param clazz
-     *            datastore object type
+     *
+     * @param clazz            datastore object type
      * @param serializedObject
      * @return
      * @throws DatamodelMappingException
      */
-    public <T> T unmarshal(Class<T> clazz, Map<String, Object> serializedObject) throws DatamodelMappingException;
+    <T> T unmarshal(Class<T> clazz, Map<String, Object> serializedObject) throws DatamodelMappingException;
 
     /**
      * Convert the datastore object to the client object
-     * 
+     *
      * @param object
      * @return
      * @throws DatamodelMappingException
      */
-    public Map<String, Object> marshal(Object object) throws DatamodelMappingException;
+    Map<String, Object> marshal(Object object) throws DatamodelMappingException;
 
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/QueryConverter.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/QueryConverter.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * Query converter definition. This object is responsible for translating datastore query model to client query.
- * 
+ *
  * @since 1.0
  */
 public interface QueryConverter {
@@ -23,25 +23,25 @@ public interface QueryConverter {
     /**
      * Query fetch style key
      */
-    public String QUERY_FETCH_STYLE_KEY = "query_fetch_style";
+    String QUERY_FETCH_STYLE_KEY = "query_fetch_style";
 
     /**
      * Convert the datastore query to the client query
-     * 
+     *
      * @param query
      * @return
      * @throws QueryMappingException
      * @throws DatamodelMappingException
      */
-    public JsonNode convertQuery(Object query) throws QueryMappingException, DatamodelMappingException;
+    JsonNode convertQuery(Object query) throws QueryMappingException, DatamodelMappingException;
 
     /**
      * Get the query fetch style
-     * 
+     *
      * @param query
      * @return
      * @throws QueryMappingException
      */
-    public Object getFetchStyle(Object query) throws QueryMappingException;
+    Object getFetchStyle(Object query) throws QueryMappingException;
 
 }

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaKeys.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaKeys.java
@@ -13,13 +13,12 @@ package org.eclipse.kapua.service.datastore.client;
 
 /**
  * Schema keys and values type definition
- * 
+ *
  * @since 1.0
  */
 public class SchemaKeys {
 
     private SchemaKeys() {
-
     }
 
     /**

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaKeys.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaKeys.java
@@ -24,144 +24,144 @@ public class SchemaKeys {
     /**
      * Query key
      */
-    public final static String KEY_QUERY = "query";
+    public static final String KEY_QUERY = "query";
     /**
      * Sort key
      */
-    public final static String KEY_SORT = "sort";
+    public static final String KEY_SORT = "sort";
     /**
      * Include fields key
      */
-    public final static String KEY_INCLUDES = "includes";
+    public static final String KEY_INCLUDES = "includes";
     /**
      * Exclude fields key
      */
-    public final static String KEY_EXCLUDES = "excludes";
+    public static final String KEY_EXCLUDES = "excludes";
     /**
      * From key (used by queries for paginating the result set)
      */
-    public final static String KEY_FROM = "from";
+    public static final String KEY_FROM = "from";
     /**
      * Size key (used by queries to limit the result set size)
      */
-    public final static String KEY_SIZE = "size";
+    public static final String KEY_SIZE = "size";
 
     /**
      * Query ascending sort key
      */
-    public final static String SORT_ASCENDING_VALUE = "asc";
+    public static final String SORT_ASCENDING_VALUE = "asc";
     /**
      * Query descending sort key
      */
-    public final static String SORT_DESCENDING_VALUE = "desc";
+    public static final String SORT_DESCENDING_VALUE = "desc";
     /**
      * All key
      */
-    public final static String KEY_ALL = "_all";
+    public static final String KEY_ALL = "_all";
     /**
      * Format key
      */
-    public final static String KEY_FORMAT = "format";
+    public static final String KEY_FORMAT = "format";
     /**
      * Index ky
      */
-    public final static String KEY_INDEX = "index";
+    public static final String KEY_INDEX = "index";
     /**
      * Source key
      */
-    public final static String KEY_SOURCE = "_source";
+    public static final String KEY_SOURCE = "_source";
     /**
      * Type key
      */
-    public final static String KEY_TYPE = "type";
+    public static final String KEY_TYPE = "type";
     /**
      * Enabled key
      */
-    public final static String KEY_ENABLED = "enabled";
+    public static final String KEY_ENABLED = "enabled";
     /**
      * Dynamic key
      */
-    public final static String KEY_DYNAMIC = "dynamic";
+    public static final String KEY_DYNAMIC = "dynamic";
     /**
      * Include in all key
      */
-    public final static String KEY_INCLUDE_IN_ALL = "include_in_all";
+    public static final String KEY_INCLUDE_IN_ALL = "include_in_all";
     /**
      * Object binary type
      */
-    public final static String TYPE_BINARY = "binary";
+    public static final String TYPE_BINARY = "binary";
     /**
      * Object date type
      */
-    public final static String TYPE_DATE = "date";
+    public static final String TYPE_DATE = "date";
     /**
      * Object double type
      */
-    public final static String TYPE_DOUBLE = "double";
+    public static final String TYPE_DOUBLE = "double";
     /**
      * Object geo point type
      */
-    public final static String TYPE_GEO_POINT = "geo_point";
+    public static final String TYPE_GEO_POINT = "geo_point";
     /**
      * Object integer type
      */
-    public final static String TYPE_INTEGER = "integer";
+    public static final String TYPE_INTEGER = "integer";
     /**
      * Object ip address type
      */
-    public final static String TYPE_IP = "ip";
+    public static final String TYPE_IP = "ip";
     /**
      * Object object type
      */
-    public final static String TYPE_OBJECT = "object";
+    public static final String TYPE_OBJECT = "object";
     /**
      * Object string type
      */
-    public final static String TYPE_STRING = "string";
+    public static final String TYPE_STRING = "string";
     /**
      * Object keyword type (Structured string that can be indexed with new ES version)<br>
      * <b>Please leave the "index" property for the keyword fields to false (default value) otherwise the value will be analyzed and indexed for the search operation)<br>
      * (see https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html)</b>
      */
-    public final static String TYPE_KEYWORD = "keyword";
+    public static final String TYPE_KEYWORD = "keyword";
 
     /**
      * "false" field value
      */
-    public final static String VALUE_FALSE = "false";
+    public static final String VALUE_FALSE = "false";
     /**
      * "true" field value
      */
-    public final static String VALUE_TRUE = "true";
+    public static final String VALUE_TRUE = "true";
 
     /**
      * Refresh interval (for schema definition)
      */
-    public final static String KEY_REFRESH_INTERVAL = "refresh_interval";
+    public static final String KEY_REFRESH_INTERVAL = "refresh_interval";
     /**
      * Shard number (for schema definition)
      */
-    public final static String KEY_SHARD_NUMBER = "number_of_shards";
+    public static final String KEY_SHARD_NUMBER = "number_of_shards";
     /**
      * Replica number (for schema definition)
      */
-    public final static String KEY_REPLICA_NUMBER = "number_of_replicas";
+    public static final String KEY_REPLICA_NUMBER = "number_of_replicas";
 
     /**
      * Message field
      */
-    public final static String FIELD_NAME_MESSAGE = "message";
+    public static final String FIELD_NAME_MESSAGE = "message";
     /**
      * Metrics field
      */
-    public final static String FIELD_NAME_METRICS = "metrics";
+    public static final String FIELD_NAME_METRICS = "metrics";
     /**
      * Position field
      */
-    public final static String FIELD_NAME_POSITION = "position";
+    public static final String FIELD_NAME_POSITION = "position";
     /**
      * Properties field
      */
-    public final static String FIELD_NAME_PROPERTIES = "properties";
+    public static final String FIELD_NAME_PROPERTIES = "properties";
 
 }

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/RestDatastoreClient.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/RestDatastoreClient.java
@@ -372,11 +372,11 @@ public class RestDatastoreClient implements org.eclipse.kapua.service.datastore.
                             failureMessage = failureNode.asText();
                         }
                         bulkResponse.add(new UpdateResponse(metricId, new TypeDescriptor(indexName, typeName), failureMessage));
-                        logger.info("Upsert failed [{}, {}, {}]", new Object[] { indexName, typeName, failureMessage });
+                        logger.info("Upsert failed [{}, {}, {}]", indexName, typeName, failureMessage);
                         continue;
                     }
                     bulkResponse.add(new UpdateResponse(metricId, new TypeDescriptor(indexName, typeName)));
-                    logger.debug("Upsert on channel metric succesfully executed [{}.{}, {}]", new Object[] { indexName, typeName, metricId });
+                    logger.debug("Upsert on channel metric successfully executed [{}.{}, {}]", indexName, typeName, metricId);
                 } else {
                     throw new ClientException(ClientErrorCodes.ACTION_ERROR, "Unexpected action response");
                 }

--- a/service/datastore/client-transport/src/test/java/org/eclipse/kapua/service/datastore/client/transport/EsTransportClientProviderTest.java
+++ b/service/datastore/client-transport/src/test/java/org/eclipse/kapua/service/datastore/client/transport/EsTransportClientProviderTest.java
@@ -11,9 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.client.transport;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Condition;
 import org.eclipse.kapua.commons.setting.AbstractBaseKapuaSetting;
-import org.eclipse.kapua.service.datastore.client.transport.EsTransportClientProvider;
-import org.eclipse.kapua.service.datastore.client.transport.EsTransportClientProvider;
+import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
+import org.elasticsearch.client.Client;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -24,16 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.Condition;
-import org.eclipse.kapua.commons.setting.AbstractBaseKapuaSetting;
-import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
-import org.eclipse.kapua.service.datastore.client.transport.ClientSettingsKey;
-import org.eclipse.kapua.service.datastore.client.transport.EsTransportClientProvider;
-import org.elasticsearch.client.Client;
-import org.junit.Ignore;
-import org.junit.Test;
-
 public class EsTransportClientProviderTest {
 
     /**
@@ -42,11 +36,11 @@ public class EsTransportClientProviderTest {
      * In case this hostname does exists on your network, which is highly unlikely, it can be overridden.
      * </p>
      */
-    private final static String UNKWNON_HOST = System.getProperty("test.org.eclipse.kapua.service.datastore.unknowHost", "26-non-existing-host-05.");
+    private static final String UNKWNON_HOST = System.getProperty("test.org.eclipse.kapua.service.datastore.unknowHost", "26-non-existing-host-05.");
 
     private static final String CLUSTER_NAME = "foo-cluster";
 
-    private final static Condition<InetSocketAddress> UNRESOLVED = new Condition<>(InetSocketAddress::isUnresolved, "Host unresolved");
+    private static final Condition<InetSocketAddress> UNRESOLVED = new Condition<>(InetSocketAddress::isUnresolved, "Host unresolved");
 
     private void assertThatResolvedAs(InetSocketAddress result, Class<? extends InetAddress> addressClazz, String hostAddress, int port) {
         Assertions.assertThat(result).isNotNull();
@@ -138,7 +132,8 @@ public class EsTransportClientProviderTest {
 
     @Test
     public void testHosts1() throws ClientUnavailableException {
-        AbstractBaseKapuaSetting<ClientSettingsKey> settings = AbstractBaseKapuaSetting.fromMap(Collections.singletonMap(ClientSettingsKey.ELASTICSEARCH_NODES.key(), "127.0.0.1,127.0.0.2:1234,[::1]:5678"));
+        AbstractBaseKapuaSetting<ClientSettingsKey> settings = AbstractBaseKapuaSetting
+                .fromMap(Collections.singletonMap(ClientSettingsKey.ELASTICSEARCH_NODES.key(), "127.0.0.1,127.0.0.2:1234,[::1]:5678"));
         List<InetSocketAddress> result = EsTransportClientProvider.parseAddresses(settings);
         Assertions.assertThat(result).hasSize(3);
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
@@ -12,10 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
@@ -50,9 +46,12 @@ import org.eclipse.kapua.service.datastore.model.query.SortField;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
 import org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory;
 import org.eclipse.kapua.service.datastore.model.query.TermPredicate;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Channel info registry implementation
@@ -217,12 +216,11 @@ public class ChannelInfoRegistryServiceImpl extends AbstractKapuaConfigurableSer
             lastPublishedMessageTimestamp = messageList.getFirstItem().getTimestamp();
         } else if (messageList.isEmpty()) {
             // this condition could happens due to the ttl of the messages (so if it happens, it does not necessarily mean there has been an error!)
-            LOG.warn("Cannot find last timestamp for the specified client id '{}' - account '{}'", new Object[] { channelInfo.getScopeId(), channelInfo.getClientId() });
+            LOG.warn("Cannot find last timestamp for the specified client id '{}' - account '{}'", channelInfo.getScopeId(), channelInfo.getClientId());
         } else {
             // this condition shouldn't never happens since the query has a limit 1
             // if happens it means than an elasticsearch internal error happens and/or our driver didn't set it correctly!
-            LOG.error("Cannot find last timestamp for the specified client id '{}' - account '{}'. More than one result returned by the query!",
-                    new Object[] { channelInfo.getScopeId(), channelInfo.getClientId() });
+            LOG.error("Cannot find last timestamp for the specified client id '{}' - account '{}'. More than one result returned by the query!", channelInfo.getScopeId(), channelInfo.getClientId());
         }
 
         channelInfo.setLastMessageId(lastPublishedMessageId);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
@@ -212,12 +212,11 @@ public class ClientInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
             lastPublishedMessageTimestamp = messageList.getFirstItem().getTimestamp();
         } else if (messageList.isEmpty()) {
             // this condition could happens due to the ttl of the messages (so if it happens, it does not necessarily mean there has been an error!)
-            LOG.warn("Cannot find last timestamp for the specified client id '{}' - account '{}'", new Object[] { clientInfo.getScopeId(), clientInfo.getClientId() });
+            LOG.warn("Cannot find last timestamp for the specified client id '{}' - account '{}'", clientInfo.getScopeId(), clientInfo.getClientId());
         } else {
             // this condition shouldn't never happens since the query has a limit 1
             // if happens it means than an elasticsearch internal error happens and/or our driver didn't set it correctly!
-            LOG.error("Cannot find last timestamp for the specified client id '{}' - account '{}'. More than one result returned by the query!",
-                    new Object[] { clientInfo.getScopeId(), clientInfo.getClientId() });
+            LOG.error("Cannot find last timestamp for the specified client id '{}' - account '{}'. More than one result returned by the query!", clientInfo.getScopeId(), clientInfo.getClientId());
         }
         clientInfo.setLastMessageId(lastPublishedMessageId);
         clientInfo.setLastMessageOn(lastPublishedMessageTimestamp);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProvider.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProvider.java
@@ -19,29 +19,26 @@ import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfigu
 /**
  * Define a datastore configuration provider.<br>
  * These service is responsible to get the configuration parameters (profiled by account) such as the data ttl.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface ConfigurationProvider {
 
     /**
      * Get the configuration for the given scope
-     * 
+     *
      * @param scopeId
      * @return
      * @throws ConfigurationException
      */
-    public MessageStoreConfiguration getConfiguration(KapuaId scopeId)
-            throws ConfigurationException;
+    MessageStoreConfiguration getConfiguration(KapuaId scopeId) throws ConfigurationException;
 
     /**
      * Get the message information for the given scope
-     * 
+     *
      * @param scopeId
      * @return
      * @throws ConfigurationException
      */
-    public MessageInfo getInfo(KapuaId scopeId)
-            throws ConfigurationException;
+    MessageInfo getInfo(KapuaId scopeId) throws ConfigurationException;
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -74,7 +74,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
     protected final AccountService accountService = LOCATOR.getService(AccountService.class);
     protected final AuthorizationService authorizationService = LOCATOR.getService(AuthorizationService.class);
     protected final PermissionFactory permissionFactory = LOCATOR.getFactory(PermissionFactory.class);
-    protected final static Integer MAX_ENTRIES_ON_DELETE = DatastoreSettings.getInstance().get(Integer.class, DatastoreSettingKey.CONFIG_MAX_ENTRIES_ON_DELETE);
+    protected static final Integer MAX_ENTRIES_ON_DELETE = DatastoreSettings.getInstance().get(Integer.class, DatastoreSettingKey.CONFIG_MAX_ENTRIES_ON_DELETE);
 
     protected final MessageStoreFacade messageStoreFacade;
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
@@ -216,13 +216,13 @@ public class MetricInfoRegistryServiceImpl extends AbstractKapuaConfigurableServ
             lastPublishedMessageTimestamp = messageList.getFirstItem().getTimestamp();
         } else if (messageList.isEmpty()) {
             // this condition could happens due to the ttl of the messages (so if it happens, it does not necessarily mean there has been an error!)
-            LOG.warn("Cannot find last timestamp for the specified client id '{}' - account '{}'", new Object[] { metricInfo.getClientId(), metricInfo.getScopeId() });
+            LOG.warn("Cannot find last timestamp for the specified client id '{}' - account '{}'", metricInfo.getClientId(), metricInfo.getScopeId());
         } else {
             // this condition shouldn't never happens since the query has a limit 1
             // if happens it means than an elasticsearch internal error happens and/or our driver didn't set it correctly!
-            LOG.error("Cannot find last timestamp for the specified client id '{}' - account '{}'. More than one result returned by the query!",
-                    new Object[] { metricInfo.getClientId(), metricInfo.getScopeId() });
+            LOG.error("Cannot find last timestamp for the specified client id '{}' - account '{}'. More than one result returned by the query!", metricInfo.getClientId(), metricInfo.getScopeId());
         }
+
         metricInfo.setLastMessageId(lastPublishedMessageId);
         metricInfo.setLastMessageOn(lastPublishedMessageTimestamp);
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreClientFactory.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreClientFactory.java
@@ -11,17 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.client;
 
-import org.eclipse.kapua.service.datastore.client.DatastoreClient;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import org.eclipse.kapua.service.datastore.client.ClientException;
 import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
+import org.eclipse.kapua.service.datastore.client.DatastoreClient;
 import org.eclipse.kapua.service.datastore.internal.converter.ModelContextImpl;
 import org.eclipse.kapua.service.datastore.internal.converter.QueryConverterImpl;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettingKey;
 import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettings;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 /**
  * Datastore client factory. It returns the singleton client instance.<br>
@@ -31,8 +30,8 @@ import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettings;
  */
 public class DatastoreClientFactory {
 
-    private final static String CANNOT_LOAD_CLIENT_ERROR_MSG = "Cannot load the provided client class name [%s]. Check the configuration.";
-    private final static String CLIENT_CLASS_NAME;
+    private static final String CANNOT_LOAD_CLIENT_ERROR_MSG = "Cannot load the provided client class name [%s]. Check the configuration.";
+    private static final String CLIENT_CLASS_NAME;
     private static Class<DatastoreClient> datastoreClientInstance;
     private static DatastoreClient instance;
 
@@ -46,11 +45,10 @@ public class DatastoreClientFactory {
 
     /**
      * Return the client instance. The implementation is specified by {@link DatastoreSettingKey#CONFIG_CLIENT_CLASS}.
-     * 
+     *
      * @return
      * @throws ClientUnavailableException
      */
-    @SuppressWarnings("unchecked")
     public static DatastoreClient getInstance() throws ClientUnavailableException {
         //lazy synchronization
         if (instance == null) {
@@ -83,7 +81,7 @@ public class DatastoreClientFactory {
 
     /**
      * Close the client instance
-     * 
+     *
      * @throws ClientException
      */
     public static void close() throws ClientException {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoRegistryMediator.java
@@ -33,7 +33,7 @@ public interface ChannelInfoRegistryMediator {
      * @return
      * @throws ClientException
      */
-    public Metadata getMetadata(KapuaId scopeId, long indexedOn)
+    Metadata getMetadata(KapuaId scopeId, long indexedOn)
             throws ClientException;
 
     /**
@@ -45,7 +45,7 @@ public interface ChannelInfoRegistryMediator {
      * @throws QueryMappingException
      * @throws ClientException
      */
-    public void onBeforeChannelInfoDelete(ChannelInfo channelInfo)
+    void onBeforeChannelInfoDelete(ChannelInfo channelInfo)
             throws KapuaIllegalArgumentException,
             ConfigurationException,
             QueryMappingException,
@@ -56,5 +56,5 @@ public interface ChannelInfoRegistryMediator {
      *
      * @param channelInfo
      */
-    public void onAfterChannelInfoDelete(ChannelInfo channelInfo);
+    void onAfterChannelInfoDelete(ChannelInfo channelInfo);
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoRegistryMediator.java
@@ -32,7 +32,7 @@ public interface ClientInfoRegistryMediator {
      * @return
      * @throws ClientException
      */
-    public Metadata getMetadata(KapuaId scopeId, long indexedOn)
+    Metadata getMetadata(KapuaId scopeId, long indexedOn)
             throws ClientException;
 
     /**
@@ -43,7 +43,7 @@ public interface ClientInfoRegistryMediator {
      * @throws KapuaIllegalArgumentException
      * @throws ConfigurationException
      */
-    public void onAfterClientInfoDelete(KapuaId scopeId, ClientInfo clientInfo)
+    void onAfterClientInfoDelete(KapuaId scopeId, ClientInfo clientInfo)
             throws KapuaIllegalArgumentException,
             ConfigurationException,
             ClientException;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.mediator;
 
-import java.util.Map;
-
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.message.KapuaPayload;
@@ -39,6 +37,8 @@ import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
 
+import java.util.Map;
+
 /**
  * Datastore mediator definition
  *
@@ -49,7 +49,7 @@ public class DatastoreMediator implements MessageStoreMediator,
         ChannelInfoRegistryMediator,
         MetricInfoRegistryMediator {
 
-    private final static DatastoreMediator INSTANCE;
+    private static final DatastoreMediator INSTANCE;
 
     private final Schema esSchema;
 
@@ -122,7 +122,7 @@ public class DatastoreMediator implements MessageStoreMediator,
     }
 
     /*
-     * 
+     *
      * Message Store Mediator methods
      */
     @Override
@@ -189,7 +189,7 @@ public class DatastoreMediator implements MessageStoreMediator,
     }
 
     /*
-     * 
+     *
      * ClientInfo Store Mediator methods
      */
     @Override
@@ -203,7 +203,7 @@ public class DatastoreMediator implements MessageStoreMediator,
     }
 
     /*
-     * 
+     *
      * ChannelInfo Store Mediator methods
      */
     @Override
@@ -225,7 +225,7 @@ public class DatastoreMediator implements MessageStoreMediator,
     }
 
     /*
-     * 
+     *
      * MetricInfo Store Mediator methods
      */
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
@@ -12,16 +12,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.mediator;
 
-import java.text.ParseException;
-import java.time.Duration;
-import java.util.Date;
-import java.util.Map;
-
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.service.datastore.internal.model.DataIndexBy;
 import org.eclipse.kapua.service.datastore.internal.model.MetricsIndexBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
 
 /**
  * Message store configuration parameters (user dependent)
@@ -36,37 +36,37 @@ public class MessageStoreConfiguration {
      * Expiration date key.<br>
      * <b>The key must be aligned with the key used in org.eclipse.kapua.service.datastore.MessageStoreService.xml meta data configuration file).</b>
      */
-    public final static String CONFIGURATION_EXPIRATION_DATE_KEY = "messageStore.expirationDate";
+    public static final String CONFIGURATION_EXPIRATION_DATE_KEY = "messageStore.expirationDate";
 
     /**
      * Data storage enabled key.<br>
      * <b>The key must be aligned with the key used in org.eclipse.kapua.service.datastore.MessageStoreService.xml meta data configuration file).</b>
      */
-    public final static String CONFIGURATION_DATA_STORAGE_ENABLED_KEY = "messageStore.enabled";
+    public static final String CONFIGURATION_DATA_STORAGE_ENABLED_KEY = "messageStore.enabled";
 
     /**
      * Data time to live key.<br>
      * <b>The key must be aligned with the key used in org.eclipse.kapua.service.datastore.MessageStoreService.xml meta data configuration file).</b>
      */
-    public final static String CONFIGURATION_DATA_TTL_KEY = "dataTTL";
+    public static final String CONFIGURATION_DATA_TTL_KEY = "dataTTL";
 
     /**
      * Data received per month limit key.<br>
      * <b>The key must be aligned with the key used in org.eclipse.kapua.service.datastore.MessageStoreService.xml meta data configuration file).</b>
      */
-    public final static String CONFIGURATION_RX_BYTE_LIMIT_KEY = "rxByteLimit";
+    public static final String CONFIGURATION_RX_BYTE_LIMIT_KEY = "rxByteLimit";
 
     /**
      * Data index by key (available options are in DataIndexBy enumeration).<br>
      * <b>The key must be aligned with the key used in org.eclipse.kapua.service.datastore.MessageStoreService.xml meta data configuration file).</b>
      */
-    public final static String CONFIGURATION_DATA_INDEX_BY_KEY = "dataIndexBy";
+    public static final String CONFIGURATION_DATA_INDEX_BY_KEY = "dataIndexBy";
 
     /**
      * Metrics index by key (available options are in MetricsIndexBy enumeration).<br>
      * <b>The key must be aligned with the key used in org.eclipse.kapua.service.datastore.MessageStoreService.xml meta data configuration file).</b>
      */
-    public final static String CONFIGURATION_METRICS_INDEX_BY_KEY = "metricsIndexBy";
+    public static final String CONFIGURATION_METRICS_INDEX_BY_KEY = "metricsIndexBy";
 
     /**
      * Defines a value in service plan as unlimited resource

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreMediator.java
@@ -11,13 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.mediator;
 
-import java.util.Map;
-
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.client.ClientException;
 import org.eclipse.kapua.service.datastore.internal.schema.Metadata;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
+
+import java.util.Map;
 
 /**
  * Message mediator definition
@@ -32,8 +32,7 @@ public interface MessageStoreMediator {
      * @return
      * @throws ClientException
      */
-    public Metadata getMetadata(KapuaId scopeId, long indexedOn)
-            throws ClientException;
+    Metadata getMetadata(KapuaId scopeId, long indexedOn) throws ClientException;
 
     /**
      * On after message mappings event handler
@@ -43,8 +42,7 @@ public interface MessageStoreMediator {
      * @param metrics
      * @throws ClientException
      */
-    public void onUpdatedMappings(KapuaId scopeId, long indexedOn, Map<String, Metric> metrics)
-            throws ClientException;
+    void onUpdatedMappings(KapuaId scopeId, long indexedOn, Map<String, Metric> metrics) throws ClientException;
 
     /**
      * On after message store event handler
@@ -53,7 +51,5 @@ public interface MessageStoreMediator {
      * @param message
      * @throws ClientException
      */
-    public void onAfterMessageStore(MessageInfo messageInfo, DatastoreMessage message)
-            throws KapuaIllegalArgumentException,
-            ConfigurationException, ClientException;
+    void onAfterMessageStore(MessageInfo messageInfo, DatastoreMessage message) throws KapuaIllegalArgumentException, ConfigurationException, ClientException;
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoRegistryMediator.java
@@ -31,7 +31,7 @@ public interface MetricInfoRegistryMediator {
      * @return
      * @throws ClientException
      */
-    public Metadata getMetadata(KapuaId scopeId, long indexedOn)
+    Metadata getMetadata(KapuaId scopeId, long indexedOn)
             throws ClientException;
 
     /**
@@ -41,5 +41,5 @@ public interface MetricInfoRegistryMediator {
      * @param metricInfo
      * @throws ClientException
      */
-    public void onAfterMetricInfoDelete(KapuaId scopeId, MetricInfo metricInfo) throws ClientException;
+    void onAfterMetricInfoDelete(KapuaId scopeId, MetricInfo metricInfo) throws ClientException;
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/PredicateConstants.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/PredicateConstants.java
@@ -13,7 +13,7 @@ package org.eclipse.kapua.service.datastore.internal.model.query;
 
 /**
  * Predicates constants (keys and fields names)
- * 
+ *
  * @since 1.0
  */
 public interface PredicateConstants {
@@ -21,51 +21,60 @@ public interface PredicateConstants {
     /**
      * Boolean term
      */
-    public String BOOL_KEY = "bool";
+    String BOOL_KEY = "bool";
+
     /**
      * Exists term
      */
-    public String EXISTS_KEY = "exists";
+    String EXISTS_KEY = "exists";
+
     /**
      * Field
      */
-    public String FIELD_KEY = "field";
+    String FIELD_KEY = "field";
+
     /**
      * Ids term
      */
-    public String IDS_KEY = "ids";
+    String IDS_KEY = "ids";
+
     /**
      * Must term
      */
-    public String MUST_KEY = "must";
+    String MUST_KEY = "must";
+
     /**
      * Prefix term
      */
-    public String PREFIX_KEY = "prefix";
+    String PREFIX_KEY = "prefix";
+
     /**
      * Range term
      */
-    public String RANGE_KEY = "range";
+    String RANGE_KEY = "range";
+
     /**
      * Term
      */
-    public String TERM_KEY = "term";
+    String TERM_KEY = "term";
+
     /**
      * Type term
      */
-    public String TYPE_KEY = "type";
+    String TYPE_KEY = "type";
+
     /**
      * Values term
      */
-    public String VALUES_KEY = "values";
+    String VALUES_KEY = "values";
 
     /**
      * Greater than comparator term
      */
-    public String GTE_KEY = "gte";
+    String GTE_KEY = "gte";
+
     /**
      * Less than comparator term
      */
-    public String LTE_KEY = "lte";
-
+    String LTE_KEY = "lte";
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -11,16 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.service.datastore.client.DatamodelMappingException;
 import org.eclipse.kapua.service.datastore.client.SchemaKeys;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 /**
  * Channel info schema definition
- * 
+ *
  * @since 1.0
  */
 public class ChannelInfoSchema {
@@ -32,15 +31,15 @@ public class ChannelInfoSchema {
     /**
      * Channel information schema name
      */
-    public final static String CHANNEL_TYPE_NAME = "channel";
+    public static final String CHANNEL_TYPE_NAME = "channel";
     /**
      * Channel information - channel
      */
-    public final static String CHANNEL_NAME = "channel";
+    public static final String CHANNEL_NAME = "channel";
     /**
      * Channel information - client identifier
      */
-    public final static String CHANNEL_CLIENT_ID = "client_id";
+    public static final String CHANNEL_CLIENT_ID = "client_id";
     /**
      * Channel information - scope id
      */
@@ -48,15 +47,15 @@ public class ChannelInfoSchema {
     /**
      * Channel information - message timestamp (of the first message published in this channel)
      */
-    public final static String CHANNEL_TIMESTAMP = "timestamp";
+    public static final String CHANNEL_TIMESTAMP = "timestamp";
     /**
      * Channel information - message identifier (of the first message published in this channel)
      */
-    public final static String CHANNEL_MESSAGE_ID = "message_id";
+    public static final String CHANNEL_MESSAGE_ID = "message_id";
 
     /**
      * Create and return the Json representation of the channel info schema
-     * 
+     *
      * @param allEnable
      * @param sourceEnable
      * @return
@@ -82,7 +81,7 @@ public class ChannelInfoSchema {
                 new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
         propertiesNode.set(CHANNEL_CLIENT_ID, channelClientId);
         ObjectNode channelName = SchemaUtil.getField(
-                new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX,SchemaKeys. VALUE_TRUE) });
+                new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
         propertiesNode.set(CHANNEL_NAME, channelName);
         ObjectNode channelTimestamp = SchemaUtil.getField(
                 new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -11,19 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
-import org.eclipse.kapua.service.datastore.client.DatamodelMappingException;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.eclipse.kapua.service.datastore.client.SchemaKeys;
-
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
-
+import org.eclipse.kapua.service.datastore.client.DatamodelMappingException;
+import org.eclipse.kapua.service.datastore.client.SchemaKeys;
 
 /**
  * Client info schema
- * 
+ *
  * @since 1.0
  */
 public class ClientInfoSchema {
@@ -35,11 +31,11 @@ public class ClientInfoSchema {
     /**
      * Client information schema name
      */
-    public final static String CLIENT_TYPE_NAME = "client";
+    public static final String CLIENT_TYPE_NAME = "client";
     /**
      * Client information - client identifier
      */
-    public final static String CLIENT_ID = "client_id";
+    public static final String CLIENT_ID = "client_id";
     /**
      * Client information - scope id
      */
@@ -47,15 +43,15 @@ public class ClientInfoSchema {
     /**
      * Client information - message timestamp (of the first message published in this channel)
      */
-    public final static String CLIENT_TIMESTAMP = "timestamp";
+    public static final String CLIENT_TIMESTAMP = "timestamp";
     /**
      * Client information - message identifier (of the first message published in this channel)
      */
-    public final static String CLIENT_MESSAGE_ID = "message_id";
+    public static final String CLIENT_MESSAGE_ID = "message_id";
 
     /**
      * Create and return the Json representation of the client info schema
-     * 
+     *
      * @param allEnable
      * @param sourceEnable
      * @return
@@ -65,20 +61,24 @@ public class ClientInfoSchema {
         ObjectNode rootNode = SchemaUtil.getObjectNode();
 
         ObjectNode clientNodeName = SchemaUtil.getObjectNode();
-        ObjectNode sourceClient = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
+        ObjectNode sourceClient = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
         clientNodeName.set(SchemaKeys.KEY_SOURCE, sourceClient);
 
-        ObjectNode allClient = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable)});
+        ObjectNode allClient = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
         clientNodeName.set(SchemaKeys.KEY_ALL, allClient);
 
         ObjectNode propertiesNode = SchemaUtil.getObjectNode();
-        ObjectNode clientId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+        ObjectNode clientId = SchemaUtil
+                .getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
         propertiesNode.set(CLIENT_ID, clientId);
-        ObjectNode clientTimestamp = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+        ObjectNode clientTimestamp = SchemaUtil
+                .getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
         propertiesNode.set(CLIENT_TIMESTAMP, clientTimestamp);
-        ObjectNode clientScopeId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+        ObjectNode clientScopeId = SchemaUtil
+                .getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
         propertiesNode.set(CLIENT_SCOPE_ID, clientScopeId);
-        ObjectNode clientMessageId = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
+        ObjectNode clientMessageId = SchemaUtil
+                .getField(new KeyValueEntry[] { new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
         propertiesNode.set(CLIENT_MESSAGE_ID, clientMessageId);
         clientNodeName.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
         rootNode.set(CLIENT_TYPE_NAME, clientNodeName);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
@@ -11,31 +11,30 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
-import java.text.ParseException;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.client.DatamodelMappingException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.model.StorableId;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.NumericNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Schema utility class
- * 
+ *
  * @since 1.0
  */
 public class SchemaUtil {
 
-    final static JsonNodeFactory FACTORY = JsonNodeFactory.instance;
+    private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
 
     private static final String UNSUPPORTED_OBJECT_TYPE_ERROR_MSG = "The conversion of object [%s] is not supported!";
     private static final String NOT_VALID_OBJECT_TYPE_ERROR_MSG = "Cannot convert date [%s]";
@@ -47,7 +46,7 @@ public class SchemaUtil {
     /**
      * Return a map of map. The contained map has, as entries, the couples subKeys-values.<br>
      * <b>NOTE! No arrays subKeys-values coherence will be done (length or null check)!</b>
-     * 
+     *
      * @param key
      * @param subKeys
      * @param values
@@ -55,7 +54,7 @@ public class SchemaUtil {
      */
     public static Map<String, Object> getMapOfMap(String key, String[] subKeys, String[] values) {
         Map<String, String> mapChildren = new HashMap<>();
-        for (int i=0; i<subKeys.length; i++) {
+        for (int i = 0; i < subKeys.length; i++) {
             mapChildren.put(subKeys[i], values[i]);
         }
         Map<String, Object> map = new HashMap<>();
@@ -65,7 +64,7 @@ public class SchemaUtil {
 
     /**
      * Get the Elasticsearch data index name
-     * 
+     *
      * @param scopeId
      * @return
      */
@@ -75,7 +74,7 @@ public class SchemaUtil {
 
     /**
      * Get the Kapua data index name
-     * 
+     *
      * @param scopeId
      * @return
      */
@@ -85,7 +84,7 @@ public class SchemaUtil {
 
     /**
      * Create a new object node with the provided fields/values
-     * 
+     *
      * @param entries
      * @return
      * @throws DatamodelMappingException
@@ -100,7 +99,7 @@ public class SchemaUtil {
 
     /**
      * Create a new object node with the provided field/value
-     * 
+     *
      * @param name
      * @param value
      * @return
@@ -114,7 +113,7 @@ public class SchemaUtil {
 
     /**
      * Append the provided field/value to the object node
-     * 
+     *
      * @param node
      * @param name
      * @param value
@@ -152,7 +151,7 @@ public class SchemaUtil {
 
     /**
      * Create a new object node
-     * 
+     *
      * @return
      */
     public static ObjectNode getObjectNode() {
@@ -161,7 +160,7 @@ public class SchemaUtil {
 
     /**
      * Create a new numeric node
-     * 
+     *
      * @param number
      * @return
      */
@@ -171,7 +170,7 @@ public class SchemaUtil {
 
     /**
      * Create a new array node
-     * 
+     *
      * @return
      */
     public static ArrayNode getArrayNode() {
@@ -180,7 +179,7 @@ public class SchemaUtil {
 
     /**
      * Create a new text node
-     * 
+     *
      * @param value
      * @return
      */
@@ -190,7 +189,7 @@ public class SchemaUtil {
 
     /**
      * Convert the provided array to an array node
-     * 
+     *
      * @param fields
      * @return
      */

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/IndexCalculatorTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/IndexCalculatorTest.java
@@ -11,14 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.TimeZone;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
@@ -29,9 +21,17 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
 public class IndexCalculatorTest extends KapuaTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(IndexCalculatorTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(IndexCalculatorTest.class);
 
     @Test
     public void testIndex() throws KapuaException, ParseException, InterruptedException {
@@ -76,8 +76,13 @@ public class IndexCalculatorTest extends KapuaTest {
         calStartDate.setTimeInMillis(startDate.getTime());
         Calendar calEndDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"), KapuaDateUtils.getLocale());
         calEndDate.setTimeInMillis(endDate.getTime());
-        logger.info("StartDate week {} - day {} *** EndDate week {} - day {}",
-                new Object[] { calStartDate.get(Calendar.WEEK_OF_YEAR), calStartDate.get(Calendar.DAY_OF_WEEK), calEndDate.get(Calendar.WEEK_OF_YEAR), calEndDate.get(Calendar.DAY_OF_WEEK) });
+
+        LOG.info("StartDate week {} - day {} *** EndDate week {} - day {}",
+                calStartDate.get(Calendar.WEEK_OF_YEAR),
+                calStartDate.get(Calendar.DAY_OF_WEEK),
+                calEndDate.get(Calendar.WEEK_OF_YEAR),
+                calEndDate.get(Calendar.DAY_OF_WEEK));
+
         String[] index = DatastoreUtils.convertToDataIndexes(KapuaEid.ONE, startDate.toInstant(), endDate.toInstant());
         compareResult(expectedIndexes, index);
     }
@@ -97,7 +102,7 @@ public class IndexCalculatorTest extends KapuaTest {
                 result.add(String.format("%s-%s-%s", scopeId, i, (j < 10 ? "0" + j : j)));
             }
         }
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     private void compareResult(String[] expected, String[] result) {

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
@@ -12,29 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.kapua.KapuaException;
@@ -115,12 +92,34 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
 
     private static final Logger logger = LoggerFactory.getLogger(MessageStoreServiceTest.class);
     private static final long PUBLISH_DATE_TEST_CHECK_TIME_WINDOW = 1000l;
 
-    @SuppressWarnings("unused")
     // this unused instance is just added to initialize the embedded node as first step before executing any action on datastore side.
     // otherwise, if the datastore service is initialized before the embedded es node startup, the transport connector is not able to be initialized (since it tries to connect to the node)
     // if the embedded node is initialized in @Before method of this class, the initialization happens after this is loaded by the classloader so the datastore service initialization, at that point,
@@ -159,9 +158,8 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
      * The method deletes all indices and resets the Kapua internal singleton state.
      * This is required to ensure that each unit test, as it currently expects, starts with an empty ES setup
      * </p>
-     * 
-     * @throws Exception
-     *             any case anything goes wrong
+     *
+     * @throws Exception any case anything goes wrong
      */
     @Before
     public void deleteAllIndices() throws Exception {
@@ -303,12 +301,12 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
     // long count6 = MESSAGE_STORE_SERVICE.count(messageQuery1);
     // setMessageQueryBaseCriteria(messageQuery1, clientId, new DateRange(KapuaDateUtils.parseDate("2017-05-01T00:00:00.000Z"), KapuaDateUtils.parseDate("2017-05-31T00:00:00.000Z")));
     // long count7 = MESSAGE_STORE_SERVICE.count(messageQuery1);
-    // logger.info("{} - {} - {} - {} - {} - {} - {} - {}", new Object[] { count0, count1, count2, count3, count4, count5, count6, count7 });
+    // logger.info("{} - {} - {} - {} - {} - {} - {} - {}",  count0, count1, count2, count3, count4, count5, count6, count7 );
     // }
 
     private KapuaDataMessage insertMessage(Account account, String clientId, KapuaId deviceId, String semanticTopic, byte[] payload, Date sentOn) throws InterruptedException {
         KapuaDataPayloadImpl messagePayload = new KapuaDataPayloadImpl();
-        Map<String, Object> metrics = new HashMap<String, Object>();
+        Map<String, Object> metrics = new HashMap<>();
         metrics.put("float", new Float((float) 0.01));
         messagePayload.setMetrics(metrics);
         messagePayload.setBody(payload);
@@ -341,7 +339,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
 
         KapuaDataPayloadImpl messagePayload = new KapuaDataPayloadImpl();
 
-        Map<String, Object> metrics = new HashMap<String, Object>();
+        Map<String, Object> metrics = new HashMap<>();
         metrics.put("float", new Float((float) 0.01));
         metrics.put("integer", new Integer(1));
         metrics.put("double", (double) 0.01);
@@ -437,7 +435,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
 
             KapuaDataPayloadImpl messagePayload = new KapuaDataPayloadImpl();
 
-            Map<String, Object> metrics = new HashMap<String, Object>();
+            Map<String, Object> metrics = new HashMap<>();
             metrics.put("float", new Float((float) 0.01));
             metrics.put("integer", new Integer(1));
             metrics.put("double", (double) 0.01);
@@ -564,15 +562,15 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
             MessageListResult messageList = MESSAGE_STORE_SERVICE.query(messageQuery);
             checkMessagesCount(messageList, semanticTopic.length);
             for (int i = 0; i < messageList.getSize(); i++) {
-                 DatastoreMessage message = messageList.getItems().get(i);
+                DatastoreMessage message = messageList.getItems().get(i);
                 KapuaDataMessage messageToCompare = messages[i];
                 checkMessageId(message, messageStoredIds.get(i));
-                 checkTopic(message, messageToCompare.getChannel().toString());
-                 checkMessageBody(message, messageToCompare.getPayload().getBody());
-                 checkMetricsSize(message, messageToCompare.getPayload().getMetrics().size());
-                 checkMetrics(message, messageToCompare.getPayload().getMetrics());
-                 checkPosition(message, messageToCompare.getPosition());
-             }
+                checkTopic(message, messageToCompare.getChannel().toString());
+                checkMessageBody(message, messageToCompare.getPayload().getBody());
+                checkMetricsSize(message, messageToCompare.getPayload().getMetrics().size());
+                checkMetrics(message, messageToCompare.getPayload().getMetrics());
+                checkPosition(message, messageToCompare.getPosition());
+            }
         } catch (KapuaException e) {
             logger.error("Exception: ", e.getMessage(), e);
         }
@@ -615,7 +613,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
     /**
      * This test checks the coherence of the registry cache for the metrics info (so if, once the cache is erased, after a new metric insert the firstMessageId and firstMessageOn contain the previous
      * value)
-     * 
+     *
      * @throws Exception
      */
     public void checkRegistryCache() throws Exception {
@@ -637,7 +635,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
 
         KapuaDataPayloadImpl messagePayload = new KapuaDataPayloadImpl();
 
-        Map<String, Object> metrics = new HashMap<String, Object>();
+        Map<String, Object> metrics = new HashMap<>();
         metrics.put("float", new Float((float) 0.01));
         metrics.put("integer", new Integer(1));
         metrics.put("double", (double) 0.01);
@@ -1796,7 +1794,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
     }
 
     private Map<String, Object> getMetrics(KapuaDataMessage message, int profile) {
-        Map<String, Object> metrics = new HashMap<String, Object>();
+        Map<String, Object> metrics = new HashMap<>();
         for (int i = 0; i < 6; i++) {
             metrics.put("metric_" + i, getMetricValue(profile + i));
         }
@@ -1979,7 +1977,6 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
     }
 
     /**
-     *
      * @param channelInfoQuery
      * @param channelPredicate
      */
@@ -2091,6 +2088,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
     //
     // Utility methods to help to check the message result
     //
+
     /**
      * Check if in the result set has the expected messages count and return the first (if any)
      *
@@ -2400,9 +2398,9 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
         checkMetricsSize(messageToCheck, correctMessage.getPayload().getMetrics().size());
         checkMetrics(messageToCheck, correctMessage.getPayload().getMetrics());
         checkPosition(messageToCheck, correctMessage.getPosition());
-        checkMessageDate(messageToCheck, new Range<Date>("timestamp", correctMessage.getCapturedOn()), new Range<Date>("sentOn", correctMessage.getSentOn()),
-                new Range<Date>("capturedOn", correctMessage.getCapturedOn()),
-                new Range<Date>("receivedOn", correctMessage.getReceivedOn()));
+        checkMessageDate(messageToCheck, new Range<>("timestamp", correctMessage.getCapturedOn()), new Range<>("sentOn", correctMessage.getSentOn()),
+                new Range<>("capturedOn", correctMessage.getCapturedOn()),
+                new Range<>("receivedOn", correctMessage.getReceivedOn()));
         checkChannelFirstMessageIdAndDate(account, correctMessage.getClientId(), firstPublishedMessage, firstPublishedOn);
         checkClientFirstMessageIdAndDate(account, correctMessage.getClientId(), firstPublishedMessage, firstPublishedOn);
         checkMetricFirstMessageIdAndDate(account, correctMessage.getClientId(), firstPublishedMessage, firstPublishedOn);
@@ -2622,6 +2620,7 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
     //
     // Configuration utility
     //
+
     /**
      * Update the store service configuration with the provided values
      *

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/DeviceManagementService.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/DeviceManagementService.java
@@ -16,10 +16,10 @@ import org.eclipse.kapua.service.KapuaService;
 
 public interface DeviceManagementService extends KapuaService, KapuaDomainService<DeviceManagementDomain> {
 
-    public static final DeviceManagementDomain DEVICE_MANAGEMENT_DOMAIN = new DeviceManagementDomain();
+    DeviceManagementDomain DEVICE_MANAGEMENT_DOMAIN = new DeviceManagementDomain();
 
     @Override
-    public default DeviceManagementDomain getServiceDomain() {
+    default DeviceManagementDomain getServiceDomain() {
         return DEVICE_MANAGEMENT_DOMAIN;
     }
 

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppChannel.java
@@ -25,26 +25,26 @@ public interface KapuaAppChannel extends KapuaControlChannel {
      *
      * @return
      */
-    public KapuaAppProperties getAppName();
+    KapuaAppProperties getAppName();
 
     /**
      * Set the application name
      *
      * @param app
      */
-    public void setAppName(KapuaAppProperties app);
+    void setAppName(KapuaAppProperties app);
 
     /**
      * Get the application version
      *
      * @return
      */
-    public KapuaAppProperties getVersion();
+    KapuaAppProperties getVersion();
 
     /**
      * Set the application version
      *
      * @param version
      */
-    public void setVersion(KapuaAppProperties version);
+    void setVersion(KapuaAppProperties version);
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppProperties.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppProperties.java
@@ -26,5 +26,5 @@ public interface KapuaAppProperties {
      *
      * @return
      */
-    public String getValue();
+    String getValue();
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppPropertiesXmlAdapter.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppPropertiesXmlAdapter.java
@@ -21,12 +21,12 @@ public class KapuaAppPropertiesXmlAdapter extends XmlAdapter<String, KapuaAppPro
     private static final KapuaRequestMessageFactory REQUEST_MESSAGE_FACTORY = LOCATOR.getFactory(KapuaRequestMessageFactory.class);
 
     @Override
-    public KapuaAppProperties unmarshal(String v) throws Exception {
-        return REQUEST_MESSAGE_FACTORY.newAppProperties(v);
+    public String marshal(KapuaAppProperties v) throws Exception {
+        return v.getValue();
     }
 
     @Override
-    public String marshal(KapuaAppProperties v) throws Exception {
-        return v.getValue();
+    public KapuaAppProperties unmarshal(String v) throws Exception {
+        return REQUEST_MESSAGE_FACTORY.newAppProperties(v);
     }
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/RequestMessageXmlRegistry.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/RequestMessageXmlRegistry.java
@@ -22,18 +22,18 @@ import javax.xml.bind.annotation.XmlRegistry;
 @XmlRegistry
 public class RequestMessageXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final KapuaRequestMessageFactory factory = locator.getFactory(KapuaRequestMessageFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final KapuaRequestMessageFactory KAPUA_REQUEST_MESSAGE_FACTORY = LOCATOR.getFactory(KapuaRequestMessageFactory.class);
 
     public KapuaRequestChannel newRequestChannel() {
-        return factory.newRequestChannel();
+        return KAPUA_REQUEST_MESSAGE_FACTORY.newRequestChannel();
     }
 
     public KapuaRequestMessage<?, ?> newRequestMessage() {
-        return factory.newRequestMessage();
+        return KAPUA_REQUEST_MESSAGE_FACTORY.newRequestMessage();
     }
 
     public KapuaRequestPayload newRequestPayload() {
-        return factory.newRequestPayload();
+        return KAPUA_REQUEST_MESSAGE_FACTORY.newRequestPayload();
     }
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestChannel.java
@@ -34,12 +34,12 @@ public interface KapuaRequestChannel extends KapuaAppChannel {
      *
      * @return
      */
-    public KapuaMethod getMethod();
+    KapuaMethod getMethod();
 
     /**
      * Set the request method
      *
      * @param method
      */
-    public void setMethod(KapuaMethod method);
+    void setMethod(KapuaMethod method);
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestMessage.java
@@ -37,7 +37,7 @@ public interface KapuaRequestMessage<C extends KapuaRequestChannel, P extends Ka
      * @return
      */
     @XmlTransient
-    public <M extends KapuaRequestMessage<C, P>> Class<M> getRequestClass();
+    <M extends KapuaRequestMessage<C, P>> Class<M> getRequestClass();
 
     /**
      * Get the response message class type
@@ -45,6 +45,6 @@ public interface KapuaRequestMessage<C extends KapuaRequestChannel, P extends Ka
      * @return
      */
     @XmlTransient
-    public <RSC extends KapuaResponseChannel, RSP extends KapuaResponsePayload, M extends KapuaResponseMessage<RSC, RSP>> Class<M> getResponseClass();
+    <RSC extends KapuaResponseChannel, RSP extends KapuaResponsePayload, M extends KapuaResponseMessage<RSC, RSP>> Class<M> getResponseClass();
 
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseMessage.java
@@ -27,12 +27,12 @@ public interface KapuaResponseMessage<C extends KapuaResponseChannel, P extends 
      *
      * @return
      */
-    public KapuaResponseCode getResponseCode();
+    KapuaResponseCode getResponseCode();
 
     /**
      * Set the response code
      *
      * @param responseCode
      */
-    public void setResponseCode(KapuaResponseCode responseCode);
+    void setResponseCode(KapuaResponseCode responseCode);
 }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponsePayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponsePayload.java
@@ -27,26 +27,26 @@ public interface KapuaResponsePayload extends KapuaPayload {
      *
      * @return
      */
-    public String getExceptionMessage();
+    String getExceptionMessage();
 
     /**
      * Set the exception message (if present)
      *
      * @param setExecptionMessage
      */
-    public void setExceptionMessage(String setExecptionMessage);
+    void setExceptionMessage(String setExecptionMessage);
 
     /**
      * Get the exception stack trace (if present)
      *
      * @return
      */
-    public String getExceptionStack();
+    String getExceptionStack();
 
     /**
      * Set the exception stack trace (if present)
      *
      * @param setExecptionStack
      */
-    public void setExceptionStack(String setExecptionStack);
+    void setExceptionStack(String setExecptionStack);
 }

--- a/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAsset.java
+++ b/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAsset.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.asset;
 
-import java.util.List;
+import org.eclipse.kapua.service.device.management.asset.xml.DeviceAssetChannelXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -20,8 +20,7 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import org.eclipse.kapua.service.device.management.asset.xml.DeviceAssetChannelXmlAdapter;
+import java.util.List;
 
 /**
  * {@link DeviceAsset} entity definition.<br>
@@ -43,41 +42,35 @@ public interface DeviceAsset {
      * Get the asset name
      *
      * @return The asset name
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the asset name
      *
-     * @param name
-     *            The name to set
-     * 
+     * @param name The name to set
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the channels available for this {@link DeviceAsset}
-     * 
+     *
      * @return The channels available for this {@link DeviceAsset}
-     * 
      * @since 1.0.0
      */
     @XmlElementWrapper(name = "channels")
     @XmlElement(name = "channel")
     @XmlJavaTypeAdapter(DeviceAssetChannelXmlAdapter.class)
-    public List<DeviceAssetChannel> getChannels();
+    List<DeviceAssetChannel> getChannels();
 
     /**
      * Sets the channels for this {@link DeviceAsset}.
-     * 
-     * @param channels
-     *            The channels to set for this {@link DeviceAsset}.
-     * 
+     *
+     * @param channels The channels to set for this {@link DeviceAsset}.
      * @since 1.0.0
      */
-    public void setChannels(List<DeviceAssetChannel> channels);
+    void setChannels(List<DeviceAssetChannel> channels);
 }

--- a/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetChannel.java
+++ b/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetChannel.java
@@ -23,122 +23,107 @@ public interface DeviceAssetChannel {
 
     /**
      * Gets the name of the channel.
-     * 
+     *
      * @return The name of the channel.
-     * 
      * @since 1.0.0
      */
-    public String getName();
+    String getName();
 
     /**
      * Gets the name of the channel.
-     * 
+     *
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the channel type.
      * This is the type returned by {@link #getValue()}.
-     * 
+     *
      * @return The channel value type.
-     * 
      * @since 1.0.0
      */
-    public Class<?> getType();
+    Class<?> getType();
 
     /**
      * Sets the channel type.
      * This type must be coherent with the value given to {@link #setValue(Object)}.
      * If not errors will occur during the interaction with the device.
-     * 
-     * @param type
-     *            The channel type.
-     * 
+     *
+     * @param type The channel type.
      * @since 1.0.0
      */
-    public void setType(Class<?> type);
+    void setType(Class<?> type);
 
     /**
      * Gets the channel mode.
-     * 
+     *
      * @return The channel mode.
-     * 
      * @since 1.0.0
      */
-    public DeviceAssetChannelMode getMode();
+    DeviceAssetChannelMode getMode();
 
     /**
      * Sets the channel mode.
      * A {@link DeviceAssetChannel} can have modes available from {@link DeviceAssetChannelMode}.
-     * 
-     * @param deviceAssetChannelMode
-     *            The channel mode to set.
-     * 
+     *
+     * @param deviceAssetChannelMode The channel mode to set.
      * @since 1.0.0
      */
-    public void setMode(DeviceAssetChannelMode deviceAssetChannelMode);
+    void setMode(DeviceAssetChannelMode deviceAssetChannelMode);
 
     /**
      * Gets the value of the channel.
      * Depending on the {@link DeviceAssetChannelMode} this can be a value {@link DeviceAssetChannelMode#READ} from the channel or
      * to {@link DeviceAssetChannelMode#WRITE} into the channel.
      * This is mutually exclusive with {@link #getError()}
-     * 
+     *
      * @return The value of the channel.
-     * 
      * @since 1.0.0
      */
-    public Object getValue();
+    Object getValue();
 
     /**
      * Sets the value of the channel.
      * Depending on the {@link DeviceAssetChannelMode} this can be a value {@link DeviceAssetChannelMode#READ} from the channel or
      * to {@link DeviceAssetChannelMode#WRITE} into the channel.
-     * 
-     * @param value
-     *            The value of the channel to set.
-     * 
+     *
+     * @param value The value of the channel to set.
      * @since 1.0.0
      */
-    public void setValue(Object value);
+    void setValue(Object value);
 
     /**
      * Gets the error message for this channel
      * When reading from or writing to a channel, if any error occurs it will be reported here.
      * This is mutually exclusive with {@link #getValue()}
-     * 
+     *
      * @return The error message, if error has occurred.
-     * 
      * @since 1.0.0
      */
-    public String getError();
+    String getError();
 
     /**
      * Sets the error message for this channel.
      * This must be set if error has occurred during reading from/wrtiting to
-     * 
-     * @param error
-     *            The error message.
+     *
+     * @param error The error message.
      */
-    public void setError(String error);
+    void setError(String error);
 
     /**
      * Gets the timestamp in millisecond of the time when the value was read from the channel.
-     * 
+     *
      * @return The timestamp in millisecond of the time when the value was read from the channel.
-     * 
      * @since 1.0.0
      */
-    public Date getTimestamp();
+    Date getTimestamp();
 
     /**
      * Sets timestamp in millisecond of the time when the value was read from the channel.
-     * 
-     * @param timestamp
-     *            The timestamp in millisecond of the time when the value was read from the channel.
-     * 
+     *
+     * @param timestamp The timestamp in millisecond of the time when the value was read from the channel.
      * @since 1.0.0
      */
-    public void setTimestamp(Date timestamp);
+    void setTimestamp(Date timestamp);
 }

--- a/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetFactory.java
+++ b/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetFactory.java
@@ -24,26 +24,23 @@ public interface DeviceAssetFactory extends KapuaObjectFactory {
      * Instantiate a new {@link DeviceAssets} instance.
      *
      * @return The newly instantiated {@link DeviceAssets}.
-     * 
      * @since 1.0.0
      */
-    public DeviceAssets newAssetListResult();
+    DeviceAssets newAssetListResult();
 
     /**
      * Instantiate a new {@link DeviceAsset} instance.
      *
      * @return The newly instantiated {@link DeviceAsset}.
-     * 
      * @since 1.0.0
      */
-    public DeviceAsset newDeviceAsset();
+    DeviceAsset newDeviceAsset();
 
     /**
      * Instantiate a new {@link DeviceAssetChannel} instance.
-     * 
+     *
      * @return The newly instantiated {@link DeviceAssetChannel}
-     * 
      * @since 1.0.0
      */
-    public DeviceAssetChannel newDeviceAssetChannel();
+    DeviceAssetChannel newDeviceAssetChannel();
 }

--- a/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetManagementService.java
+++ b/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetManagementService.java
@@ -34,8 +34,7 @@ public interface DeviceAssetManagementService extends KapuaService, DeviceManage
      * @throws KapuaException
      * @since 1.0.0
      */
-    public DeviceAssets get(KapuaId scopeId, KapuaId deviceId, DeviceAssets deviceAssets, Long timeout)
-            throws KapuaException;
+    DeviceAssets get(KapuaId scopeId, KapuaId deviceId, DeviceAssets deviceAssets, Long timeout) throws KapuaException;
 
     /**
      * Reads current values from the device channels
@@ -48,8 +47,7 @@ public interface DeviceAssetManagementService extends KapuaService, DeviceManage
      * @throws KapuaException
      * @since 1.0.0
      */
-    public DeviceAssets read(KapuaId scopeId, KapuaId deviceId, DeviceAssets deviceAssets, Long timeout)
-            throws KapuaException;
+    DeviceAssets read(KapuaId scopeId, KapuaId deviceId, DeviceAssets deviceAssets, Long timeout) throws KapuaException;
 
     /**
      * Writes values to the device channels
@@ -62,7 +60,5 @@ public interface DeviceAssetManagementService extends KapuaService, DeviceManage
      * @throws KapuaException
      * @since 1.0.0
      */
-    public DeviceAssets write(KapuaId scopeId, KapuaId deviceId, DeviceAssets deviceAssets, Long timeout)
-            throws KapuaException;
-
+    DeviceAssets write(KapuaId scopeId, KapuaId deviceId, DeviceAssets deviceAssets, Long timeout) throws KapuaException;
 }

--- a/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetXmlRegistry.java
+++ b/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetXmlRegistry.java
@@ -11,9 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.asset;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 /**
  * {@link DeviceAsset} XML factory class
@@ -23,40 +23,36 @@ import org.eclipse.kapua.locator.KapuaLocator;
 @XmlRegistry
 public class DeviceAssetXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-
-    private final DeviceAssetFactory factory = locator.getFactory(DeviceAssetFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceAssetFactory DEVICE_ASSET_FACTORY = LOCATOR.getFactory(DeviceAssetFactory.class);
 
     /**
      * Instantiate a new {@link DeviceAssets}.
      *
      * @return The newly instantiate {@link DeviceAssets}.
-     * 
      * @since 1.0.0
      */
     public DeviceAssets newAssetListResult() {
-        return factory.newAssetListResult();
+        return DEVICE_ASSET_FACTORY.newAssetListResult();
     }
 
     /**
      * Instantiate a new {@link DeviceAsset}.
      *
      * @return The newly instantiated {@link DeviceAsset}.
-     * 
      * @since 1.0.0
      */
     public DeviceAsset newDeviceAsset() {
-        return factory.newDeviceAsset();
+        return DEVICE_ASSET_FACTORY.newDeviceAsset();
     }
 
     /**
      * Instantiate a new {@link DeviceAssetChannel}.
-     * 
+     *
      * @return The newly instantiated {@link DeviceAssetChannel}.
-     * 
      * @since 1.0.0
      */
     public DeviceAssetChannel newDeviceAssetChannel() {
-        return factory.newDeviceAssetChannel();
+        return DEVICE_ASSET_FACTORY.newDeviceAssetChannel();
     }
 }

--- a/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssets.java
+++ b/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssets.java
@@ -11,15 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.asset;
 
-import java.util.List;
+import org.eclipse.kapua.KapuaSerializable;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.KapuaSerializable;
+import java.util.List;
 
 /**
  * {@link DeviceAsset}s list entity definition.
@@ -35,19 +34,16 @@ public interface DeviceAssets extends KapuaSerializable {
      * Get the {@link DeviceAsset} {@link List}
      *
      * @return The {@link DeviceAsset} {@link List}.
-     * 
      * @since 1.0.0
      */
     @XmlElement(name = "deviceAsset")
-    public List<DeviceAsset> getAssets();
+    List<DeviceAsset> getAssets();
 
     /**
      * Sets the {@link DeviceAsset} {@link List}.
-     * 
-     * @param assets
-     *            The {@link DeviceAsset} {@link List}.
-     * 
+     *
+     * @param assets The {@link DeviceAsset} {@link List}.
      * @since 1.0.0
      */
-    public void setAssets(List<DeviceAsset> assets);
+    void setAssets(List<DeviceAsset> assets);
 }

--- a/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/DeviceAssetChannelXmlAdapter.java
+++ b/service/device/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/DeviceAssetChannelXmlAdapter.java
@@ -11,21 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.asset.xml;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.type.ObjectValueConverter;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannel;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory;
 
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
 /**
  * XML adapter for {@link DeviceAssetChannel}.
- * 
+ *
  * @since 1.0.0
  */
 public class DeviceAssetChannelXmlAdapter extends XmlAdapter<XmlAdaptedDeviceAssetChannel, DeviceAssetChannel> {
 
-    DeviceAssetFactory factory = KapuaLocator.getInstance().getFactory(DeviceAssetFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceAssetFactory DEVICE_ASSET_FACTORY = LOCATOR.getFactory(DeviceAssetFactory.class);
 
     @Override
     public XmlAdaptedDeviceAssetChannel marshal(DeviceAssetChannel deviceAssetChannel) throws Exception {
@@ -44,7 +45,7 @@ public class DeviceAssetChannelXmlAdapter extends XmlAdapter<XmlAdaptedDeviceAss
     @Override
     public DeviceAssetChannel unmarshal(XmlAdaptedDeviceAssetChannel xmlAdaptedDeviceAssetChannel) throws Exception {
 
-        DeviceAssetChannel adaptedDeviceAssetChannel = factory.newDeviceAssetChannel();
+        DeviceAssetChannel adaptedDeviceAssetChannel = DEVICE_ASSET_FACTORY.newDeviceAssetChannel();
         adaptedDeviceAssetChannel.setName(xmlAdaptedDeviceAssetChannel.getName());
         adaptedDeviceAssetChannel.setType(xmlAdaptedDeviceAssetChannel.getValueType());
         adaptedDeviceAssetChannel.setValue(ObjectValueConverter.fromString(xmlAdaptedDeviceAssetChannel.getValue(), adaptedDeviceAssetChannel.getType()));

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
@@ -22,7 +22,6 @@ import javax.xml.bind.annotation.XmlType;
  * This entity is used to get information about bundles installed in the device.
  *
  * @since 1.0
- *
  */
 @XmlRootElement(name = "bundle")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -35,14 +34,14 @@ public interface DeviceBundle {
      * @return
      */
     @XmlElement(name = "id")
-    public long getId();
+    long getId();
 
     /**
      * Set the bundle identifier
      *
      * @param id
      */
-    public void setId(long id);
+    void setId(long id);
 
     /**
      * Get the bundle name
@@ -50,14 +49,14 @@ public interface DeviceBundle {
      * @return
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the bundle name
      *
      * @param name
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the bundle state
@@ -65,14 +64,14 @@ public interface DeviceBundle {
      * @return
      */
     @XmlElement(name = "state")
-    public String getState();
+    String getState();
 
     /**
      * Set the bundle state
      *
      * @param state
      */
-    public void setState(String state);
+    void setState(String state);
 
     /**
      * Get the bundle version
@@ -80,13 +79,13 @@ public interface DeviceBundle {
      * @return
      */
     @XmlElement(name = "version")
-    public String getVersion();
+    String getVersion();
 
     /**
      * Set the bundle version
      *
      * @param version
      */
-    public void setVersion(String version);
+    void setVersion(String version);
 
 }

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
@@ -17,7 +17,6 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
  * Device bundle entity service factory definition.
  *
  * @since 1.0
- *
  */
 public interface DeviceBundleFactory extends KapuaObjectFactory {
 
@@ -26,12 +25,12 @@ public interface DeviceBundleFactory extends KapuaObjectFactory {
      *
      * @return
      */
-    public DeviceBundles newBundleListResult();
+    DeviceBundles newBundleListResult();
 
     /**
      * Create a new {@link DeviceBundle}
      *
      * @return
      */
-    public DeviceBundle newDeviceBundle();
+    DeviceBundle newDeviceBundle();
 }

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
@@ -32,8 +32,7 @@ public interface DeviceBundleManagementService extends KapuaService, DeviceManag
      * @return
      * @throws KapuaException
      */
-    public DeviceBundles get(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException;
+    DeviceBundles get(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
     /**
      * Start the device bundle identified by the given device identifier and device bundle identifier
@@ -44,8 +43,7 @@ public interface DeviceBundleManagementService extends KapuaService, DeviceManag
      * @param timeout  timeout waiting for the device response
      * @throws KapuaException
      */
-    public void start(KapuaId scopeId, KapuaId deviceId, String bundleId, Long timeout)
-            throws KapuaException;
+    void start(KapuaId scopeId, KapuaId deviceId, String bundleId, Long timeout) throws KapuaException;
 
     /**
      * Stop the device bundle identified by the given device identifier and device bundle identifier
@@ -56,6 +54,5 @@ public interface DeviceBundleManagementService extends KapuaService, DeviceManag
      * @param timeout  timeout waiting for the device response
      * @throws KapuaException
      */
-    public void stop(KapuaId scopeId, KapuaId deviceId, String bundleId, Long timeout)
-            throws KapuaException;
+    void stop(KapuaId scopeId, KapuaId deviceId, String bundleId, Long timeout) throws KapuaException;
 }

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
@@ -17,12 +17,10 @@ import org.eclipse.kapua.locator.KapuaLocator;
  * Device bundle xml factory class
  *
  * @since 1.0
- *
  */
 public class DeviceBundleXmlRegistry {
 
     private final KapuaLocator locator = KapuaLocator.getInstance();
-
     private final DeviceBundleFactory factory = locator.getFactory(DeviceBundleFactory.class);
 
     /**

--- a/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
+++ b/service/device/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
@@ -12,19 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.bundle;
 
-import java.util.List;
+import org.eclipse.kapua.KapuaSerializable;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.KapuaSerializable;
+import java.util.List;
 
 /**
  * Device bundles list entity definition.
  *
  * @since 1.0
- *
  */
 @XmlType(propOrder = { "bundles" }, factoryClass = DeviceBundleXmlRegistry.class, factoryMethod = "newBundleListResult")
 @XmlRootElement(name = "bundles")
@@ -36,5 +34,5 @@ public interface DeviceBundles extends KapuaSerializable {
      * @return
      */
     @XmlElement(name = "bundle")
-    public List<DeviceBundle> getBundles();
+    List<DeviceBundle> getBundles();
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCall.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCall.java
@@ -19,88 +19,76 @@ import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponse
 /**
  * Device call definition.
  *
- * @param <RQ>
- *            device request message type
- * @param <RS>
- *            device response message type
- * 
+ * @param <RQ> device request message type
+ * @param <RS> device response message type
  * @since 1.0
- * 
  */
-@SuppressWarnings("rawtypes")
 public interface DeviceCall<RQ extends DeviceRequestMessage, RS extends DeviceResponseMessage> {
 
     /**
      * Executes a 'read command'
-     * 
+     *
      * @param requestMessage
      * @param timeout
      * @return
      * @throws KapuaException
      */
-    public RS read(RQ requestMessage, Long timeout)
-            throws KapuaException;
+    RS read(RQ requestMessage, Long timeout) throws KapuaException;
 
     /**
      * Executes a 'create command'
-     * 
+     *
      * @param requestMessage
      * @param timeout
      * @return
      * @throws KapuaException
      */
-    public RS create(RQ requestMessage, Long timeout)
-            throws KapuaException;
+    RS create(RQ requestMessage, Long timeout) throws KapuaException;
 
     /**
      * Executes a 'write command'
-     * 
+     *
      * @param requestMessage
      * @param timeout
      * @return
      * @throws KapuaException
      */
-    public RS write(RQ requestMessage, Long timeout)
-            throws KapuaException;
+    RS write(RQ requestMessage, Long timeout) throws KapuaException;
 
     /**
      * Executes a 'delete command'
-     * 
+     *
      * @param requestMessage
      * @param timeout
      * @return
      * @throws KapuaException
      */
-    public RS delete(RQ requestMessage, Long timeout)
-            throws KapuaException;
+    RS delete(RQ requestMessage, Long timeout) throws KapuaException;
 
     /**
      * Executes an 'execute command'
-     * 
+     *
      * @param requestMessage
      * @param timeout
      * @return
      * @throws KapuaException
      */
-    public RS execute(RQ requestMessage, Long timeout)
-            throws KapuaException;
+    RS execute(RQ requestMessage, Long timeout) throws KapuaException;
 
     /**
      * Executes an 'options command'
-     * 
+     *
      * @param requestMessage
      * @param timeout
      * @return
      * @throws KapuaException
      */
-    public RS options(RQ requestMessage, Long timeout)
-            throws KapuaException;
+    RS options(RQ requestMessage, Long timeout) throws KapuaException;
 
     /**
      * Get the device base message type
-     * 
+     *
      * @return
      */
-    public <M extends DeviceMessage> Class<M> getBaseMessageClass();
-
+    <M extends DeviceMessage> Class<M> getBaseMessageClass();
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallFactory.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallFactory.java
@@ -15,18 +15,16 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
 
 /**
  * Device call service factory definition.
- * 
+ *
  * @since 1.0
- * 
  */
-@SuppressWarnings("rawtypes")
 public interface DeviceCallFactory extends KapuaObjectFactory {
 
     /**
      * Creates a new {@link DeviceCall}
-     * 
+     *
      * @return
      */
-    public DeviceCall newDeviceCall();
+    DeviceCall newDeviceCall();
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallback.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallback.java
@@ -15,25 +15,22 @@ import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 
 /**
  * Device callback definition
- * 
- * @param <RSM>
- *            response message type
- * 
+ *
+ * @param <RSM> response message type
  * @since 1.0
- * 
  */
 public interface DeviceCallback<RSM extends DeviceMessage<?, ?>> {
 
     /**
      * Action to be invoked on response received
-     * 
+     *
      * @param response
      */
-    public void responseReceived(RSM response);
+    void responseReceived(RSM response);
 
     /**
      * Action to be invoked on timed out
      */
-    public void timedOut();
+    void timedOut();
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceMessageFactory.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/DeviceMessageFactory.java
@@ -21,53 +21,51 @@ import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestPa
 
 /**
  * Device message service factory definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
-@SuppressWarnings("rawtypes")
 public interface DeviceMessageFactory extends KapuaObjectFactory {
 
     /**
      * Creates a new device message
-     * 
+     *
      * @return
      */
-    public DeviceMessage newMessage();
+    DeviceMessage newMessage();
 
     /**
      * Creates a new device request message
-     * 
+     *
      * @return
      */
-    public DeviceRequestMessage newRequestMessage();
+    DeviceRequestMessage newRequestMessage();
 
     /**
      * Creates a new device channel
-     * 
+     *
      * @return
      */
-    public DeviceChannel newChannel();
+    DeviceChannel newChannel();
 
     /**
      * Creates a new device request channel
-     * 
+     *
      * @return
      */
-    public DeviceRequestChannel newRequestChannel();
+    DeviceRequestChannel newRequestChannel();
 
     /**
      * Creates a new device payload
-     * 
+     *
      * @return
      */
-    public DevicePayload newPayload();
+    DevicePayload newPayload();
 
     /**
      * Creates a new device request payload
-     * 
+     *
      * @return
      */
-    public DeviceRequestPayload newRequestPayload();
+    DeviceRequestPayload newRequestPayload();
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DeviceChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DeviceChannel.java
@@ -25,7 +25,7 @@ public interface DeviceChannel extends Channel {
      *
      * @return
      */
-    public String getMessageClassification();
+    String getMessageClassification();
 
     /**
      * Sets the message classification.<br>
@@ -34,34 +34,34 @@ public interface DeviceChannel extends Channel {
      *
      * @param messageClassification
      */
-    public void setMessageClassification(String messageClassification);
+    void setMessageClassification(String messageClassification);
 
     /**
      * Get the message scope
      *
      * @return
      */
-    public String getScope();
+    String getScope();
 
     /**
      * Set th emessage scope
      *
      * @param scope
      */
-    public void setScope(String scope);
+    void setScope(String scope);
 
     /**
      * Get the client identifier
      *
      * @return
      */
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set the client identifier
      *
      * @param clientId
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DevicePosition.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/DevicePosition.java
@@ -27,125 +27,125 @@ public interface DevicePosition extends Position {
      *
      * @return
      */
-    public Double getLongitude();
+    Double getLongitude();
 
     /**
      * Set the device position longitude
      *
      * @param longitude
      */
-    public void setLongitude(Double longitude);
+    void setLongitude(Double longitude);
 
     /**
      * Get the device position latitude
      *
      * @return
      */
-    public Double getLatitude();
+    Double getLatitude();
 
     /**
      * Set the device position latitude
      *
      * @param latitude
      */
-    public void setLatitude(Double latitude);
+    void setLatitude(Double latitude);
 
     /**
      * Get the device position altitude
      *
      * @return
      */
-    public Double getAltitude();
+    Double getAltitude();
 
     /**
      * Set the device position altitude
      *
      * @param altitude
      */
-    public void setAltitude(Double altitude);
+    void setAltitude(Double altitude);
 
     /**
      * Get the device precision
      *
      * @return
      */
-    public Double getPrecision();
+    Double getPrecision();
 
     /**
      * Set the device precision
      *
      * @param precision
      */
-    public void setPrecision(Double precision);
+    void setPrecision(Double precision);
 
     /**
      * Get the device heading
      *
      * @return
      */
-    public Double getHeading();
+    Double getHeading();
 
     /**
      * Set the device heading
      *
      * @param heading
      */
-    public void setHeading(Double heading);
+    void setHeading(Double heading);
 
     /**
      * Get the device speed
      *
      * @return
      */
-    public Double getSpeed();
+    Double getSpeed();
 
     /**
      * Set the device speed
      *
      * @param speed
      */
-    public void setSpeed(Double speed);
+    void setSpeed(Double speed);
 
     /**
      * Get the timestamp
      *
      * @return
      */
-    public Date getTimestamp();
+    Date getTimestamp();
 
     /**
      * Set the timestamp
      *
      * @param timestamp
      */
-    public void setTimestamp(Date timestamp);
+    void setTimestamp(Date timestamp);
 
     /**
      * Get the satellites count
      *
      * @return
      */
-    public Integer getSatellites();
+    Integer getSatellites();
 
     /**
      * Set the satellites count
      *
      * @param satellites
      */
-    public void setSatellites(Integer satellites);
+    void setSatellites(Integer satellites);
 
     /**
      * Get the device status
      *
      * @return
      */
-    public Integer getStatus();
+    Integer getStatus();
 
     /**
      * Set the device status
      *
      * @param status
      */
-    public void setStatus(Integer status);
+    void setStatus(Integer status);
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/DeviceAppChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/DeviceAppChannel.java
@@ -15,24 +15,23 @@ import org.eclipse.kapua.service.device.call.message.DeviceChannel;
 
 /**
  * Device application channel definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DeviceAppChannel extends DeviceChannel {
 
     /**
      * Get the application identifier
-     * 
+     *
      * @return
      */
-    public String getAppId();
+    String getAppId();
 
     /**
      * Set the application identifier
-     * 
+     *
      * @param appId
      */
-    public void setAppId(String appId);
+    void setAppId(String appId);
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestChannel.java
@@ -16,68 +16,67 @@ import org.eclipse.kapua.service.device.call.message.app.DeviceAppChannel;
 
 /**
  * Device request channel definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DeviceRequestChannel extends DeviceAppChannel {
 
     /**
      * Get the request method
-     * 
+     *
      * @return
      */
-    public DeviceMethod getMethod();
+    DeviceMethod getMethod();
 
     /**
      * Set the request method
-     * 
+     *
      * @param method
      */
-    public void setMethod(DeviceMethod method);
+    void setMethod(DeviceMethod method);
 
     /**
      * Get the request resources
-     * 
+     *
      * @return
      */
-    public String[] getResources();
+    String[] getResources();
 
     /**
      * Set the request resources
-     * 
+     *
      * @param resources
      */
-    public void setResources(String[] resources);
+    void setResources(String[] resources);
 
     /**
      * Get the request identifier
-     * 
+     *
      * @return
      */
-    public String getRequestId();
+    String getRequestId();
 
     /**
      * Set the request identifier
-     * 
+     *
      * @param requestId
      */
-    public void setRequestId(String requestId);
+    void setRequestId(String requestId);
 
     /**
      * Get the requester client identifier.<br>
      * May be useful to reply only to the requester
-     * 
+     *
      * @return
      */
-    public String getRequesterClientId();
+    String getRequesterClientId();
 
     /**
      * Set the requester client identifier.<br>
      * May be useful to reply only to the requester
-     * 
+     *
      * @param requesterClientId
      */
-    public void setRequesterClientId(String requesterClientId);
+    void setRequesterClientId(String requesterClientId);
 
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestPayload.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/request/DeviceRequestPayload.java
@@ -25,14 +25,14 @@ public interface DeviceRequestPayload extends DeviceAppPayload {
      *
      * @return
      */
-    public String getRequestId();
+    String getRequestId();
 
     /**
      * Set the request identifier
      *
      * @param requestId
      */
-    public void setRequestId(String requestId);
+    void setRequestId(String requestId);
 
     /**
      * Get the requester client identifier.<br>
@@ -40,7 +40,7 @@ public interface DeviceRequestPayload extends DeviceAppPayload {
      *
      * @return
      */
-    public String getRequesterClientId();
+    String getRequesterClientId();
 
     /**
      * Set the requester client identifier.<br>
@@ -48,5 +48,5 @@ public interface DeviceRequestPayload extends DeviceAppPayload {
      *
      * @param requesterId
      */
-    public void setRequesterClientId(String requesterId);
+    void setRequesterClientId(String requesterId);
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseChannel.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseChannel.java
@@ -15,37 +15,36 @@ import org.eclipse.kapua.service.device.call.message.app.DeviceAppChannel;
 
 /**
  * Device response channel definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DeviceResponseChannel extends DeviceAppChannel {
 
     /**
      * Get the reply part
-     * 
+     *
      * @return
      */
-    public String getReplyPart();
+    String getReplyPart();
 
     /**
      * Set the reply part
-     * 
+     *
      * @param replyPart
      */
-    public void setReplyPart(String replyPart);
+    void setReplyPart(String replyPart);
 
     /**
      * Get the request identifier
-     * 
+     *
      * @return
      */
-    public String getRequestId();
+    String getRequestId();
 
     /**
      * Set the request identifier
-     * 
+     *
      * @param requestId
      */
-    public void setRequestId(String requestId);
+    void setRequestId(String requestId);
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseCode.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponseCode.java
@@ -19,11 +19,11 @@ package org.eclipse.kapua.service.device.call.message.app.response;
  */
 public interface DeviceResponseCode {
 
-    public boolean isAccepted();
+    boolean isAccepted();
 
-    public boolean isBadRequest();
+    boolean isBadRequest();
 
-    public boolean isNotFound();
+    boolean isNotFound();
 
-    public boolean isInternalError();
+    boolean isInternalError();
 }

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponsePayload.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/response/DeviceResponsePayload.java
@@ -23,27 +23,27 @@ public interface DeviceResponsePayload extends DeviceAppPayload {
      *
      * @return
      */
-    public <C extends DeviceResponseCode> C getResponseCode();
+    <C extends DeviceResponseCode> C getResponseCode();
 
     /**
      * Get the command exception message
      *
      * @return
      */
-    public String getExceptionMessage();
+    String getExceptionMessage();
 
     /**
      * Get the command exception stack
      *
      * @return
      */
-    public String getExceptionStack();
+    String getExceptionStack();
 
     /**
      * Get the command response body
      *
      * @return
      */
-    public byte[] getResponseBody();
+    byte[] getResponseBody();
 
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraDisconnectPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/lifecycle/KuraDisconnectPayload.java
@@ -22,11 +22,11 @@ public class KuraDisconnectPayload extends KuraPayload implements DeviceLifecycl
     /**
      * Uptime metric name
      */
-    private final static String UPTIME = "uptime";
+    private static final String UPTIME = "uptime";
     /**
      * Uptime device displayble name metric name
      */
-    private final static String DISPLAY_NAME = "display_name";
+    private static final String DISPLAY_NAME = "display_name";
 
     /**
      * Constructor
@@ -71,9 +71,13 @@ public class KuraDisconnectPayload extends KuraPayload implements DeviceLifecycl
      *
      * @return
      */
+    @Override
     public String toDisplayString() {
-        return new StringBuilder().append("[ getUptime()=").append(getUptime())
-                .append(", getDisplayName()=").append(getDisplayName())
+        return new StringBuilder()
+                .append("[ getUptime()=")
+                .append(getUptime())
+                .append(", getDisplayName()=")
+                .append(getDisplayName())
                 .append("]")
                 .toString();
     }

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandFactory.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandFactory.java
@@ -17,21 +17,20 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
  * Device command entity service factory definition.
  *
  * @since 1.0
- * 
  */
 public interface DeviceCommandFactory extends KapuaObjectFactory {
 
     /**
      * Creates a new {@link DeviceCommandInput}
-     * 
+     *
      * @return
      */
-    public DeviceCommandInput newCommandInput();
+    DeviceCommandInput newCommandInput();
 
     /**
      * Create a new {@link DeviceCommandOutput}
-     * 
+     *
      * @return
      */
-    public DeviceCommandOutput newCommandOutput();
+    DeviceCommandOutput newCommandOutput();
 }

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.command;
 
+import org.eclipse.kapua.model.KapuaEntity;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -18,13 +20,10 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.KapuaEntity;
-
 /**
  * Device command input entity definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "commandInput")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -43,137 +42,137 @@ public interface DeviceCommandInput extends KapuaEntity {
 
     /**
      * Get the device command
-     * 
+     *
      * @return
      */
     @XmlElement(name = "command")
-    public String getCommand();
+    String getCommand();
 
     /**
      * Set the device command
-     * 
+     *
      * @param command
      */
-    public void setCommand(String command);
+    void setCommand(String command);
 
     /**
      * Get the device password
-     * 
+     *
      * @return
      */
     @XmlElement(name = "password")
-    public String getPassword();
+    String getPassword();
 
     /**
      * Set the device password
-     * 
+     *
      * @param password
      */
-    public void setPassword(String password);
+    void setPassword(String password);
 
     /**
      * Get command arguments
-     * 
+     *
      * @return
      */
     @XmlElementWrapper(name = "arguments")
     @XmlElement(name = "argument")
-    public String[] getArguments();
+    String[] getArguments();
 
     /**
      * Set command arguments
-     * 
+     *
      * @param arguments
      */
-    public void setArguments(String[] arguments);
+    void setArguments(String[] arguments);
 
     /**
      * Get the command timeout
-     * 
+     *
      * @return
      */
     @XmlElement(name = "timeout")
-    public Integer getTimeout();
+    Integer getTimeout();
 
     /**
      * Set the command timeout
-     * 
+     *
      * @param timeout
      */
-    public void setTimeout(Integer timeout);
+    void setTimeout(Integer timeout);
 
     /**
      * Get the working directory
-     * 
+     *
      * @return
      */
     @XmlElement(name = "workingDir")
-    public String getWorkingDir();
+    String getWorkingDir();
 
     /**
      * Set the working directory
-     * 
+     *
      * @param workingDir
      */
-    public void setWorkingDir(String workingDir);
+    void setWorkingDir(String workingDir);
 
     /**
      * Get the command input body
-     * 
+     *
      * @return
      */
     @XmlElement(name = "body")
-    public byte[] getBody();
+    byte[] getBody();
 
     /**
      * Set the command input body
-     * 
+     *
      * @param bytes
      */
-    public void setBody(byte[] bytes);
+    void setBody(byte[] bytes);
 
     /**
      * Get the environment attributes
-     * 
+     *
      * @return
      */
     @XmlElement(name = "environment")
-    public String[] getEnvironment();
+    String[] getEnvironment();
 
     /**
      * Set the environment attributes
-     * 
+     *
      * @param environment
      */
-    public void setEnvironment(String[] environment);
+    void setEnvironment(String[] environment);
 
     /**
      * Get the asynchronous run flag
-     * 
+     *
      * @return
      */
     @XmlElement(name = "runAsynch")
-    public boolean isRunAsynch();
+    boolean isRunAsynch();
 
     /**
      * Set the asynchronous run flag
-     * 
+     *
      * @param runAsync
      */
-    public void setRunAsynch(boolean runAsync);
+    void setRunAsynch(boolean runAsync);
 
     /**
      * Get the device standard input
-     * 
+     *
      * @return
      */
     @XmlElement(name = "stdin")
-    public String getStdin();
+    String getStdin();
 
     /**
      * Set the device standard input
-     * 
+     *
      * @param stdin
      */
-    public void setStdin(String stdin);
+    void setStdin(String stdin);
 }

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
@@ -33,6 +33,5 @@ public interface DeviceCommandManagementService extends KapuaService, DeviceMana
      * @return
      * @throws KapuaException
      */
-    public DeviceCommandOutput exec(KapuaId scopeId, KapuaId deviceId, DeviceCommandInput commandInput, Long timeout)
-            throws KapuaException;
+    DeviceCommandOutput exec(KapuaId scopeId, KapuaId deviceId, DeviceCommandInput commandInput, Long timeout) throws KapuaException;
 }

--- a/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
+++ b/service/device/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
@@ -11,19 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.command;
 
+import org.eclipse.kapua.KapuaSerializable;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.KapuaSerializable;
-
 /**
  * Device command output entity definition.
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "commandOutput")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -39,91 +38,91 @@ public interface DeviceCommandOutput extends KapuaSerializable {
 
     /**
      * Get the standard error
-     * 
+     *
      * @return
      */
     @XmlElement(name = "stderr")
-    public String getStderr();
+    String getStderr();
 
     /**
      * Set the standard error
-     * 
+     *
      * @param stderr
      */
-    public void setStderr(String stderr);
+    void setStderr(String stderr);
 
     /**
      * Get the standard output
-     * 
+     *
      * @return
      */
     @XmlElement(name = "stdout")
-    public String getStdout();
+    String getStdout();
 
     /**
      * Set the standard output
-     * 
+     *
      * @param stdout
      */
-    public void setStdout(String stdout);
+    void setStdout(String stdout);
 
     /**
      * Get the command execution exception message
-     * 
+     *
      * @return
      */
     @XmlElement(name = "exceptionMessage")
-    public String getExceptionMessage();
+    String getExceptionMessage();
 
     /**
      * Set the command execution exception message
-     * 
+     *
      * @param exceptionMessage
      */
-    public void setExceptionMessage(String exceptionMessage);
+    void setExceptionMessage(String exceptionMessage);
 
     /**
      * Get the command execution exception stack
-     * 
+     *
      * @return
      */
     @XmlElement(name = "exceptionStack")
-    public String getExceptionStack();
+    String getExceptionStack();
 
     /**
      * Set the command execution exception stack
-     * 
+     *
      * @param exceptionStack
      */
-    public void setExceptionStack(String exceptionStack);
+    void setExceptionStack(String exceptionStack);
 
     /**
      * Get the command execution exit code
-     * 
+     *
      * @return
      */
     @XmlElement(name = "exitCode")
-    public Integer getExitCode();
+    Integer getExitCode();
 
     /**
      * Set the command execution exit code
-     * 
+     *
      * @param exitCode
      */
-    public void setExitCode(Integer exitCode);
+    void setExitCode(Integer exitCode);
 
     /**
      * Get the command execution timed out flag
-     * 
+     *
      * @return
      */
     @XmlElement(name = "hasTimedout")
-    public Boolean getHasTimedout();
+    Boolean getHasTimedout();
 
     /**
      * Set the command execution timed out flag
-     * 
+     *
      * @param hasTimedout
      */
-    public void setHasTimedout(Boolean hasTimedout);
+    void setHasTimedout(Boolean hasTimedout);
 }

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallExecutor.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -43,11 +43,11 @@ import org.eclipse.kapua.translator.Translator;
  */
 public class DeviceCallExecutor<C extends KapuaRequestChannel, P extends KapuaRequestPayload, RQ extends KapuaRequestMessage<C, P>, RS extends KapuaResponseMessage> {
 
-    private final static KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
-    private final static DeviceCallFactory DEVICE_CALL_FACTORY = LOCATOR.getFactory(DeviceCallFactory.class);
+    private static final DeviceCallFactory DEVICE_CALL_FACTORY = LOCATOR.getFactory(DeviceCallFactory.class);
 
-    private final static DeviceRegistryService DEVICE_REGISTRY_SERVICE = LOCATOR.getService(DeviceRegistryService.class);
+    private static final DeviceRegistryService DEVICE_REGISTRY_SERVICE = LOCATOR.getService(DeviceRegistryService.class);
 
     private RQ requestMessage;
     private Long timeout;

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
@@ -11,7 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration;
 
-import java.util.Map;
+import org.eclipse.kapua.commons.configuration.metatype.XmlConfigPropertiesAdapter;
+import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -20,15 +21,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import org.eclipse.kapua.commons.configuration.metatype.XmlConfigPropertiesAdapter;
-import org.eclipse.kapua.model.config.metatype.KapuaTocd;
+import java.util.Map;
 
 /**
  * Device component configuration entity definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "configuration")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -42,62 +40,62 @@ public interface DeviceComponentConfiguration {
 
     /**
      * Get device configuration component identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "id")
-    public String getId();
+    String getId();
 
     /**
      * Set device configuration component identifier
-     * 
+     *
      * @param id
      */
-    public void setId(String id);
+    void setId(String id);
 
     /**
      * Get device configuration component name
-     * 
+     *
      * @return
      */
     @XmlAttribute(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set device configuration component name
-     * 
+     *
      * @param unescapedComponentName
      */
-    public void setName(String unescapedComponentName);
+    void setName(String unescapedComponentName);
 
     /**
      * Get device configuration component definition
-     * 
+     *
      * @return
      */
     @XmlElement(name = "definition")
-    public KapuaTocd getDefinition();
+    KapuaTocd getDefinition();
 
     /**
      * Set device configuration component definition
-     * 
+     *
      * @param definition
      */
-    public void setDefinition(KapuaTocd definition);
+    void setDefinition(KapuaTocd definition);
 
     /**
      * Get device configuration component properties
-     * 
+     *
      * @return
      */
     @XmlElement(name = "properties")
     @XmlJavaTypeAdapter(XmlConfigPropertiesAdapter.class)
-    public Map<String, Object> getProperties();
+    Map<String, Object> getProperties();
 
     /**
      * Set device configuration component properties
-     * 
+     *
      * @param properties
      */
-    public void setProperties(Map<String, Object> properties);
+    void setProperties(Map<String, Object> properties);
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
@@ -12,21 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration;
 
-import java.util.List;
+import org.eclipse.kapua.KapuaSerializable;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.KapuaSerializable;
+import java.util.List;
 
 /**
  * Device configuration entity definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "configurations")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -35,9 +33,9 @@ public interface DeviceConfiguration extends KapuaSerializable {
 
     /**
      * Get the device component configuration list
-     * 
+     *
      * @return
      */
     @XmlElement(name = "configuration")
-    public List<DeviceComponentConfiguration> getComponentConfigurations();
+    List<DeviceComponentConfiguration> getComponentConfigurations();
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
@@ -17,21 +17,20 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
  * Device configuration entity service factory definition.
  *
  * @since 1.0
- * 
  */
 public interface DeviceConfigurationFactory extends KapuaObjectFactory {
 
     /**
      * Creates a new {@link DeviceComponentConfiguration} using the given component configuration identifier
-     * 
+     *
      * @return
      */
-    public DeviceComponentConfiguration newComponentConfigurationInstance(String componentConfigurationId);
+    DeviceComponentConfiguration newComponentConfigurationInstance(String componentConfigurationId);
 
     /**
      * Creates a new {@link DeviceConfiguration}
-     * 
+     *
      * @return
      */
-    public DeviceConfiguration newConfigurationInstance();
+    DeviceConfiguration newConfigurationInstance();
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
@@ -34,8 +34,7 @@ public interface DeviceConfigurationManagementService extends KapuaService, Devi
      * @return
      * @throws KapuaException
      */
-    public DeviceConfiguration get(KapuaId scopeId,
-            KapuaId deviceId,
+    DeviceConfiguration get(KapuaId scopeId, KapuaId deviceId,
             String configurationId,
             String configurationComponentPid,
             Long timeout)
@@ -50,8 +49,7 @@ public interface DeviceConfigurationManagementService extends KapuaService, Devi
      * @param timeout         timeout waiting for the device response
      * @throws KapuaException
      */
-    public void put(KapuaId scopeId, KapuaId deviceId, String xmlDeviceConfig, Long timeout)
-            throws KapuaException;
+    void put(KapuaId scopeId, KapuaId deviceId, String xmlDeviceConfig, Long timeout) throws KapuaException;
 
     /**
      * Put the provided configuration to the device identified by the provided device identifier
@@ -62,8 +60,7 @@ public interface DeviceConfigurationManagementService extends KapuaService, Devi
      * @param timeout      timeout waiting for the device response
      * @throws KapuaException
      */
-    public void put(KapuaId scopeId, KapuaId deviceId, DeviceConfiguration deviceConfig, Long timeout)
-            throws KapuaException;
+    void put(KapuaId scopeId, KapuaId deviceId, DeviceConfiguration deviceConfig, Long timeout) throws KapuaException;
 
     /**
      * Put the provided configuration to the device identified by the provided device identifier
@@ -74,6 +71,5 @@ public interface DeviceConfigurationManagementService extends KapuaService, Devi
      * @param timeout               timeout waiting for the device response
      * @throws KapuaException
      */
-    public void put(KapuaId scopeId, KapuaId deviceId, DeviceComponentConfiguration deviceComponentConfig, Long timeout)
-            throws KapuaException;
+    void put(KapuaId scopeId, KapuaId deviceId, DeviceComponentConfiguration deviceComponentConfig, Long timeout) throws KapuaException;
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
@@ -11,37 +11,36 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * Device bundle xml factory class
- * 
- * @since 1.0
+ * {@link DeviceConfiguration} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class DeviceConfigurationXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DeviceConfigurationFactory factory = locator.getFactory(DeviceConfigurationFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceConfigurationFactory DEVICE_CONFIGURATION_FACTORY = LOCATOR.getFactory(DeviceConfigurationFactory.class);
 
     /**
      * Creates a new device configuration
-     * 
+     *
      * @return
      */
     public DeviceConfiguration newConfiguration() {
-        return factory.newConfigurationInstance();
+        return DEVICE_CONFIGURATION_FACTORY.newConfigurationInstance();
     }
 
     /**
      * Creates a new device component configuration
-     * 
+     *
      * @return
      */
     public DeviceComponentConfiguration newComponentConfiguration() {
-        return factory.newComponentConfigurationInstance(null);
+        return DEVICE_CONFIGURATION_FACTORY.newComponentConfigurationInstance(null);
     }
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
@@ -19,9 +19,8 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Device snapshot entity definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "snapshot")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -31,31 +30,31 @@ public interface DeviceSnapshot {
 
     /**
      * Get the snapshot identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "id")
-    public String getId();
+    String getId();
 
     /**
      * Set the snapshot identifier
-     * 
+     *
      * @param id
      */
-    public void setId(String id);
+    void setId(String id);
 
     /**
      * Get the snapshot timestamp
-     * 
+     *
      * @return
      */
     @XmlElement(name = "timestamp")
-    public Long getTimestamp();
+    Long getTimestamp();
 
     /**
      * Set the snapshot timestamp
-     * 
+     *
      * @param timestamp
      */
-    public void setTimestamp(Long timestamp);
+    void setTimestamp(Long timestamp);
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotFactory.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotFactory.java
@@ -17,21 +17,20 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
  * Device snapshot entity service factory definition.
  *
  * @since 1.0
- * 
  */
 public interface DeviceSnapshotFactory extends KapuaObjectFactory {
 
     /**
      * Creates a new {@link DeviceSnapshot}
-     * 
+     *
      * @return
      */
-    public DeviceSnapshot newDeviceSnapshot();
+    DeviceSnapshot newDeviceSnapshot();
 
     /**
      * Creates a new {@link DeviceSnapshots}
-     * 
+     *
      * @return
      */
-    public DeviceSnapshots newDeviceSnapshots();
+    DeviceSnapshots newDeviceSnapshots();
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotManagementService.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotManagementService.java
@@ -32,8 +32,7 @@ public interface DeviceSnapshotManagementService extends KapuaService, DeviceMan
      * @return
      * @throws KapuaException
      */
-    public DeviceSnapshots get(KapuaId scopeId, KapuaId deviceid, Long timeout)
-            throws KapuaException;
+    DeviceSnapshots get(KapuaId scopeId, KapuaId deviceid, Long timeout) throws KapuaException;
 
     /**
      * Rollback the device configuration to the device snapshot identified by the provided snapshot identifier
@@ -44,6 +43,5 @@ public interface DeviceSnapshotManagementService extends KapuaService, DeviceMan
      * @param timeout    timeout waiting for the device response
      * @throws KapuaException
      */
-    public void rollback(KapuaId scopeId, KapuaId deviceid, String snapshotId, Long timeout)
-            throws KapuaException;
+    void rollback(KapuaId scopeId, KapuaId deviceid, String snapshotId, Long timeout) throws KapuaException;
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
@@ -11,37 +11,36 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.snapshot;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * Device bundle xml factory class
- * 
- * @since 1.0
+ * {@link DeviceSnapshot} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class DeviceSnapshotXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DeviceSnapshotFactory factory = locator.getFactory(DeviceSnapshotFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceSnapshotFactory DEVICE_SNAPSHOT_FACTORY = LOCATOR.getFactory(DeviceSnapshotFactory.class);
 
     /**
      * Creates a new device snapshots list
-     * 
+     *
      * @return
      */
     public DeviceSnapshots newDeviceSnapshots() {
-        return factory.newDeviceSnapshots();
+        return DEVICE_SNAPSHOT_FACTORY.newDeviceSnapshots();
     }
 
     /**
      * Creates a new device snapshot
-     * 
+     *
      * @return
      */
     public DeviceSnapshot newDeviceSnapshot() {
-        return factory.newDeviceSnapshot();
+        return DEVICE_SNAPSHOT_FACTORY.newDeviceSnapshot();
     }
 }

--- a/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
+++ b/service/device/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.snapshot;
 
-import java.util.List;
+import org.eclipse.kapua.KapuaSerializable;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.KapuaSerializable;
+import java.util.List;
 
 /**
  * Device snapshots entity definition.<br>
  * This entity manages a list of {@link DeviceSnapshot}
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "snapshots")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -35,9 +33,9 @@ public interface DeviceSnapshots extends KapuaSerializable {
 
     /**
      * Get the device snapshot list
-     * 
+     *
      * @return
      */
     @XmlElement(name = "snapshotId")
-    public List<DeviceSnapshot> getSnapshots();
+    List<DeviceSnapshot> getSnapshots();
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageFactory.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageFactory.java
@@ -23,74 +23,76 @@ import org.eclipse.kapua.service.device.management.packages.model.uninstall.Devi
 
 /**
  * Device package service definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DevicePackageFactory extends KapuaObjectFactory {
 
     /**
      * Creates a new {@link DevicePackages}
-     * 
+     *
      * @return
      */
-    public DevicePackages newDeviceDeploymentPackages();
+    DevicePackages newDeviceDeploymentPackages();
 
     /**
      * Creates a new {@link DevicePackage}
-     * 
+     *
      * @return
      */
-    public DevicePackage newDeviceDeploymentPackage();
+    DevicePackage newDeviceDeploymentPackage();
 
     /**
      * Creates a new device package bundle information
-     * 
+     *
      * @return
      */
-    public DevicePackageBundleInfo newDevicePackageBundleInfo();
+    DevicePackageBundleInfo newDevicePackageBundleInfo();
 
     /**
      * Creates a new device package bundle informations
-     * 
+     *
      * @return
      */
-    public DevicePackageBundleInfos newDevicePackageBundleInfos();
+    DevicePackageBundleInfos newDevicePackageBundleInfos();
 
     //
     // Download operation
     //
+
     /**
      * Creates a new device package download request
-     * 
+     *
      * @return
      */
-    public DevicePackageDownloadRequest newPackageDownloadRequest();
+    DevicePackageDownloadRequest newPackageDownloadRequest();
 
     /**
      * Creates a new device package download operation
-     * 
+     *
      * @return
      */
-    public DevicePackageDownloadOperation newPackageDownloadOperation();
+    DevicePackageDownloadOperation newPackageDownloadOperation();
 
     //
     // Install operation
     //
+
     /**
      * Creates a new {@link DevicePackageInstallRequest}
      *
      * @return
      */
-    public DevicePackageInstallRequest newPackageInstallRequest();
+    DevicePackageInstallRequest newPackageInstallRequest();
 
     //
     // Uninstall operation
     //
+
     /**
      * Creates a new device package uninstall request
-     * 
+     *
      * @return
      */
-    public DevicePackageUninstallRequest newPackageUninstallRequest();
+    DevicePackageUninstallRequest newPackageUninstallRequest();
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
@@ -39,8 +39,7 @@ public interface DevicePackageManagementService extends KapuaService, DeviceMana
      * @return
      * @throws KapuaException
      */
-    public DevicePackages getInstalled(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException;
+    DevicePackages getInstalled(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
     /**
      * Starts a download package operation
@@ -51,8 +50,7 @@ public interface DevicePackageManagementService extends KapuaService, DeviceMana
      * @param timeout
      * @throws KapuaException
      */
-    public void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, Long timeout)
-            throws KapuaException;
+    void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, Long timeout) throws KapuaException;
 
     /**
      * Interrupt a download package operation
@@ -62,8 +60,7 @@ public interface DevicePackageManagementService extends KapuaService, DeviceMana
      * @param timeout
      * @throws KapuaException
      */
-    public void downloadStop(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException;
+    void downloadStop(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
     /**
      * Gets the download package status
@@ -74,8 +71,7 @@ public interface DevicePackageManagementService extends KapuaService, DeviceMana
      * @return
      * @throws KapuaException
      */
-    public DevicePackageDownloadOperation downloadStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException;
+    DevicePackageDownloadOperation downloadStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
     /**
      * Installs a package
@@ -86,8 +82,7 @@ public interface DevicePackageManagementService extends KapuaService, DeviceMana
      * @param timeout
      * @throws KapuaException
      */
-    public void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, Long timeout)
-            throws KapuaException;
+    void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, Long timeout) throws KapuaException;
 
     /**
      * Gets the package installation status
@@ -98,8 +93,7 @@ public interface DevicePackageManagementService extends KapuaService, DeviceMana
      * @return
      * @throws KapuaException
      */
-    public DevicePackageInstallOperation installStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException;
+    DevicePackageInstallOperation installStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
     /**
      * Uninstalls a package
@@ -110,8 +104,7 @@ public interface DevicePackageManagementService extends KapuaService, DeviceMana
      * @param timeout
      * @throws KapuaException
      */
-    public void uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, Long timeout)
-            throws KapuaException;
+    void uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, Long timeout) throws KapuaException;
 
     /**
      * Gets the package uninstallation status
@@ -122,6 +115,5 @@ public interface DevicePackageManagementService extends KapuaService, DeviceMana
      * @return
      * @throws KapuaException
      */
-    public DevicePackageUninstallOperation uninstallStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException;
+    DevicePackageUninstallOperation uninstallStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
@@ -11,19 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.model;
 
-import java.util.Date;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.Date;
 
 /**
  * Device package definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "devicePackage")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -35,59 +33,59 @@ public interface DevicePackage {
 
     /**
      * Get the package name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the package name
-     * 
+     *
      * @param dpName
      */
-    public void setName(String dpName);
+    void setName(String dpName);
 
     /**
      * Get the package version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "version")
-    public String getVersion();
+    String getVersion();
 
     /**
      * Set the package version
-     * 
+     *
      * @param dpVersion
      */
-    public void setVersion(String dpVersion);
+    void setVersion(String dpVersion);
 
     /**
      * Get device package bundle informations
-     * 
+     *
      * @return
      */
     @XmlElement(name = "bundleInfos")
-    public <B extends DevicePackageBundleInfos> B getBundleInfos();
+    <B extends DevicePackageBundleInfos> B getBundleInfos();
 
     /**
      * Set device package bundle informations
      */
-    public <B extends DevicePackageBundleInfos> void setBundleInfos(B bundleInfos);
+    <B extends DevicePackageBundleInfos> void setBundleInfos(B bundleInfos);
 
     /**
      * Get the installation date
-     * 
+     *
      * @return
      */
     @XmlElement(name = "installDate")
-    public Date getInstallDate();
+    Date getInstallDate();
 
     /**
      * Set the installation date
-     * 
+     *
      * @param installDate
      */
-    public void setInstallDate(Date installDate);
+    void setInstallDate(Date installDate);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfo.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfo.java
@@ -19,9 +19,8 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Device package bundle information definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "devicePackageBundleInfo")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -30,31 +29,31 @@ public interface DevicePackageBundleInfo {
 
     /**
      * Get the package bundle name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the package bundle name
-     * 
+     *
      * @param name
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the package bundle version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "version")
-    public String getVersion();
+    String getVersion();
 
     /**
      * Set the package bundle version
-     * 
+     *
      * @param version
      */
-    public void setVersion(String version);
+    void setVersion(String version);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfos.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfos.java
@@ -12,18 +12,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.model;
 
-import java.util.List;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.List;
 
 /**
  * Package bundle informations list container definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newDevicePackageBundleInfos")
@@ -31,9 +29,9 @@ public interface DevicePackageBundleInfos {
 
     /**
      * Get the device package bundle informations
-     * 
+     *
      * @return
      */
     @XmlElement(name = "bundleInfo")
-    public List<DevicePackageBundleInfo> getBundlesInfos();
+    List<DevicePackageBundleInfo> getBundlesInfos();
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageXmlRegistry.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageXmlRegistry.java
@@ -11,76 +11,75 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.model;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.packages.DevicePackageFactory;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
  * Device package xml factory class
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class DevicePackageXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DevicePackageFactory factory = locator.getFactory(DevicePackageFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DevicePackageFactory DEVICE_PACKAGE_FACTORY = LOCATOR.getFactory(DevicePackageFactory.class);
 
     /**
      * Creates a new device package instance
-     * 
+     *
      * @return
      */
     public DevicePackage newDevicePackage() {
-        return factory.newDeviceDeploymentPackage();
+        return DEVICE_PACKAGE_FACTORY.newDeviceDeploymentPackage();
     }
 
     /**
      * Creates a new device packages instance
-     * 
+     *
      * @return
      */
     public DevicePackages newDevicePackages() {
-        return factory.newDeviceDeploymentPackages();
+        return DEVICE_PACKAGE_FACTORY.newDeviceDeploymentPackages();
     }
 
     /**
      * Creates a new device package bundle information instance
-     * 
+     *
      * @return
      */
     public DevicePackageBundleInfo newDevicePackageBundleInfo() {
-        return factory.newDevicePackageBundleInfo();
+        return DEVICE_PACKAGE_FACTORY.newDevicePackageBundleInfo();
     }
 
     /**
      * Creates a new device package bundle informations instance
-     * 
+     *
      * @return
      */
     public DevicePackageBundleInfos newDevicePackageBundleInfos() {
-        return factory.newDevicePackageBundleInfos();
+        return DEVICE_PACKAGE_FACTORY.newDevicePackageBundleInfos();
     }
 
     /**
      * Creates a new device package download request instance
-     * 
+     *
      * @return
      */
     public DevicePackageDownloadRequest newDevicePackageDownloadRequest() {
-        return factory.newPackageDownloadRequest();
+        return DEVICE_PACKAGE_FACTORY.newPackageDownloadRequest();
     }
 
     /**
      * Creates a new device package uninstall request instance
-     * 
+     *
      * @return
      */
     public DevicePackageUninstallRequest newDevicePackageUninstallRequest() {
-        return factory.newPackageUninstallRequest();
+        return DEVICE_PACKAGE_FACTORY.newPackageUninstallRequest();
     }
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackages.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackages.java
@@ -12,21 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.model;
 
-import java.util.List;
+import org.eclipse.kapua.KapuaSerializable;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.KapuaSerializable;
+import java.util.List;
 
 /**
  * Device packages list container definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "devicePackages")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -35,9 +33,9 @@ public interface DevicePackages extends KapuaSerializable {
 
     /**
      * Get the device package list
-     * 
+     *
      * @return
      */
     @XmlElement(name = "devicePackage")
-    public List<DevicePackage> getPackages();
+    List<DevicePackage> getPackages();
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
@@ -15,66 +15,65 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * Device download package operation entity definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DevicePackageDownloadOperation {
 
     /**
      * Get the download package identifier
-     * 
+     *
      * @return
      */
-    public KapuaId getId();
+    KapuaId getId();
 
     /**
      * Set the download package identifier
-     * 
+     *
      * @param id
      */
-    public void setId(KapuaId id);
+    void setId(KapuaId id);
 
     /**
      * Get the package size
-     * 
+     *
      * @return
      */
-    public Integer getSize();
+    Integer getSize();
 
     /**
      * Set the package size
-     * 
+     *
      * @param downloadSize
      */
-    public void setSize(Integer downloadSize);
+    void setSize(Integer downloadSize);
 
     /**
      * Get the download progress
-     * 
+     *
      * @return
      */
-    public Integer getProgress();
+    Integer getProgress();
 
     /**
      * Set the download progress
-     * 
+     *
      * @param downloadProgress
      */
-    public void setProgress(Integer downloadProgress);
+    void setProgress(Integer downloadProgress);
 
     /**
      * Get the download status
-     * 
+     *
      * @return
      */
-    public DevicePackageDownloadStatus getStatus();
+    DevicePackageDownloadStatus getStatus();
 
     /**
      * Set the download status
-     * 
+     *
      * @param status
      */
-    public void setStatus(DevicePackageDownloadStatus status);
+    void setStatus(DevicePackageDownloadStatus status);
 
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadRequest.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadRequest.java
@@ -11,21 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.model.download;
 
-import java.net.URI;
+import org.eclipse.kapua.service.device.management.packages.model.DevicePackageXmlRegistry;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.service.device.management.packages.model.DevicePackageXmlRegistry;
+import java.net.URI;
 
 /**
  * Device package download request definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "downloadRequest")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -43,91 +41,91 @@ public interface DevicePackageDownloadRequest {
 
     /**
      * Get the download URI
-     * 
+     *
      * @return
      */
     @XmlElement(name = "uri")
-    public URI getUri();
+    URI getUri();
 
     /**
      * Set the download URI
-     * 
+     *
      * @param uri
      */
-    public void setUri(URI uri);
+    void setUri(URI uri);
 
     /**
      * Get the package name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set the package name
-     * 
+     *
      * @param name
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the package version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "version")
-    public String getVersion();
+    String getVersion();
 
     /**
      * Set the package version
-     * 
+     *
      * @param version
      */
-    public void setVersion(String version);
+    void setVersion(String version);
 
     /**
      * Get the package installed flag
-     * 
+     *
      * @return
      */
     @XmlElement(name = "install")
-    public Boolean getInstall();
+    Boolean getInstall();
 
     /**
      * Set the package installed flag
-     * 
+     *
      * @param install
      */
-    public void setInstall(Boolean install);
+    void setInstall(Boolean install);
 
     /**
      * Get the device reboot flag
-     * 
+     *
      * @return
      */
     @XmlElement(name = "reboot")
-    public Boolean getReboot();
+    Boolean getReboot();
 
     /**
      * Set the device reboot flag
-     * 
+     *
      * @param reboot
      */
-    public void setReboot(Boolean reboot);
+    void setReboot(Boolean reboot);
 
     /**
      * Get the reboot delay
-     * 
+     *
      * @return
      */
     @XmlElement(name = "rebootDelay")
-    public Integer getRebootDelay();
+    Integer getRebootDelay();
 
     /**
      * Set the reboot delay
-     * 
+     *
      * @param rebootDelay
      */
-    public void setRebootDelay(Integer rebootDelay);
+    void setRebootDelay(Integer rebootDelay);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
@@ -15,65 +15,64 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * Device package install operation entity definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DevicePackageInstallOperation {
 
     /**
      * Get the package identifier
-     * 
+     *
      * @return
      */
-    public KapuaId getId();
+    KapuaId getId();
 
     /**
      * Set the package identifier
-     * 
+     *
      * @param id
      */
-    public void setId(KapuaId id);
+    void setId(KapuaId id);
 
     /**
      * Get the package name
-     * 
+     *
      * @return
      */
-    public String getName();
+    String getName();
 
     /**
      * Set the package name
-     * 
+     *
      * @param packageName
      */
-    public void setName(String packageName);
+    void setName(String packageName);
 
     /**
      * Get the package version
-     * 
+     *
      * @return
      */
-    public String getVersion();
+    String getVersion();
 
     /**
      * Set the package version
-     * 
+     *
      * @param version
      */
-    public void setVersion(String version);
+    void setVersion(String version);
 
     /**
      * Get the package install status
-     * 
+     *
      * @return
      */
-    public DevicePackageInstallStatus getStatus();
+    DevicePackageInstallStatus getStatus();
 
     /**
      * Set the package install status
-     * 
+     *
      * @param status
      */
-    public void setStatus(DevicePackageInstallStatus status);
+    void setStatus(DevicePackageInstallStatus status);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
@@ -13,65 +13,64 @@ package org.eclipse.kapua.service.device.management.packages.model.install;
 
 /**
  * Device package install request definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DevicePackageInstallRequest {
 
     /**
      * Get the package name
-     * 
+     *
      * @return
      */
-    public String getName();
+    String getName();
 
     /**
      * Set the package name
-     * 
+     *
      * @param name
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get the package version
-     * 
+     *
      * @return
      */
-    public String getVersion();
+    String getVersion();
 
     /**
      * Set the package version
-     * 
+     *
      * @param version
      */
-    public void setVersion(String version);
+    void setVersion(String version);
 
     /**
      * Get the device reboot flag
-     * 
+     *
      * @return
      */
-    public Boolean isReboot();
+    Boolean isReboot();
 
     /**
      * Set the device reboot flag
-     * 
+     *
      * @param reboot
      */
-    public void setReboot(Boolean reboot);
+    void setReboot(Boolean reboot);
 
     /**
      * Get the reboot delay
-     * 
+     *
      * @return
      */
-    public Integer getRebootDelay();
+    Integer getRebootDelay();
 
     /**
      * Set the reboot delay
-     * 
+     *
      * @param rebootDelay
      */
-    public void setRebootDelay(Integer rebootDelay);
+    void setRebootDelay(Integer rebootDelay);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
@@ -15,65 +15,64 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * Device package uninstall operation entity definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DevicePackageUninstallOperation {
 
     /**
      * Get the package identifier
-     * 
+     *
      * @return
      */
-    public KapuaId getId();
+    KapuaId getId();
 
     /**
      * Set the package identifier
-     * 
+     *
      * @param id
      */
-    public void setId(KapuaId id);
+    void setId(KapuaId id);
 
     /**
      * Get the package name
-     * 
+     *
      * @return
      */
-    public String getName();
+    String getName();
 
     /**
      * Set the package name
-     * 
+     *
      * @param packageName
      */
-    public void setName(String packageName);
+    void setName(String packageName);
 
     /**
      * Get the package version
-     * 
+     *
      * @return
      */
-    public String getVersion();
+    String getVersion();
 
     /**
      * Set the package version
-     * 
+     *
      * @param version
      */
-    public void setVersion(String version);
+    void setVersion(String version);
 
     /**
      * Get the package uninstall status
-     * 
+     *
      * @return
      */
-    public DevicePackageUninstallStatus getStatus();
+    DevicePackageUninstallStatus getStatus();
 
     /**
      * Set the package uninstall status
-     * 
+     *
      * @param status
      */
-    public void setStatus(DevicePackageUninstallStatus status);
+    void setStatus(DevicePackageUninstallStatus status);
 }

--- a/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
+++ b/service/device/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
@@ -11,19 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.model.uninstall;
 
+import org.eclipse.kapua.service.device.management.packages.model.DevicePackageXmlRegistry;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.service.device.management.packages.model.DevicePackageXmlRegistry;
-
 /**
  * Device package uninstall request definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "uninstallRequest")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -31,68 +30,68 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackageX
         "name",
         "version",
         "reboot",
-        "rebootDelay"},
+        "rebootDelay" },
         factoryClass = DevicePackageXmlRegistry.class,
         factoryMethod = "newDevicePackageUninstallRequest")
 public interface DevicePackageUninstallRequest {
 
     /**
      * Get package name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Set package name
-     * 
+     *
      * @param name
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Get package version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "version")
-    public String getVersion();
+    String getVersion();
 
     /**
      * Set package version
-     * 
+     *
      * @param version
      */
-    public void setVersion(String version);
+    void setVersion(String version);
 
     /**
      * Get the device reboot flag
-     * 
+     *
      * @return
      */
     @XmlElement(name = "reboot")
-    public Boolean isReboot();
+    Boolean isReboot();
 
     /**
      * Set the device reboot flag
-     * 
+     *
      * @param reboot
      */
-    public void setReboot(Boolean reboot);
+    void setReboot(Boolean reboot);
 
     /**
      * Get the reboot delay
-     * 
+     *
      * @return
      */
     @XmlElement(name = "rebootDelay")
-    public Integer getRebootDelay();
+    Integer getRebootDelay();
 
     /**
      * Set the reboot delay
-     * 
+     *
      * @param rebootDelay
      */
-    public void setRebootDelay(Integer rebootDelay);
+    void setRebootDelay(Integer rebootDelay);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
@@ -11,7 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
-import java.util.Set;
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -20,19 +25,13 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
-import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
+import java.util.Set;
 
 /**
  * {@link Device} is an object representing a device or gateway connected to the Kapua platform.<br>
  * The {@link Device} object contains several attributes regarding the Device itself and its software configuration.<br>
  * {@link Device} contains also references to {@link DeviceConnection} and the last {@link DeviceEvent}.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "device")
@@ -67,40 +66,27 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
         "customAttribute4",
         "customAttribute5",
         "tagIds"
-        // // derived attributes
-        // "uptime",
-        // "modelName",
-        // "partNumber",
-        // "availableProcessors",
-        // "totalMemory",
-        // "os",
-        // "osArch",
-        // "jvmName",
-        // "jvmProfile",
-        // "osgiFramework",
-        // "connectionInterface",
-        // "gpsAltitude"
 }, factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDevice")
 public interface Device extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "device";
+    String TYPE = "device";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Sets the set of Tag id of this entity.
-     * 
-     * @param tagIds
-     *            The set Tag id to assign.
+     *
+     * @param tagIds The set Tag id to assign.
      * @since 1.0.0
      */
-    public void setTagIds(Set<KapuaId> tagIds);
+    void setTagIds(Set<KapuaId> tagIds);
 
     /**
      * Gets the set of Tag id assigned to this entity.
-     * 
+     *
      * @return The set Tag id assigned to this entity.
      * @since 1.0.0
      */
@@ -108,287 +94,288 @@ public interface Device extends KapuaUpdatableEntity {
     @XmlElement(name = "tagId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public Set<KapuaId> getTagIds();
+    Set<KapuaId> getTagIds();
 
     /**
      * Get the group identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "groupId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getGroupId();
+    KapuaId getGroupId();
 
     /**
      * Set the group identifier
-     * 
+     *
      * @param groupId
      */
-    public void setGroupId(KapuaId groupId);
+    void setGroupId(KapuaId groupId);
 
     /**
      * Get the client identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "clientId")
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set the client identifier
-     * 
+     *
      * @param clientId
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the connection identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "connectionId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getConnectionId();
+    KapuaId getConnectionId();
 
     /**
      * Set the connection identifier
-     * 
+     *
      * @param connectionId
      */
-    public void setConnectionId(KapuaId connectionId);
+    void setConnectionId(KapuaId connectionId);
 
     /**
      * Gets the {@link DeviceConnection}
-     * 
+     *
      * @return
      */
     @XmlElement(name = "connection")
-    public <C extends DeviceConnection> C getConnection();
+    <C extends DeviceConnection> C getConnection();
 
     /**
      * Get the connection status
-     * 
+     *
      * @return
      */
     @XmlElement(name = "status")
-    public DeviceStatus getStatus();
+    DeviceStatus getStatus();
 
     /**
      * Set the connection status
-     * 
+     *
      * @param status
      */
-    public void setStatus(DeviceStatus status);
+    void setStatus(DeviceStatus status);
 
     /**
      * Get the display name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "displayName")
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * Set the display name
-     * 
+     *
      * @param diplayName
      */
-    public void setDisplayName(String diplayName);
+    void setDisplayName(String diplayName);
 
     /**
      * Gets the last {@link DeviceEvent} {@link KapuaId}.
-     * 
+     *
      * @return
      */
     @XmlElement(name = "lastEventId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getLastEventId();
+    KapuaId getLastEventId();
 
     /**
      * Set the last {@link DeviceEvent} {@link KapuaId}.
-     * 
+     *
      * @param lastEventId
      */
-    public void setLastEventId(KapuaId lastEventId);
+    void setLastEventId(KapuaId lastEventId);
 
     /**
      * Get the last {@link DeviceEvent} for this {@link Device}.
-     * 
+     *
      * @return The last {@link DeviceEvent} for this {@link Device}.
      */
     @XmlElement(name = "lastEvent")
-    public <E extends DeviceEvent> E getLastEvent();
+    <E extends DeviceEvent> E getLastEvent();
 
     /**
      * Get the serial number
-     * 
+     *
      * @return
      */
     @XmlElement(name = "serialNumber")
-    public String getSerialNumber();
+    String getSerialNumber();
 
     /**
      * Set the serial number
-     * 
+     *
      * @param serialNumber
      */
-    public void setSerialNumber(String serialNumber);
+    void setSerialNumber(String serialNumber);
 
     /**
      * Get the model identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "modelId")
-    public String getModelId();
+    String getModelId();
 
     /**
      * Set the model identifier
-     * 
+     *
      * @param modelId
      */
-    public void setModelId(String modelId);
+    void setModelId(String modelId);
 
     /**
      * Get the imei
-     * 
+     *
      * @return
      */
     @XmlElement(name = "imei")
-    public String getImei();
+    String getImei();
 
     /**
      * Set the imei
-     * 
+     *
      * @param imei
      */
-    public void setImei(String imei);
+    void setImei(String imei);
 
     /**
      * Get the imsi
-     * 
+     *
      * @return
      */
     @XmlElement(name = "imsi")
-    public String getImsi();
+    String getImsi();
 
     /**
      * Set the imsi
-     * 
+     *
      * @param imsi
      */
-    public void setImsi(String imsi);
+    void setImsi(String imsi);
 
     /**
      * Get the iccid
-     * 
+     *
      * @return
      */
     @XmlElement(name = "iccid")
-    public String getIccid();
+    String getIccid();
 
     /**
      * Set the iccid
-     * 
+     *
      * @param iccid
      */
-    public void setIccid(String iccid);
+    void setIccid(String iccid);
 
     /**
      * Get bios version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "biosVersion")
-    public String getBiosVersion();
+    String getBiosVersion();
 
     /**
      * Set bios version
-     * 
+     *
      * @param biosVersion
      */
-    public void setBiosVersion(String biosVersion);
+    void setBiosVersion(String biosVersion);
 
     /**
      * Get firmware version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "firmwareVersion")
-    public String getFirmwareVersion();
+    String getFirmwareVersion();
 
     /**
      * Set firmware version
-     * 
+     *
      * @param firmwareVersion
      */
-    public void setFirmwareVersion(String firmwareVersion);
+    void setFirmwareVersion(String firmwareVersion);
 
     /**
      * Get os version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "osVersion")
-    public String getOsVersion();
+    String getOsVersion();
 
     /**
      * Set os version
-     * 
+     *
      * @param osVersion
      */
-    public void setOsVersion(String osVersion);
+    void setOsVersion(String osVersion);
 
     /**
      * Get jvm version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "jvmVersion")
-    public String getJvmVersion();
+    String getJvmVersion();
 
     /**
      * Set jvm version
-     * 
+     *
      * @param jvmVersion
      */
-    public void setJvmVersion(String jvmVersion);
+    void setJvmVersion(String jvmVersion);
 
     /**
      * Get osgi framework version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "osgiFrameworkVersion")
-    public String getOsgiFrameworkVersion();
+    String getOsgiFrameworkVersion();
 
     /**
      * Set osgi framework version
-     * 
+     *
      * @param osgiFrameworkVersion
      */
-    public void setOsgiFrameworkVersion(String osgiFrameworkVersion);
+    void setOsgiFrameworkVersion(String osgiFrameworkVersion);
 
     /**
      * Get application framework version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "applicationFrameworkVersion")
-    public String getApplicationFrameworkVersion();
+    String getApplicationFrameworkVersion();
 
     /**
      * Set application framework version
-     * 
+     *
      * @param appFrameworkVersion
      */
-    public void setApplicationFrameworkVersion(String appFrameworkVersion);
+    void setApplicationFrameworkVersion(String appFrameworkVersion);
 
     /**
      * Gets the device's primary connection interface name
+     *
      * @return The device's primary connection interface name
      */
     @XmlElement(name = "connectionInterface")
@@ -396,125 +383,128 @@ public interface Device extends KapuaUpdatableEntity {
 
     /**
      * Sets the device's primary connection interface name
+     *
      * @param connectionInterface The device's primary connection interface name
      */
     void setConnectionInterface(String connectionInterface);
 
     /**
      * Gets the device's primary connection interface IP address
+     *
      * @return The device's primary connection interface IP address
      */
-    @XmlElement(name="connectionIp")
+    @XmlElement(name = "connectionIp")
     String getConnectionIp();
 
     /**
      * Sets the device's primary connection interface IP address
+     *
      * @param connectionIp The device's primary connection interface IP address
      */
     void setConnectionIp(String connectionIp);
 
     /**
      * Get application identifiers
-     * 
+     *
      * @return
      */
     @XmlElement(name = "applicationIdentifiers")
-    public String getApplicationIdentifiers();
+    String getApplicationIdentifiers();
 
     /**
      * Set application identifiers
-     * 
+     *
      * @param applicationIdentifiers
      */
-    public void setApplicationIdentifiers(String applicationIdentifiers);
+    void setApplicationIdentifiers(String applicationIdentifiers);
 
     /**
      * Get accept encoding flag
-     * 
+     *
      * @return
      */
     @XmlElement(name = "acceptEncoding")
-    public String getAcceptEncoding();
+    String getAcceptEncoding();
 
     /**
      * Set accept encoding flag
-     * 
+     *
      * @param acceptEncoding
      */
-    public void setAcceptEncoding(String acceptEncoding);
+    void setAcceptEncoding(String acceptEncoding);
 
     /**
      * Get custom attribute 1
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute1")
-    public String getCustomAttribute1();
+    String getCustomAttribute1();
 
     /**
      * Set custom attribute 1
-     * 
+     *
      * @param customAttribute1
      */
-    public void setCustomAttribute1(String customAttribute1);
+    void setCustomAttribute1(String customAttribute1);
 
     /**
      * Get custom attribute 2
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute2")
-    public String getCustomAttribute2();
+    String getCustomAttribute2();
 
     /**
      * Set custom attribute 2
-     * 
+     *
      * @param customAttribute2
      */
-    public void setCustomAttribute2(String customAttribute2);
+    void setCustomAttribute2(String customAttribute2);
 
     /**
      * Get custom attribute 3
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute3")
-    public String getCustomAttribute3();
+    String getCustomAttribute3();
 
     /**
      * Set custom attribute 3
-     * 
+     *
      * @param customAttribute3
      */
-    public void setCustomAttribute3(String customAttribute3);
+    void setCustomAttribute3(String customAttribute3);
 
     /**
      * Get custom attribute 4
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute4")
-    public String getCustomAttribute4();
+    String getCustomAttribute4();
 
     /**
      * Set custom attribute 4
-     * 
+     *
      * @param customAttribute4
      */
-    public void setCustomAttribute4(String customAttribute4);
+    void setCustomAttribute4(String customAttribute4);
 
     /**
      * Get custom attribute 5
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute5")
-    public String getCustomAttribute5();
+    String getCustomAttribute5();
 
     /**
      * Set custom attribute 5
-     * 
+     *
      * @param customAttribute5
      */
-    public void setCustomAttribute5(String customAttribute5);
+    void setCustomAttribute5(String customAttribute5);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
@@ -11,18 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 
 /**
  * {@link DeviceCreator} encapsulates all the information needed to create a new {@link Device} in the system.<br>
@@ -31,7 +31,7 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
  * The DeviceCreator Properties field can be used to provide additional properties associated to the Device;
  * those properties will not be searchable through Device queries.<br>
  * The clientId field of the Device is used to store the MAC address of the primary network interface of the device.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "deviceCreator")
@@ -69,267 +69,268 @@ public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
 
     /**
      * Get the group identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "groupId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getGroupId();
+    KapuaId getGroupId();
 
     /**
      * Set the group identifier
-     * 
+     *
      * @param groupId
      */
-    public void setGroupId(KapuaId groupId);
+    void setGroupId(KapuaId groupId);
 
     /**
      * Get the client identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "clientId")
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set the client identifier
-     * 
+     *
      * @param clientId
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the device status
-     * 
+     *
      * @return
      */
     @XmlElement
-    public DeviceStatus getStatus();
+    DeviceStatus getStatus();
 
     /**
      * Sets the device status
-     * 
+     *
      * @param status
      */
-    public void setStatus(DeviceStatus status);
+    void setStatus(DeviceStatus status);
 
     /**
      * Get the connection identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "connectionId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getConnectionId();
+    KapuaId getConnectionId();
 
     /**
      * Set the connection identifier
-     * 
+     *
      * @param connectionId
      */
-    public void setConnectionId(KapuaId connectionId);
+    void setConnectionId(KapuaId connectionId);
 
     /**
      * Get the last {@link DeviceEvent} identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "lastEventId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getLastEventId();
+    KapuaId getLastEventId();
 
     /**
      * Set the last {@link DeviceEvent} identifier.
-     * 
+     *
      * @param lastEventId
      */
-    public void setLastEventId(KapuaId lastEventId);
+    void setLastEventId(KapuaId lastEventId);
 
     /**
      * Get the display name
-     * 
+     *
      * @return
      */
     @XmlElement(name = "displayName")
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * Set the display name
-     * 
+     *
      * @param displayName
      */
-    public void setDisplayName(String displayName);
+    void setDisplayName(String displayName);
 
     /**
      * Get the serial number
-     * 
+     *
      * @return
      */
     @XmlElement(name = "serialNumber")
-    public String getSerialNumber();
+    String getSerialNumber();
 
     /**
      * Set the serial number
-     * 
+     *
      * @param serialNumber
      */
-    public void setSerialNumber(String serialNumber);
+    void setSerialNumber(String serialNumber);
 
     /**
      * Get the model identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "modelId")
-    public String getModelId();
+    String getModelId();
 
     /**
      * Set the model identifier
-     * 
+     *
      * @param modelId
      */
-    public void setModelId(String modelId);
+    void setModelId(String modelId);
 
     /**
      * Get the imei
-     * 
+     *
      * @return
      */
     @XmlElement(name = "imei")
-    public String getImei();
+    String getImei();
 
     /**
      * Set the imei
-     * 
+     *
      * @param imei
      */
-    public void setImei(String imei);
+    void setImei(String imei);
 
     /**
      * Get the imsi
-     * 
+     *
      * @return
      */
     @XmlElement(name = "imsi")
-    public String getImsi();
+    String getImsi();
 
     /**
      * Set the imsi
-     * 
+     *
      * @param imsi
      */
-    public void setImsi(String imsi);
+    void setImsi(String imsi);
 
     /**
      * Get the iccid
-     * 
+     *
      * @return
      */
     @XmlElement(name = "iccid")
-    public String getIccid();
+    String getIccid();
 
     /**
      * Set the iccid
-     * 
+     *
      * @param iccid
      */
-    public void setIccid(String iccid);
+    void setIccid(String iccid);
 
     /**
      * Get bios version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "biosVersion")
-    public String getBiosVersion();
+    String getBiosVersion();
 
     /**
      * Set bios version
-     * 
+     *
      * @param biosVersion
      */
-    public void setBiosVersion(String biosVersion);
+    void setBiosVersion(String biosVersion);
 
     /**
      * Get firmware version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "firmwareVersion")
-    public String getFirmwareVersion();
+    String getFirmwareVersion();
 
     /**
      * Set firmware version
-     * 
+     *
      * @param firmwareVersion
      */
-    public void setFirmwareVersion(String firmwareVersion);
+    void setFirmwareVersion(String firmwareVersion);
 
     /**
      * Get os version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "osVersion")
-    public String getOsVersion();
+    String getOsVersion();
 
     /**
      * Set os version
-     * 
+     *
      * @param osVersion
      */
-    public void setOsVersion(String osVersion);
+    void setOsVersion(String osVersion);
 
     /**
      * Get jvm version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "jvmVersion")
-    public String getJvmVersion();
+    String getJvmVersion();
 
     /**
      * Set jvm version
-     * 
+     *
      * @param jvmVersion
      */
-    public void setJvmVersion(String jvmVersion);
+    void setJvmVersion(String jvmVersion);
 
     /**
      * Get osgi framework version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "osgiFrameworkVersion")
-    public String getOsgiFrameworkVersion();
+    String getOsgiFrameworkVersion();
 
     /**
      * Set osgi framework version
-     * 
+     *
      * @param osgiFrameworkVersion
      */
-    public void setOsgiFrameworkVersion(String osgiFrameworkVersion);
+    void setOsgiFrameworkVersion(String osgiFrameworkVersion);
 
     /**
      * Get application framework version
-     * 
+     *
      * @return
      */
     @XmlElement(name = "applicationFrameworkVersion")
-    public String getApplicationFrameworkVersion();
+    String getApplicationFrameworkVersion();
 
     /**
      * Set application framework version
-     * 
+     *
      * @param appFrameworkVersion
      */
-    public void setApplicationFrameworkVersion(String appFrameworkVersion);
+    void setApplicationFrameworkVersion(String appFrameworkVersion);
 
     /**
      * Gets the device's primary connection interface name
+     *
      * @return The device's primary connection interface name
      */
     @XmlElement(name = "connectionInterface")
@@ -337,125 +338,128 @@ public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
 
     /**
      * Sets the device's primary connection interface name
+     *
      * @param connectionInterface The device's primary connection interface name
      */
     void setConnectionInterface(String connectionInterface);
 
     /**
      * Gets the device's primary connection interface IP address
+     *
      * @return The device's primary connection interface IP address
      */
-    @XmlElement(name="connectionIp")
+    @XmlElement(name = "connectionIp")
     String getConnectionIp();
 
     /**
      * Sets the device's primary connection interface IP address
+     *
      * @param connectionIp The device's primary connection interface IP address
      */
     void setConnectionIp(String connectionIp);
 
     /**
      * Get application identifiers
-     * 
+     *
      * @return
      */
     @XmlElement(name = "applicationIdentifiers")
-    public String getApplicationIdentifiers();
+    String getApplicationIdentifiers();
 
     /**
      * Set application identifiers
-     * 
+     *
      * @param applicationIdentifiers
      */
-    public void setApplicationIdentifiers(String applicationIdentifiers);
+    void setApplicationIdentifiers(String applicationIdentifiers);
 
     /**
      * Get accept encoding flag
-     * 
+     *
      * @return
      */
     @XmlElement(name = "acceptEncoding")
-    public String getAcceptEncoding();
+    String getAcceptEncoding();
 
     /**
      * Set accept encoding flag
-     * 
+     *
      * @param acceptEncoding
      */
-    public void setAcceptEncoding(String acceptEncoding);
+    void setAcceptEncoding(String acceptEncoding);
 
     /**
      * Get custom attribute 1
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute1")
-    public String getCustomAttribute1();
+    String getCustomAttribute1();
 
     /**
      * Set custom attribute 1
-     * 
+     *
      * @param customAttribute1
      */
-    public void setCustomAttribute1(String customAttribute1);
+    void setCustomAttribute1(String customAttribute1);
 
     /**
      * Get custom attribute 2
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute2")
-    public String getCustomAttribute2();
+    String getCustomAttribute2();
 
     /**
      * Set custom attribute 2
-     * 
+     *
      * @param customAttribute2
      */
-    public void setCustomAttribute2(String customAttribute2);
+    void setCustomAttribute2(String customAttribute2);
 
     /**
      * Get custom attribute 3
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute3")
-    public String getCustomAttribute3();
+    String getCustomAttribute3();
 
     /**
      * Set custom attribute 3
-     * 
+     *
      * @param customAttribute3
      */
-    public void setCustomAttribute3(String customAttribute3);
+    void setCustomAttribute3(String customAttribute3);
 
     /**
      * Get custom attribute 4
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute4")
-    public String getCustomAttribute4();
+    String getCustomAttribute4();
 
     /**
      * Set custom attribute 4
-     * 
+     *
      * @param customAttribute4
      */
-    public void setCustomAttribute4(String customAttribute4);
+    void setCustomAttribute4(String customAttribute4);
 
     /**
      * Get custom attribute 5
-     * 
+     *
      * @return
      */
     @XmlElement(name = "customAttribute5")
-    public String getCustomAttribute5();
+    String getCustomAttribute5();
 
     /**
      * Set custom attribute 5
-     * 
+     *
      * @param customAttribute5
      */
-    public void setCustomAttribute5(String customAttribute5);
+    void setCustomAttribute5(String customAttribute5);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceFactory.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceFactory.java
@@ -16,19 +16,18 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * Device service factory definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public interface DeviceFactory extends KapuaEntityFactory<Device, DeviceCreator, DeviceQuery, DeviceListResult> {
 
     /**
      * Creates a new device creator
-     * 
+     *
      * @param scopeId
      * @param clientId
      * @return
      */
-    public DeviceCreator newCreator(KapuaId scopeId, String clientId);
+    DeviceCreator newCreator(KapuaId scopeId, String clientId);
 
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
@@ -29,10 +29,10 @@ public interface DeviceRegistryService extends KapuaEntityService<Device, Device
         KapuaDomainService<DeviceDomain>,
         KapuaConfigurableService {
 
-    public static final DeviceDomain DEVICE_DOMAIN = new DeviceDomain();
+    DeviceDomain DEVICE_DOMAIN = new DeviceDomain();
 
     @Override
-    public default DeviceDomain getServiceDomain() {
+    default DeviceDomain getServiceDomain() {
         return DEVICE_DOMAIN;
     }
 
@@ -45,8 +45,7 @@ public interface DeviceRegistryService extends KapuaEntityService<Device, Device
      * @since 1.0.0
      */
     @Override
-    public DeviceListResult query(KapuaQuery<Device> query)
-            throws KapuaException;
+    DeviceListResult query(KapuaQuery<Device> query) throws KapuaException;
 
     /**
      * Finds a device by its unique clientId and loads it with all its properties.
@@ -56,6 +55,5 @@ public interface DeviceRegistryService extends KapuaEntityService<Device, Device
      * @return
      * @throws KapuaException
      */
-    public Device findByClientId(KapuaId scopeId, String clientId)
-            throws KapuaException;
+    Device findByClientId(KapuaId scopeId, String clientId) throws KapuaException;
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
@@ -11,50 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * Device xml factory class
- * 
- * @since 1.0
+ * {@link Device} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class DeviceXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DeviceFactory factory = locator.getFactory(DeviceFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceFactory DEVICE_FACTORY = LOCATOR.getFactory(DeviceFactory.class);
 
     /**
      * Creates a new {@link Device}
-     * 
+     *
      * @return
      */
     public Device newDevice() {
-        return factory.newEntity(null);
+        return DEVICE_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new device creator
-     * 
+     *
      * @return
      */
     public DeviceCreator newDeviceCreator() {
-        return factory.newCreator(null, null);
+        return DEVICE_FACTORY.newCreator(null, null);
     }
 
     /**
      * Creates a new device list result
-     * 
+     *
      * @return
      */
     public DeviceListResult newDeviceListResult() {
-        return factory.newListResult();
+        return DEVICE_FACTORY.newListResult();
     }
 
     public DeviceQuery newQuery() {
-        return factory.newQuery(null);
+        return DEVICE_FACTORY.newQuery(null);
     }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
@@ -11,18 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
 
 /**
  * Device connection entity definition.
@@ -45,9 +45,10 @@ import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
         factoryMethod = "newDeviceConnection")
 public interface DeviceConnection extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "deviceConnection";
+    String TYPE = "deviceConnection";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
@@ -57,14 +58,14 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
      * @return
      */
     @XmlElement(name = "status")
-    public DeviceConnectionStatus getStatus();
+    DeviceConnectionStatus getStatus();
 
     /**
      * Set the device connection status
      *
      * @param status
      */
-    public void setStatus(DeviceConnectionStatus status);
+    void setStatus(DeviceConnectionStatus status);
 
     /**
      * Get the client identifier
@@ -72,14 +73,14 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
      * @return
      */
     @XmlElement(name = "clientId")
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set the client identifier
      *
      * @param clientId
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the user identifier
@@ -89,29 +90,29 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getUserId();
+    KapuaId getUserId();
 
     /**
      * Set the user identifier
      *
      * @param userId
      */
-    public void setUserId(KapuaId userId);
+    void setUserId(KapuaId userId);
 
     /**
      * Gets whether or not the {@link DeviceConnection} can change user on the next login.
-     * 
+     *
      * @return <code>true</code> if device can changhe user to connect, <code>false</code> if not.
      */
     @XmlElement(name = "allowUserChange")
-    public boolean getAllowUserChange();
+    boolean getAllowUserChange();
 
     /**
      * Sets whether or not the {@link DeviceConnection} can change user on the next login.
-     * 
+     *
      * @param allowUserChange
      */
-    public void setAllowUserChange(boolean allowUserChange);
+    void setAllowUserChange(boolean allowUserChange);
 
     /**
      * Get the device connection user coupling mode.
@@ -119,14 +120,14 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
      * @return
      */
     @XmlElement(name = "userCouplingMode")
-    public ConnectionUserCouplingMode getUserCouplingMode();
+    ConnectionUserCouplingMode getUserCouplingMode();
 
     /**
      * Set the device connection user coupling mode.
      *
      * @param userCouplingMode
      */
-    public void setUserCouplingMode(ConnectionUserCouplingMode userCouplingMode);
+    void setUserCouplingMode(ConnectionUserCouplingMode userCouplingMode);
 
     /**
      * Get the reserved user identifier
@@ -136,14 +137,14 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
     @XmlElement(name = "reservedUserId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getReservedUserId();
+    KapuaId getReservedUserId();
 
     /**
      * Set the reserved user identifier
      *
      * @param reservedUserId
      */
-    public void setReservedUserId(KapuaId reservedUserId);
+    void setReservedUserId(KapuaId reservedUserId);
 
     /**
      * Get the device protocol
@@ -151,14 +152,14 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
      * @return
      */
     @XmlElement(name = "protocol")
-    public String getProtocol();
+    String getProtocol();
 
     /**
      * Set the device protocol
      *
      * @param protocol
      */
-    public void setProtocol(String protocol);
+    void setProtocol(String protocol);
 
     /**
      * Get the client ip
@@ -166,14 +167,14 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
      * @return
      */
     @XmlElement(name = "clientIp")
-    public String getClientIp();
+    String getClientIp();
 
     /**
      * Set the client ip
      *
      * @param clientIp
      */
-    public void setClientIp(String clientIp);
+    void setClientIp(String clientIp);
 
     /**
      * Get the server ip
@@ -181,12 +182,12 @@ public interface DeviceConnection extends KapuaUpdatableEntity {
      * @return
      */
     @XmlElement(name = "serverIp")
-    public String getServerIp();
+    String getServerIp();
 
     /**
      * Set the server ip
      *
      * @param serverIp
      */
-    public void setServerIp(String serverIp);
+    void setServerIp(String serverIp);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
@@ -30,70 +30,70 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
      * @return
      */
     @XmlElement(name = "status")
-    public DeviceConnectionStatus getStatus();
+    DeviceConnectionStatus getStatus();
 
     /**
      * Set the device connection status
      *
      * @param status
      */
-    public void setStatus(DeviceConnectionStatus status);
+    void setStatus(DeviceConnectionStatus status);
 
     /**
      * Get the client identifier
      *
      * @return
      */
-    public String getClientId();
+    String getClientId();
 
     /**
      * Set the client identifier
      *
      * @param clientId
      */
-    public void setClientId(String clientId);
+    void setClientId(String clientId);
 
     /**
      * Get the user identifier
      *
      * @return
      */
-    public KapuaId getUserId();
+    KapuaId getUserId();
 
     /**
      * Set the user identifier
      *
      * @param userId
      */
-    public void setUserId(KapuaId userId);
+    void setUserId(KapuaId userId);
 
     /**
      * Get the device connection user coupling mode.
      *
      * @return
      */
-    public ConnectionUserCouplingMode getUserCouplingMode();
+    ConnectionUserCouplingMode getUserCouplingMode();
 
     /**
      * Set the device connection user coupling mode.
      *
      * @param userCouplingMode
      */
-    public void setUserCouplingMode(ConnectionUserCouplingMode userCouplingMode);
+    void setUserCouplingMode(ConnectionUserCouplingMode userCouplingMode);
 
     /**
      * Get the reserved user identifier
      *
      * @return
      */
-    public KapuaId getReservedUserId();
+    KapuaId getReservedUserId();
 
     /**
      * Set the reserved user identifier
      *
      * @param reservedUserId
      */
-    public void setReservedUserId(KapuaId reservedUserId);
+    void setReservedUserId(KapuaId reservedUserId);
 
     /**
      * Gets whether or not the {@link DeviceConnection} can change user on the next login.
@@ -101,54 +101,54 @@ public interface DeviceConnectionCreator extends KapuaUpdatableEntityCreator<Dev
      * @return <code>true</code> if device can changhe user to connect, <code>false</code> if not.
      */
     @XmlElement(name = "allowUserChange")
-    public boolean getAllowUserChange();
+    boolean getAllowUserChange();
 
     /**
      * Sets whether or not the {@link DeviceConnection} can change user on the next login.
      *
      * @param allowUserChange
      */
-    public void setAllowUserChange(boolean allowUserChange);
+    void setAllowUserChange(boolean allowUserChange);
 
     /**
      * Get the device protocol
      *
      * @return
      */
-    public String getProtocol();
+    String getProtocol();
 
     /**
      * Set the device protocol
      *
      * @param protocol
      */
-    public void setProtocol(String protocol);
+    void setProtocol(String protocol);
 
     /**
      * Get the client ip
      *
      * @return
      */
-    public String getClientIp();
+    String getClientIp();
 
     /**
      * Set the client ip
      *
      * @param clientIp
      */
-    public void setClientIp(String clientIp);
+    void setClientIp(String clientIp);
 
     /**
      * Get the server ip
      *
      * @return
      */
-    public String getServerIp();
+    String getServerIp();
 
     /**
      * Set the server ip
      *
      * @param serverIp
      */
-    public void setServerIp(String serverIp);
+    void setServerIp(String serverIp);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
@@ -30,10 +30,10 @@ public interface DeviceConnectionService extends KapuaEntityService<DeviceConnec
         KapuaDomainService<DeviceConnectionDomain>,
         KapuaConfigurableService {
 
-    public static final DeviceConnectionDomain DEVICE_CONNECTION_DOMAIN = new DeviceConnectionDomain();
+    DeviceConnectionDomain DEVICE_CONNECTION_DOMAIN = new DeviceConnectionDomain();
 
     @Override
-    public default DeviceConnectionDomain getServiceDomain() {
+    default DeviceConnectionDomain getServiceDomain() {
         return DEVICE_CONNECTION_DOMAIN;
     }
 
@@ -45,7 +45,7 @@ public interface DeviceConnectionService extends KapuaEntityService<DeviceConnec
      * @return
      * @throws KapuaException
      */
-    public DeviceConnection findByClientId(KapuaId scopeId, String clientId)
+    DeviceConnection findByClientId(KapuaId scopeId, String clientId)
             throws KapuaException;
 
     /**
@@ -57,7 +57,7 @@ public interface DeviceConnectionService extends KapuaEntityService<DeviceConnec
      * @since 1.0.0
      */
     @Override
-    public DeviceConnectionListResult query(KapuaQuery<DeviceConnection> query)
+    DeviceConnectionListResult query(KapuaQuery<DeviceConnection> query)
             throws KapuaException;
 
     /**
@@ -68,7 +68,7 @@ public interface DeviceConnectionService extends KapuaEntityService<DeviceConnec
      * @param creator
      * @throws KapuaException
      */
-    public void connect(DeviceConnectionCreator creator)
+    void connect(DeviceConnectionCreator creator)
             throws KapuaException;
 
     /**
@@ -78,6 +78,6 @@ public interface DeviceConnectionService extends KapuaEntityService<DeviceConnec
      * @param clientId
      * @throws KapuaException
      */
-    public void disconnect(KapuaId scopeId, String clientId)
+    void disconnect(KapuaId scopeId, String clientId)
             throws KapuaException;
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
@@ -11,40 +11,40 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * Device connection xml factory class
+ * {@link DeviceConnection} xml factory class
  *
  * @since 1.0
  */
 @XmlRegistry
 public class DeviceConnectionXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DeviceConnectionFactory factory = locator.getFactory(DeviceConnectionFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceConnectionFactory DEVICE_CONNECTION_FACTORY = LOCATOR.getFactory(DeviceConnectionFactory.class);
 
     /**
      * Creates a new {@link DeviceConnection}
-     * 
+     *
      * @return
      */
     public DeviceConnection newDeviceConnection() {
-        return factory.newEntity(null);
+        return DEVICE_CONNECTION_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new device list result
-     * 
+     *
      * @return
      */
     public DeviceConnectionListResult newDeviceConnectionListResult() {
-        return factory.newListResult();
+        return DEVICE_CONNECTION_FACTORY.newListResult();
     }
 
     public DeviceConnectionQuery newQuery() {
-        return factory.newQuery(null);
+        return DEVICE_CONNECTION_FACTORY.newQuery(null);
     }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
@@ -11,18 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection.option;
 
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
-import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 
 /**
  * Device connection options entity definition.
@@ -40,26 +40,27 @@ import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
         factoryMethod = "newDeviceConnectionOption")
 public interface DeviceConnectionOption extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "deviceConnectionOption";
+    String TYPE = "deviceConnectionOption";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Gets whether or not the {@link DeviceConnection} can change user on the next login.
-     * 
+     *
      * @return <code>true</code> if device can changhe user to connect, <code>false</code> if not.
      */
     @XmlElement(name = "allowUserChange")
-    public boolean getAllowUserChange();
+    boolean getAllowUserChange();
 
     /**
      * Sets whether or not the {@link DeviceConnection} can change user on the next login.
-     * 
+     *
      * @param allowUserChange
      */
-    public void setAllowUserChange(boolean allowUserChange);
+    void setAllowUserChange(boolean allowUserChange);
 
     /**
      * Get the device connection user coupling mode.
@@ -67,14 +68,14 @@ public interface DeviceConnectionOption extends KapuaUpdatableEntity {
      * @return
      */
     @XmlElement(name = "userCouplingMode")
-    public ConnectionUserCouplingMode getUserCouplingMode();
+    ConnectionUserCouplingMode getUserCouplingMode();
 
     /**
      * Set the device connection user coupling mode.
      *
      * @param userCouplingMode
      */
-    public void setUserCouplingMode(ConnectionUserCouplingMode userCouplingMode);
+    void setUserCouplingMode(ConnectionUserCouplingMode userCouplingMode);
 
     /**
      * Get the reserved user identifier
@@ -83,12 +84,12 @@ public interface DeviceConnectionOption extends KapuaUpdatableEntity {
      */
     @XmlElement(name = "reservedUserId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
-    public KapuaId getReservedUserId();
+    KapuaId getReservedUserId();
 
     /**
      * Set the reserved user identifier
      *
      * @param reservedUserId
      */
-    public void setReservedUserId(KapuaId reservedUserId);
+    void setReservedUserId(KapuaId reservedUserId);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionCreator.java
@@ -27,26 +27,26 @@ public interface DeviceConnectionOptionCreator extends KapuaUpdatableEntityCreat
      *
      * @return
      */
-    public ConnectionUserCouplingMode getUserCouplingMode();
+    ConnectionUserCouplingMode getUserCouplingMode();
 
     /**
      * Set the device connection user coupling mode.
      *
      * @param userCouplingMode
      */
-    public void setUserCouplingMode(ConnectionUserCouplingMode userCouplingMode);
+    void setUserCouplingMode(ConnectionUserCouplingMode userCouplingMode);
 
     /**
      * Get the reserved user identifier
      *
      * @return
      */
-    public KapuaId getReservedUserId();
+    KapuaId getReservedUserId();
 
     /**
      * Set the reserved user identifier
      *
      * @param reservedUserId
      */
-    public void setReservedUserId(KapuaId reservedUserId);
+    void setReservedUserId(KapuaId reservedUserId);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionService.java
@@ -25,10 +25,10 @@ public interface DeviceConnectionOptionService extends KapuaEntityService<Device
         KapuaUpdatableEntityService<DeviceConnectionOption>,
         KapuaDomainService<DeviceConnectionDomain> {
 
-    public static final DeviceConnectionDomain DEVICE_CONNECTION_DOMAIN = new DeviceConnectionDomain();
+    DeviceConnectionDomain DEVICE_CONNECTION_DOMAIN = new DeviceConnectionDomain();
 
     @Override
-    public default DeviceConnectionDomain getServiceDomain() {
+    default DeviceConnectionDomain getServiceDomain() {
         return DEVICE_CONNECTION_DOMAIN;
     }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionXmlRegistry.java
@@ -11,40 +11,40 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection.option;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * Device connection options XML factory class
+ * {@link DeviceConnectionOptionService} XML factory class
  *
  * @since 1.0
  */
 @XmlRegistry
 public class DeviceConnectionOptionXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DeviceConnectionOptionFactory factory = locator.getFactory(DeviceConnectionOptionFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceConnectionOptionFactory DEVICE_CONNECTION_OPTION_FACTORY = LOCATOR.getFactory(DeviceConnectionOptionFactory.class);
 
     /**
      * Creates a new {@link DeviceConnectionOption}
-     * 
+     *
      * @return
      */
     public DeviceConnectionOption newDeviceConnectionOption() {
-        return factory.newEntity(null);
+        return DEVICE_CONNECTION_OPTION_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new device connection options list result
-     * 
+     *
      * @return
      */
     public DeviceConnectionOptionListResult newDeviceConnectionOptionListResult() {
-        return factory.newListResult();
+        return DEVICE_CONNECTION_OPTION_FACTORY.newListResult();
     }
 
     public DeviceConnectionOptionQuery newQuery() {
-        return factory.newQuery(null);
+        return DEVICE_CONNECTION_OPTION_FACTORY.newQuery(null);
     }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
@@ -49,10 +49,10 @@ import java.util.Date;
         factoryMethod = "newDeviceEvent")
 public interface DeviceEvent extends KapuaEntity {
 
-    public static final String TYPE = "deviceEvent";
+    String TYPE = "deviceEvent";
 
     @Override
-    public default String getType() {
+    default String getType() {
         return TYPE;
     }
 
@@ -65,7 +65,7 @@ public interface DeviceEvent extends KapuaEntity {
     @XmlElement(name = "deviceId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getDeviceId();
+    KapuaId getDeviceId();
 
     /**
      * Set the device identifier
@@ -73,7 +73,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @param deviceId
      * @since 1.0.0
      */
-    public void setDeviceId(KapuaId deviceId);
+    void setDeviceId(KapuaId deviceId);
 
     /**
      * Get the sent on date
@@ -83,7 +83,7 @@ public interface DeviceEvent extends KapuaEntity {
      */
     @XmlElement(name = "sentOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getSentOn();
+    Date getSentOn();
 
     /**
      * Set the sent on date
@@ -91,7 +91,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @param sentOn
      * @since 1.0.0
      */
-    public void setSentOn(Date sentOn);
+    void setSentOn(Date sentOn);
 
     /**
      * Get the received on date
@@ -101,7 +101,7 @@ public interface DeviceEvent extends KapuaEntity {
      */
     @XmlElement(name = "receivedOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getReceivedOn();
+    Date getReceivedOn();
 
     /**
      * Set the received on date
@@ -109,7 +109,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @param receivedOn
      * @since 1.0.0
      */
-    public void setReceivedOn(Date receivedOn);
+    void setReceivedOn(Date receivedOn);
 
     /**
      * Get the device position
@@ -118,7 +118,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @since 1.0.0
      */
     @XmlElement(name = "position")
-    public KapuaPosition getPosition();
+    KapuaPosition getPosition();
 
     /**
      * Set the device position
@@ -126,7 +126,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @param position
      * @since 1.0.0
      */
-    public void setPosition(KapuaPosition position);
+    void setPosition(KapuaPosition position);
 
     /**
      * Get resource
@@ -135,14 +135,14 @@ public interface DeviceEvent extends KapuaEntity {
      * @since 1.0.0
      */
     @XmlElement(name = "resource")
-    public String getResource();
+    String getResource();
 
     /**
      * Set resource
      *
      * @param resource
      */
-    public void setResource(String resource);
+    void setResource(String resource);
 
     /**
      * Get action
@@ -151,7 +151,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @since 1.0.0
      */
     @XmlElement(name = "action")
-    public KapuaMethod getAction();
+    KapuaMethod getAction();
 
     /**
      * Set action
@@ -159,7 +159,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @param action
      * @since 1.0.0
      */
-    public void setAction(KapuaMethod action);
+    void setAction(KapuaMethod action);
 
     /**
      * Get response code
@@ -168,7 +168,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @since 1.0.0
      */
     @XmlElement(name = "responseCode")
-    public KapuaResponseCode getResponseCode();
+    KapuaResponseCode getResponseCode();
 
     /**
      * Set the response code
@@ -176,7 +176,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @param responseCode
      * @since 1.0.0
      */
-    public void setResponseCode(KapuaResponseCode responseCode);
+    void setResponseCode(KapuaResponseCode responseCode);
 
     /**
      * Get event message
@@ -185,7 +185,7 @@ public interface DeviceEvent extends KapuaEntity {
      * @since 1.0.0
      */
     @XmlElement(name = "eventMessage")
-    public String getEventMessage();
+    String getEventMessage();
 
     /**
      * Set the event message
@@ -193,6 +193,6 @@ public interface DeviceEvent extends KapuaEntity {
      * @param eventMessage
      * @since 1.0.0
      */
-    public void setEventMessage(String eventMessage);
+    void setEventMessage(String eventMessage);
 
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
@@ -31,110 +31,110 @@ public interface DeviceEventCreator extends KapuaEntityCreator<DeviceEvent> {
      *
      * @return
      */
-    public KapuaId getDeviceId();
+    KapuaId getDeviceId();
 
     /**
      * Set the device identifier
      *
      * @param deviceId
      */
-    public void setDeviceId(KapuaId deviceId);
+    void setDeviceId(KapuaId deviceId);
 
     /**
      * Get the sent on date
      *
      * @return
      */
-    public Date getSentOn();
+    Date getSentOn();
 
     /**
      * Set the sent on date
      *
      * @param sentOn
      */
-    public void setSentOn(Date sentOn);
+    void setSentOn(Date sentOn);
 
     /**
      * Get the received on date
      *
      * @return
      */
-    public Date getReceivedOn();
+    Date getReceivedOn();
 
     /**
      * Set the received on date
      *
      * @param receivedOn
      */
-    public void setReceivedOn(Date receivedOn);
+    void setReceivedOn(Date receivedOn);
 
     /**
      * Get device position
      *
      * @return
      */
-    public KapuaPosition getPosition();
+    KapuaPosition getPosition();
 
     /**
      * Set device position
      *
      * @param position
      */
-    public void setPosition(KapuaPosition position);
+    void setPosition(KapuaPosition position);
 
     /**
      * Get resource
      *
      * @return
      */
-    public String getResource();
+    String getResource();
 
     /**
      * Set resource
      *
      * @param resource
      */
-    public void setResource(String resource);
+    void setResource(String resource);
 
     /**
      * GHet action
      *
      * @return
      */
-    public KapuaMethod getAction();
+    KapuaMethod getAction();
 
     /**
      * Set action
      *
      * @param action
      */
-    public void setAction(KapuaMethod action);
+    void setAction(KapuaMethod action);
 
     /**
      * Get response code
      *
      * @return
      */
-    public KapuaResponseCode getResponseCode();
+    KapuaResponseCode getResponseCode();
 
     /**
      * Set response code
      *
      * @param responseCode
      */
-    public void setResponseCode(KapuaResponseCode responseCode);
+    void setResponseCode(KapuaResponseCode responseCode);
 
     /**
      * Get event message
      *
      * @return
      */
-    public String getEventMessage();
+    String getEventMessage();
 
     /**
      * Set event message
      *
      * @param eventMessage
      */
-    public void setEventMessage(String eventMessage);
+    void setEventMessage(String eventMessage);
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
@@ -24,10 +24,10 @@ import org.eclipse.kapua.service.device.registry.Device;
  */
 public interface DeviceEventService extends KapuaEntityService<DeviceEvent, DeviceEventCreator>, KapuaDomainService<DeviceEventDomain> {
 
-    public static final DeviceEventDomain DEVICE_EVENT_DOMAIN = new DeviceEventDomain();
+    DeviceEventDomain DEVICE_EVENT_DOMAIN = new DeviceEventDomain();
 
     @Override
-    public default DeviceEventDomain getServiceDomain() {
+    default DeviceEventDomain getServiceDomain() {
         return DEVICE_EVENT_DOMAIN;
     }
 
@@ -42,8 +42,7 @@ public interface DeviceEventService extends KapuaEntityService<DeviceEvent, Devi
      * @throws KapuaException
      * @since 1.0.0
      */
-    public DeviceEvent create(DeviceEventCreator creator, boolean updateDeviceLastEventId)
-            throws KapuaException;
+    DeviceEvent create(DeviceEventCreator creator, boolean updateDeviceLastEventId) throws KapuaException;
 
     /**
      * Returns the {@link DeviceEventListResult} with elements matching the provided query.
@@ -54,7 +53,6 @@ public interface DeviceEventService extends KapuaEntityService<DeviceEvent, Devi
      * @since 1.0.0
      */
     @Override
-    public DeviceEventListResult query(KapuaQuery<DeviceEvent> query)
-            throws KapuaException;
+    DeviceEventListResult query(KapuaQuery<DeviceEvent> query) throws KapuaException;
 
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
@@ -11,41 +11,40 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.event;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * Device event xml factory class.
- * 
- * @since 1.0
+ * {@link DeviceEvent} xml factory class.
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class DeviceEventXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DeviceEventFactory factory = locator.getFactory(DeviceEventFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DeviceEventFactory DEVICE_EVENT_FACTORY = LOCATOR.getFactory(DeviceEventFactory.class);
 
     /**
      * Creates a new device event
-     * 
+     *
      * @return
      */
     public DeviceEvent newDeviceEvent() {
-        return factory.newEntity(null);
+        return DEVICE_EVENT_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new device event list result
-     * 
+     *
      * @return
      */
     public DeviceEventListResult newDeviceEventListResult() {
-        return factory.newListResult();
+        return DEVICE_EVENT_FACTORY.newListResult();
     }
 
     public DeviceEventQuery newQuery() {
-        return factory.newQuery(null);
+        return DEVICE_EVENT_FACTORY.newQuery(null);
     }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifeCycleService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifeCycleService.java
@@ -28,10 +28,10 @@ import org.eclipse.kapua.service.KapuaService;
  */
 public interface DeviceLifeCycleService extends KapuaService, KapuaDomainService<DeviceLifecycleDomain> {
 
-    public static final DeviceLifecycleDomain DEVICE_LIFECYCLE_DOMAIN = new DeviceLifecycleDomain();
+    DeviceLifecycleDomain DEVICE_LIFECYCLE_DOMAIN = new DeviceLifecycleDomain();
 
     @Override
-    public default DeviceLifecycleDomain getServiceDomain() {
+    default DeviceLifecycleDomain getServiceDomain() {
         return DEVICE_LIFECYCLE_DOMAIN;
     }
 
@@ -42,8 +42,7 @@ public interface DeviceLifeCycleService extends KapuaService, KapuaDomainService
      * @param message
      * @throws KapuaException
      */
-    public <M extends KapuaBirthMessage> void birth(KapuaId connectionId, M message)
-            throws KapuaException;
+    <M extends KapuaBirthMessage> void birth(KapuaId connectionId, M message) throws KapuaException;
 
     /**
      * Processes a death certificate for a device, updating the device footprint with the information supplied.
@@ -52,8 +51,7 @@ public interface DeviceLifeCycleService extends KapuaService, KapuaDomainService
      * @param message
      * @throws KapuaException
      */
-    public <M extends KapuaDisconnectMessage> void death(KapuaId connectionId, M message)
-            throws KapuaException;
+    <M extends KapuaDisconnectMessage> void death(KapuaId connectionId, M message) throws KapuaException;
 
     /**
      * Processes a last-will testament for a device, updating the device footprint with the information supplied.
@@ -62,8 +60,7 @@ public interface DeviceLifeCycleService extends KapuaService, KapuaDomainService
      * @param message
      * @throws KapuaException
      */
-    public <M extends KapuaMissingMessage> void missing(KapuaId connectionId, M message)
-            throws KapuaException;
+    <M extends KapuaMissingMessage> void missing(KapuaId connectionId, M message) throws KapuaException;
 
     /**
      * Processes a birth certificate for a device, creating or updating the device footprint with the information supplied.
@@ -72,6 +69,5 @@ public interface DeviceLifeCycleService extends KapuaService, KapuaDomainService
      * @param message
      * @throws KapuaException
      */
-    public <M extends KapuaAppsMessage> void applications(KapuaId connectionId, M message)
-            throws KapuaException;
+    <M extends KapuaAppsMessage> void applications(KapuaId connectionId, M message) throws KapuaException;
 }

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
@@ -27,6 +27,5 @@ public interface DeviceRequestManagementService extends KapuaService, DeviceMana
      * @return response output
      * @throws KapuaException
      */
-    GenericResponseMessage exec(GenericRequestMessage requestInput, Long timeout)
-            throws KapuaException;
+    GenericResponseMessage exec(GenericRequestMessage requestInput, Long timeout) throws KapuaException;
 }

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
@@ -33,39 +33,39 @@ import java.util.Set;
 @XmlType(factoryClass = EndpointInfoXmlRegistry.class, factoryMethod = "newEntity")
 public interface EndpointInfo extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "endpointInfo";
+    String TYPE = "endpointInfo";
 
     @Override
-    public default String getType() {
+    default String getType() {
         return TYPE;
     }
 
     @XmlElement(name = "schema")
-    public String getSchema();
+    String getSchema();
 
-    public void setSchema(String schema);
+    void setSchema(String schema);
 
     @XmlElement(name = "dns")
-    public String getDns();
+    String getDns();
 
-    public void setDns(String dns);
+    void setDns(String dns);
 
     @XmlElement(name = "port")
-    public int getPort();
+    int getPort();
 
-    public void setPort(int port);
+    void setPort(int port);
 
     @XmlElement(name = "secure")
-    public boolean getSecure();
+    boolean getSecure();
 
-    public void setSecure(boolean secure);
+    void setSecure(boolean secure);
 
     @XmlElement(name = "usages")
-    public <E extends EndpointUsage> Set<E> getUsages();
+    <E extends EndpointUsage> Set<E> getUsages();
 
-    public void setUsages(Set<EndpointUsage> endpointUsages);
+    void setUsages(Set<EndpointUsage> endpointUsages);
 
-    public default String toStringURI() {
+    default String toStringURI() {
         try {
             return new URI(
                     getSchema(),

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoCreator.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoCreator.java
@@ -30,23 +30,23 @@ import java.util.Set;
 @XmlType(factoryClass = EndpointInfoXmlRegistry.class, factoryMethod = "newCreator")
 public interface EndpointInfoCreator extends KapuaEntityCreator<EndpointInfo> {
 
-    public String getSchema();
+    String getSchema();
 
-    public void setSchema(String schema);
+    void setSchema(String schema);
 
-    public String getDns();
+    String getDns();
 
-    public void setDns(String dns);
+    void setDns(String dns);
 
-    public int getPort();
+    int getPort();
 
-    public void setPort(int port);
+    void setPort(int port);
 
-    public boolean getSecure();
+    boolean getSecure();
 
-    public void setSecure(boolean secure);
+    void setSecure(boolean secure);
 
-    public Set<EndpointUsage> getUsages();
+    Set<EndpointUsage> getUsages();
 
-    public void setUsages(Set<EndpointUsage> usages);
+    void setUsages(Set<EndpointUsage> usages);
 }

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoFactory.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoFactory.java
@@ -20,5 +20,5 @@ import org.eclipse.kapua.model.KapuaEntityFactory;
  */
 public interface EndpointInfoFactory extends KapuaEntityFactory<EndpointInfo, EndpointInfoCreator, EndpointInfoQuery, EndpointInfoListResult> {
 
-    public EndpointUsage newEndpointUsage(String name);
+    EndpointUsage newEndpointUsage(String name);
 }

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoService.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoService.java
@@ -26,10 +26,10 @@ public interface EndpointInfoService extends KapuaEntityService<EndpointInfo, En
         KapuaUpdatableEntityService<EndpointInfo>,
         KapuaDomainService<EndpointInfoDomain> {
 
-    public static final EndpointInfoDomain ENDPOINT_INFO_DOMAIN = new EndpointInfoDomain();
+    EndpointInfoDomain ENDPOINT_INFO_DOMAIN = new EndpointInfoDomain();
 
     @Override
-    public default EndpointInfoDomain getServiceDomain() {
+    default EndpointInfoDomain getServiceDomain() {
         return ENDPOINT_INFO_DOMAIN;
     }
 
@@ -42,6 +42,6 @@ public interface EndpointInfoService extends KapuaEntityService<EndpointInfo, En
      * @since 1.0.0
      */
     @Override
-    public EndpointInfoListResult query(KapuaQuery<EndpointInfo> query)
+    EndpointInfoListResult query(KapuaQuery<EndpointInfo> query)
             throws KapuaException;
 }

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoXmlRegistry.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoXmlRegistry.java
@@ -18,8 +18,8 @@ import javax.xml.bind.annotation.XmlRegistry;
 @XmlRegistry
 public class EndpointInfoXmlRegistry {
 
-    private final static KapuaLocator LOCATOR = KapuaLocator.getInstance();
-    private final static EndpointInfoFactory FACTORY = LOCATOR.getFactory(EndpointInfoFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final EndpointInfoFactory FACTORY = LOCATOR.getFactory(EndpointInfoFactory.class);
 
     /**
      * Creates a new {@link EndpointInfo} instance

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/Job.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/Job.java
@@ -11,43 +11,42 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job;
 
-import java.util.List;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.service.job.step.JobStep;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaNamedEntity;
-import org.eclipse.kapua.service.job.step.JobStep;
+import java.util.List;
 
 /**
  * {@link Job} entity.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 @XmlRootElement(name = "job")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobXmlRegistry.class, factoryMethod = "newJob")
 public interface Job extends KapuaNamedEntity {
 
-    public static final String TYPE = "job";
+    String TYPE = "job";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
-    public String getDescription();
+    String getDescription();
 
-    public void setDescription(String description);
+    void setDescription(String description);
 
-    public List<JobStep> getJobSteps();
+    List<JobStep> getJobSteps();
 
-    public void setJobSteps(List<JobStep> jobSteps);
+    void setJobSteps(List<JobStep> jobSteps);
 
-    public String getJobXmlDefinition();
+    String getJobXmlDefinition();
 
-    public void setJobXmlDefinition(String jobXmlDefinition);
+    void setJobXmlDefinition(String jobXmlDefinition);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobCreator.java
@@ -11,38 +11,36 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job;
 
-import java.util.List;
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+import org.eclipse.kapua.service.job.step.JobStep;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaNamedEntityCreator;
-import org.eclipse.kapua.service.job.step.JobStep;
+import java.util.List;
 
 /**
  * {@link JobCreator} encapsulates all the information needed to create a new JobStepDefinition in the system.<br>
  * The data provided will be used to seed the new JobStepDefinition.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 @XmlRootElement(name = "jobCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobXmlRegistry.class, factoryMethod = "newJobCreator")
 public interface JobCreator extends KapuaNamedEntityCreator<Job> {
 
-    public String getDescription();
+    String getDescription();
 
-    public void setDescription(String description);
+    void setDescription(String description);
 
-    public List<JobStep> getJobSteps();
+    List<JobStep> getJobSteps();
 
-    public void setJobSteps(List<JobStep> jobSteps);
+    void setJobSteps(List<JobStep> jobSteps);
 
-    public String getJobXmlDefinition();
+    String getJobXmlDefinition();
 
-    public void setJobXmlDefinition(String jobXmlDefinition);
+    void setJobXmlDefinition(String jobXmlDefinition);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobService.java
@@ -30,10 +30,10 @@ public interface JobService extends KapuaEntityService<Job, JobCreator>,
         KapuaDomainService<JobDomain>,
         KapuaConfigurableService {
 
-    public static final JobDomain JOB_DOMAIN = new JobDomain();
+    JobDomain JOB_DOMAIN = new JobDomain();
 
     @Override
-    public default JobDomain getServiceDomain() {
+    default JobDomain getServiceDomain() {
         return JOB_DOMAIN;
     }
 
@@ -46,6 +46,6 @@ public interface JobService extends KapuaEntityService<Job, JobCreator>,
      * @since 1.0.0
      */
     @Override
-    public JobListResult query(KapuaQuery<Job> query)
+    JobListResult query(KapuaQuery<Job> query)
             throws KapuaException;
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobXmlRegistry.java
@@ -11,50 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * Job xml factory class
- * 
- * @since 1.0
+ * {@link Job} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class JobXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final JobFactory factory = locator.getFactory(JobFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final JobFactory JOB_FACTORY = LOCATOR.getFactory(JobFactory.class);
 
     /**
      * Creates a new job instance
-     * 
+     *
      * @return
      */
     public Job newJob() {
-        return factory.newEntity(null);
+        return JOB_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new job creator instance
-     * 
+     *
      * @return
      */
     public JobCreator newJobCreator() {
-        return factory.newCreator(null);
+        return JOB_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new job list result instance
-     * 
+     *
      * @return
      */
     public JobListResult newJobListResult() {
-        return factory.newListResult();
+        return JOB_FACTORY.newListResult();
     }
 
     public JobQuery newQuery() {
-        return factory.newQuery(null);
+        return JOB_FACTORY.newQuery(null);
     }
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -11,43 +11,42 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.execution;
 
-import java.util.Date;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
+import java.util.Date;
 
 /**
  * {@link JobExecution} entity.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "jobExecution")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobExecutionXmlRegistry.class, factoryMethod = "newJobExecution")
 public interface JobExecution extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "jobExecution";
+    String TYPE = "jobExecution";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
-    public KapuaId getJobId();
+    KapuaId getJobId();
 
-    public void setJobId(KapuaId jobId);
+    void setJobId(KapuaId jobId);
 
-    public Date getStartedOn();
+    Date getStartedOn();
 
-    public void setStartedOn(Date startedOn);
+    void setStartedOn(Date startedOn);
 
-    public Date getEndedOn();
+    Date getEndedOn();
 
-    public void setEndedOn(Date endedOn);
+    void setEndedOn(Date endedOn);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
@@ -11,33 +11,31 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.execution;
 
-import java.util.Date;
+import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
-import org.eclipse.kapua.model.id.KapuaId;
+import java.util.Date;
 
 /**
  * {@link JobExecutionCreator} encapsulates all the information needed to create a new JobExecution in the system.<br>
  * The data provided will be used to seed the new JobExecution.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 @XmlRootElement(name = "jobExecutionCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobExecutionXmlRegistry.class, factoryMethod = "newJobExecutionCreator")
 public interface JobExecutionCreator extends KapuaUpdatableEntityCreator<JobExecution> {
 
-    public KapuaId getJobId();
+    KapuaId getJobId();
 
-    public void setJobId(KapuaId jobId);
+    void setJobId(KapuaId jobId);
 
-    public Date getStartedOn();
+    Date getStartedOn();
 
-    public void setStartedOn(Date startedOn);
+    void setStartedOn(Date startedOn);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionService.java
@@ -31,10 +31,10 @@ public interface JobExecutionService extends KapuaEntityService<JobExecution, Jo
         KapuaDomainService<JobDomain>,
         KapuaConfigurableService {
 
-    public static final JobDomain JOB_DOMAIN = new JobDomain();
+    JobDomain JOB_DOMAIN = new JobDomain();
 
     @Override
-    public default JobDomain getServiceDomain() {
+    default JobDomain getServiceDomain() {
         return JOB_DOMAIN;
     }
 
@@ -47,6 +47,6 @@ public interface JobExecutionService extends KapuaEntityService<JobExecution, Jo
      * @since 1.0.0
      */
     @Override
-    public JobExecutionListResult query(KapuaQuery<JobExecution> query)
+    JobExecutionListResult query(KapuaQuery<JobExecution> query)
             throws KapuaException;
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionXmlRegistry.java
@@ -11,50 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.execution;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * JobExecution xml factory class
- * 
- * @since 1.0
+ * {@link JobExecution} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class JobExecutionXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final JobExecutionFactory factory = locator.getFactory(JobExecutionFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final JobExecutionFactory JOB_EXECUTION_FACTORY = LOCATOR.getFactory(JobExecutionFactory.class);
 
     /**
      * Creates a new job instance
-     * 
+     *
      * @return
      */
     public JobExecution newJobExecution() {
-        return factory.newEntity(null);
+        return JOB_EXECUTION_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new job creator instance
-     * 
+     *
      * @return
      */
     public JobExecutionCreator newJobExecutionCreator() {
-        return factory.newCreator(null);
+        return JOB_EXECUTION_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new job list result instance
-     * 
+     *
      * @return
      */
     public JobExecutionListResult newJobExecutionListResult() {
-        return factory.newListResult();
+        return JOB_EXECUTION_FACTORY.newListResult();
     }
 
     public JobExecutionQuery newQuery() {
-        return factory.newQuery(null);
+        return JOB_EXECUTION_FACTORY.newQuery(null);
     }
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStep.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStep.java
@@ -11,52 +11,51 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step;
 
-import java.util.List;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaNamedEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
+import java.util.List;
 
 /**
  * {@link JobStep} entity.
  *
  * @since 1.0
- *
  */
 @XmlRootElement(name = "jobStep")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobStepXmlRegistry.class, factoryMethod = "newJobStep")
 public interface JobStep extends KapuaNamedEntity {
 
-    public static final String TYPE = "jobStep";
+    String TYPE = "jobStep";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
-    public String getDescription();
+    String getDescription();
 
-    public void setDescription(String description);
+    void setDescription(String description);
 
-    public KapuaId getJobId();
+    KapuaId getJobId();
 
-    public void setJobId(KapuaId jobId);
+    void setJobId(KapuaId jobId);
 
-    public int getStepIndex();
+    int getStepIndex();
 
-    public void setStepIndex(int stepIndex);
+    void setStepIndex(int stepIndex);
 
-    public KapuaId getJobStepDefinitionId();
+    KapuaId getJobStepDefinitionId();
 
-    public void setJobStepDefinitionId(KapuaId jobDefinitionId);
+    void setJobStepDefinitionId(KapuaId jobDefinitionId);
 
-    public <P extends JobStepProperty> List<P> getStepProperties();
+    <P extends JobStepProperty> List<P> getStepProperties();
 
-    public void setStepProperties(List<JobStepProperty> jobStepProperties);
+    void setStepProperties(List<JobStepProperty> jobStepProperties);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepCreator.java
@@ -32,23 +32,23 @@ import java.util.List;
 @XmlType(factoryClass = JobStepXmlRegistry.class, factoryMethod = "newJobStepCreator")
 public interface JobStepCreator extends KapuaNamedEntityCreator<JobStep> {
 
-    public String getDescription();
+    String getDescription();
 
-    public void setDescription(String description);
+    void setDescription(String description);
 
-    public KapuaId getJobId();
+    KapuaId getJobId();
 
-    public void setJobId(KapuaId jobId);
+    void setJobId(KapuaId jobId);
 
-    public int getStepIndex();
+    int getStepIndex();
 
-    public void setStepIndex(int stepIndex);
+    void setStepIndex(int stepIndex);
 
-    public KapuaId getJobStepDefinitionId();
+    KapuaId getJobStepDefinitionId();
 
-    public void setJobStepDefinitionId(KapuaId jobStepDefinitionId);
+    void setJobStepDefinitionId(KapuaId jobStepDefinitionId);
 
-    public <P extends JobStepProperty> List<P> getStepProperties();
+    <P extends JobStepProperty> List<P> getStepProperties();
 
-    public void setJobStepProperties(List<JobStepProperty> jobStepProperties);
+    void setJobStepProperties(List<JobStepProperty> jobStepProperties);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepFactory.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepFactory.java
@@ -16,12 +16,11 @@ import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 
 /**
  * {@link JobStepFactory} definition.
- * 
+ *
  * @since 1.0
- * 
  */
 public interface JobStepFactory extends KapuaEntityFactory<JobStep, JobStepCreator, JobStepQuery, JobStepListResult> {
 
-    public JobStepProperty newStepProperty(String name, String propertyType, String propertyValue);
+    JobStepProperty newStepProperty(String name, String propertyType, String propertyValue);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepService.java
@@ -31,10 +31,10 @@ public interface JobStepService extends KapuaEntityService<JobStep, JobStepCreat
         KapuaDomainService<JobDomain>,
         KapuaConfigurableService {
 
-    public static final JobDomain JOB_DOMAIN = new JobDomain();
+    JobDomain JOB_DOMAIN = new JobDomain();
 
     @Override
-    public default JobDomain getServiceDomain() {
+    default JobDomain getServiceDomain() {
         return JOB_DOMAIN;
     }
 
@@ -47,6 +47,6 @@ public interface JobStepService extends KapuaEntityService<JobStep, JobStepCreat
      * @since 1.0.0
      */
     @Override
-    public JobStepListResult query(KapuaQuery<JobStep> query)
+    JobStepListResult query(KapuaQuery<JobStep> query)
             throws KapuaException;
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepXmlRegistry.java
@@ -11,50 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * JobStep xml factory class
- * 
- * @since 1.0
+ * {@link JobStep} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class JobStepXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final JobStepFactory factory = locator.getFactory(JobStepFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final JobStepFactory JOB_STEP_FACTORY = LOCATOR.getFactory(JobStepFactory.class);
 
     /**
      * Creates a new job instance
-     * 
+     *
      * @return
      */
     public JobStep newJobStep() {
-        return factory.newEntity(null);
+        return JOB_STEP_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new job creator instance
-     * 
+     *
      * @return
      */
     public JobStepCreator newJobStepCreator() {
-        return factory.newCreator(null);
+        return JOB_STEP_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new job list result instance
-     * 
+     *
      * @return
      */
     public JobStepListResult newJobStepListResult() {
-        return factory.newListResult();
+        return JOB_STEP_FACTORY.newListResult();
     }
 
     public JobStepQuery newQuery() {
-        return factory.newQuery(null);
+        return JOB_STEP_FACTORY.newQuery(null);
     }
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinition.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinition.java
@@ -11,54 +11,53 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition;
 
-import java.util.List;
+import org.eclipse.kapua.model.KapuaNamedEntity;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaNamedEntity;
+import java.util.List;
 
 /**
  * {@link JobStepDefinition} entity.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "jobStepDefinition")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobStepDefinitionXmlRegistry.class, factoryMethod = "newJobStepDefinition")
 public interface JobStepDefinition extends KapuaNamedEntity {
 
-    public static final String TYPE = "stepDefinition";
+    String TYPE = "stepDefinition";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
-    public String getDescription();
+    String getDescription();
 
-    public void setDescription(String description);
+    void setDescription(String description);
 
-    public JobStepType getStepType();
+    JobStepType getStepType();
 
-    public void setStepType(JobStepType jobStepType);
+    void setStepType(JobStepType jobStepType);
 
-    public String getReaderName();
+    String getReaderName();
 
-    public void setReaderName(String readerName);
+    void setReaderName(String readerName);
 
-    public String getProcessorName();
+    String getProcessorName();
 
-    public void setProcessorName(String processorName);
+    void setProcessorName(String processorName);
 
-    public String getWriterName();
+    String getWriterName();
 
-    public void setWriterName(String writesName);
+    void setWriterName(String writesName);
 
-    public <P extends JobStepProperty> List<P> getStepProperties();
+    <P extends JobStepProperty> List<P> getStepProperties();
 
-    public void setStepProperties(List<JobStepProperty> jobStepProperties);
+    void setStepProperties(List<JobStepProperty> jobStepProperties);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionCreator.java
@@ -11,48 +11,46 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition;
 
-import java.util.List;
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+import java.util.List;
 
 /**
  * {@link JobStepDefinitionCreator} encapsulates all the information needed to create a new JobStepDefinition in the system.<br>
  * The data provided will be used to seed the new JobStepDefinition.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 @XmlRootElement(name = "jobStepDefinitionCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobStepDefinitionXmlRegistry.class, factoryMethod = "newJobStepDefinitionCreator")
 public interface JobStepDefinitionCreator extends KapuaNamedEntityCreator<JobStepDefinition> {
 
-    public String getDescription();
+    String getDescription();
 
-    public void setDescription(String description);
+    void setDescription(String description);
 
-    public JobStepType getStepType();
+    JobStepType getStepType();
 
-    public void setStepType(JobStepType jobStepType);
+    void setStepType(JobStepType jobStepType);
 
-    public String getReaderName();
+    String getReaderName();
 
-    public void setReaderName(String readerName);
+    void setReaderName(String readerName);
 
-    public String getProcessorName();
+    String getProcessorName();
 
-    public void setProcessorName(String processorName);
+    void setProcessorName(String processorName);
 
-    public String getWriterName();
+    String getWriterName();
 
-    public void setWriterName(String writesName);
+    void setWriterName(String writesName);
 
-    public List<JobStepProperty> getStepProperties();
+    List<JobStepProperty> getStepProperties();
 
-    public void setStepProperties(List<JobStepProperty> jobStepProperties);
+    void setStepProperties(List<JobStepProperty> jobStepProperties);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionFactory.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionFactory.java
@@ -15,12 +15,11 @@ import org.eclipse.kapua.model.KapuaEntityFactory;
 
 /**
  * {@link JobStepDefinitionFactory} definition.
- * 
+ *
  * @since 1.0
- * 
  */
 public interface JobStepDefinitionFactory extends KapuaEntityFactory<JobStepDefinition, JobStepDefinitionCreator, JobStepDefinitionQuery, JobStepDefinitionListResult> {
 
-    public JobStepProperty newStepProperty(String name, String type, String value);
+    JobStepProperty newStepProperty(String name, String type, String value);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionService.java
@@ -31,10 +31,10 @@ public interface JobStepDefinitionService extends KapuaEntityService<JobStepDefi
         KapuaDomainService<JobDomain>,
         KapuaConfigurableService {
 
-    public static final JobDomain JOB_DOMAIN = new JobDomain();
+    JobDomain JOB_DOMAIN = new JobDomain();
 
     @Override
-    public default JobDomain getServiceDomain() {
+    default JobDomain getServiceDomain() {
         return JOB_DOMAIN;
     }
 
@@ -47,6 +47,5 @@ public interface JobStepDefinitionService extends KapuaEntityService<JobStepDefi
      * @since 1.0.0
      */
     @Override
-    public JobStepDefinitionListResult query(KapuaQuery<JobStepDefinition> query)
-            throws KapuaException;
+    JobStepDefinitionListResult query(KapuaQuery<JobStepDefinition> query) throws KapuaException;
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionXmlRegistry.java
@@ -11,50 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * JobStepDefinition xml factory class
- * 
- * @since 1.0
+ * {@link JobStepDefinition} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class JobStepDefinitionXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final JobStepDefinitionFactory factory = locator.getFactory(JobStepDefinitionFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final JobStepDefinitionFactory JOB_STEP_DEFINITION_FACTORY = LOCATOR.getFactory(JobStepDefinitionFactory.class);
 
     /**
      * Creates a new job instance
-     * 
+     *
      * @return
      */
     public JobStepDefinition newJobStepDefinition() {
-        return factory.newEntity(null);
+        return JOB_STEP_DEFINITION_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new job creator instance
-     * 
+     *
      * @return
      */
     public JobStepDefinitionCreator newJobStepDefinitionCreator() {
-        return factory.newCreator(null);
+        return JOB_STEP_DEFINITION_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new job list result instance
-     * 
+     *
      * @return
      */
     public JobStepDefinitionListResult newJobStepDefinitionListResult() {
-        return factory.newListResult();
+        return JOB_STEP_DEFINITION_FACTORY.newListResult();
     }
 
     public JobStepDefinitionQuery newQuery() {
-        return factory.newQuery(null);
+        return JOB_STEP_DEFINITION_FACTORY.newQuery(null);
     }
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
@@ -13,16 +13,16 @@ package org.eclipse.kapua.service.job.step.definition;
 
 public interface JobStepProperty {
 
-    public String getName();
+    String getName();
 
-    public void setName(String name);
+    void setName(String name);
 
-    public String getPropertyType();
+    String getPropertyType();
 
-    public void setPropertyType(String propertyType);
+    void setPropertyType(String propertyType);
 
-    public String getPropertyValue();
+    String getPropertyValue();
 
-    public void setPropertyValue(String propertyValue);
+    void setPropertyValue(String propertyValue);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTarget.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTarget.java
@@ -11,49 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.targets;
 
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-
 /**
  * {@link JobTarget} entity.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "jobTarget")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobTargetXmlRegistry.class, factoryMethod = "newJobTarget")
 public interface JobTarget extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "jobTarget";
+    String TYPE = "jobTarget";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
-    public KapuaId getJobId();
+    KapuaId getJobId();
 
-    public void setJobId(KapuaId jobId);
+    void setJobId(KapuaId jobId);
 
-    public KapuaId getJobTargetId();
+    KapuaId getJobTargetId();
 
-    public void setJobTargetId(KapuaId jobTargetId);
+    void setJobTargetId(KapuaId jobTargetId);
 
-    public JobTargetStatus getStatus();
+    JobTargetStatus getStatus();
 
-    public void setStatus(JobTargetStatus status);
+    void setStatus(JobTargetStatus status);
 
-    public int getStepIndex();
+    int getStepIndex();
 
-    public void setStepIndex(int stepIndex);
+    void setStepIndex(int stepIndex);
 
-    public Exception getException();
+    Exception getException();
 
-    public void setException(Exception e);
+    void setException(Exception e);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetCreator.java
@@ -11,31 +11,30 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.targets;
 
+import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
-import org.eclipse.kapua.model.id.KapuaId;
-
 /**
  * {@link JobTargetCreator} encapsulates all the information needed to create a new JobTarget in the system.<br>
  * The data provided will be used to seed the new JobTarget.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 @XmlRootElement(name = "jobTargetCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobTargetXmlRegistry.class, factoryMethod = "newJobTargetCreator")
 public interface JobTargetCreator extends KapuaUpdatableEntityCreator<JobTarget> {
 
-    public KapuaId getJobId();
+    KapuaId getJobId();
 
-    public void setJobId(KapuaId jobId);
+    void setJobId(KapuaId jobId);
 
-    public KapuaId getJobTargetId();
+    KapuaId getJobTargetId();
 
-    public void setJobTargetId(KapuaId jobTargetId);
+    void setJobTargetId(KapuaId jobTargetId);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetService.java
@@ -31,10 +31,10 @@ public interface JobTargetService extends KapuaEntityService<JobTarget, JobTarge
         KapuaDomainService<JobDomain>,
         KapuaConfigurableService {
 
-    public static final JobDomain JOB_DOMAIN = new JobDomain();
+    JobDomain JOB_DOMAIN = new JobDomain();
 
     @Override
-    public default JobDomain getServiceDomain() {
+    default JobDomain getServiceDomain() {
         return JOB_DOMAIN;
     }
 
@@ -47,6 +47,5 @@ public interface JobTargetService extends KapuaEntityService<JobTarget, JobTarge
      * @since 1.0.0
      */
     @Override
-    public JobTargetListResult query(KapuaQuery<JobTarget> query)
-            throws KapuaException;
+    JobTargetListResult query(KapuaQuery<JobTarget> query) throws KapuaException;
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetStatus.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetStatus.java
@@ -12,6 +12,8 @@
 package org.eclipse.kapua.service.job.targets;
 
 public enum JobTargetStatus {
-    PROCESS_OK, PROCESS_FAILED, PROCESS_AWAITING
+    PROCESS_OK,
+    PROCESS_FAILED,
+    PROCESS_AWAITING
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetXmlRegistry.java
@@ -11,50 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.targets;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * JobTarget xml factory class
- * 
- * @since 1.0
+ * {@link JobTarget} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class JobTargetXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final JobTargetFactory factory = locator.getFactory(JobTargetFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final JobTargetFactory JOB_TARGET_FACTORY = LOCATOR.getFactory(JobTargetFactory.class);
 
     /**
      * Creates a new job instance
-     * 
+     *
      * @return
      */
     public JobTarget newJobTarget() {
-        return factory.newEntity(null);
+        return JOB_TARGET_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new job creator instance
-     * 
+     *
      * @return
      */
     public JobTargetCreator newJobTargetCreator() {
-        return factory.newCreator(null);
+        return JOB_TARGET_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new job list result instance
-     * 
+     *
      * @return
      */
     public JobTargetListResult newJobTargetListResult() {
-        return factory.newListResult();
+        return JOB_TARGET_FACTORY.newListResult();
     }
 
     public JobTargetQuery newQuery() {
-        return factory.newQuery(null);
+        return JOB_TARGET_FACTORY.newQuery(null);
     }
 }

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerService.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerService.java
@@ -16,10 +16,10 @@ import org.eclipse.kapua.service.KapuaService;
 
 public interface SchedulerService extends KapuaService, KapuaDomainService<SchedulerDomain> {
 
-    public static final SchedulerDomain SCHEDULER_DOMAIN = new SchedulerDomain();
+    SchedulerDomain SCHEDULER_DOMAIN = new SchedulerDomain();
 
     @Override
-    public default SchedulerDomain getServiceDomain() {
+    default SchedulerDomain getServiceDomain() {
         return SCHEDULER_DOMAIN;
     }
 

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/Trigger.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/Trigger.java
@@ -11,50 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger;
 
-import java.util.Date;
-import java.util.List;
+import org.eclipse.kapua.model.KapuaNamedEntity;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaNamedEntity;
+import java.util.Date;
+import java.util.List;
 
 /**
  * User schedule entity.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "schedule")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = TriggerXmlRegistry.class, factoryMethod = "newTrigger")
 public interface Trigger extends KapuaNamedEntity {
 
-    public static final String TYPE = "schedule";
+    String TYPE = "schedule";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
-    public Date getStartsOn();
+    Date getStartsOn();
 
-    public void setStartsOn(Date starstOn);
+    void setStartsOn(Date starstOn);
 
-    public Date getEndsOn();
+    Date getEndsOn();
 
-    public void setEndsOn(Date endsOn);
+    void setEndsOn(Date endsOn);
 
-    public String getCronScheduling();
+    String getCronScheduling();
 
-    public void setCronScheduling(String cronScheduling);
+    void setCronScheduling(String cronScheduling);
 
-    public Long getRetryInterval();
+    Long getRetryInterval();
 
-    public void setRetryInterval(Long retryInterval);
+    void setRetryInterval(Long retryInterval);
 
-    public <P extends TriggerProperty> List<P> getTriggerProperties();
+    <P extends TriggerProperty> List<P> getTriggerProperties();
 
-    public void setTriggerProperties(List<TriggerProperty> triggerProperties);
+    void setTriggerProperties(List<TriggerProperty> triggerProperties);
 }

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerCreator.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerCreator.java
@@ -11,45 +11,43 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger;
 
-import java.util.Date;
-import java.util.List;
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+import java.util.Date;
+import java.util.List;
 
 /**
  * TriggerCreator encapsulates all the information needed to create a new Trigger in the system.<br>
  * The data provided will be used to seed the new Trigger and its related information such as the associated organization and users.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "accountCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = TriggerXmlRegistry.class, factoryMethod = "newTriggerCreator")
 public interface TriggerCreator extends KapuaNamedEntityCreator<Trigger> {
 
-    public Date getStartsOn();
+    Date getStartsOn();
 
-    public void setStartsOn(Date starstOn);
+    void setStartsOn(Date starstOn);
 
-    public Date getEndsOn();
+    Date getEndsOn();
 
-    public void setEndsOn(Date endsOn);
+    void setEndsOn(Date endsOn);
 
-    public String getCronScheduling();
+    String getCronScheduling();
 
-    public void setCronScheduling(String cronScheduling);
+    void setCronScheduling(String cronScheduling);
 
-    public Long getRetryInterval();
+    Long getRetryInterval();
 
-    public void setRetryInterval(Long retryInterval);
+    void setRetryInterval(Long retryInterval);
 
-    public <P extends TriggerProperty> List<P> getTriggerProperties();
+    <P extends TriggerProperty> List<P> getTriggerProperties();
 
-    public void setTriggerProperties(List<TriggerProperty> triggerProperties);
+    void setTriggerProperties(List<TriggerProperty> triggerProperties);
 }

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerFactory.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerFactory.java
@@ -15,11 +15,10 @@ import org.eclipse.kapua.model.KapuaEntityFactory;
 
 /**
  * Trigger factory service definition.
- * 
+ *
  * @since 1.0
- * 
  */
 public interface TriggerFactory extends KapuaEntityFactory<Trigger, TriggerCreator, TriggerQuery, TriggerListResult> {
 
-    public TriggerProperty newTriggerProperty(String name, String type, String value);
+    TriggerProperty newTriggerProperty(String name, String type, String value);
 }

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerProperty.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerProperty.java
@@ -13,16 +13,16 @@ package org.eclipse.kapua.service.scheduler.trigger;
 
 public interface TriggerProperty {
 
-    public String getName();
+    String getName();
 
-    public void setName(String name);
+    void setName(String name);
 
-    public String getPropertyType();
+    String getPropertyType();
 
-    public void setPropertyType(String propertyType);
+    void setPropertyType(String propertyType);
 
-    public String getPropertyValue();
+    String getPropertyValue();
 
-    public void setPropertyValue(String propertyValue);
+    void setPropertyValue(String propertyValue);
 
 }

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerService.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerService.java
@@ -39,7 +39,6 @@ public interface TriggerService extends KapuaEntityService<Trigger, TriggerCreat
      * @since 1.0.0
      */
     @Override
-    public TriggerListResult query(KapuaQuery<Trigger> query)
-            throws KapuaException;
+    TriggerListResult query(KapuaQuery<Trigger> query) throws KapuaException;
 
 }

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerXmlRegistry.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerXmlRegistry.java
@@ -11,50 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * Trigger xml factory class
- * 
- * @since 1.0
+ * {@link Trigger} xml factory class
  *
+ * @since 1.0
  */
 @XmlRegistry
 public class TriggerXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final TriggerFactory factory = locator.getFactory(TriggerFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final TriggerFactory TRIGGER_FACTORY = LOCATOR.getFactory(TriggerFactory.class);
 
     /**
      * Creates a new schedule instance
-     * 
+     *
      * @return
      */
     public Trigger newTrigger() {
-        return factory.newEntity(null);
+        return TRIGGER_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new schedule creator instance
-     * 
+     *
      * @return
      */
     public TriggerCreator newTriggerCreator() {
-        return factory.newCreator(null);
+        return TRIGGER_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new schedule list result instance
-     * 
+     *
      * @return
      */
     public TriggerListResult newTriggerListResult() {
-        return factory.newListResult();
+        return TRIGGER_FACTORY.newListResult();
     }
 
     public TriggerQuery newQuery() {
-        return factory.newQuery(null);
+        return TRIGGER_FACTORY.newQuery(null);
     }
 }

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/SchedulerServiceInit.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/SchedulerServiceInit.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 public class SchedulerServiceInit {
 
-    private final static Logger logger = LoggerFactory.getLogger(SchedulerServiceInit.class);
+    private static final Logger logger = LoggerFactory.getLogger(SchedulerServiceInit.class);
 
     private SchedulerServiceInit() {
     }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
@@ -18,9 +18,8 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Username and password {@link AuthenticationCredentials} definition.
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "accessTokenCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -29,15 +28,15 @@ public interface AccessTokenCredentials extends SessionCredentials {
 
     /**
      * Return the token id
-     * 
+     *
      * @return
      */
-    public String getTokenId();
+    String getTokenId();
 
     /**
      * Set the token id
-     * 
+     *
      * @param tokenId
      */
-    public void setTokenId(String tokenId);
+    void setTokenId(String tokenId);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
@@ -19,9 +19,8 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Api key {@link LoginCredentials} definition.
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "apiKeyCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -30,16 +29,16 @@ public interface ApiKeyCredentials extends LoginCredentials {
 
     /**
      * return the api key
-     * 
+     *
      * @return
      */
     @XmlElement(name = "apiKey")
-    public String getApiKey();
+    String getApiKey();
 
     /**
      * Set the api key
-     * 
+     *
      * @param apiKey
      */
-    public void setApiKey(String apiKey);
+    void setApiKey(String apiKey);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -31,8 +31,7 @@ public interface AuthenticationService extends KapuaService {
      * @return
      * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
      */
-    public AccessToken login(LoginCredentials loginCredentials)
-            throws KapuaException;
+    AccessToken login(LoginCredentials loginCredentials) throws KapuaException;
 
     /**
      * FIXME: add javadoc
@@ -40,16 +39,14 @@ public interface AuthenticationService extends KapuaService {
      * @param sessionCredentials
      * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
      */
-    public void authenticate(SessionCredentials sessionCredentials)
-            throws KapuaException;
+    void authenticate(SessionCredentials sessionCredentials) throws KapuaException;
 
     /**
      * Logout the current logged user
      *
      * @throws KapuaException
      */
-    public void logout()
-            throws KapuaException;
+    void logout() throws KapuaException;
 
     /**
      * Return the {@link AccessToken} identified by the provided token identifier
@@ -58,11 +55,9 @@ public interface AuthenticationService extends KapuaService {
      * @return
      * @throws KapuaException if no {@link AccessToken} is found for that token identifier
      */
-    public AccessToken findAccessToken(String tokenId)
-            throws KapuaException;
+    AccessToken findAccessToken(String tokenId) throws KapuaException;
 
-    public AccessToken refreshAccessToken(String tokenId, String refreshToken)
-            throws KapuaException;
+    AccessToken refreshAccessToken(String tokenId, String refreshToken) throws KapuaException;
 
     /**
      * Verifies the password of a user without logging him in, and thus create any kind of session
@@ -70,7 +65,6 @@ public interface AuthenticationService extends KapuaService {
      * @param loginCredentials
      * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
      */
-    public void verifyCredentials(LoginCredentials loginCredentials)
-            throws KapuaException;
+    void verifyCredentials(LoginCredentials loginCredentials) throws KapuaException;
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationXmlRegistry.java
@@ -16,51 +16,51 @@ import org.eclipse.kapua.locator.KapuaLocator;
 
 public class AuthenticationXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final CredentialsFactory credentialsFactory = locator.getFactory(CredentialsFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final CredentialsFactory CREDENTIALS_FACTORY = LOCATOR.getFactory(CredentialsFactory.class);
 
     /**
      * Creates a new {@link UsernamePasswordCredentials} instance
-     * 
+     *
      * @return
      */
     public UsernamePasswordCredentials newUsernamePasswordCredentials() {
-        return credentialsFactory.newUsernamePasswordCredentials();
+        return CREDENTIALS_FACTORY.newUsernamePasswordCredentials();
     }
 
     /**
      * Creates a new {@link ApiKeyCredentials} instance
-     * 
+     *
      * @return
      */
     public ApiKeyCredentials newApiKeyCredentials() {
-        return credentialsFactory.newApiKeyCredentials(null);
+        return CREDENTIALS_FACTORY.newApiKeyCredentials(null);
     }
 
     /**
      * Creates a new {@link JwtCredentials} instance
-     * 
+     *
      * @return
      */
     public JwtCredentials newJwtCredentials() {
-        return credentialsFactory.newJwtCredentials(null);
+        return CREDENTIALS_FACTORY.newJwtCredentials(null);
     }
 
     /**
      * Creates a new {@link AccessTokenCredentials} instance
-     * 
+     *
      * @return
      */
     public AccessTokenCredentials newAccessTokenCredentials() {
-        return credentialsFactory.newAccessTokenCredentials(null);
+        return CREDENTIALS_FACTORY.newAccessTokenCredentials(null);
     }
 
     /**
      * Creates a new {@link RefreshTokenCredentials} instance
-     * 
+     *
      * @return
      */
     public RefreshTokenCredentials newRefreshTokenCredentials() {
-        return credentialsFactory.newRefreshTokenCredentials(null, null);
+        return CREDENTIALS_FACTORY.newRefreshTokenCredentials(null, null);
     }
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
@@ -21,54 +21,52 @@ public interface CredentialsFactory extends KapuaObjectFactory {
 
     /**
      * Creates a new {@link UsernamePasswordCredentials} instance based on provided username and password
-     * 
-     * @param username
-     *            the name of the user
-     * @param password
-     *            the password of the user
+     *
+     * @param username the name of the user
+     * @param password the password of the user
      * @return the new credentials
      */
-    public UsernamePasswordCredentials newUsernamePasswordCredentials(String username, String password);
+    UsernamePasswordCredentials newUsernamePasswordCredentials(String username, String password);
 
     /**
      * Creates a new {@link UsernamePasswordCredentials} instance based on username and password with no preset values
-     * 
+     *
      * @return the new, empty credentials instance
      */
-    public default UsernamePasswordCredentials newUsernamePasswordCredentials() {
+    default UsernamePasswordCredentials newUsernamePasswordCredentials() {
         return newUsernamePasswordCredentials(null, null);
     }
 
     /**
      * Creates a new {@link ApiKeyCredentials} instance based on provided api key
-     * 
+     *
      * @param apiKey
      * @return
      */
-    public ApiKeyCredentials newApiKeyCredentials(String apiKey);
+    ApiKeyCredentials newApiKeyCredentials(String apiKey);
 
     /**
      * Creates a new {@link JwtCredentials} instance based on provided Json Web Token
-     * 
+     *
      * @param jwt
      * @return
      */
-    public JwtCredentials newJwtCredentials(String jwt);
+    JwtCredentials newJwtCredentials(String jwt);
 
     /**
      * Creates a new {@link AccessTokenCredentials} instance based on provided tokenId
-     * 
+     *
      * @param tokenId
      * @return
      */
-    public AccessTokenCredentials newAccessTokenCredentials(String tokenId);
+    AccessTokenCredentials newAccessTokenCredentials(String tokenId);
 
     /**
      * Creates a new {@link RefreshTokenCredentials} instance based on provided tokenId and refresh token
-     * 
+     *
      * @param tokenId
      * @return
      */
-    public RefreshTokenCredentials newRefreshTokenCredentials(String tokenId, String refreshToken);
+    RefreshTokenCredentials newRefreshTokenCredentials(String tokenId, String refreshToken);
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
@@ -19,9 +19,8 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Jwt {@link LoginCredentials} definition.
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "jwtCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -30,16 +29,16 @@ public interface JwtCredentials extends LoginCredentials {
 
     /**
      * Gets the Json Web Token
-     * 
+     *
      * @return
      */
     @XmlElement(name = "jwt")
-    public String getJwt();
+    String getJwt();
 
     /**
      * Set the Json Web Token
-     * 
+     *
      * @param jwt
      */
-    public void setJwt(String jwt);
+    void setJwt(String jwt);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/KapuaPrincipal.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/KapuaPrincipal.java
@@ -11,53 +11,52 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication;
 
-import java.security.Principal;
-
 import org.eclipse.kapua.model.id.KapuaId;
+
+import java.security.Principal;
 
 /**
  * Kapua {@link Principal} implementation.<br>
  * Uniquely identifies a user.
- * 
+ *
  * @since 1.0
- * 
  */
 // TODO it's an object used by both authorization and authentication... should leave it in authentication module?
 public interface KapuaPrincipal extends Principal, java.io.Serializable {
 
     /**
      * Return the token identifier
-     * 
+     *
      * @return
      */
-    public String getTokenId();
+    String getTokenId();
 
     /**
      * Return the user id
-     * 
+     *
      * @return
      */
-    public KapuaId getUserId();
+    KapuaId getUserId();
 
     /**
      * Retur the account it
-     * 
+     *
      * @return
      */
-    public KapuaId getAccountId();
+    KapuaId getAccountId();
 
     /**
      * Return the remote client ip from which the user should be connected
-     * 
+     *
      * @return
      */
-    public String getClientIp();
+    String getClientIp();
 
     /**
      * Return the client identifiers from which the user should be connected
-     * 
+     *
      * @return
      */
-    public String getClientId();
+    String getClientId();
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
@@ -19,9 +19,8 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Api key {@link LoginCredentials} definition.
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "refreshTokenCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -30,31 +29,31 @@ public interface RefreshTokenCredentials extends LoginCredentials {
 
     /**
      * return the token id
-     * 
+     *
      * @return
      */
     @XmlElement(name = "tokenId")
-    public String getTokenId();
+    String getTokenId();
 
     /**
      * Set the token id
-     * 
+     *
      * @param tokenId
      */
-    public void setTokenId(String tokenId);
+    void setTokenId(String tokenId);
 
     /**
      * return the refresh token
-     * 
+     *
      * @return
      */
     @XmlElement(name = "refreshToken")
-    public String getRefreshToken();
+    String getRefreshToken();
 
     /**
      * Set the refresh token
-     * 
+     *
      * @param refreshToken
      */
-    public void setRefreshToken(String refreshToken);
+    void setRefreshToken(String refreshToken);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -18,9 +18,8 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Username and password {@link LoginCredentials} definition.
- * 
+ *
  * @since 1.0
- * 
  */
 @XmlRootElement(name = "usernamePasswordCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -29,29 +28,29 @@ public interface UsernamePasswordCredentials extends LoginCredentials {
 
     /**
      * return the username
-     * 
+     *
      * @return
      */
-    public String getUsername();
+    String getUsername();
 
     /**
      * Set the username
-     * 
+     *
      * @param username
      */
-    public void setUsername(String username);
+    void setUsername(String username);
 
     /**
      * return the password
-     * 
+     *
      * @return
      */
-    public String getPassword();
+    String getPassword();
 
     /**
      * Set the password
-     * 
+     *
      * @param password
      */
-    public void setPassword(String password);
+    void setPassword(String password);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
@@ -11,27 +11,25 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 
 /**
  * Credential definition.<br>
  * Used to handle credentials needed by the various authentication algorithms.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "credential")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -43,62 +41,64 @@ import java.util.Date;
         "loginFailures",
         "firstLoginFailure",
         "loginFailuresReset",
-        "lockoutReset"}, //
+        "lockoutReset" }, //
         factoryClass = CredentialXmlRegistry.class, //
         factoryMethod = "newCredential") //
 public interface Credential extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "credential";
+    String TYPE = "credential";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Return the user identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getUserId();
+    KapuaId getUserId();
 
     /**
      * Sets the user identifier
      */
-    public void setUserId(KapuaId userId);
+    void setUserId(KapuaId userId);
 
     /**
      * Return the credential type
-     * 
+     *
      * @return
      */
     @XmlElement(name = "credentialType")
-    public CredentialType getCredentialType();
+    CredentialType getCredentialType();
 
     /**
      * Sets the user credential type
      */
-    public void setCredentialType(CredentialType credentialType);
+    void setCredentialType(CredentialType credentialType);
 
     /**
      * Return the credential key
-     * 
+     *
      * @return
      */
     @XmlElement(name = "credentialKey")
-    public String getCredentialKey();
+    String getCredentialKey();
 
     /**
      * Sets the credential key
-     * 
+     *
      * @param credentialKey
      */
-    public void setCredentialKey(String credentialKey);
+    void setCredentialKey(String credentialKey);
 
     /**
      * Returns the current Credential status
+     *
      * @return the Credential status
      * @see CredentialStatus
      */
@@ -107,32 +107,37 @@ public interface Credential extends KapuaUpdatableEntity {
 
     /**
      * Sets the current Credential status
+     *
      * @param status The credential status
      */
     void setCredentialStatus(CredentialStatus status);
 
     /**
      * Gets the current Credential expiration date
+     *
      * @return the current Credential expiration date
      */
-    @XmlElement(name="expirationDate")
+    @XmlElement(name = "expirationDate")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
     Date getExpirationDate();
 
     /**
      * Sets the current Credential expiration date
+     *
      * @param expirationDate the current Credential expiration date
      */
     void setExpirationDate(Date expirationDate);
 
     /**
      * Gets how many times this credential failed a login
+     *
      * @return an integer representing login failures for this credential
      */
     int getLoginFailures();
 
     /**
      * Sets how many times this credential failed a login
+     *
      * @param loginFailures the new failed logins count
      */
     void setLoginFailures(int loginFailures);
@@ -140,46 +145,49 @@ public interface Credential extends KapuaUpdatableEntity {
     /**
      * Gets a date indicating when the first login attempt failed after
      * the login attempts have been reset
-     * @return A {@link Date} object indicating when the first login
-     * attempt failed after the login attempts have been reset
+     *
+     * @return A {@link Date} object indicating when the first login attempt failed after the login attempts have been reset
      */
-    @XmlElement(name="firstLoginFailure")
+    @XmlElement(name = "firstLoginFailure")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
     Date getFirstLoginFailure();
 
     /**
      * Sets a date indicating when the first login attempt failed after
      * the login attempts have been reset
-     * @param firstLoginFailure A {@link Date} object indicating when the first login
-     * attempt failed after the login attempts have been reset
+     *
+     * @param firstLoginFailure A {@link Date} object indicating when the first login attempt failed after the login attempts have been reset
      */
     void setFirstLoginFailure(Date firstLoginFailure);
 
     /**
      * Gets a date indicating when the failed login attempts will be reset
+     *
      * @return A {@link Date} object indicating when the failed login attempts will be reset
      */
-    @XmlElement(name="loginFailuresReset")
+    @XmlElement(name = "loginFailuresReset")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
     Date getLoginFailuresReset();
 
     /**
      * Sets a date indicating when the failed login attempts will be reset
-     * @param loginFailuresReset A {@link Date} object indicating when the
-     * failed login attempts will be reset
+     *
+     * @param loginFailuresReset A {@link Date} object indicating when the failed login attempts will be reset
      */
     void setLoginFailuresReset(Date loginFailuresReset);
 
     /**
      * Gets a date indicating when the lockout will be lifted from the credential
+     *
      * @return A {@link Date} object indicating when the lockout will be reset
      */
-    @XmlElement(name="lockoutReset")
+    @XmlElement(name = "lockoutReset")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
     Date getLockoutReset();
 
     /**
      * Sets a date indicating when the lockout will be lifted from the credential
+     *
      * @param lockoutReset A {@link Date} object indicating when the lockout will be reset
      */
     void setLockoutReset(Date lockoutReset);

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
@@ -11,26 +11,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 
 /**
  * Credential creator service definition.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @XmlRootElement(name = "credentialCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -43,51 +41,51 @@ public interface CredentialCreator extends KapuaEntityCreator<Credential> {
 
     /**
      * Return the user identifier
-     * 
+     *
      * @return
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getUserId();
+    KapuaId getUserId();
 
     /**
      * Set the credential user id
-     * 
+     *
      * @param userId
      */
-    public void setUserId(KapuaId userId);
+    void setUserId(KapuaId userId);
 
     /**
      * Return the credential type.<br>
      * The returned object will depend on the authentication algorithm.
-     * 
+     *
      * @return
      */
     @XmlElement(name = "credentialType")
-    public CredentialType getCredentialType();
+    CredentialType getCredentialType();
 
     /**
      * Set the credential type
-     * 
+     *
      * @param credentialType
      */
-    public void setCredentialType(CredentialType credentialType);
+    void setCredentialType(CredentialType credentialType);
 
     /**
      * Return the plain credential (unencrypted value).
-     * 
+     *
      * @return
      */
     @XmlElement(name = "credentialKey")
-    public String getCredentialPlainKey();
+    String getCredentialPlainKey();
 
     /**
      * Set the credential plain key
-     * 
+     *
      * @param plainKey
      */
-    public void setCredentialPlainKey(String plainKey);
+    void setCredentialPlainKey(String plainKey);
 
     @XmlElement(name = "expirationDate")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialFactory.java
@@ -20,7 +20,6 @@ import java.util.Date;
  * Credential factory service definition.
  *
  * @since 1.0
- *
  */
 public interface CredentialFactory extends KapuaEntityFactory<Credential, CredentialCreator, CredentialQuery, CredentialListResult> {
 
@@ -33,7 +32,7 @@ public interface CredentialFactory extends KapuaEntityFactory<Credential, Creden
      * @param credentialKey
      * @return
      */
-    public Credential newCredential(KapuaId scopeId, KapuaId userId, CredentialType credentialType, String credentialKey, CredentialStatus credentialStatus, Date expirationDate);
+    Credential newCredential(KapuaId scopeId, KapuaId userId, CredentialType credentialType, String credentialKey, CredentialStatus credentialStatus, Date expirationDate);
 
     /**
      * Create a new {@link CredentialCreator} for the specific credential type
@@ -44,6 +43,6 @@ public interface CredentialFactory extends KapuaEntityFactory<Credential, Creden
      * @param credentialKey
      * @return
      */
-    public CredentialCreator newCreator(KapuaId scopeId, KapuaId userId, CredentialType credentialType, String credentialKey, CredentialStatus credentialStatus, Date expirationDate);
+    CredentialCreator newCreator(KapuaId scopeId, KapuaId userId, CredentialType credentialType, String credentialKey, CredentialStatus credentialStatus, Date expirationDate);
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialPredicates.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialPredicates.java
@@ -11,21 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential;
 
+import org.eclipse.kapua.model.KapuaUpdatableEntityPredicates;
+
 /**
  * Credential predicates used to build query predicates.
- * 
+ *
  * @since 1.0.0
- * 
  */
-public class CredentialPredicates {
+public interface CredentialPredicates extends KapuaUpdatableEntityPredicates {
 
-    private CredentialPredicates() {
-    }
-
-    public static final String USER_ID = "userId";
-    public static final String CREDENTIAL_TYPE = "credentialType";
-    public static final String CREDENTIAL_KEY = "credentialKey";
-    public static final String USER_NAME = "userName";
-    public static final String EXPIRATION_DATE = "expirationDate";
+    String USER_ID = "userId";
+    String CREDENTIAL_TYPE = "credentialType";
+    String CREDENTIAL_KEY = "credentialKey";
+    String EXPIRATION_DATE = "expirationDate";
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
@@ -29,10 +29,10 @@ public interface CredentialService extends KapuaEntityService<Credential, Creden
         KapuaDomainService<CredentialDomain>,
         KapuaConfigurableService {
 
-    public static final CredentialDomain CREDENTIAL_DOMAIN = new CredentialDomain();
+    CredentialDomain CREDENTIAL_DOMAIN = new CredentialDomain();
 
     @Override
-    public default CredentialDomain getServiceDomain() {
+    default CredentialDomain getServiceDomain() {
         return CREDENTIAL_DOMAIN;
     }
 
@@ -45,7 +45,7 @@ public interface CredentialService extends KapuaEntityService<Credential, Creden
      * @throws KapuaException
      * @since 1.0
      */
-    public CredentialListResult findByUserId(KapuaId scopeId, KapuaId userId)
+    CredentialListResult findByUserId(KapuaId scopeId, KapuaId userId)
             throws KapuaException;
 
     /**
@@ -56,7 +56,7 @@ public interface CredentialService extends KapuaEntityService<Credential, Creden
      * @throws KapuaException
      * @since 1.0
      */
-    public Credential findByApiKey(String tokenApiKey) throws KapuaException;
+    Credential findByApiKey(String tokenApiKey) throws KapuaException;
 
     /**
      * Queries for all users
@@ -64,7 +64,7 @@ public interface CredentialService extends KapuaEntityService<Credential, Creden
      * @param query
      */
     @Override
-    public CredentialListResult query(KapuaQuery<Credential> query)
+    CredentialListResult query(KapuaQuery<Credential> query)
             throws KapuaException;
 
     /**
@@ -74,5 +74,5 @@ public interface CredentialService extends KapuaEntityService<Credential, Creden
      * @param credentialId
      * @throws KapuaException
      */
-    public void unlock(KapuaId scopeId, KapuaId credentialId) throws KapuaException;
+    void unlock(KapuaId scopeId, KapuaId credentialId) throws KapuaException;
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialXmlRegistry.java
@@ -11,44 +11,44 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class CredentialXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final CredentialFactory factory = locator.getFactory(CredentialFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final CredentialFactory CREDENTIAL_FACTORY = LOCATOR.getFactory(CredentialFactory.class);
 
     /**
      * Creates a new credential instance
-     * 
+     *
      * @return
      */
     public Credential newCredential() {
-        return factory.newEntity(null);
+        return CREDENTIAL_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new credential list result instance
-     * 
+     *
      * @return
      */
     public CredentialListResult newCredentialListResult() {
-        return factory.newListResult();
+        return CREDENTIAL_FACTORY.newListResult();
     }
 
     /**
      * Creates a new credential creator instance
-     * 
+     *
      * @return
      */
     public CredentialCreator newCredentialCreator() {
-        return factory.newCreator(null, null, null, null, null, null);
+        return CREDENTIAL_FACTORY.newCreator(null, null, null, null, null, null);
     }
 
     public CredentialQuery newQuery() {
-        return factory.newQuery(null);
+        return CREDENTIAL_FACTORY.newQuery(null);
     }
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/registration/RegistrationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/registration/RegistrationService.java
@@ -17,11 +17,12 @@ import org.eclipse.kapua.service.authentication.JwtCredentials;
 
 public interface RegistrationService extends KapuaService {
 
-    public boolean createAccount(JwtCredentials credentials) throws KapuaException;
+    boolean createAccount(JwtCredentials credentials) throws KapuaException;
 
     /**
      * Test if account creation is enabled
+     *
      * @return {@code true} if account creation is enabled, {@code false} otherwise
      */
-    public boolean isAccountCreationEnabled();
+    boolean isAccountCreationEnabled();
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
@@ -11,8 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.token;
 
-import java.io.Serializable;
-import java.util.Date;
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
+import org.eclipse.kapua.service.user.User;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -20,13 +24,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.model.xml.DateXmlAdapter;
-import org.eclipse.kapua.service.user.User;
+import java.io.Serializable;
+import java.util.Date;
 
 /**
  * {@link AccessToken} entity.
@@ -47,9 +46,10 @@ import org.eclipse.kapua.service.user.User;
         factoryMethod = "newAccessToken")
 public interface AccessToken extends KapuaUpdatableEntity, Serializable {
 
-    public static final String TYPE = "accessToken";
+    String TYPE = "accessToken";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
@@ -60,37 +60,34 @@ public interface AccessToken extends KapuaUpdatableEntity, Serializable {
      * @since 1.0.0
      */
     @XmlElement(name = "tokenId")
-    public String getTokenId();
+    String getTokenId();
 
     /**
      * Sets the token id
      *
-     * @param tokenId
-     *            The token id.
+     * @param tokenId The token id.
      * @since 1.0.0
      */
-    public void setTokenId(String tokenId);
+    void setTokenId(String tokenId);
 
     /**
      * Return the user identifier
      *
      * @return The user identifier.
-     *
      * @since 1.0.0
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getUserId();
+    KapuaId getUserId();
 
     /**
      * Sets the {@link User} id of this {@link AccessToken}
      *
-     * @param userId
-     *            The {@link User} id to set.
+     * @param userId The {@link User} id to set.
      * @since 1.0.0
      */
-    public void setUserId(KapuaId userId);
+    void setUserId(KapuaId userId);
 
     /**
      * Gets the expire date of this token.
@@ -100,16 +97,15 @@ public interface AccessToken extends KapuaUpdatableEntity, Serializable {
      */
     @XmlElement(name = "expiresOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getExpiresOn();
+    Date getExpiresOn();
 
     /**
      * Sets the expire date of this token.
      *
-     * @param expiresOn
-     *            The expire date of this token.
+     * @param expiresOn The expire date of this token.
      * @since 1.0.0
      */
-    public void setExpiresOn(Date expiresOn);
+    void setExpiresOn(Date expiresOn);
 
     /**
      * Gets the refresh token to obtain a new {@link AccessToken} after expiration.
@@ -118,16 +114,15 @@ public interface AccessToken extends KapuaUpdatableEntity, Serializable {
      * @since 1.0.0
      */
     @XmlElement(name = "refreshToken")
-    public String getRefreshToken();
+    String getRefreshToken();
 
     /**
      * Sets the refresh token to obtain a new {@link AccessToken} after expiration.
      *
-     * @param refreshToken
-     *            The refresh token
+     * @param refreshToken The refresh token
      * @since 1.0.0
      */
-    public void setRefreshToken(String refreshToken);
+    void setRefreshToken(String refreshToken);
 
     /**
      * Gets the expiration date of the refresh token.
@@ -137,16 +132,15 @@ public interface AccessToken extends KapuaUpdatableEntity, Serializable {
      */
     @XmlElement(name = "refreshExpiresOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getRefreshExpiresOn();
+    Date getRefreshExpiresOn();
 
     /**
      * Sets the expire date of this token.
      *
-     * @param refreshExpiresOn
-     *            The expiration date of the refresh token.
+     * @param refreshExpiresOn The expiration date of the refresh token.
      * @since 1.0.0
      */
-    public void setRefreshExpiresOn(Date refreshExpiresOn);
+    void setRefreshExpiresOn(Date refreshExpiresOn);
 
     /**
      * Gets the date the token has been invalidated (i.e. the date
@@ -154,22 +148,20 @@ public interface AccessToken extends KapuaUpdatableEntity, Serializable {
      * to a logout)
      *
      * @return The date the token has been invalidated.
-     *
      * @since 1.0.0
      */
     @XmlElement(name = "invalidatedOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getInvalidatedOn();
+    Date getInvalidatedOn();
 
     /**
      * Sets the date the token has been invalidated (i.e. the date
      * the refresh token has been used, or it has been invalidated due
      * to a logout)
      *
-     * @param invalidatedOn
-     *            The date when the token has been invalidated.
+     * @param invalidatedOn The date when the token has been invalidated.
      * @since 1.0.0
      */
-    public void setInvalidatedOn(Date invalidatedOn);
+    void setInvalidatedOn(Date invalidatedOn);
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
@@ -11,22 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.token;
 
-import java.util.Date;
+import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.model.KapuaEntityCreator;
-import org.eclipse.kapua.model.id.KapuaId;
+import java.util.Date;
 
 /**
  * Access token creator service definition
  *
  * @since 1.0
- * 
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -42,57 +40,54 @@ public interface AccessTokenCreator extends KapuaEntityCreator<AccessToken> {
 
     /**
      * Gets the token id
-     * 
+     *
      * @return The token id
      * @since 1.0
      */
     @XmlElement(name = "tokenId")
-    public String getTokenId();
+    String getTokenId();
 
     /**
      * Sets the token id
-     * 
-     * @param tokenId
-     *            the token id to set
+     *
+     * @param tokenId the token id to set
      * @since 1.0
      */
-    public void setTokenId(String tokenId);
+    void setTokenId(String tokenId);
 
     /**
      * Gets the user id owner of this token
-     * 
+     *
      * @return The user id owner of this token
      * @since 1.0
      */
     @XmlElement(name = "userId")
-    public KapuaId getUserId();
+    KapuaId getUserId();
 
     /**
      * Sets the user id owner of this token.
-     * 
-     * @param userId
-     *            The user id owner of this token.
+     *
+     * @param userId The user id owner of this token.
      * @since 1.0
      */
-    public void setUserId(KapuaId userId);
+    void setUserId(KapuaId userId);
 
     /**
      * Gets the expire date of this token.
-     * 
+     *
      * @return The expire date of this token.
      * @since 1.0
      */
     @XmlElement(name = "expiresOn")
-    public Date getExpiresOn();
+    Date getExpiresOn();
 
     /**
      * Sets the expire date of this token.
-     * 
-     * @param expiresOn
-     *            The expire date of this token.
+     *
+     * @param expiresOn The expire date of this token.
      * @since 1.0
      */
-    public void setExpiresOn(Date expiresOn);
+    void setExpiresOn(Date expiresOn);
 
     /**
      * Gets the refresh token to obtain a new {@link AccessToken} after expiration.
@@ -100,16 +95,15 @@ public interface AccessTokenCreator extends KapuaEntityCreator<AccessToken> {
      * @since 1.0
      */
     @XmlElement(name = "refreshToken")
-    public String getRefreshToken();
+    String getRefreshToken();
 
     /**
      * Sets the refresh token to obtain a new {@link AccessToken} after expiration.
-     * 
-     * @param refreshToken
-     *            The refresh token
+     *
+     * @param refreshToken The refresh token
      * @since 1.0
      */
-    public void setRefreshToken(String refreshToken);
+    void setRefreshToken(String refreshToken);
 
     /**
      * Gets the expiration date of the refresh token.
@@ -117,14 +111,13 @@ public interface AccessTokenCreator extends KapuaEntityCreator<AccessToken> {
      * @since 1.0
      */
     @XmlElement(name = "refreshExpiresOn")
-    public Date getRefreshExpiresOn();
+    Date getRefreshExpiresOn();
 
     /**
      * Sets the expire date of this token.
      *
-     * @param refreshExpiresOn
-     *            The expiration date of the refresh token.
+     * @param refreshExpiresOn The expiration date of the refresh token.
      * @since 1.0
      */
-    public void setRefreshExpiresOn(Date refreshExpiresOn);
+    void setRefreshExpiresOn(Date refreshExpiresOn);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenFactory.java
@@ -11,37 +11,29 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.token;
 
-import java.util.Date;
-
 import org.eclipse.kapua.model.KapuaEntityFactory;
 import org.eclipse.kapua.model.id.KapuaId;
 
+import java.util.Date;
+
 /**
  * Access token factory service definition.
- * 
+ *
  * @since 1.0
- * 
  */
 public interface AccessTokenFactory extends KapuaEntityFactory<AccessToken, AccessTokenCreator, AccessTokenQuery, AccessTokenListResult> {
 
     /**
      * Create a new {@link AccessTokenCreator} for the specific access credential type
-     * 
-     * @param scopeId
-     *            The scopeId of the new {@link AccessToken}.
-     * @param userId
-     *            The userId owner of the new {@link AccessToken}.
-     * @param tokenId
-     *            The tokenId of the new {@link AccessToken}.
-     * @param expiresOn
-     *            The expiration date after which the token is no longer valid.
-     * @param refreshToken
-     *            The refresh token to obtain a new {@link AccessToken} after expiration.
-     * 
+     *
+     * @param scopeId      The scopeId of the new {@link AccessToken}.
+     * @param userId       The userId owner of the new {@link AccessToken}.
+     * @param tokenId      The tokenId of the new {@link AccessToken}.
+     * @param expiresOn    The expiration date after which the token is no longer valid.
+     * @param refreshToken The refresh token to obtain a new {@link AccessToken} after expiration.
      * @return A new instance of {@link AccessTokenCreator}.
-     * 
      * @since 1.0
      */
-    public AccessTokenCreator newCreator(KapuaId scopeId, KapuaId userId, String tokenId, Date expiresOn, String refreshToken, Date refreshExpiresOn);
+    AccessTokenCreator newCreator(KapuaId scopeId, KapuaId userId, String tokenId, Date expiresOn, String refreshToken, Date refreshExpiresOn);
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenPredicates.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenPredicates.java
@@ -11,18 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.token;
 
+import org.eclipse.kapua.model.KapuaUpdatableEntityPredicates;
+
 /**
  * Access Token predicates used to build query predicates.
- * 
+ *
  * @since 1.0
- * 
  */
-public class AccessTokenPredicates {
+public interface AccessTokenPredicates extends KapuaUpdatableEntityPredicates {
 
-    private AccessTokenPredicates() {
-    }
-
-    public static final String TOKEN_ID = "tokenId";
-    public static final String USER_ID = "userId";
+    String TOKEN_ID = "tokenId";
+    String USER_ID = "userId";
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
@@ -25,10 +25,10 @@ import org.eclipse.kapua.service.authentication.AuthenticationService;
  */
 public interface AccessTokenService extends KapuaEntityService<AccessToken, AccessTokenCreator>, KapuaUpdatableEntityService<AccessToken>, KapuaDomainService<AccessTokenDomain> {
 
-    public static final AccessTokenDomain ACCESS_TOKEN_DOMAIN = new AccessTokenDomain();
+    AccessTokenDomain ACCESS_TOKEN_DOMAIN = new AccessTokenDomain();
 
     @Override
-    public default AccessTokenDomain getServiceDomain() {
+    default AccessTokenDomain getServiceDomain() {
         return ACCESS_TOKEN_DOMAIN;
     }
 
@@ -41,8 +41,7 @@ public interface AccessTokenService extends KapuaEntityService<AccessToken, Acce
      * @throws KapuaException
      * @since 1.0
      */
-    public AccessTokenListResult findByUserId(KapuaId scopeId, KapuaId userId)
-            throws KapuaException;
+    AccessTokenListResult findByUserId(KapuaId scopeId, KapuaId userId) throws KapuaException;
 
     /**
      * Find the access token by the given tokenId.
@@ -52,8 +51,7 @@ public interface AccessTokenService extends KapuaEntityService<AccessToken, Acce
      * @throws KapuaException
      * @since 1.0
      */
-    public AccessToken findByTokenId(String tokenId)
-            throws KapuaException;
+    AccessToken findByTokenId(String tokenId) throws KapuaException;
 
     /**
      * Invalidated the {@link AccessToken} by its id. After calling this method the token will be no longer valid and a new
@@ -63,5 +61,5 @@ public interface AccessTokenService extends KapuaEntityService<AccessToken, Acce
      * @param id      The {@link KapuaId} of the {@link AccessToken} to delete.
      * @since 1.0
      */
-    public void invalidate(KapuaId scopeId, KapuaId id) throws KapuaException;
+    void invalidate(KapuaId scopeId, KapuaId id) throws KapuaException;
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenXmlRegistry.java
@@ -15,14 +15,14 @@ import org.eclipse.kapua.locator.KapuaLocator;
 
 public class AccessTokenXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final AccessTokenFactory factory = locator.getFactory(AccessTokenFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AccessTokenFactory ACCESS_TOKEN_FACTORY = LOCATOR.getFactory(AccessTokenFactory.class);
 
     public AccessToken newAccessToken() {
-        return factory.newEntity(null);
+        return ACCESS_TOKEN_FACTORY.newEntity(null);
     }
 
     public AccessTokenCreator newAccessTokenCreator() {
-        return factory.newCreator(null, null, null, null, null, null);
+        return ACCESS_TOKEN_FACTORY.newCreator(null, null, null, null, null, null);
     }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationService.java
@@ -19,35 +19,27 @@ import org.eclipse.kapua.service.authorization.permission.Permission;
  * AuthenticationService exposes APIs to manage User object under an Account.<br>
  * It includes APIs to create, update, find, list and delete Users.<br>
  * Instances of the UserService can be acquired through the ServiceLocator.
- * 
+ *
  * @since 1.0.0
- * 
  */
 public interface AuthorizationService extends KapuaService {
 
     /**
      * Returns if the user (the current logged user retrieved by thread context) is allowed to perform the operation identified by provided the permission.
-     * 
-     * @param permission
-     *            The permission to check.
+     *
+     * @param permission The permission to check.
      * @return {@code true} if the current user has the given permission, {@code false} otherwise.
-     * @throws KapuaException
-     *             If there is no logged context.
-     * 
+     * @throws KapuaException If there is no logged context.
      * @since 1.0.0
      */
-    public boolean isPermitted(Permission permission)
-            throws KapuaException;
+    boolean isPermitted(Permission permission) throws KapuaException;
 
     /**
      * Checks if the user (the current logged user retrieved by thread context) is allowed to perform the operation identified by provided the permission.
-     * 
-     * @param permission
-     *            The permission to check.
-     * @throws KapuaException
-     *             if there is no logged context or if the user has no right for the provided permission.
+     *
+     * @param permission The permission to check.
+     * @throws KapuaException if there is no logged context or if the user has no right for the provided permission.
      * @since 1.0.0
      */
-    public void checkPermission(Permission permission)
-            throws KapuaException;
+    void checkPermission(Permission permission) throws KapuaException;
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
@@ -11,6 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -18,18 +23,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-
 /**
  * Access info entity definition.<br>
  * It contains all authorization accesses for a {@link org.eclipse.kapua.service.user.User}.<br>
  * It refers to the {@link org.eclipse.kapua.service.user.User} entity by the {@link AccessInfo#getUserId()} property.<br>
  * <br>
  * {@link AccessInfo} is unique by the {@link AccessInfo#getUserId()} property.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement
@@ -39,29 +39,29 @@ import org.eclipse.kapua.model.id.KapuaIdAdapter;
         factoryMethod = "newAccessInfo")
 public interface AccessInfo extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "accessInfo";
+    String TYPE = "accessInfo";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Sets the user id.
-     * 
-     * @param userId
-     *            The user id.
+     *
+     * @param userId The user id.
      * @since 1.0.0
      */
-    public void setUserId(KapuaId userId);
+    void setUserId(KapuaId userId);
 
     /**
      * Gets the user id.
-     * 
+     *
      * @return The user id.
      * @since 1.0.0
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getUserId();
+    KapuaId getUserId();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
@@ -11,17 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
-import java.security.Permissions;
-import java.util.Set;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -30,55 +19,63 @@ import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.user.User;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.security.Permissions;
+import java.util.Set;
+
 /**
  * {@link AccessInfo} creator definition.<br>
  * It is used to assign a set of {@link Domain}s and {@link Permission}s to the referenced {@link User}.<br>
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder = { "userId",
-                       "roleIds",
-                       "permissions" },
-         factoryClass = AccessInfoXmlRegistry.class, 
-         factoryMethod = "newAccessInfoCreator")
+        "roleIds",
+        "permissions" },
+        factoryClass = AccessInfoXmlRegistry.class,
+        factoryMethod = "newAccessInfoCreator")
 public interface AccessInfoCreator extends KapuaEntityCreator<AccessInfo> {
 
     /**
      * Sets the user identifier.
-     * 
-     * @param userId
-     *            The user id to set.
+     *
+     * @param userId The user id to set.
      * @since 1.0.0
      */
-    public void setUserId(KapuaId userId);
+    void setUserId(KapuaId userId);
 
     /**
      * Gets the user id.
-     * 
+     *
      * @return The user id.
      * @since 1.0.0
      */
     @XmlElement(name = "userId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getUserId();
+    KapuaId getUserId();
 
     /**
      * Sets the set of {@link Domain} ids to assign to the {@link AccessInfo} created entity.
      * It up to the implementation class to make a clone of the set or use the given set.
-     * 
-     * @param roleIds
-     *            The set of {@link Domain} ids.
+     *
+     * @param roleIds The set of {@link Domain} ids.
      * @since 1.0.0
      */
-    public void setRoleIds(Set<KapuaId> roleIds);
+    void setRoleIds(Set<KapuaId> roleIds);
 
     /**
      * Gets the set of {@link Domain} ids added to this {@link AccessInfoCreator}.
      * The implementation must return the reference of the set and not make a clone.
-     * 
+     *
      * @return The set of {@link Domain} ids.
      * @since 1.0.0
      */
@@ -86,27 +83,26 @@ public interface AccessInfoCreator extends KapuaEntityCreator<AccessInfo> {
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public Set<KapuaId> getRoleIds();
+    Set<KapuaId> getRoleIds();
 
     /**
      * Sets the set of {@link Permissions} to assign to the {@link AccessInfo} created entity.
      * It up to the implementation class to make a clone of the set or use the given set.
-     * 
-     * @param permissions
-     *            The set of {@link Permissions}.
+     *
+     * @param permissions The set of {@link Permissions}.
      * @since 1.0.0
      */
-    public void setPermissions(Set<Permission> permissions);
+    void setPermissions(Set<Permission> permissions);
 
     /**
      * Gets the set of {@link Permission} added to this {@link AccessInfoCreator}.
      * The implementation must return the reference of the set and not make a clone.
-     * 
+     *
      * @return The set of {@link Permission}.
      * @since 1.0.0
      */
     @XmlElementWrapper(name = "permissions")
     @XmlElement(name = "permission")
-    public <P extends Permission> Set<P> getPermissions();
+    <P extends Permission> Set<P> getPermissions();
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoPredicates.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoPredicates.java
@@ -11,19 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
+import org.eclipse.kapua.model.KapuaUpdatableEntityPredicates;
+
 /**
  * Query predicate attribute name for {@link AccessInfo} entity.
- * 
+ *
  * @since 1.0.0
- * 
  */
-public class AccessInfoPredicates {
-
-    private AccessInfoPredicates() {
-    }
+public interface AccessInfoPredicates extends KapuaUpdatableEntityPredicates {
 
     /**
      * User id
      */
-    public static final String USER_ID = "userId";
+    String USER_ID = "userId";
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoService.java
@@ -25,10 +25,10 @@ import org.eclipse.kapua.service.user.User;
  */
 public interface AccessInfoService extends KapuaEntityService<AccessInfo, AccessInfoCreator>, KapuaDomainService<AccessInfoDomain> {
 
-    public static final AccessInfoDomain ACCESS_INFO_DOMAIN = new AccessInfoDomain();
+    AccessInfoDomain ACCESS_INFO_DOMAIN = new AccessInfoDomain();
 
     @Override
-    public default AccessInfoDomain getServiceDomain() {
+    default AccessInfoDomain getServiceDomain() {
         return ACCESS_INFO_DOMAIN;
     }
 
@@ -42,7 +42,7 @@ public interface AccessInfoService extends KapuaEntityService<AccessInfo, Access
      * @since 1.0.0
      */
     @Override
-    public AccessInfo create(AccessInfoCreator accessInfoCreator)
+    AccessInfo create(AccessInfoCreator accessInfoCreator)
             throws KapuaException;
 
     /**
@@ -54,7 +54,7 @@ public interface AccessInfoService extends KapuaEntityService<AccessInfo, Access
      * @throws KapuaException
      * @since 1.0.0
      */
-    public AccessInfo findByUserId(KapuaId scopeId, KapuaId userId)
+    AccessInfo findByUserId(KapuaId scopeId, KapuaId userId)
             throws KapuaException;
 
     /**
@@ -67,7 +67,7 @@ public interface AccessInfoService extends KapuaEntityService<AccessInfo, Access
      * @since 1.0.0
      */
     @Override
-    public AccessInfo find(KapuaId scopeId, KapuaId accessInfoId)
+    AccessInfo find(KapuaId scopeId, KapuaId accessInfoId)
             throws KapuaException;
 
     /**
@@ -79,7 +79,7 @@ public interface AccessInfoService extends KapuaEntityService<AccessInfo, Access
      * @since 1.0.0
      */
     @Override
-    public AccessInfoListResult query(KapuaQuery<AccessInfo> query)
+    AccessInfoListResult query(KapuaQuery<AccessInfo> query)
             throws KapuaException;
 
     /**
@@ -91,7 +91,7 @@ public interface AccessInfoService extends KapuaEntityService<AccessInfo, Access
      * @since 1.0.0
      */
     @Override
-    public long count(KapuaQuery<AccessInfo> query)
+    long count(KapuaQuery<AccessInfo> query)
             throws KapuaException;
 
     /**
@@ -103,6 +103,6 @@ public interface AccessInfoService extends KapuaEntityService<AccessInfo, Access
      * @since 1.0.0
      */
     @Override
-    public void delete(KapuaId scopeId, KapuaId accessInfoId)
+    void delete(KapuaId scopeId, KapuaId accessInfoId)
             throws KapuaException;
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoXmlRegistry.java
@@ -11,44 +11,44 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class AccessInfoXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final AccessInfoFactory factory = locator.getFactory(AccessInfoFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AccessInfoFactory ACCESS_INFO_FACTORY = LOCATOR.getFactory(AccessInfoFactory.class);
 
     /**
      * Creates a new access info instance
-     * 
+     *
      * @return
      */
     public AccessInfo newAccessInfo() {
-        return factory.newEntity(null);
+        return ACCESS_INFO_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new access info creator instance
-     * 
+     *
      * @return
      */
     public AccessInfoCreator newAccessInfoCreator() {
-        return factory.newCreator(null);
+        return ACCESS_INFO_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new {@link AccessInfoListResult} instance
-     * 
+     *
      * @return
      */
     public AccessInfoListResult newAccessInfoListResult() {
-        return factory.newListResult();
+        return ACCESS_INFO_FACTORY.newListResult();
     }
 
     public AccessInfoQuery newQuery() {
-        return factory.newQuery(null);
+        return ACCESS_INFO_FACTORY.newQuery(null);
     }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
@@ -11,18 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.authorization.permission.Permission;
 
 /**
  * Access permission entity.<br>
@@ -32,7 +32,7 @@ import org.eclipse.kapua.service.authorization.permission.Permission;
  * <br>
  * This is a not editable entity so it can be only removed or created and therefore any change to
  * {@link AccessPermission#getAccessInfoId()} and {@link AccessPermission#getPermission()} property is forbidden.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "accessPermission")
@@ -42,48 +42,47 @@ import org.eclipse.kapua.service.authorization.permission.Permission;
         factoryMethod = "newAccessPermission")
 public interface AccessPermission extends KapuaEntity {
 
-    public static final String TYPE = "accessPermission";
+    String TYPE = "accessPermission";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Sets the {@link AccessInfo} id of which this {@link AccessPermission} belongs.
-     * 
-     * @param accessId
-     *            The {@link AccessInfo} id.
+     *
+     * @param accessId The {@link AccessInfo} id.
      * @since 1.0.0
      */
-    public void setAccessInfoId(KapuaId accessId);
+    void setAccessInfoId(KapuaId accessId);
 
     /**
      * Gets the {@link AccessInfo} id of which this {@link AccessPermission} belongs.
-     * 
+     *
      * @return The {@link AccessInfo} id.
      * @since 1.0.0
      */
     @XmlElement(name = "accessInfoId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getAccessInfoId();
+    KapuaId getAccessInfoId();
 
     /**
      * Sets the {@link Permission} that this {@link AccessPermission} has.<br>
      * It up to the implementation class to make a clone of the given {@link Permission} or use the given {@link Permission}.
-     * 
-     * @param permission
-     *            The {@link Permission} to set for this {@link AccessPermission}.
+     *
+     * @param permission The {@link Permission} to set for this {@link AccessPermission}.
      * @since 1.0.0
      */
-    public void setPermission(Permission permission);
+    void setPermission(Permission permission);
 
     /**
      * Gets the {@link Permission} that this {@link AccessPermission} has.
-     * 
+     *
      * @return The {@link Permission} that this {@link AccessPermission} has.
      */
     @XmlElement(name = "permission")
-    public <P extends Permission> P getPermission();
+    <P extends Permission> P getPermission();
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
@@ -11,6 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -18,16 +24,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaEntityCreator;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.authorization.permission.Permission;
-
 /**
  * {@link AccessPermission} creator definition.<br>
  * It is used to create a new {@link AccessPermission}.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "accessPermissionCreator")
@@ -38,41 +38,38 @@ public interface AccessPermissionCreator extends KapuaEntityCreator<AccessPermis
 
     /**
      * Sets the {@link AccessInfo} id for this {@link AccessPermission}.
-     * 
-     * @param accessInfoId
-     *            The {@link AccessInfo} id for this {@link AccessPermission}.
-     * 
+     *
+     * @param accessInfoId The {@link AccessInfo} id for this {@link AccessPermission}.
      * @since 1.0.0
      */
-    public void setAccessInfoId(KapuaId accessInfoId);
+    void setAccessInfoId(KapuaId accessInfoId);
 
     /**
      * Gets the {@link AccessInfo} id of this {@link AccessPermission}.
-     * 
+     *
      * @return The {@link AccessInfo} id of this {@link AccessPermission}.
      * @since 1.0.0
      */
     @XmlElement(name = "accessInfoId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getAccessInfoId();
+    KapuaId getAccessInfoId();
 
     /**
      * Sets the {@link Permission} to assign to the {@link AccessPermission} created entity.
      * It up to the implementation class to make a clone of the object or use the given object.
-     * 
-     * @param permission
-     *            The {@link Permission}.
+     *
+     * @param permission The {@link Permission}.
      * @since 1.0.0
      */
-    public void setPermission(Permission permission);
+    void setPermission(Permission permission);
 
     /**
      * Gets the set of {@link Permission} added to this {@link AccessPermission}.
-     * 
+     *
      * @return The set of {@link Permission}.
      * @since 1.0.0
      */
     @XmlElement(name = "permission")
-    public <P extends Permission> P getPermission();
+    <P extends Permission> P getPermission();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionService.java
@@ -24,10 +24,10 @@ import org.eclipse.kapua.service.KapuaEntityService;
  */
 public interface AccessPermissionService extends KapuaEntityService<AccessPermission, AccessPermissionCreator>, KapuaDomainService<AccessInfoDomain> {
 
-    public static final AccessInfoDomain ACCESS_INFO_DOMAIN = new AccessInfoDomain();
+    AccessInfoDomain ACCESS_INFO_DOMAIN = new AccessInfoDomain();
 
     @Override
-    public default AccessInfoDomain getServiceDomain() {
+    default AccessInfoDomain getServiceDomain() {
         return ACCESS_INFO_DOMAIN;
     }
 
@@ -40,8 +40,7 @@ public interface AccessPermissionService extends KapuaEntityService<AccessPermis
      * @since 1.0.0
      */
     @Override
-    public AccessPermission create(AccessPermissionCreator accessPermissionCreator)
-            throws KapuaException;
+    AccessPermission create(AccessPermissionCreator accessPermissionCreator) throws KapuaException;
 
     /**
      * Finds the {@link AccessPermission} by scope identifier and {@link AccessPermission} id.
@@ -53,8 +52,7 @@ public interface AccessPermissionService extends KapuaEntityService<AccessPermis
      * @since 1.0.0
      */
     @Override
-    public AccessPermission find(KapuaId scopeId, KapuaId accessPermissionId)
-            throws KapuaException;
+    AccessPermission find(KapuaId scopeId, KapuaId accessPermissionId) throws KapuaException;
 
     /**
      * Finds the {@link AccessPermission}s by scope identifier and {@link AccessInfo} id.
@@ -65,8 +63,7 @@ public interface AccessPermissionService extends KapuaEntityService<AccessPermis
      * @throws KapuaException
      * @since 1.0.0
      */
-    public AccessPermissionListResult findByAccessInfoId(KapuaId scopeId, KapuaId accessInfoId)
-            throws KapuaException;
+    AccessPermissionListResult findByAccessInfoId(KapuaId scopeId, KapuaId accessInfoId) throws KapuaException;
 
     /**
      * Returns the {@link AccessPermissionListResult} with elements matching the provided query.
@@ -77,8 +74,7 @@ public interface AccessPermissionService extends KapuaEntityService<AccessPermis
      * @since 1.0.0
      */
     @Override
-    public AccessPermissionListResult query(KapuaQuery<AccessPermission> query)
-            throws KapuaException;
+    AccessPermissionListResult query(KapuaQuery<AccessPermission> query) throws KapuaException;
 
     /**
      * Returns the count of the {@link AccessPermission} elements matching the provided query.
@@ -89,8 +85,7 @@ public interface AccessPermissionService extends KapuaEntityService<AccessPermis
      * @since 1.0.0
      */
     @Override
-    public long count(KapuaQuery<AccessPermission> query)
-            throws KapuaException;
+    long count(KapuaQuery<AccessPermission> query) throws KapuaException;
 
     /**
      * Delete the {@link AccessPermission} by scope id and {@link AccessPermission} id.
@@ -101,7 +96,6 @@ public interface AccessPermissionService extends KapuaEntityService<AccessPermis
      * @since 1.0.0
      */
     @Override
-    public void delete(KapuaId scopeId, KapuaId accessPermissionId)
-            throws KapuaException;
+    void delete(KapuaId scopeId, KapuaId accessPermissionId) throws KapuaException;
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionXmlRegistry.java
@@ -11,44 +11,44 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class AccessPermissionXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final AccessPermissionFactory factory = locator.getFactory(AccessPermissionFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AccessPermissionFactory ACCESS_PERMISSION_FACTORY = LOCATOR.getFactory(AccessPermissionFactory.class);
 
     /**
      * Creates a new {@link AccessPermission} instance
-     * 
+     *
      * @return
      */
     public AccessPermission newAccessPermission() {
-        return factory.newEntity(null);
+        return ACCESS_PERMISSION_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new {@link AccessPermission} instance
-     * 
+     *
      * @return
      */
     public AccessPermissionCreator newCreator() {
-        return factory.newCreator(null);
+        return ACCESS_PERMISSION_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new {@link AccessPermission} instance
-     * 
+     *
      * @return
      */
     public AccessPermissionListResult newAccessPermissionListResult() {
-        return factory.newListResult();
+        return ACCESS_PERMISSION_FACTORY.newListResult();
     }
 
     public AccessPermissionQuery newQuery() {
-        return factory.newQuery(null);
+        return ACCESS_PERMISSION_FACTORY.newQuery(null);
     }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
@@ -11,13 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.KapuaEntity;
@@ -25,6 +18,13 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.service.authorization.role.Role;
 import org.eclipse.kapua.service.authorization.role.RoleService;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * Access role entity.<br>
@@ -36,7 +36,7 @@ import org.eclipse.kapua.service.authorization.role.RoleService;
  * {@link AccessRole#getAccessInfoId()} and {@link AccessRole#getRoleId()} property is forbidden.<br>
  * <br>
  * To edit {@link Role} entity please refer to {@link RoleService#update(Role)}
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "accessRole")
@@ -46,49 +46,48 @@ import org.eclipse.kapua.service.authorization.role.RoleService;
         factoryMethod = "newAccessRole")
 public interface AccessRole extends KapuaEntity {
 
-    public static final String TYPE = "accessRole";
+    String TYPE = "accessRole";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Sets the {@link KapuaId} id of which this {@link AccessRole} belongs.
-     * 
-     * @param accessInfoId
-     *            The {@link KapuaId} id.
+     *
+     * @param accessInfoId The {@link KapuaId} id.
      * @since 1.0.0
      */
-    public void setAccessInfoId(KapuaId accessInfoId);
+    void setAccessInfoId(KapuaId accessInfoId);
 
     /**
      * Gets the {@link AccessInfo} id of which this {@link AccessRole} belongs.
-     * 
+     *
      * @return The {@link AccessInfo} id.
      * @since 1.0.0
      */
     @XmlElement(name = "accessInfoId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getAccessInfoId();
+    KapuaId getAccessInfoId();
 
     /**
      * Sets the {@link Role} id that this {@link AccessRole} has.<br>
      * It up to the implementation class to make a clone of the given {@link Role} or use the given {@link Role}.
-     * 
-     * @param roleId
-     *            The {@link Role} id to set for this {@link AccessRole}.
+     *
+     * @param roleId The {@link Role} id to set for this {@link AccessRole}.
      * @since 1.0.0
      */
-    public void setRoleId(KapuaId roleId) throws KapuaException;
+    void setRoleId(KapuaId roleId) throws KapuaException;
 
     /**
      * Gets the {@link Role} id that this {@link AccessRole} has.
-     * 
+     *
      * @return The {@link Role} id that this {@link AccessRole} has.
      */
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getRoleId();
+    KapuaId getRoleId();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
@@ -11,6 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.authorization.role.Role;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -18,16 +24,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaEntityCreator;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.authorization.role.Role;
-
 /**
  * {@link AccessRole} creator definition.<br>
  * It is used to create a new {@link AccessRole}.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "accessRoleCreator")
@@ -38,43 +38,40 @@ public interface AccessRoleCreator extends KapuaEntityCreator<AccessRole> {
 
     /**
      * Sets the {@link AccessInfo} id for this {@link AccessRole}.
-     * 
-     * @param accessInfoId
-     *            The {@link AccessInfo} id for this {@link AccessRole}.
-     * 
+     *
+     * @param accessInfoId The {@link AccessInfo} id for this {@link AccessRole}.
      * @since 1.0.0
      */
-    public void setAccessInfoId(KapuaId accessInfoId);
+    void setAccessInfoId(KapuaId accessInfoId);
 
     /**
      * Gets the {@link AccessInfo} id of this {@link AccessRole}.
-     * 
+     *
      * @return The {@link AccessInfo} id of this {@link AccessRole}.
      * @since 1.0.0
      */
     @XmlElement(name = "accessInfoId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getAccessInfoId();
+    KapuaId getAccessInfoId();
 
     /**
      * Sets the {@link Role} id to assign to the {@link AccessRole} created entity.
      * It up to the implementation class to make a clone of the object or use the given object.
-     * 
-     * @param roleId
-     *            The {@link Role} id
+     *
+     * @param roleId The {@link Role} id
      * @since 1.0.0
      */
-    public void setRoleId(KapuaId roleId);
+    void setRoleId(KapuaId roleId);
 
     /**
      * Gets the {@link Role} id added to this {@link AccessRole}.
-     * 
+     *
      * @return The {@link Role} id added to this {@link AccessRole}.
      * @since 1.0.0
      */
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getRoleId();
+    KapuaId getRoleId();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleService.java
@@ -24,10 +24,10 @@ import org.eclipse.kapua.service.KapuaEntityService;
  */
 public interface AccessRoleService extends KapuaEntityService<AccessRole, AccessRoleCreator>, KapuaDomainService<AccessInfoDomain> {
 
-    public static final AccessInfoDomain ACCESS_INFO_DOMAIN = new AccessInfoDomain();
+    AccessInfoDomain ACCESS_INFO_DOMAIN = new AccessInfoDomain();
 
     @Override
-    public default AccessInfoDomain getServiceDomain() {
+    default AccessInfoDomain getServiceDomain() {
         return ACCESS_INFO_DOMAIN;
     }
 
@@ -40,8 +40,7 @@ public interface AccessRoleService extends KapuaEntityService<AccessRole, Access
      * @since 1.0.0
      */
     @Override
-    public AccessRole create(AccessRoleCreator accessRoleCreator)
-            throws KapuaException;
+    AccessRole create(AccessRoleCreator accessRoleCreator) throws KapuaException;
 
     /**
      * Finds the {@link AccessRole} by scope identifier and {@link AccessRole} id.
@@ -53,8 +52,7 @@ public interface AccessRoleService extends KapuaEntityService<AccessRole, Access
      * @since 1.0.0
      */
     @Override
-    public AccessRole find(KapuaId scopeId, KapuaId accessRoleId)
-            throws KapuaException;
+    AccessRole find(KapuaId scopeId, KapuaId accessRoleId) throws KapuaException;
 
     /**
      * Finds the {@link AccessRole}s by scope identifier and {@link AccessInfo} id.
@@ -65,8 +63,7 @@ public interface AccessRoleService extends KapuaEntityService<AccessRole, Access
      * @throws KapuaException
      * @since 1.0.0
      */
-    public AccessRoleListResult findByAccessInfoId(KapuaId scopeId, KapuaId accessInfoId)
-            throws KapuaException;
+    AccessRoleListResult findByAccessInfoId(KapuaId scopeId, KapuaId accessInfoId) throws KapuaException;
 
     /**
      * Returns the {@link AccessRoleListResult} with elements matching the provided query.
@@ -77,8 +74,7 @@ public interface AccessRoleService extends KapuaEntityService<AccessRole, Access
      * @since 1.0.0
      */
     @Override
-    public AccessRoleListResult query(KapuaQuery<AccessRole> query)
-            throws KapuaException;
+    AccessRoleListResult query(KapuaQuery<AccessRole> query) throws KapuaException;
 
     /**
      * Returns the count of the {@link AccessRole} elements matching the provided query.
@@ -89,8 +85,7 @@ public interface AccessRoleService extends KapuaEntityService<AccessRole, Access
      * @since 1.0.0
      */
     @Override
-    public long count(KapuaQuery<AccessRole> query)
-            throws KapuaException;
+    long count(KapuaQuery<AccessRole> query) throws KapuaException;
 
     /**
      * Delete the {@link AccessRole} by scope id and {@link AccessRole} id.
@@ -101,7 +96,6 @@ public interface AccessRoleService extends KapuaEntityService<AccessRole, Access
      * @since 1.0.0
      */
     @Override
-    public void delete(KapuaId scopeId, KapuaId accessRoleId)
-            throws KapuaException;
+    void delete(KapuaId scopeId, KapuaId accessRoleId) throws KapuaException;
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleXmlRegistry.java
@@ -11,44 +11,44 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class AccessRoleXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final AccessRoleFactory factory = locator.getFactory(AccessRoleFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AccessRoleFactory ACCESS_ROLE_FACTORY = LOCATOR.getFactory(AccessRoleFactory.class);
 
     /**
      * Creates a new {@link AccessRole} instance
-     * 
+     *
      * @return
      */
     public AccessRole newAccessRole() {
-        return factory.newEntity(null);
+        return ACCESS_ROLE_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new {@link AccessRole} instance
-     * 
+     *
      * @return
      */
     public AccessRoleCreator newCreator() {
-        return factory.newCreator(null);
+        return ACCESS_ROLE_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new {@link AccessRole} instance
-     * 
+     *
      * @return
      */
     public AccessRoleListResult newAccessRoleListResult() {
-        return factory.newListResult();
+        return ACCESS_ROLE_FACTORY.newListResult();
     }
 
     public AccessRoleQuery newQuery() {
-        return factory.newQuery(null);
+        return ACCESS_ROLE_FACTORY.newQuery(null);
     }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -42,10 +42,10 @@ import java.util.Set;
         "groupable" })
 public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.Domain {
 
-    public static final String TYPE = "domain";
+    String TYPE = "domain";
 
     @Override
-    public default String getType() {
+    default String getType() {
         return TYPE;
     }
 
@@ -56,7 +56,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      * @param name The name of the {@link Domain}
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the {@link Domain} name.
@@ -65,7 +65,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Sets the {@link KapuaService} name that use this {@link Domain}.<br>
@@ -79,7 +79,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      * @param serviceName The {@link KapuaService} that use this {@link Domain}.<br>
      * @since 1.0.0
      */
-    public void setServiceName(String serviceName);
+    void setServiceName(String serviceName);
 
     /**
      * Gets the {@link KapuaService} name that use this {@link Domain}.<br>
@@ -89,7 +89,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      * @since 1.0.0
      */
     @XmlElement(name = "serviceName")
-    public String getServiceName();
+    String getServiceName();
 
     /**
      * Sets the set of {@link Actions} available in this {@link Domain}.<br>
@@ -98,7 +98,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      * @param actions The set of {@link Actions}.
      * @since 1.0.0
      */
-    public void setActions(Set<Actions> actions);
+    void setActions(Set<Actions> actions);
 
     /**
      * Gets the set of {@link Actions} available in this {@link Domain}.<br>
@@ -109,7 +109,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      */
     @XmlElementWrapper(name = "actions")
     @XmlElement(name = "action")
-    public Set<Actions> getActions();
+    Set<Actions> getActions();
 
     /**
      * Sets whether or not this {@link Domain} is group-able or not.
@@ -119,7 +119,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      * @param groupable {@code true} if the {@link org.eclipse.kapua.service.authorization.permission.Permission} on this {@link Domain} can have the {@link Permission#getGroupId()} property set, {@code false} otherwise.
      * @since 0.3.1
      */
-    public void setGroupable(boolean groupable);
+    void setGroupable(boolean groupable);
 
     /**
      * Gets whether or not this {@link Domain} is group-able or not.
@@ -128,7 +128,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      * @since 0.3.1
      */
     @XmlElement(name = "groupable")
-    public boolean getGroupable();
+    boolean getGroupable();
 
     /**
      * Returns the {@link KapuaService} {@link org.eclipse.kapua.model.domain.Domain} represented from {@code this} {@link Domain} registry entry.
@@ -137,7 +137,7 @@ public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.
      * @since 1.0.0
      */
     @XmlTransient
-    public default org.eclipse.kapua.model.domain.Domain getDomain() {
+    default org.eclipse.kapua.model.domain.Domain getDomain() {
         return new AbstractDomain() {
 
             @Override

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
@@ -37,7 +37,7 @@ public interface DomainCreator extends KapuaEntityCreator<Domain>, org.eclipse.k
      * @param name The {@link Domain} name.
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Sets the {@link KapuaService} name that uses the {@link Domain}.
@@ -45,7 +45,7 @@ public interface DomainCreator extends KapuaEntityCreator<Domain>, org.eclipse.k
      * @param serviceName The {@link KapuaService} name that uses the {@link Domain}.
      * @since 1.0.0
      */
-    public void setServiceName(String serviceName);
+    void setServiceName(String serviceName);
 
     /**
      * Sets the set of {@link Actions} available in the {@link Domain}.<br>
@@ -54,7 +54,7 @@ public interface DomainCreator extends KapuaEntityCreator<Domain>, org.eclipse.k
      * @param actions The set of {@link Actions}.
      * @since 1.0.0
      */
-    public void setActions(Set<Actions> actions);
+    void setActions(Set<Actions> actions);
 
     /**
      * Sets whether or not this {@link Domain} is group-able or not.
@@ -64,6 +64,6 @@ public interface DomainCreator extends KapuaEntityCreator<Domain>, org.eclipse.k
      * @param groupable {@code true} if the {@link org.eclipse.kapua.service.authorization.permission.Permission} on this {@link Domain} can have the {@link Permission#getGroupId()} property set, {@code false} otherwise.
      * @since 0.3.1
      */
-    public void setGroupable(boolean groupable);
+    void setGroupable(boolean groupable);
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainFactory.java
@@ -16,22 +16,19 @@ import org.eclipse.kapua.service.KapuaService;
 
 /**
  * {@link Domain} object factory.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 public interface DomainFactory extends KapuaEntityFactory<Domain, DomainCreator, DomainQuery, DomainListResult> {
 
     /**
      * Instantiate a new {@link DomainCreator} implementing object with the provided parameters.
-     * 
-     * @param name
-     *            The {@link Domain} name to set.
-     * @param serviceName
-     *            The {@link KapuaService} the uses this {@link Domain}.
+     *
+     * @param name        The {@link Domain} name to set.
+     * @param serviceName The {@link KapuaService} the uses this {@link Domain}.
      * @return A instance of the implementing class of {@link Domain}.
      * @since 1.0.0
      */
-    public DomainCreator newCreator(String name, String serviceName);
+    DomainCreator newCreator(String name, String serviceName);
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainRegistryService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainRegistryService.java
@@ -24,10 +24,10 @@ import org.eclipse.kapua.service.KapuaEntityService;
  */
 public interface DomainRegistryService extends KapuaEntityService<Domain, DomainCreator>, KapuaDomainService<DomainDomain> {
 
-    public static final DomainDomain DOMAIN_DOMAIN = new DomainDomain();
+    DomainDomain DOMAIN_DOMAIN = new DomainDomain();
 
     @Override
-    public default DomainDomain getServiceDomain() {
+    default DomainDomain getServiceDomain() {
         return DOMAIN_DOMAIN;
     }
 
@@ -41,8 +41,7 @@ public interface DomainRegistryService extends KapuaEntityService<Domain, Domain
      * @since 1.0.0
      */
     @Override
-    public Domain create(DomainCreator domainCreator)
-            throws KapuaException;
+    Domain create(DomainCreator domainCreator) throws KapuaException;
 
     /**
      * Finds the {@link Domain} by scope identifier and {@link Domain} id.
@@ -54,8 +53,7 @@ public interface DomainRegistryService extends KapuaEntityService<Domain, Domain
      * @since 1.0.0
      */
     @Override
-    public Domain find(KapuaId scopeId, KapuaId domainId)
-            throws KapuaException;
+    Domain find(KapuaId scopeId, KapuaId domainId) throws KapuaException;
 
     /**
      * Finds the {@link Domain} by the service name.
@@ -65,8 +63,7 @@ public interface DomainRegistryService extends KapuaEntityService<Domain, Domain
      * @throws KapuaException
      * @since 1.0.0
      */
-    public Domain findByServiceName(String servicename)
-            throws KapuaException;
+    Domain findByServiceName(String servicename) throws KapuaException;
 
     /**
      * Returns the {@link DomainListResult} with elements matching the provided query.
@@ -77,8 +74,7 @@ public interface DomainRegistryService extends KapuaEntityService<Domain, Domain
      * @since 1.0.0
      */
     @Override
-    public DomainListResult query(KapuaQuery<Domain> query)
-            throws KapuaException;
+    DomainListResult query(KapuaQuery<Domain> query) throws KapuaException;
 
     /**
      * Returns the count of the {@link Domain} elements matching the provided query.
@@ -89,8 +85,7 @@ public interface DomainRegistryService extends KapuaEntityService<Domain, Domain
      * @since 1.0.0
      */
     @Override
-    public long count(KapuaQuery<Domain> query)
-            throws KapuaException;
+    long count(KapuaQuery<Domain> query) throws KapuaException;
 
     /**
      * Delete the {@link Domain} by scope id and {@link Domain} id.
@@ -101,7 +96,6 @@ public interface DomainRegistryService extends KapuaEntityService<Domain, Domain
      * @since 1.0.0
      */
     @Override
-    public void delete(KapuaId scopeId, KapuaId roleId)
-            throws KapuaException;
+    void delete(KapuaId scopeId, KapuaId roleId) throws KapuaException;
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainXmlRegistry.java
@@ -11,17 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.domain;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class DomainXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final DomainFactory factory = locator.getFactory(DomainFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final DomainFactory DOMAIN_FACTORY = LOCATOR.getFactory(DomainFactory.class);
 
     public DomainQuery newQuery() {
-        return factory.newQuery(null);
+        return DOMAIN_FACTORY.newQuery(null);
     }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Group.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Group.java
@@ -11,15 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group;
 
-import java.math.BigInteger;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -27,47 +18,54 @@ import org.eclipse.kapua.model.id.KapuaIdFactory;
 import org.eclipse.kapua.service.authorization.access.AccessPermission;
 import org.eclipse.kapua.service.authorization.role.RolePermission;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+import java.math.BigInteger;
+
 /**
  * Group entity definition.<br>
  * Groups serve as tag for entities marked as {@link Groupable}.
  * It is possible to assign a group to an entity.
  * It is possible to assign {@link AccessPermission} and {@link RolePermission} based on the {@link Group#getId()}.
  * {@link Group#getName()} must be unique within the scope.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "group")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name" }, //
-        factoryClass = GroupXmlRegistry.class, factoryMethod = "newGroup")
+@XmlType(factoryClass = GroupXmlRegistry.class, factoryMethod = "newGroup")
 public interface Group extends KapuaUpdatableEntity {
 
     @XmlTransient
-    public static final KapuaId ANY = KapuaLocator.getInstance().getFactory(KapuaIdFactory.class).newKapuaId(BigInteger.ONE.negate());
+    KapuaId ANY = KapuaLocator.getInstance().getFactory(KapuaIdFactory.class).newKapuaId(BigInteger.ONE.negate());
 
-    public static final String TYPE = "group";
+    String TYPE = "group";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Sets the {@link Group} name.<br>
      * It must be unique within the scope.
-     * 
-     * @param name
-     *            The name of the {@link Group}
+     *
+     * @param name The name of the {@link Group}
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the {@link Group} name.
-     * 
+     *
      * @return The {@link Group} name.
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupCreator.java
@@ -11,18 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group;
 
+import org.eclipse.kapua.model.KapuaEntityCreator;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.KapuaEntityCreator;
-
 /**
  * {@link Group} creator definition.<br>
  * It is used to create a new {@link Group}.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "groupCreator")
@@ -34,20 +34,18 @@ public interface GroupCreator extends KapuaEntityCreator<Group> {
 
     /**
      * Sets the {@link Group} name.
-     * 
-     * @param name
-     *            The {@link Group} name.
-     * 
+     *
+     * @param name The {@link Group} name.
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the {@link Group} name.
-     * 
+     *
      * @return The {@link Group} name.
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupFactory.java
@@ -16,22 +16,19 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * {@link Group} object factory.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 public interface GroupFactory extends KapuaEntityFactory<Group, GroupCreator, GroupQuery, GroupListResult> {
 
     /**
      * Instantiate a new {@link GroupCreator} implementing object with the provided parameters.
      *
-     * @param scopeId
-     *            The scope id of the group.
-     * @param name
-     *            The {@link Group} name to set.
+     * @param scopeId The scope id of the group.
+     * @param name    The {@link Group} name to set.
      * @return A instance of the implementing class of {@link Group}.
      * @since 1.0.0
      */
-    public GroupCreator newCreator(KapuaId scopeId, String name);
+    GroupCreator newCreator(KapuaId scopeId, String name);
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupService.java
@@ -29,10 +29,10 @@ public interface GroupService extends KapuaEntityService<Group, GroupCreator>,
         KapuaDomainService<GroupDomain>,
         KapuaConfigurableService {
 
-    public static final GroupDomain GROUP_DOMAIN = new GroupDomain();
+    GroupDomain GROUP_DOMAIN = new GroupDomain();
 
     @Override
-    public default GroupDomain getServiceDomain() {
+    default GroupDomain getServiceDomain() {
         return GROUP_DOMAIN;
     }
 
@@ -46,8 +46,7 @@ public interface GroupService extends KapuaEntityService<Group, GroupCreator>,
      * @since 1.0.0
      */
     @Override
-    public Group create(GroupCreator groupCreator)
-            throws KapuaException;
+    Group create(GroupCreator groupCreator) throws KapuaException;
 
     /**
      * Updates the {@link Group} according the given updated entity.<br>
@@ -59,8 +58,7 @@ public interface GroupService extends KapuaEntityService<Group, GroupCreator>,
      * @since 1.0.0
      */
     @Override
-    public Group update(Group group)
-            throws KapuaException;
+    Group update(Group group) throws KapuaException;
 
     /**
      * Finds the {@link Group} by scope identifier and {@link Group} id.
@@ -72,8 +70,7 @@ public interface GroupService extends KapuaEntityService<Group, GroupCreator>,
      * @since 1.0.0
      */
     @Override
-    public Group find(KapuaId scopeId, KapuaId groupId)
-            throws KapuaException;
+    Group find(KapuaId scopeId, KapuaId groupId) throws KapuaException;
 
     /**
      * Returns the {@link GroupListResult} with elements matching the provided query.
@@ -84,8 +81,7 @@ public interface GroupService extends KapuaEntityService<Group, GroupCreator>,
      * @since 1.0.0
      */
     @Override
-    public GroupListResult query(KapuaQuery<Group> query)
-            throws KapuaException;
+    GroupListResult query(KapuaQuery<Group> query) throws KapuaException;
 
     /**
      * Returns the count of the {@link Group} elements matching the provided query.
@@ -96,8 +92,7 @@ public interface GroupService extends KapuaEntityService<Group, GroupCreator>,
      * @since 1.0.0
      */
     @Override
-    public long count(KapuaQuery<Group> query)
-            throws KapuaException;
+    long count(KapuaQuery<Group> query) throws KapuaException;
 
     /**
      * Delete the {@link Group} by scope id and {@link Group} id.
@@ -108,7 +103,6 @@ public interface GroupService extends KapuaEntityService<Group, GroupCreator>,
      * @since 1.0.0
      */
     @Override
-    public void delete(KapuaId scopeId, KapuaId groupId)
-            throws KapuaException;
+    void delete(KapuaId scopeId, KapuaId groupId) throws KapuaException;
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupXmlRegistry.java
@@ -11,56 +11,53 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class GroupXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final GroupFactory factory = locator.getFactory(GroupFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final GroupFactory GROUP_FACTORY = LOCATOR.getFactory(GroupFactory.class);
 
     /**
      * Creates a new {@link Group} instance
-     * 
+     *
      * @return The newly created {@link Group} instance.
-     * 
      * @since 1.0.0
      */
     public Group newGroup() {
-        return factory.newEntity(null);
+        return GROUP_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new {@link GroupCreator} instance.
-     * 
+     *
      * @return The newly created {@link GroupCreator} instance.
-     * 
      * @since 1.0.0
      */
     public GroupCreator newGroupCreator() {
-        return factory.newCreator(null, null);
+        return GROUP_FACTORY.newCreator(null, null);
     }
 
     /**
      * Creates a new {@link GroupListResult} instance.
-     * 
+     *
      * @return The newly created {@link GroupListResult} instance.
      * @since 1.0.0
      */
     public GroupListResult newGroupListResult() {
-        return factory.newListResult();
+        return GROUP_FACTORY.newListResult();
     }
 
     /**
      * Creates a new {@link GroupQuery} instance.
-     * 
+     *
      * @return The newly created {@link GroupQuery} instance.
-     * 
      * @since 1.0.0
      */
     public GroupQuery newQuery() {
-        return factory.newQuery(null);
+        return GROUP_FACTORY.newQuery(null);
     }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Groupable.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Groupable.java
@@ -11,37 +11,35 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
 /**
  * Interface used to mark group-able entities.
- *
  */
 public interface Groupable {
 
     /**
      * Sets the {@link Group} id of this entity.
-     * 
-     * @param groupId
-     *            The {@link Group} id to assign.
+     *
+     * @param groupId The {@link Group} id to assign.
      * @since 1.0.0
      */
-    public void setGroupId(KapuaId groupId);
+    void setGroupId(KapuaId groupId);
 
     /**
      * Gets the {@link Group} id assigned to this entity.
-     * 
+     *
      * @return The {@link Group} id assigned to this entity.
      * @since 1.0.0
      */
     @XmlElement(name = "groupId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getGroupId();
+    KapuaId getGroupId();
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
@@ -47,8 +47,8 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
         factoryMethod = "newPermission")
 public interface Permission {
 
-    public static final String WILDCARD = "*";
-    public static final String SEPARATOR = ":";
+    String WILDCARD = "*";
+    String SEPARATOR = ":";
 
     /**
      * Sets the domain on which the {@link Permission} gives access.
@@ -56,7 +56,7 @@ public interface Permission {
      * @param domain The domain of the {@link Permission}.
      * @since 1.0.0
      */
-    public void setDomain(String domain);
+    void setDomain(String domain);
 
     /**
      * Gets the domain on which the {@link Permission} gives access.
@@ -65,7 +65,7 @@ public interface Permission {
      * @since 1.0.0
      */
     @XmlElement(name = "domain")
-    public String getDomain();
+    String getDomain();
 
     /**
      * Sets the {@link org.eclipse.kapua.model.domain.Actions} that this {@link Permission} allows to do on the domain.
@@ -73,7 +73,7 @@ public interface Permission {
      * @param action The {@link javax.swing.Action} that this {@link Permission} allows
      * @since 1.0.0
      */
-    public void setAction(Actions action);
+    void setAction(Actions action);
 
     /**
      * Gets the {@link Actions} that this {@link Permission} allows to do on the domain.
@@ -82,7 +82,7 @@ public interface Permission {
      * @since 1.0.0
      */
     @XmlElement(name = "action")
-    public Actions getAction();
+    Actions getAction();
 
     /**
      * Sets the target scope id that this {@link Permission} gives access.
@@ -90,7 +90,7 @@ public interface Permission {
      * @param targetScopeId The target scope id that this {@link Permission} gives access.
      * @since 1.0.0
      */
-    public void setTargetScopeId(KapuaId targetScopeId);
+    void setTargetScopeId(KapuaId targetScopeId);
 
     /**
      * Gets the target scope id that this {@link Permission} gives access.
@@ -101,7 +101,7 @@ public interface Permission {
     @XmlElement(name = "targetScopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getTargetScopeId();
+    KapuaId getTargetScopeId();
 
     /**
      * Sets the {@link Group} id that this {@link Permission} gives access.
@@ -109,7 +109,7 @@ public interface Permission {
      * @param groupId The {@link Group} id that this {@link Permission} gives access.
      * @since 1.0.0
      */
-    public void setGroupId(KapuaId groupId);
+    void setGroupId(KapuaId groupId);
 
     /**
      * Gets the {@link Group} id that this {@link Permission} gives access.
@@ -120,7 +120,7 @@ public interface Permission {
     @XmlElement(name = "groupId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getGroupId();
+    KapuaId getGroupId();
 
     /**
      * Sets whether or not this {@link Permission} is valid also for children scopeId.
@@ -128,7 +128,7 @@ public interface Permission {
      * @param forwardable {@code true} if this {@link Permission} is forward-able to children scopeIds.
      * @since 1.0.0
      */
-    public void setForwardable(boolean forwardable);
+    void setForwardable(boolean forwardable);
 
     /**
      * Gets whether or not this {@link Permission} is valid also for children scopeIds.
@@ -139,5 +139,5 @@ public interface Permission {
      * @since 1.0.0
      */
     @XmlElement(name = "forwardable")
-    public boolean getForwardable();
+    boolean getForwardable();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionFactory.java
@@ -35,7 +35,7 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param targetScopeId The target scope id of the new {@link Permission}.
      * @return A instance of the implementing class of {@link Permission}.
      */
-    public default Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId) {
+    default Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId) {
         return newPermission(domain, action, targetScopeId, null);
     }
 
@@ -48,7 +48,7 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param groupId       The {@link Group} id that this {@link Permission} gives access.
      * @return A instance of the implementing class of {@link Permission}.
      */
-    public default Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId) {
+    default Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId) {
         return newPermission(domain, action, targetScopeId, groupId, false);
     }
 
@@ -62,7 +62,7 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param forwardable   If the {@link Permission} is forward-able to children scopeIds
      * @return A instance of the implementing class of {@link Permission}.
      */
-    public Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId, boolean forwardable);
+    Permission newPermission(Domain domain, Actions action, KapuaId targetScopeId, KapuaId groupId, boolean forwardable);
 
     /**
      * Instantiate new {@link Permission}s implementing object with the provided parameters.
@@ -72,7 +72,7 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param actions       The {@link Actions} of the new {@link Permission}s.
      * @return A collection of instances of the implementing class of {@link Permission}.
      */
-    public default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, Actions... actions) {
+    default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, Actions... actions) {
         return newPermissions(domain, targetScopeId, null, actions);
     }
 
@@ -85,7 +85,7 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param actions       The {@link Actions} of the new {@link Permission}s.
      * @return A collection of instances of the implementing class of {@link Permission}.
      */
-    public default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, KapuaId groupId, Actions... actions) {
+    default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, KapuaId groupId, Actions... actions) {
         return newPermissions(domain, targetScopeId, groupId, false, actions);
     }
 
@@ -99,7 +99,7 @@ public interface PermissionFactory extends KapuaObjectFactory {
      * @param actions       The {@link Actions} of the new {@link Permission}s.
      * @return A collection of instances of the implementing class of {@link Permission}.
      */
-    public default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, KapuaId groupId, boolean forwardable, Actions... actions) {
+    default Collection<Permission> newPermissions(Domain domain, KapuaId targetScopeId, KapuaId groupId, boolean forwardable, Actions... actions) {
         return Arrays.stream(actions)
                 .map(action -> newPermission(domain, action, targetScopeId, groupId, forwardable))
                 .collect(Collectors.toList());

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionXmlRegistry.java
@@ -11,24 +11,23 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.permission;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class PermissionXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final PermissionFactory factory = locator.getFactory(PermissionFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     /**
      * Creates a new {@link Permission} instance
-     * 
+     *
      * @return A new {@link Permission} instance
-     * 
      * @since 1.0.0
      */
     public Permission newPermission() {
-        return factory.newPermission(null, null, null, null);
+        return PERMISSION_FACTORY.newPermission(null, null, null, null);
     }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/Role.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/Role.java
@@ -11,20 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.service.authorization.access.AccessInfo;
-
 /**
  * Role entity definition.<br>
  * Role is a collection of {@link RolePermission}s that can be assigned to one or more {@link org.eclipse.kapua.service.user.User}s (using {@link AccessInfo}).<br>
  * {@link Role#getName()} must be unique within the scope.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "role")
@@ -33,28 +33,28 @@ import org.eclipse.kapua.service.authorization.access.AccessInfo;
         factoryClass = RoleXmlRegistry.class, factoryMethod = "newRole")
 public interface Role extends KapuaUpdatableEntity {
 
-    public static final String TYPE = "role";
+    String TYPE = "role";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Sets the {@link Role} name.<br>
      * It must be unique within the scope.
-     * 
-     * @param name
-     *            The name of the {@link Role}
+     *
+     * @param name The name of the {@link Role}
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the {@link Role} name.
-     * 
+     *
      * @return The {@link Role} name.
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleCreator.java
@@ -44,7 +44,7 @@ public interface RoleCreator extends KapuaEntityCreator<Role> {
      * @param name The {@link Role} name.
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the {@link Role} name.
@@ -53,7 +53,7 @@ public interface RoleCreator extends KapuaEntityCreator<Role> {
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
     /**
      * Sets the set of {@link Permissions} to assign to the {@link Role} created entity.
@@ -62,7 +62,7 @@ public interface RoleCreator extends KapuaEntityCreator<Role> {
      * @param permissions The set of {@link Permissions}.
      * @since 1.0.0
      */
-    public void setPermissions(Set<Permission> permissions);
+    void setPermissions(Set<Permission> permissions);
 
     /**
      * Gets the set of {@link Permission} added to this {@link Role}.
@@ -74,5 +74,5 @@ public interface RoleCreator extends KapuaEntityCreator<Role> {
      */
     @XmlElementWrapper(name = "permissions")
     @XmlElement(name = "permission")
-    public <P extends Permission> Set<P> getPermissions();
+    <P extends Permission> Set<P> getPermissions();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleFactory.java
@@ -15,17 +15,16 @@ import org.eclipse.kapua.model.KapuaEntityFactory;
 
 /**
  * {@link Role} object factory.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 public interface RoleFactory extends KapuaEntityFactory<Role, RoleCreator, RoleQuery, RoleListResult> {
 
     /**
      * Instantiate a new {@link RolePermission} implementing object.
-     * 
+     *
      * @return A instance of the implementing class of {@link RolePermission}.
      * @since 1.0.0
      */
-    public RolePermission newRolePermission();
+    RolePermission newRolePermission();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
@@ -44,10 +44,10 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
         factoryMethod = "newRolePermission")
 public interface RolePermission extends KapuaEntity {
 
-    public static final String TYPE = "rolePermission";
+    String TYPE = "rolePermission";
 
     @Override
-    public default String getType() {
+    default String getType() {
         return TYPE;
     }
 
@@ -57,7 +57,7 @@ public interface RolePermission extends KapuaEntity {
      * @param roleId The {@link RoleInfo} id.
      * @since 1.0.0
      */
-    public void setRoleId(KapuaId roleId);
+    void setRoleId(KapuaId roleId);
 
     /**
      * Gets the {@link Role} id of which this {@link RolePermission} belongs.
@@ -68,7 +68,7 @@ public interface RolePermission extends KapuaEntity {
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getRoleId();
+    KapuaId getRoleId();
 
     /**
      * Sets the {@link Permission} that this {@link RolePermission} has.<br>
@@ -77,7 +77,7 @@ public interface RolePermission extends KapuaEntity {
      * @param permission The {@link Permission} to set for this {@link RolePermission}.
      * @since 1.0.0
      */
-    public void setPermission(Permission permission);
+    void setPermission(Permission permission);
 
     /**
      * Gets the {@link Permission} that this {@link RolePermission} has.
@@ -87,5 +87,5 @@ public interface RolePermission extends KapuaEntity {
      * @since 1.0.0
      */
     @XmlElement(name = "permission")
-    public <P extends Permission> P getPermission();
+    <P extends Permission> P getPermission();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
@@ -11,6 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -18,16 +24,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.model.KapuaEntityCreator;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-import org.eclipse.kapua.service.authorization.permission.Permission;
-
 /**
  * {@link RolePermission} creator definition.<br>
  * It is used to create a new {@link RolePermission}.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "rolePermissionCreator")
@@ -38,41 +38,38 @@ public interface RolePermissionCreator extends KapuaEntityCreator<RolePermission
 
     /**
      * Sets the {@link Role} id for this {@link RolePermission}.
-     * 
-     * @param roleId
-     *            The {@link Role} id for this {@link RolePermission}.
-     * 
+     *
+     * @param roleId The {@link Role} id for this {@link RolePermission}.
      * @since 1.0.0
      */
-    public void setRoleId(KapuaId roleId);
+    void setRoleId(KapuaId roleId);
 
     /**
      * Gets the {@link Role} id of this {@link RolePermission}.
-     * 
+     *
      * @return The {@link Role} id of this {@link RolePermission}.
      * @since 1.0.0
      */
     @XmlElement(name = "roleId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getRoleId();
+    KapuaId getRoleId();
 
     /**
      * Sets the {@link Permission} to assign to the {@link RolePermission} created entity.
      * It up to the implementation class to make a clone of the object or use the given object.
-     * 
-     * @param permission
-     *            The {@link Permission}.
+     *
+     * @param permission The {@link Permission}.
      * @since 1.0.0
      */
-    public void setPermission(Permission permission);
+    void setPermission(Permission permission);
 
     /**
      * Gets the set of {@link Permission} added to this {@link RolePermission}.
-     * 
+     *
      * @return The set of {@link Permission}.
      * @since 1.0.0
      */
     @XmlElement(name = "permission")
-    public <P extends Permission> P getPermission();
+    <P extends Permission> P getPermission();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionService.java
@@ -24,10 +24,10 @@ import org.eclipse.kapua.service.KapuaEntityService;
  */
 public interface RolePermissionService extends KapuaEntityService<RolePermission, RolePermissionCreator>, KapuaDomainService<RoleDomain> {
 
-    public static final RoleDomain ROLE_DOMAIN = new RoleDomain();
+    RoleDomain ROLE_DOMAIN = new RoleDomain();
 
     @Override
-    public default RoleDomain getServiceDomain() {
+    default RoleDomain getServiceDomain() {
         return ROLE_DOMAIN;
     }
 
@@ -40,8 +40,7 @@ public interface RolePermissionService extends KapuaEntityService<RolePermission
      * @since 1.0.0
      */
     @Override
-    public RolePermission create(RolePermissionCreator rolePermissionCreator)
-            throws KapuaException;
+    RolePermission create(RolePermissionCreator rolePermissionCreator) throws KapuaException;
 
     /**
      * Finds the {@link RolePermission} by scope identifier and {@link RolePermission} id.
@@ -53,8 +52,7 @@ public interface RolePermissionService extends KapuaEntityService<RolePermission
      * @since 1.0.0
      */
     @Override
-    public RolePermission find(KapuaId scopeId, KapuaId rolePermissionId)
-            throws KapuaException;
+    RolePermission find(KapuaId scopeId, KapuaId rolePermissionId) throws KapuaException;
 
     /**
      * Finds the {@link RolePermission}s by scope identifier and {@link Role} id.
@@ -65,8 +63,7 @@ public interface RolePermissionService extends KapuaEntityService<RolePermission
      * @throws KapuaException
      * @since 1.0.0
      */
-    public RolePermissionListResult findByRoleId(KapuaId scopeId, KapuaId roleId)
-            throws KapuaException;
+    RolePermissionListResult findByRoleId(KapuaId scopeId, KapuaId roleId) throws KapuaException;
 
     /**
      * Returns the {@link RolePermissionListResult} with elements matching the provided query.
@@ -77,8 +74,7 @@ public interface RolePermissionService extends KapuaEntityService<RolePermission
      * @since 1.0.0
      */
     @Override
-    public RolePermissionListResult query(KapuaQuery<RolePermission> query)
-            throws KapuaException;
+    RolePermissionListResult query(KapuaQuery<RolePermission> query) throws KapuaException;
 
     /**
      * Returns the count of the {@link RolePermission} elements matching the provided query.
@@ -89,8 +85,7 @@ public interface RolePermissionService extends KapuaEntityService<RolePermission
      * @since 1.0.0
      */
     @Override
-    public long count(KapuaQuery<RolePermission> query)
-            throws KapuaException;
+    long count(KapuaQuery<RolePermission> query) throws KapuaException;
 
     /**
      * Delete the {@link RolePermission} by scope id and {@link RolePermission} id.
@@ -101,7 +96,6 @@ public interface RolePermissionService extends KapuaEntityService<RolePermission
      * @since 1.0.0
      */
     @Override
-    public void delete(KapuaId scopeId, KapuaId rolePermissionId)
-            throws KapuaException;
+    void delete(KapuaId scopeId, KapuaId rolePermissionId) throws KapuaException;
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionXmlRegistry.java
@@ -11,44 +11,44 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class RolePermissionXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final RolePermissionFactory factory = locator.getFactory(RolePermissionFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final RolePermissionFactory ROLE_PERMISSION_FACTORY = LOCATOR.getFactory(RolePermissionFactory.class);
 
     /**
      * Creates a new {@link RolePermission} instance
-     * 
+     *
      * @return
      */
     public RolePermission newRolePermission() {
-        return factory.newEntity(null);
+        return ROLE_PERMISSION_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new {@link RolePermission} instance
-     * 
+     *
      * @return
      */
     public RolePermissionCreator newCreator() {
-        return factory.newCreator(null);
+        return ROLE_PERMISSION_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new {@link RolePermissionListResult} instance
-     * 
+     *
      * @return
      */
     public RolePermissionListResult newRolePermissionListResult() {
-        return factory.newListResult();
+        return ROLE_PERMISSION_FACTORY.newListResult();
     }
 
     public RolePermissionQuery newQuery() {
-        return factory.newQuery(null);
+        return ROLE_PERMISSION_FACTORY.newQuery(null);
     }
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleService.java
@@ -29,10 +29,10 @@ public interface RoleService extends KapuaEntityService<Role, RoleCreator>,
         KapuaDomainService<RoleDomain>,
         KapuaConfigurableService {
 
-    public static final RoleDomain ROLE_DOMAIN = new RoleDomain();
+    RoleDomain ROLE_DOMAIN = new RoleDomain();
 
     @Override
-    public default RoleDomain getServiceDomain() {
+    default RoleDomain getServiceDomain() {
         return ROLE_DOMAIN;
     }
 
@@ -45,8 +45,7 @@ public interface RoleService extends KapuaEntityService<Role, RoleCreator>,
      * @since 1.0.0
      */
     @Override
-    public Role create(RoleCreator roleCreator)
-            throws KapuaException;
+    Role create(RoleCreator roleCreator) throws KapuaException;
 
     /**
      * Updates the {@link Role} according the given updated entity.<br>
@@ -58,8 +57,7 @@ public interface RoleService extends KapuaEntityService<Role, RoleCreator>,
      * @since 1.0.0
      */
     @Override
-    public Role update(Role role)
-            throws KapuaException;
+    Role update(Role role) throws KapuaException;
 
     /**
      * Finds the {@link Role} by scope identifier and {@link Role} id.
@@ -71,8 +69,7 @@ public interface RoleService extends KapuaEntityService<Role, RoleCreator>,
      * @since 1.0.0
      */
     @Override
-    public Role find(KapuaId scopeId, KapuaId roleId)
-            throws KapuaException;
+    Role find(KapuaId scopeId, KapuaId roleId) throws KapuaException;
 
     /**
      * Returns the {@link RoleListResult} with elements matching the provided query.
@@ -83,8 +80,7 @@ public interface RoleService extends KapuaEntityService<Role, RoleCreator>,
      * @since 1.0.0
      */
     @Override
-    public RoleListResult query(KapuaQuery<Role> query)
-            throws KapuaException;
+    RoleListResult query(KapuaQuery<Role> query) throws KapuaException;
 
     /**
      * Returns the count of the {@link Role} elements matching the provided query.
@@ -95,8 +91,7 @@ public interface RoleService extends KapuaEntityService<Role, RoleCreator>,
      * @since 1.0.0
      */
     @Override
-    public long count(KapuaQuery<Role> query)
-            throws KapuaException;
+    long count(KapuaQuery<Role> query) throws KapuaException;
 
     /**
      * Delete the {@link Role} by scope id and {@link Role} id.
@@ -107,7 +102,6 @@ public interface RoleService extends KapuaEntityService<Role, RoleCreator>,
      * @since 1.0.0
      */
     @Override
-    public void delete(KapuaId scopeId, KapuaId roleId)
-            throws KapuaException;
+    void delete(KapuaId scopeId, KapuaId roleId) throws KapuaException;
 
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleXmlRegistry.java
@@ -11,57 +11,53 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class RoleXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final RoleFactory factory = locator.getFactory(RoleFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final RoleFactory ROLE_FACTORY = LOCATOR.getFactory(RoleFactory.class);
 
     /**
      * Creates a new {@link Role} instance.
-     * 
+     *
      * @return The newly created {@link Role} instance.
-     * 
      * @since 1.0.0
      */
     public Role newRole() {
-        return factory.newEntity(null);
+        return ROLE_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new {@link RoleCreator} instance.
-     * 
+     *
      * @return The newly created {@link RoleCreator} instance.
-     * 
      * @since 1.0.0
      */
     public RoleCreator newRoleCreator() {
-        return factory.newCreator(null);
+        return ROLE_FACTORY.newCreator(null);
     }
 
     /**
      * Creates a new {@link RoleListResult} instance.
-     * 
+     *
      * @return The newly created {@link RoleListResult} instance.
-     * 
      * @since 1.0.0
      */
     public RoleListResult newRoleListResult() {
-        return factory.newListResult();
+        return ROLE_FACTORY.newListResult();
     }
 
     /**
      * Creates a new {@link RoleQuery} instance.
-     * 
+     *
      * @return The newly created {@link RoleQuery} instance.
-     * 
      * @since 1.0.0
      */
     public RoleQuery newQuery() {
-        return factory.newQuery(null);
+        return ROLE_FACTORY.newQuery(null);
     }
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
@@ -51,92 +51,92 @@ import java.util.Set;
 }, factoryClass = CertificateXmlRegistry.class, factoryMethod = "newCertificate")
 public interface Certificate extends KapuaNamedEntity {
 
-    public static final String TYPE = "certificate";
+    String TYPE = "certificate";
 
     @Override
     default String getType() {
         return TYPE;
     }
 
-    public String getCertificate();
+    String getCertificate();
 
-    public void setCertificate(String certificate);
+    void setCertificate(String certificate);
 
-    public Integer getVersion();
+    Integer getVersion();
 
-    public void setVersion(Integer version);
+    void setVersion(Integer version);
 
-    public String getSerial();
+    String getSerial();
 
-    public void setSerial(String serial);
+    void setSerial(String serial);
 
-    public String getAlgorithm();
+    String getAlgorithm();
 
-    public void setAlgorithm(String algorithm);
+    void setAlgorithm(String algorithm);
 
-    public String getSubject();
+    String getSubject();
 
-    public void setSubject(String subject);
+    void setSubject(String subject);
 
-    public String getIssuer();
+    String getIssuer();
 
-    public void setIssuer(String issuer);
-
-    @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getNotBefore();
-
-    public void setNotBefore(Date notBefore);
+    void setIssuer(String issuer);
 
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getNotAfter();
+    Date getNotBefore();
 
-    public void setNotAfter(Date notAfter);
+    void setNotBefore(Date notBefore);
 
-    public CertificateStatus getStatus();
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
+    Date getNotAfter();
 
-    public void setStatus(CertificateStatus status);
+    void setNotAfter(Date notAfter);
+
+    CertificateStatus getStatus();
+
+    void setStatus(CertificateStatus status);
 
     @XmlElement(name = "signature")
     @XmlJavaTypeAdapter(BinaryXmlAdapter.class)
-    public byte[] getSignature();
+    byte[] getSignature();
 
-    public void setSignature(byte[] signature);
+    void setSignature(byte[] signature);
 
-    public String getPrivateKey();
+    String getPrivateKey();
 
-    public void setPrivateKey(String privateKey);
+    void setPrivateKey(String privateKey);
 
-    public Boolean getCa();
+    Boolean getCa();
 
-    public void setCa(Boolean isCa);
+    void setCa(Boolean isCa);
 
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public KapuaId getCaId();
+    KapuaId getCaId();
 
-    public void setCaId(KapuaId caId);
+    void setCaId(KapuaId caId);
 
-    public String getPassword();
+    String getPassword();
 
-    public void setPassword(String password);
+    void setPassword(String password);
 
-    public <K extends KeyUsageSetting> Set<K> getKeyUsageSettings();
+    <K extends KeyUsageSetting> Set<K> getKeyUsageSettings();
 
-    public void setKeyUsageSettings(Set<KeyUsageSetting> keyUsages);
+    void setKeyUsageSettings(Set<KeyUsageSetting> keyUsages);
 
-    public void addKeyUsageSetting(KeyUsageSetting keyUsage);
+    void addKeyUsageSetting(KeyUsageSetting keyUsage);
 
-    public void removeKeyUsageSetting(KeyUsageSetting keyUsage);
+    void removeKeyUsageSetting(KeyUsageSetting keyUsage);
 
-    public <C extends CertificateUsage> Set<C> getCertificateUsages();
+    <C extends CertificateUsage> Set<C> getCertificateUsages();
 
-    public void setCertificateUsages(Set<CertificateUsage> certificateUsages);
+    void setCertificateUsages(Set<CertificateUsage> certificateUsages);
 
-    public void addCertificateUsage(CertificateUsage certificateUsage);
+    void addCertificateUsage(CertificateUsage certificateUsage);
 
-    public void removeCertificateUsage(CertificateUsage certificateUsage);
+    void removeCertificateUsage(CertificateUsage certificateUsage);
 
-    public Boolean getForwardable();
+    Boolean getForwardable();
 
-    public void setForwardable(Boolean forwardable);
+    void setForwardable(Boolean forwardable);
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
@@ -64,11 +64,11 @@ public interface CertificateCreator extends KapuaNamedEntityCreator<Certificate>
 
     void setPassword(String password);
 
-    public <C extends CertificateUsage> Set<C> getCertificateUsages();
+    <C extends CertificateUsage> Set<C> getCertificateUsages();
 
-    public void setCertificateUsages(Set<CertificateUsage> certificateUsages);
+    void setCertificateUsages(Set<CertificateUsage> certificateUsages);
 
-    public Boolean getForwardable();
+    Boolean getForwardable();
 
-    public void setForwardable(Boolean forwardable);
+    void setForwardable(Boolean forwardable);
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateFactory.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateFactory.java
@@ -15,10 +15,10 @@ import org.eclipse.kapua.model.KapuaEntityFactory;
 
 public interface CertificateFactory extends KapuaEntityFactory<Certificate, CertificateCreator, CertificateQuery, CertificateListResult> {
 
-    public CertificateUsage newCertificateUsage(String name);
+    CertificateUsage newCertificateUsage(String name);
 
-    public KeyUsageSetting newKeyUsageSetting(KeyUsage usage, boolean allowed, Boolean kapuaAllowed);
+    KeyUsageSetting newKeyUsageSetting(KeyUsage usage, boolean allowed, Boolean kapuaAllowed);
 
-    public CertificateGenerator newCertificateGenerator();
+    CertificateGenerator newCertificateGenerator();
 
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateGenerator.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateGenerator.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate;
 
+import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -19,8 +21,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import java.util.Date;
 import java.util.Set;
-
-import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 
 /**
  * {@link CertificateGenerator} encapsulates all the information needed to generate a new Certificate in the system.
@@ -76,7 +76,7 @@ public interface CertificateGenerator {
 
     void setCertificateUsages(Set<CertificateUsage> certificateUsages);
 
-    public Boolean getForwardable();
+    Boolean getForwardable();
 
-    public void setForwardable(Boolean forwardable);
+    void setForwardable(Boolean forwardable);
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
@@ -26,7 +26,7 @@ import javax.xml.bind.annotation.XmlType;
 public interface CertificateQuery extends KapuaQuery<Certificate> {
 
     @XmlElement(name = "includeInherited")
-    public Boolean getIncludeInherited();
+    Boolean getIncludeInherited();
 
-    public void setIncludeInherited(Boolean includeInherited);
+    void setIncludeInherited(Boolean includeInherited);
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
@@ -26,10 +26,10 @@ public interface CertificateService extends KapuaEntityService<Certificate, Cert
         KapuaUpdatableEntityService<Certificate>,
         KapuaDomainService<CertificateDomain> {
 
-    public static final CertificateDomain CERTIFICATE_DOMAIN = new CertificateDomain();
+    CertificateDomain CERTIFICATE_DOMAIN = new CertificateDomain();
 
     @Override
-    public default CertificateDomain getServiceDomain() {
+    default CertificateDomain getServiceDomain() {
         return CERTIFICATE_DOMAIN;
     }
 

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateUsage.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateUsage.java
@@ -25,8 +25,8 @@ import javax.xml.bind.annotation.XmlType;
         factoryMethod = "newCertificateUsage")
 public interface CertificateUsage {
 
-    public String getName();
+    String getName();
 
-    public void setName(String name);
+    void setName(String name);
 
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/KeyUsageSetting.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/KeyUsageSetting.java
@@ -13,16 +13,16 @@ package org.eclipse.kapua.service.certificate;
 
 public interface KeyUsageSetting {
 
-    public KeyUsage getKeyUsage();
+    KeyUsage getKeyUsage();
 
-    public void setKeyUsage(KeyUsage keyUsage);
+    void setKeyUsage(KeyUsage keyUsage);
 
-    public boolean getAllowed();
+    boolean getAllowed();
 
-    public void setAllowed(boolean allowed);
+    void setAllowed(boolean allowed);
 
-    public Boolean getKapuaAllowed();
+    Boolean getKapuaAllowed();
 
-    public void setKapuaAllowed(Boolean allowed);
+    void setKapuaAllowed(Boolean allowed);
 
 }

--- a/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/RegistrationProcessor.java
+++ b/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/RegistrationProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2018 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,17 +8,18 @@
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation
+ *     Eurotech
  *******************************************************************************/
 package org.eclipse.kapua.security.registration;
-
-import java.util.Optional;
 
 import org.eclipse.kapua.service.user.User;
 import org.jose4j.jwt.consumer.JwtContext;
 
+import java.util.Optional;
+
 /**
  * A registration processor
- * 
+ *
  * <p>
  * A registration process may be able to create a new user based on the provided
  * SSO authentication context.
@@ -28,12 +29,10 @@ public interface RegistrationProcessor extends AutoCloseable {
 
     /**
      * Ask the registration process to create a new user
-     * 
-     * @param context
-     *            the context to use as reference
+     *
+     * @param context the context to use as reference
      * @return an optional new user, never returns {@code null}, but may return {@link Optional#empty()}
-     * @throws Exception
-     *             if anything goes wrong
+     * @throws Exception if anything goes wrong
      */
-    public Optional<User> createUser(JwtContext context) throws Exception;
+    Optional<User> createUser(JwtContext context) throws Exception;
 }

--- a/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/RegistrationProcessorProvider.java
+++ b/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/RegistrationProcessorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2018 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation
+ *     Eurotech
  *******************************************************************************/
 package org.eclipse.kapua.security.registration;
 
@@ -35,8 +36,8 @@ public interface RegistrationProcessorProvider {
      * <b>Note:</b> The caller takes ownership of the returned resources and must close them
      * properly once they are no longer used.
      * </p>
-     * 
+     *
      * @return A collection of processors provided by this provider
      */
-    public Collection<? extends RegistrationProcessor> createAll();
+    Collection<? extends RegistrationProcessor> createAll();
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -74,7 +74,7 @@ import java.util.UUID;
 @KapuaProvider
 public class AuthenticationServiceShiroImpl implements AuthenticationService {
 
-    private final static Logger LOG = LoggerFactory.getLogger(AuthenticationServiceShiroImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AuthenticationServiceShiroImpl.class);
 
     static {
         // Make the SecurityManager instance available to the entire application:

--- a/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamService.java
+++ b/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamService.java
@@ -20,13 +20,12 @@ import org.eclipse.kapua.service.device.management.message.response.KapuaRespons
 
 public interface StreamService extends KapuaService, KapuaDomainService<StreamDomain> {
 
-    public static final StreamDomain STREAM_DOMAIN = new StreamDomain();
+    StreamDomain STREAM_DOMAIN = new StreamDomain();
 
     @Override
-    public default StreamDomain getServiceDomain() {
+    default StreamDomain getServiceDomain() {
         return STREAM_DOMAIN;
     }
 
-    KapuaResponseMessage<?, ?> publish(KapuaDataMessage message, Long timeout)
-            throws KapuaException;
+    KapuaResponseMessage<?, ?> publish(KapuaDataMessage message, Long timeout) throws KapuaException;
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Tag.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Tag.java
@@ -11,7 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag;
 
-import java.math.BigInteger;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdFactory;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -19,18 +22,14 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdFactory;
+import java.math.BigInteger;
 
 /**
  * Tag entity definition.<br>
  * Tags serve as tag for entities marked as {@link Taggable}.
  * It is possible to assign a tag to an entity.
  * {@link Tag#getName()} must be unique within the scope.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "tag")
@@ -40,31 +39,31 @@ import org.eclipse.kapua.model.id.KapuaIdFactory;
 public interface Tag extends KapuaUpdatableEntity {
 
     @XmlTransient
-    public static final KapuaId ANY = KapuaLocator.getInstance().getFactory(KapuaIdFactory.class).newKapuaId(BigInteger.ONE.negate());
+    KapuaId ANY = KapuaLocator.getInstance().getFactory(KapuaIdFactory.class).newKapuaId(BigInteger.ONE.negate());
 
-    public static final String TYPE = "tag";
+    String TYPE = "tag";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
     /**
      * Sets the {@link Tag} name.<br>
      * It must be unique within the scope.
-     * 
-     * @param name
-     *            The name of the {@link Tag}
+     *
+     * @param name The name of the {@link Tag}
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the {@link Tag} name.
-     * 
+     *
      * @return The {@link Tag} name.
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagCreator.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagCreator.java
@@ -11,18 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag;
 
+import org.eclipse.kapua.model.KapuaEntityCreator;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.KapuaEntityCreator;
-
 /**
  * {@link Tag} creator definition.<br>
  * It is used to create a new {@link Tag}.
- * 
+ *
  * @since 1.0.0
  */
 @XmlRootElement(name = "tagCreator")
@@ -34,20 +34,18 @@ public interface TagCreator extends KapuaEntityCreator<Tag> {
 
     /**
      * Sets the {@link Tag} name.
-     * 
-     * @param name
-     *            The {@link Tag} name.
-     * 
+     *
+     * @param name The {@link Tag} name.
      * @since 1.0.0
      */
-    public void setName(String name);
+    void setName(String name);
 
     /**
      * Gets the {@link Tag} name.
-     * 
+     *
      * @return The {@link Tag} name.
      * @since 1.0.0
      */
     @XmlElement(name = "name")
-    public String getName();
+    String getName();
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagFactory.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagFactory.java
@@ -16,22 +16,19 @@ import org.eclipse.kapua.model.id.KapuaId;
 
 /**
  * {@link Tag} object factory.
- * 
- * @since 1.0.0
  *
+ * @since 1.0.0
  */
 public interface TagFactory extends KapuaEntityFactory<Tag, TagCreator, TagQuery, TagListResult> {
 
     /**
      * Instantiate a new {@link TagCreator} implementing object with the provided parameters.
      *
-     * @param scopeId
-     *            The scope id of the tag.
-     * @param name
-     *            The {@link Tag} name to set.
+     * @param scopeId The scope id of the tag.
+     * @param name    The {@link Tag} name to set.
      * @return A instance of the implementing class of {@link Tag}.
      * @since 1.0.0
      */
-    public TagCreator newCreator(KapuaId scopeId, String name);
+    TagCreator newCreator(KapuaId scopeId, String name);
 
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagService.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagService.java
@@ -29,10 +29,10 @@ public interface TagService extends KapuaEntityService<Tag, TagCreator>,
         KapuaDomainService<TagDomain>,
         KapuaConfigurableService {
 
-    public static final TagDomain TAG_DOMAIN = new TagDomain();
+    TagDomain TAG_DOMAIN = new TagDomain();
 
     @Override
-    public default TagDomain getServiceDomain() {
+    default TagDomain getServiceDomain() {
         return TAG_DOMAIN;
     }
 
@@ -46,8 +46,7 @@ public interface TagService extends KapuaEntityService<Tag, TagCreator>,
      * @since 1.0.0
      */
     @Override
-    public Tag create(TagCreator tagCreator)
-            throws KapuaException;
+    Tag create(TagCreator tagCreator) throws KapuaException;
 
     /**
      * Updates the {@link Tag} according the given updated entity.<br>
@@ -59,8 +58,7 @@ public interface TagService extends KapuaEntityService<Tag, TagCreator>,
      * @since 1.0.0
      */
     @Override
-    public Tag update(Tag tag)
-            throws KapuaException;
+    Tag update(Tag tag) throws KapuaException;
 
     /**
      * Finds the {@link Tag} by scope identifier and {@link Tag} id.
@@ -72,8 +70,7 @@ public interface TagService extends KapuaEntityService<Tag, TagCreator>,
      * @since 1.0.0
      */
     @Override
-    public Tag find(KapuaId scopeId, KapuaId tagId)
-            throws KapuaException;
+    Tag find(KapuaId scopeId, KapuaId tagId) throws KapuaException;
 
     /**
      * Returns the {@link TagListResult} with elements matching the provided query.
@@ -84,8 +81,7 @@ public interface TagService extends KapuaEntityService<Tag, TagCreator>,
      * @since 1.0.0
      */
     @Override
-    public TagListResult query(KapuaQuery<Tag> query)
-            throws KapuaException;
+    TagListResult query(KapuaQuery<Tag> query) throws KapuaException;
 
     /**
      * Returns the count of the {@link Tag} elements matching the provided query.
@@ -96,8 +92,7 @@ public interface TagService extends KapuaEntityService<Tag, TagCreator>,
      * @since 1.0.0
      */
     @Override
-    public long count(KapuaQuery<Tag> query)
-            throws KapuaException;
+    long count(KapuaQuery<Tag> query) throws KapuaException;
 
     /**
      * Delete the {@link Tag} by scope id and {@link Tag} id.
@@ -108,7 +103,6 @@ public interface TagService extends KapuaEntityService<Tag, TagCreator>,
      * @since 1.0.0
      */
     @Override
-    public void delete(KapuaId scopeId, KapuaId tagId)
-            throws KapuaException;
+    void delete(KapuaId scopeId, KapuaId tagId) throws KapuaException;
 
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagXmlRegistry.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagXmlRegistry.java
@@ -11,44 +11,44 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
 
 @XmlRegistry
 public class TagXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final TagFactory factory = locator.getFactory(TagFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final TagFactory TAG_FACTORY = LOCATOR.getFactory(TagFactory.class);
 
     /**
      * Creates a new tag instance
-     * 
+     *
      * @return
      */
     public Tag newTag() {
-        return factory.newEntity(null);
+        return TAG_FACTORY.newEntity(null);
     }
 
     /**
      * Creates a new tag creator instance
-     * 
+     *
      * @return
      */
     public TagCreator newTagCreator() {
-        return factory.newCreator(null, null);
+        return TAG_FACTORY.newCreator(null, null);
     }
 
     /**
      * Creates a new tag creator instance
-     * 
+     *
      * @return
      */
     public TagListResult newTagListResult() {
-        return factory.newListResult();
+        return TAG_FACTORY.newListResult();
     }
 
     public TagQuery newQuery() {
-        return factory.newQuery(null);
+        return TAG_FACTORY.newQuery(null);
     }
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Taggable.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Taggable.java
@@ -11,14 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag;
 
-import java.util.Set;
-
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Set;
 
 /**
  * Interface used to mark tag-able entities.
@@ -29,22 +28,22 @@ public interface Taggable {
 
     /**
      * Sets the set of {@link Tag} id of this entity.
-     * 
-     * @param tagIds
-     *            The set {@link Tag} id to assign.
+     *
+     * @param tagIds The set {@link Tag} id to assign.
      * @since 1.0.0
      */
-    public void setTagIds(Set<KapuaId> tagIds);
+
+    void setTagIds(Set<KapuaId> tagIds);
 
     /**
      * Gets the set of {@link Tag} id assigned to this entity.
-     * 
+     *
      * @return The set {@link Tag} id assigned to this entity.
      * @since 1.0.0
      */
     @XmlElement(name = "tagId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
-    public <I extends KapuaId> Set<I> getTagIds();
+    <I extends KapuaId> Set<I> getTagIds();
 
 }

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/User.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/User.java
@@ -11,16 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user;
 
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import org.eclipse.kapua.model.KapuaNamedEntity;
-import org.eclipse.kapua.model.xml.DateXmlAdapter;
-
 import java.util.Date;
 
 /**
@@ -42,9 +41,10 @@ import java.util.Date;
         factoryMethod = "newUser")
 public interface User extends KapuaNamedEntity {
 
-    public static final String TYPE = "user";
+    String TYPE = "user";
 
-    public default String getType() {
+    @Override
+    default String getType() {
         return TYPE;
     }
 
@@ -54,14 +54,14 @@ public interface User extends KapuaNamedEntity {
      * @return
      */
     @XmlElement(name = "status")
-    public UserStatus getStatus();
+    UserStatus getStatus();
 
     /**
      * Get the user status
      *
      * @param status
      */
-    public void setStatus(UserStatus status);
+    void setStatus(UserStatus status);
 
     /**
      * Return the display name (may be a friendly username to show in the UI)
@@ -69,14 +69,14 @@ public interface User extends KapuaNamedEntity {
      * @return
      */
     @XmlElement(name = "displayName")
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * Set the display name
      *
      * @param displayName
      */
-    public void setDisplayName(String displayName);
+    void setDisplayName(String displayName);
 
     /**
      * Get the user email
@@ -84,14 +84,14 @@ public interface User extends KapuaNamedEntity {
      * @return
      */
     @XmlElement(name = "email")
-    public String getEmail();
+    String getEmail();
 
     /**
      * Set the user email
      *
      * @param email
      */
-    public void setEmail(String email);
+    void setEmail(String email);
 
     /**
      * Get the phone number
@@ -99,14 +99,14 @@ public interface User extends KapuaNamedEntity {
      * @return
      */
     @XmlElement(name = "phoneNumber")
-    public String getPhoneNumber();
+    String getPhoneNumber();
 
     /**
      * Set the phone number
      *
      * @param phoneNumber
      */
-    public void setPhoneNumber(String phoneNumber);
+    void setPhoneNumber(String phoneNumber);
 
     /**
      * Get the user type
@@ -114,12 +114,12 @@ public interface User extends KapuaNamedEntity {
      * @return
      */
     @XmlElement(name = "userType")
-    public UserType getUserType();
+    UserType getUserType();
 
     /**
      * Set the user type
      */
-    public void setUserType(UserType userType);
+    void setUserType(UserType userType);
 
     /**
      * Get the external ID
@@ -127,18 +127,18 @@ public interface User extends KapuaNamedEntity {
      * @return
      */
     @XmlElement(name = "externalId")
-    public String getExternalId();
+    String getExternalId();
 
     /**
      * Set the external ID
      *
      * @param externalId
      */
-    public void setExternalId(String externalId);
+    void setExternalId(String externalId);
 
-    @XmlElement(name="expirationDate")
+    @XmlElement(name = "expirationDate")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    public Date getExpirationDate();
+    Date getExpirationDate();
 
-    public void setExpirationDate(Date expirationDate);
+    void setExpirationDate(Date expirationDate);
 }

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
@@ -11,16 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user;
 
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
-import org.eclipse.kapua.model.KapuaNamedEntityCreator;
-import org.eclipse.kapua.model.xml.DateXmlAdapter;
-
 import java.util.Date;
 
 /**
@@ -36,7 +35,7 @@ import java.util.Date;
         "userType",
         "externalId",
         "expirationDate",
-        "userStatus"},
+        "userStatus" },
         factoryClass = UserXmlRegistry.class,
         factoryMethod = "newUserCreator")
 public interface UserCreator extends KapuaNamedEntityCreator<User> {
@@ -47,14 +46,14 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
      * @return
      */
     @XmlElement(name = "displayName")
-    public String getDisplayName();
+    String getDisplayName();
 
     /**
      * Set the display name
      *
      * @param displayName
      */
-    public void setDisplayName(String displayName);
+    void setDisplayName(String displayName);
 
     /**
      * Get the email
@@ -62,14 +61,14 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
      * @return
      */
     @XmlElement(name = "email")
-    public String getEmail();
+    String getEmail();
 
     /**
      * Set the email
      *
      * @param email
      */
-    public void setEmail(String email);
+    void setEmail(String email);
 
     /**
      * Get the phone number
@@ -77,14 +76,14 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
      * @return
      */
     @XmlElement(name = "phoneNumber")
-    public String getPhoneNumber();
+    String getPhoneNumber();
 
     /**
      * Set the phone number
      *
      * @param phoneNumber
      */
-    public void setPhoneNumber(String phoneNumber);
+    void setPhoneNumber(String phoneNumber);
 
     /**
      * Get the user type
@@ -92,14 +91,14 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
      * @return
      */
     @XmlElement(name = "userType")
-    public UserType getUserType();
+    UserType getUserType();
 
     /**
      * Set the user type
      *
      * @param userType
      */
-    public void setUserType(UserType userType);
+    void setUserType(UserType userType);
 
     /**
      * Get the external ID
@@ -107,14 +106,14 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
      * @return
      */
     @XmlElement(name = "externalId")
-    public String getExternalId();
+    String getExternalId();
 
     /**
      * Set the external ID
      *
      * @param externalId
      */
-    public void setExternalId(String externalId);
+    void setExternalId(String externalId);
 
     @XmlElement(name = "expirationDate")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
@@ -122,7 +121,7 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
 
     void setExpirationDate(Date expirationDate);
 
-    @XmlElement(name="userStatus")
+    @XmlElement(name = "userStatus")
     UserStatus getUserStatus();
 
     void setUserStatus(UserStatus userStatus);

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserFactory.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserFactory.java
@@ -28,6 +28,6 @@ public interface UserFactory extends KapuaEntityFactory<User, UserCreator, UserQ
      * @param name
      * @return
      */
-    public UserCreator newCreator(KapuaId scopedId, String name);
+    UserCreator newCreator(KapuaId scopedId, String name);
 
 }

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
@@ -33,7 +33,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
         KapuaDomainService<UserDomain>,
         KapuaConfigurableService {
 
-    public static final UserDomain USER_DOMAIN = new UserDomain();
+    UserDomain USER_DOMAIN = new UserDomain();
 
     @Override
     default UserDomain getServiceDomain() {
@@ -50,8 +50,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      * @throws KapuaException
      */
     @Override
-    public User create(UserCreator userCreator)
-            throws KapuaException;
+    User create(UserCreator userCreator) throws KapuaException;
 
     /**
      * Updates an User in the database and returns the refreshed/reloaded entity instance.<br>
@@ -63,8 +62,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      * @throws KapuaException
      */
     @Override
-    public User update(User user)
-            throws KapuaException;
+    User update(User user) throws KapuaException;
 
     /**
      * Delete the supplied User.
@@ -72,8 +70,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      * @param user
      * @throws KapuaException
      */
-    public void delete(User user)
-            throws KapuaException;
+    void delete(User user) throws KapuaException;
 
     /**
      * Returns the User with the specified Id; returns null if the user is not found.<br>
@@ -84,8 +81,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      * @throws KapuaException
      */
     @Override
-    public User find(KapuaId accountId, KapuaId userId)
-            throws KapuaException;
+    User find(KapuaId accountId, KapuaId userId) throws KapuaException;
 
     /**
      * Returns the User with the specified username; returns null if the user is not found.
@@ -94,8 +90,7 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      * @throws KapuaException
      */
     @Override
-    public User findByName(String name)
-            throws KapuaException;
+    User findByName(String name) throws KapuaException;
 
     /**
      * Find user by external id
@@ -104,13 +99,12 @@ public interface UserService extends KapuaEntityService<User, UserCreator>,
      * @return the user or {@code null} if the user could not be found
      * @throws KapuaException in case anything goes wrong
      */
-    public User findByExternalId(String externalId) throws KapuaException;
+    User findByExternalId(String externalId) throws KapuaException;
 
     /**
      * Queries for all users
      */
     @Override
-    public UserListResult query(KapuaQuery<User> query)
-            throws KapuaException;
+    UserListResult query(KapuaQuery<User> query) throws KapuaException;
 
 }

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserXmlRegistry.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserXmlRegistry.java
@@ -11,20 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user;
 
-import javax.xml.bind.annotation.XmlRegistry;
-
 import org.eclipse.kapua.locator.KapuaLocator;
 
+import javax.xml.bind.annotation.XmlRegistry;
+
 /**
- * User xml factory class
+ * {@link User} xml factory class
  *
  * @since 1.0
  */
 @XmlRegistry
 public class UserXmlRegistry {
 
-    private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final UserFactory factory = locator.getFactory(UserFactory.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
 
     /**
      * Creates a new user instance
@@ -32,7 +32,7 @@ public class UserXmlRegistry {
      * @return
      */
     public User newUser() {
-        return factory.newEntity(null);
+        return USER_FACTORY.newEntity(null);
     }
 
     /**
@@ -41,7 +41,7 @@ public class UserXmlRegistry {
      * @return
      */
     public UserCreator newUserCreator() {
-        return factory.newCreator(null, null);
+        return USER_FACTORY.newCreator(null, null);
     }
 
     /**
@@ -50,10 +50,10 @@ public class UserXmlRegistry {
      * @return
      */
     public UserListResult newUserListResult() {
-        return factory.newListResult();
+        return USER_FACTORY.newListResult();
     }
 
     public UserQuery newQuery() {
-        return factory.newQuery(null);
+        return USER_FACTORY.newQuery(null);
     }
 }

--- a/test/src/main/java/org/eclipse/kapua/test/MockedLocator.java
+++ b/test/src/main/java/org/eclipse/kapua/test/MockedLocator.java
@@ -11,11 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.google.inject.ConfigurationException;
 import com.google.inject.Injector;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -24,27 +19,31 @@ import org.eclipse.kapua.service.KapuaService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Locator service implementation used for mocking Kapua services and Kapua object
  * factories. Mocking framework such as Mockito can be used to create mocked service
  * which is than injected into this locator using setters.
  * Mocked services can be set multiple times, for each test case individually. This
  * locator implementation should be used only for testing purposes.
- * 
+ * <p>
  * Locator can be configured in maven pom file or command line as system parameter:
- * 
+ * <p>
  * -Dlocator.class.impl=org.eclipse.kapua.test.MockedLocator
- *
+ * <p>
  * In cucumber setting is done in custom cucumber runner CucumberWithProperties.
- *
+ * <p>
  * Mocked locator can be used in two ways:
- *  - setting services with seter and having local Map of services and factories
- *  - setting services with Google Guice DI
- *
+ * - setting services with seter and having local Map of services and factories
+ * - setting services with Google Guice DI
  */
 public class MockedLocator extends KapuaLocator {
 
-    private final static Logger logger = LoggerFactory.getLogger(MockedLocator.class);
+    private static final Logger logger = LoggerFactory.getLogger(MockedLocator.class);
 
     private Map<Class<?>, KapuaService> serviceMap = new HashMap<>();
 
@@ -70,13 +69,11 @@ public class MockedLocator extends KapuaLocator {
         factoryMap.put(clazz, factory);
     }
 
-    @SuppressWarnings("unchecked")
     private <S extends KapuaService> S getMockedService(Class<S> clazz) {
 
         return (S) serviceMap.get(clazz);
     }
 
-    @SuppressWarnings("unchecked")
     private <F extends KapuaObjectFactory> F getMockedFactory(Class<F> clazz) {
 
         return (F) factoryMap.get(clazz);

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/MethodDictionaryKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/MethodDictionaryKapuaKura.java
@@ -29,7 +29,7 @@ public class MethodDictionaryKapuaKura {
     /**
      * Translations dictionary map
      */
-    private final static Map<KapuaMethod, KuraMethod> DICTIONARY;
+    private static final Map<KapuaMethod, KuraMethod> DICTIONARY;
 
     static {
         DICTIONARY = new HashMap<>(5);

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/MethodDictionaryKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/MethodDictionaryKuraKapua.java
@@ -29,7 +29,7 @@ public class MethodDictionaryKuraKapua {
     /**
      * Translations dictionary map
      */
-    private final static Map<KuraMethod, KapuaMethod> DICTIONARY;
+    private static final Map<KuraMethod, KapuaMethod> DICTIONARY;
 
     static {
         DICTIONARY = new HashMap<>(5);

--- a/transport/jms/src/main/java/org/eclipse/kapua/transport/message/jms/JmsTopic.java
+++ b/transport/jms/src/main/java/org/eclipse/kapua/transport/message/jms/JmsTopic.java
@@ -17,30 +17,29 @@ import org.eclipse.kapua.transport.message.TransportChannel;
 
 /**
  * Implementation of {@link TransportChannel} API for JMS transport facade
- * 
+ *
  * @since 1.0.0
  */
 public class JmsTopic implements TransportChannel {
 
     /**
      * The topic separator value for JMS topics returned from {@link JmsClientSetting}.{@link JmsClientSettingKeys#TRANSPORT_TOPIC_SEPARATOR}
-     * 
+     *
      * @since 1.0.0
      */
-    private final static String TOPIC_SEPARATOR = JmsClientSetting.getInstance().getString(JmsClientSettingKeys.TRANSPORT_TOPIC_SEPARATOR);
+    private static final String TOPIC_SEPARATOR = JmsClientSetting.getInstance().getString(JmsClientSettingKeys.TRANSPORT_TOPIC_SEPARATOR);
 
     /**
      * The full topic.
-     * 
+     *
      * @since 1.0.0
      */
     private String topic;
 
     /**
      * Construct a {@link JmsTopic} with the given parameter
-     * 
-     * @param topic
-     *            The topic to set for this {@link JmsTopic}
+     *
+     * @param topic The topic to set for this {@link JmsTopic}
      * @since 1.0.0
      */
     public JmsTopic(String topic) {
@@ -53,9 +52,8 @@ public class JmsTopic implements TransportChannel {
      * Topic is built by concatenating all {@link String}[] token following the array order,
      * separating each token with the topic separator configured in {@link JmsClientSetting}.{@link JmsClientSettingKeys#TRANSPORT_TOPIC_SEPARATOR}
      * </p>
-     * 
-     * @param topicParts
-     *            The {@link String}[] from which build the full topic.
+     *
+     * @param topicParts The {@link String}[] from which build the full topic.
      * @since 1.0.0
      */
     public JmsTopic(String[] topicParts) {
@@ -74,7 +72,7 @@ public class JmsTopic implements TransportChannel {
 
     /**
      * Gets the full topic set for this {@link JmsTopic}
-     * 
+     *
      * @return the full topic of this {@link JmsTopic}
      * @since 1.0.0
      */
@@ -84,9 +82,8 @@ public class JmsTopic implements TransportChannel {
 
     /**
      * Sets the full topic for this {@link JmsTopic}
-     * 
-     * @param topic
-     *            The full topic to set for this {@link JmsTopic}
+     *
+     * @param topic The full topic to set for this {@link JmsTopic}
      * @since 1.0.0
      */
     public void setTopic(String topic) {
@@ -95,7 +92,7 @@ public class JmsTopic implements TransportChannel {
 
     /**
      * Gets the topic split-ed by the topic separator configured in {@link JmsClientSetting}.{@link JmsClientSettingKeys#TRANSPORT_TOPIC_SEPARATOR}
-     * 
+     *
      * @return The topic tokens or {@code null} if full topic has been set to {@code null}
      * @since 1.0.0
      */

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClient.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClient.java
@@ -11,10 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.transport.mqtt;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.transport.TransportClientConnectOptions;
 import org.eclipse.kapua.transport.message.mqtt.MqttMessage;
@@ -24,11 +20,15 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
 /**
  * Class that wrap a {@link org.eclipse.paho.client.mqttv3.MqttClient} and
  * adds some utility methods to manage the operations at the transport level
  * in Kapua.
- * 
+ *
  * @since 1.0.0
  */
 public class MqttClient {
@@ -46,13 +46,12 @@ public class MqttClient {
     //
     // Connection management
     //
+
     /**
      * Connects the {@link MqttClient#pahoMqttClient} according to the given {@link TransportClientConnectOptions}.
-     * 
-     * @param options
-     *            The connection options to use
-     * @throws MqttClientException
-     *             When connect fails.
+     *
+     * @param options The connection options to use
+     * @throws MqttClientException When connect fails.
      * @since 1.0.0
      */
     public void connectClient(TransportClientConnectOptions options)
@@ -79,9 +78,9 @@ public class MqttClient {
         } catch (MqttException e) {
             throw new MqttClientException(MqttClientErrorCodes.CLIENT_CONNECT_ERROR,
                     e,
-                    new Object[] { options.getEndpointURI().toString(),
-                            options.getClientId(),
-                            options.getUsername() });
+                    options.getEndpointURI().toString(),
+                    options.getClientId(),
+                    options.getUsername());
         }
     }
 
@@ -90,10 +89,8 @@ public class MqttClient {
      * <p>
      * Before disconnecting cleaning of subscriptions is attempted.
      * </p>
-     * 
-     * @throws KapuaException
-     *             When disconnect fails.
-     * 
+     *
+     * @throws KapuaException When disconnect fails.
      * @since 1.0.0
      */
     public void disconnectClient()
@@ -101,13 +98,9 @@ public class MqttClient {
         try {
             unsubscribeAll();
 
-            if (getPahoClient() != null) {
-                getPahoClient().disconnect();
-            }
+            getPahoClient().disconnect();
         } catch (MqttException e) {
-            throw new MqttClientException(MqttClientErrorCodes.CLIENT_DISCONNECT_ERROR,
-                    e,
-                    (Object[]) null);
+            throw new MqttClientException(MqttClientErrorCodes.CLIENT_DISCONNECT_ERROR, e, (Object) null);
         }
     }
 
@@ -116,32 +109,28 @@ public class MqttClient {
      * <p>
      * Before termination {@link MqttClient#disconnectClient()} is invoked to clean up appended subscriptions and close connection.
      * </p>
-     * 
-     * @throws KapuaException
-     *             Whne close fails.
+     *
+     * @throws KapuaException Whne close fails.
      * @since 1.0.0
      */
     public void terminateClient()
             throws KapuaException {
         try {
-            if (getPahoClient() != null) {
-                if (getPahoClient().isConnected()) {
-                    disconnectClient();
-                }
-
-                getPahoClient().close();
-                pahoMqttClient = null;
+            if (getPahoClient().isConnected()) {
+                disconnectClient();
             }
+
+            getPahoClient().close();
+
+            pahoMqttClient = null;
         } catch (MqttException e) {
-            throw new MqttClientException(MqttClientErrorCodes.CLIENT_TERMINATE_ERROR,
-                    e,
-                    (Object[]) null);
+            throw new MqttClientException(MqttClientErrorCodes.CLIENT_TERMINATE_ERROR, e, (Object) null);
         }
     }
 
     /**
      * Checks if this {@link MqttClient} is connected.
-     * 
+     *
      * @return {@code true} if connected, {@code false} otherwise.
      * @since 1.0.0
      */
@@ -157,17 +146,15 @@ public class MqttClient {
     //
     // Message management
     //
+
     /**
      * Publish a {@link MqttMessage}.
      * <p>
      * QoS of publishing is set to 0.
      * </p>
-     * 
-     * @param mqttMessage
-     *            The {@link MqttMessage} to publish.
-     * 
-     * @throws KapuaException
-     *             When publish fails.
+     *
+     * @param mqttMessage The {@link MqttMessage} to publish.
+     * @throws KapuaException When publish fails.
      * @since 1.0.0
      */
     public void publish(MqttMessage mqttMessage)
@@ -181,19 +168,15 @@ public class MqttClient {
                     0,
                     false);
         } catch (MqttException | KapuaException e) {
-            throw new MqttClientException(MqttClientErrorCodes.CLIENT_SUBSCRIBE_ERROR,
-                    e,
-                    new Object[] { mqttTopic.toString() });
+            throw new MqttClientException(MqttClientErrorCodes.CLIENT_SUBSCRIBE_ERROR, e, mqttTopic.toString());
         }
     }
 
     /**
      * Subscribes this client to the given {@link MqttTopic}.
-     * 
-     * @param mqttTopic
-     *            The {@link MqttTopic} to subscribe to.
-     * @throws KapuaException
-     *             When subscribe fails.
+     *
+     * @param mqttTopic The {@link MqttTopic} to subscribe to.
+     * @throws KapuaException When subscribe fails.
      * @since 1.0.0
      */
     public void subscribe(MqttTopic mqttTopic)
@@ -202,19 +185,15 @@ public class MqttClient {
             getPahoClient().subscribe(mqttTopic.getTopic());
             subscribedTopics.add(mqttTopic);
         } catch (MqttException | KapuaException e) {
-            throw new MqttClientException(MqttClientErrorCodes.CLIENT_SUBSCRIBE_ERROR,
-                    e,
-                    new Object[] { mqttTopic.getTopic() });
+            throw new MqttClientException(MqttClientErrorCodes.CLIENT_SUBSCRIBE_ERROR, e, mqttTopic.getTopic());
         }
     }
 
     /**
      * Unsubscribes this client from the given {@link MqttTopic}.
-     * 
-     * @param mqttTopic
-     *            The {@link MqttTopic} to unsubscribe to.
-     * @throws KapuaException
-     *             When unsubscribe fails.
+     *
+     * @param mqttTopic The {@link MqttTopic} to unsubscribe to.
+     * @throws KapuaException When unsubscribe fails.
      * @since 1.0.0
      */
     private void unsubscribe(MqttTopic mqttTopic)
@@ -222,17 +201,15 @@ public class MqttClient {
         try {
             getPahoClient().unsubscribe(mqttTopic.getTopic());
         } catch (MqttException | KapuaException e) {
-            throw new MqttClientException(MqttClientErrorCodes.CLIENT_UNSUBSCRIBE_ERROR,
-                    e,
-                    new Object[] { mqttTopic.toString() });
+            throw new MqttClientException(MqttClientErrorCodes.CLIENT_UNSUBSCRIBE_ERROR, e, mqttTopic.toString());
         }
+
     }
 
     /**
      * Unsubscribes this client from all topics subscribed.
-     * 
-     * @throws KapuaException
-     *             When any of the unsubscribe fails.
+     *
+     * @throws KapuaException When any of the unsubscribe fails.
      * @since 1.0.0
      */
     public synchronized void unsubscribeAll()
@@ -242,7 +219,6 @@ public class MqttClient {
         while (subscribptionIterator.hasNext()) {
             MqttTopic mqttTopic = subscribptionIterator.next();
             unsubscribe(mqttTopic);
-
         }
 
         subscribedTopics.clear();
@@ -250,29 +226,24 @@ public class MqttClient {
 
     /**
      * Sets a {@link MqttClientCallback} to this client.
-     * 
-     * @param mqttClientCallback
-     *            The {@link MqttClientCallback} to use.
-     * @throws KapuaException
-     *             When set the callback fails.
+     *
+     * @param mqttClientCallback The {@link MqttClientCallback} to use.
+     * @throws KapuaException When set the callback fails.
      */
     public void setCallback(MqttClientCallback mqttClientCallback)
             throws KapuaException {
         try {
             getPahoClient().setCallback(mqttClientCallback);
         } catch (KapuaException e) {
-            throw new MqttClientException(MqttClientErrorCodes.CLIENT_CALLBACK_ERROR,
-                    e,
-                    (Object[]) null);
+            throw new MqttClientException(MqttClientErrorCodes.CLIENT_CALLBACK_ERROR, e, (Object) null);
         }
 
     }
 
     /**
      * Cleans this client from any callback set and unsubscribes from all {@link MqttTopic} subscribed.
-     * 
-     * @throws KapuaException
-     *             When any of the clean operations fails.
+     *
+     * @throws KapuaException When any of the clean operations fails.
      */
     public void clean()
             throws KapuaException {
@@ -281,9 +252,7 @@ public class MqttClient {
             unsubscribeAll();
         } catch (KapuaException e) {
             terminateClient();
-            throw new MqttClientException(MqttClientErrorCodes.CLIENT_CLEAN_ERROR,
-                    e,
-                    (Object[]) null);
+            throw new MqttClientException(MqttClientErrorCodes.CLIENT_CLEAN_ERROR, e, (Object) null);
         }
 
     }
@@ -291,9 +260,10 @@ public class MqttClient {
     //
     // Utilty
     //
+
     /**
      * Gets the clientId of the wrapped {@link MqttClient#pahoMqttClient}.
-     * 
+     *
      * @return The clientId of the wrapped {@link MqttClient#pahoMqttClient}.
      */
     public String getClientId() {
@@ -306,17 +276,13 @@ public class MqttClient {
 
     /**
      * Gets the reference to the wrapped {@link MqttClient#pahoMqttClient} ready to be used.
-     * 
+     *
      * @return The wrapped {@link MqttClient#pahoMqttClient}.
-     * @throws KapuaException
-     *             If client has never been connected using {@link MqttClient#connectClient(TransportClientConnectOptions)}.
+     * @throws KapuaException If client has never been connected using {@link MqttClient#connectClient(TransportClientConnectOptions)}.
      */
-    private synchronized org.eclipse.paho.client.mqttv3.MqttClient getPahoClient()
-            throws KapuaException {
+    private synchronized org.eclipse.paho.client.mqttv3.MqttClient getPahoClient() throws KapuaException {
         if (pahoMqttClient == null) {
-            throw new MqttClientException(MqttClientErrorCodes.CLIENT_NOT_CONNECTED,
-                    null,
-                    (Object[]) null);
+            throw new MqttClientException(MqttClientErrorCodes.CLIENT_NOT_CONNECTED, null, (Object) null);
         }
 
         return pahoMqttClient;

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttFacade.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttFacade.java
@@ -87,12 +87,7 @@ public class MqttFacade implements TransportFacade<MqttTopic, MqttPayload, MqttM
 
         if (timeout != null) {
             if (responses.isEmpty()) {
-                throw new MqttClientException(MqttClientErrorCodes.CLIENT_TIMEOUT_EXCEPTION,
-                        null,
-                        new Object[] {
-                                mqttMessage.getRequestTopic()
-                        });
-
+                throw new MqttClientException(MqttClientErrorCodes.CLIENT_TIMEOUT_EXCEPTION, null, mqttMessage.getRequestTopic());
             }
 
             return responses.get(0);
@@ -112,7 +107,7 @@ public class MqttFacade implements TransportFacade<MqttTopic, MqttPayload, MqttM
      * @param timeout     The timeout of waiting the response from the device.
      *                    If {@code null} request will be fired without waiting for the response.
      *                    If mqttMessage has no response message set, timeout will be ignore even if set.
-     * @throws KapuaException FIXME [javadoc] document exception
+     * @throws KapuaException
      * @see MqttMessage#getResponseTopic()
      * @since 1.0.0.
      */
@@ -127,9 +122,7 @@ public class MqttFacade implements TransportFacade<MqttTopic, MqttPayload, MqttM
                     borrowedClient.setCallback(mqttClientCallback);
                     borrowedClient.subscribe(mqttMessage.getResponseTopic());
                 } catch (KapuaException e) {
-                    throw new MqttClientException(MqttClientErrorCodes.CLIENT_SUBSCRIBE_ERROR,
-                            e,
-                            new Object[] { mqttMessage.getResponseTopic().getTopic() });
+                    throw new MqttClientException(MqttClientErrorCodes.CLIENT_SUBSCRIBE_ERROR, e, mqttMessage.getResponseTopic().getTopic());
                 }
             }
 
@@ -138,10 +131,11 @@ public class MqttFacade implements TransportFacade<MqttTopic, MqttPayload, MqttM
             try {
                 borrowedClient.publish(mqttMessage);
             } catch (KapuaException e) {
-                throw new MqttClientException(MqttClientErrorCodes.CLIENT_PUBLISH_ERROR,
+                throw new MqttClientException(
+                        MqttClientErrorCodes.CLIENT_PUBLISH_ERROR,
                         e,
-                        new Object[] { mqttMessage.getRequestTopic().getTopic(),
-                                mqttMessage.getPayload().getBody() });
+                        mqttMessage.getRequestTopic().getTopic(),
+                        mqttMessage.getPayload().getBody());
             }
 
             //
@@ -173,9 +167,7 @@ public class MqttFacade implements TransportFacade<MqttTopic, MqttPayload, MqttM
                     }
                 } catch (InterruptedException e) {
                     Thread.interrupted();
-                    throw new MqttClientException(MqttClientErrorCodes.CLIENT_CALLBACK_ERROR,
-                            e,
-                            (Object[]) null);
+                    throw new MqttClientException(MqttClientErrorCodes.CLIENT_CALLBACK_ERROR, e, (Object) null);
                 } finally {
                     timeoutTimer.cancel();
                 }


### PR DESCRIPTION
This PR solves a bunch of issues reported by Eclipse Sonar.

This PR fixes in particular this rule: https://sonar.eclipse.org/drilldown/issues/144827?&rule=checkstyle%3Acom.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck&rule_sev=MINOR

Removed a lot of `public` and `public static final` modifiers from `interfaces`.