### PR TITLE
Credential Type/Username display fix

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -45,6 +45,7 @@ public class CredentialAddDialog extends EntityAddEditDialog {
     private String selectedUserId;
     private String selectedUserName;
     SimpleComboBox<GwtCredentialType> credentialType;
+    protected LabelField credentialTypeLabel;
     private LabelField subject;
     protected TextField<String> password;
     protected TextField<String> confirmPassword;
@@ -71,6 +72,12 @@ public class CredentialAddDialog extends EntityAddEditDialog {
         subject.setFieldLabel(MSGS.dialogAddFieldSubject());
         subject.setLabelSeparator(":");
         credentialFormPanel.add(subject);
+
+        credentialTypeLabel = new LabelField();
+        credentialTypeLabel.setFieldLabel(MSGS.dialogAddFieldCredentialType());
+        credentialTypeLabel.setLabelSeparator(":");
+        credentialTypeLabel.setVisible(false);
+        credentialFormPanel.add(credentialTypeLabel);
 
         credentialType = new SimpleComboBox<GwtCredentialType>();
         credentialType.setEditable(false);

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
@@ -90,7 +90,9 @@ public class CredentialEditDialog extends CredentialAddDialog {
     @Override
     protected void onRender(Element parent, int pos) {
         super.onRender(parent, pos);
-        credentialType.disable();
+        credentialFormPanel.remove(credentialType);
+        credentialTypeLabel.setVisible(true);
+        credentialTypeLabel.setValue(selectedCredential.getCredentialType());
         password.setValidator(new PasswordUpdateFieldValidator(password));
         password.setFieldLabel(MSGS.dialogEditFieldNewPassword());
         password.setAllowBlank(true);

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -48,7 +48,9 @@ public class UserAddDialog extends EntityAddEditDialog {
 
     protected static final ConsoleUserMessages USER_MSGS = GWT.create(ConsoleUserMessages.class);
 
+    protected FieldSet infoFieldSet;
     protected KapuaTextField<String> username;
+    protected LabelField usernameLabel;
     protected KapuaTextField<String> password;
     protected KapuaTextField<String> confirmPassword;
     protected LabelField passwordTooltip;
@@ -89,7 +91,7 @@ public class UserAddDialog extends EntityAddEditDialog {
         //
         // User info tab
         //
-        FieldSet infoFieldSet = new FieldSet();
+        infoFieldSet = new FieldSet();
         infoFieldSet.setHeading(USER_MSGS.dialogAddFieldSet());
         infoFieldSet.setBorders(true);
         infoFieldSet.setStyleAttribute("margin", "0px 10px 0px 10px");
@@ -107,6 +109,12 @@ public class UserAddDialog extends EntityAddEditDialog {
         infoFieldSet.setStyleAttribute("background-color", "E8E8E8");
         statusFieldSet.setLayout(statusLayout);
         statusFieldSet.setStyleAttribute("background-color", "E8E8E8");
+
+        usernameLabel = new LabelField();
+        usernameLabel.setFieldLabel(USER_MSGS.dialogAddFieldUsername());
+        usernameLabel.setLabelSeparator(":");
+        usernameLabel.setVisible(false);
+        infoFieldSet.add(usernameLabel);
 
         username = new KapuaTextField<String>();
         username.setAllowBlank(false);

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -112,8 +112,9 @@ public class UserEditDialog extends UserAddDialog {
     }
 
     private void populateEditDialog(GwtUser gwtUser) {
-        username.setValue(gwtUser.getUsername());
-        username.disable();
+        infoFieldSet.remove(username);
+        usernameLabel.setVisible(true);
+        usernameLabel.setValue(gwtUser.getUsername());
         if (password != null) {
             password.setVisible(false);
             password.setAllowBlank(true);


### PR DESCRIPTION
Added LabelFields for credential type and username, to be displayed on
Edit forms.
Solves issue: #1670

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>