### PR TITLE
Delay added before login screen is loaded after session timeout

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/FailureHandler.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/FailureHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ import com.extjs.gxt.ui.client.widget.form.FormPanel;
 import com.extjs.gxt.ui.client.widget.form.TextArea;
 import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.StatusCodeException;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
@@ -47,7 +48,14 @@ public class FailureHandler {
 
             case UNAUTHENTICATED:
                 ConsoleInfo.display(CMSGS.loggedOut(), caught.getLocalizedMessage());
-                Window.Location.reload();
+                Timer timer = new Timer() {
+
+                    @Override
+                    public void run() {
+                        Window.Location.reload();
+                    }
+                };
+                timer.schedule(5000);
                 break;
 
             default:


### PR DESCRIPTION
When session timeouts login was presented to user before error message
could be read by user.
I added timer that waits 5 seconds before login screen is presented to
user. This way user can read error message that says that he was logged
out due to inactivity.

This fixes issue #1635

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>