### PR TITLE
Making Endpoints visible to subaccounts of kapua-sys

### DIFF
--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointViewDescriptor.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointViewDescriptor.java
@@ -47,6 +47,6 @@ public class EndpointViewDescriptor extends AbstractEntityViewDescriptor<GwtEndp
 
     @Override
     public Boolean isEnabled(GwtSession currentSession) {
-        return currentSession.hasPermission(EndpointSessionPermission.readAll());
+        return currentSession.hasPermission(EndpointSessionPermission.read());
     }
 }


### PR DESCRIPTION
Because permission *:*:ALL was required for Endpoints it didn't work
for subaccounts. Change was made to EndpointViewDescriptor to require
read instead of readAll.

This fixes issue #1596

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>