### PR TITLE
Fixed permission to show/hide Device Management tabs

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssetsDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssetsDescriptor.java
@@ -15,6 +15,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.Abstra
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.client.device.DeviceView;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceManagementSessionPermission;
 
 public class DeviceTabAssetsDescriptor extends AbstractEntityTabDescriptor<GwtDevice, DeviceTabAssets, DeviceView> {
 
@@ -35,6 +36,6 @@ public class DeviceTabAssetsDescriptor extends AbstractEntityTabDescriptor<GwtDe
 
     @Override
     public Boolean isEnabled(GwtSession currentSession) {
-        return true;
+        return currentSession.hasPermission(DeviceManagementSessionPermission.read());
     }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfigurationDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfigurationDescriptor.java
@@ -15,6 +15,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.Abstra
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.client.device.DeviceView;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceManagementSessionPermission;
 
 public class DeviceTabConfigurationDescriptor extends AbstractEntityTabDescriptor<GwtDevice, DeviceTabConfiguration, DeviceView> {
 
@@ -35,6 +36,6 @@ public class DeviceTabConfigurationDescriptor extends AbstractEntityTabDescripto
 
     @Override
     public Boolean isEnabled(GwtSession currentSession) {
-        return true;
+        return currentSession.hasPermission(DeviceManagementSessionPermission.read());
     }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceManagementSessionPermission.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceManagementSessionPermission.java
@@ -22,7 +22,7 @@ public class DeviceManagementSessionPermission extends GwtSessionPermission {
     }
 
     private DeviceManagementSessionPermission(GwtSessionPermissionAction action) {
-        super("device", action, GwtSessionPermissionScope.SELF);
+        super("device_management", action, GwtSessionPermissionScope.SELF);
     }
 
     public static DeviceManagementSessionPermission read() {


### PR DESCRIPTION
This PR fixes #1677 

Fixed `return true;` in tab descriptors and fixed the Domain name in the `DeviceManagementSessionPermission` class.

Regards, 

_Alberto_