### PR TITLE
Grid refresh after delete

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -654,7 +654,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
 
         try {
             accounts = ACCOUNT_SERVICE.query(query);
-            totalLength = Long.valueOf(ACCOUNT_SERVICE.count(query)).intValue();
+            totalLength = (int) ACCOUNT_SERVICE.count(query);
             if (!accounts.isEmpty()) {
                 final UserQuery userQuery = USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtAccountQuery.getScopeId()));
                 Map<String, String> usernameMap = new HashMap<String, String>();

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -654,6 +654,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
 
         try {
             accounts = ACCOUNT_SERVICE.query(query);
+            totalLength = Long.valueOf(ACCOUNT_SERVICE.count(query)).intValue();
             if (!accounts.isEmpty()) {
                 final UserQuery userQuery = USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtAccountQuery.getScopeId()));
                 Map<String, String> usernameMap = new HashMap<String, String>();
@@ -668,8 +669,6 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
                 for (User user : usernames.getItems()) {
                     usernameMap.put(user.getId().toCompactId(), user.getName());
                 }
-
-                totalLength = Long.valueOf(ACCOUNT_SERVICE.count(query)).intValue();
 
                 for (Account a : accounts.getItems()) {
                     GwtAccount gwtAccount = KapuaGwtAccountModelConverter.convertAccount(a);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
@@ -124,6 +124,8 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
             GroupQuery groupQuery = GwtKapuaAuthorizationModelConverter.convertGroupQuery(loadConfig,
                     gwtGroupQuery);
             GroupListResult groups = groupService.query(groupQuery);
+            totalLength = Long.valueOf(groupService.count(groupQuery)).intValue();
+
             UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
                 @Override
@@ -136,7 +138,6 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
                 usernameMap.put(user.getId().toCompactId(), user.getName());
             }
             if (!groups.isEmpty()) {
-                totalLength = Long.valueOf(groupService.count(groupQuery)).intValue();
                 for (Group g : groups.getItems()) {
                     GwtGroup gwtGroup = KapuaGwtAuthorizationModelConverter.convertGroup(g);
                     gwtGroup.setUserName(usernameMap.get(g.getCreatedBy().toCompactId()));

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
@@ -124,7 +124,7 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
             GroupQuery groupQuery = GwtKapuaAuthorizationModelConverter.convertGroupQuery(loadConfig,
                     gwtGroupQuery);
             GroupListResult groups = groupService.query(groupQuery);
-            totalLength = Long.valueOf(groupService.count(groupQuery)).intValue();
+            totalLength = (int) groupService.count(groupQuery);
 
             UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
@@ -137,12 +137,10 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
             for (User user : userListResult.getItems()) {
                 usernameMap.put(user.getId().toCompactId(), user.getName());
             }
-            if (!groups.isEmpty()) {
-                for (Group g : groups.getItems()) {
-                    GwtGroup gwtGroup = KapuaGwtAuthorizationModelConverter.convertGroup(g);
-                    gwtGroup.setUserName(usernameMap.get(g.getCreatedBy().toCompactId()));
-                    gwtGroupList.add(gwtGroup);
-                }
+            for (Group g : groups.getItems()) {
+                GwtGroup gwtGroup = KapuaGwtAuthorizationModelConverter.convertGroup(g);
+                gwtGroup.setUserName(usernameMap.get(g.getCreatedBy().toCompactId()));
+                gwtGroupList.add(gwtGroup);
             }
         } catch (Exception e) {
             KapuaExceptionHandler.handle(e);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
@@ -280,9 +280,9 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
             query.setSortCriteria(sortCriteria);
 
             RolePermissionListResult list = ROLE_PERMISSION_SERVICE.query(query);
+            totalLength = (int) ROLE_PERMISSION_SERVICE.count(query);
 
             if (list != null) {
-                totalLength = (int) ROLE_PERMISSION_SERVICE.count(query);
                 for (final RolePermission rolePermission : list.getItems()) {
                     User createdByUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
@@ -177,6 +177,7 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
             // query
             RoleListResult roles = ROLE_SERVICE.query(roleQuery);
+            totalLength = Long.valueOf(ROLE_SERVICE.count(roleQuery)).intValue();
 
             UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
@@ -193,9 +194,6 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
             // If there are results
             if (!roles.isEmpty()) {
-                // count
-                totalLength = Long.valueOf(ROLE_SERVICE.count(roleQuery)).intValue();
-
                 // Converto to GWT entity
                 for (Role r : roles.getItems()) {
                     GwtRole gwtRole = KapuaGwtAuthorizationModelConverter.convertRole(r);

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
@@ -147,8 +147,8 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
                 usernameMap.put(user.getId().toCompactId(), user.getName());
             }
             EndpointInfoListResult endpoints = ENDPOINT_INFO_SERVICE.query(endpointQuery);
+            totalLength = Long.valueOf(ENDPOINT_INFO_SERVICE.count(endpointQuery)).intValue();
             if (!endpoints.isEmpty()) {
-                totalLength = Long.valueOf(ENDPOINT_INFO_SERVICE.count(endpointQuery)).intValue();
 
                 for (EndpointInfo ei : endpoints.getItems()) {
                     GwtEndpoint gwtEndpoint = KapuaGwtEndpointModelConverter.convertEndpoint(ei);

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
@@ -147,16 +147,12 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
                 usernameMap.put(user.getId().toCompactId(), user.getName());
             }
             EndpointInfoListResult endpoints = ENDPOINT_INFO_SERVICE.query(endpointQuery);
-            totalLength = Long.valueOf(ENDPOINT_INFO_SERVICE.count(endpointQuery)).intValue();
-            if (!endpoints.isEmpty()) {
-
-                for (EndpointInfo ei : endpoints.getItems()) {
-                    GwtEndpoint gwtEndpoint = KapuaGwtEndpointModelConverter.convertEndpoint(ei);
-                    gwtEndpoint.setCreatedByName(ei.getCreatedBy() != null ? usernameMap.get(ei.getCreatedBy().toCompactId()) : null);
-                    gwtEndpoint.setModifiedByName(ei.getModifiedBy() != null ? usernameMap.get(ei.getModifiedBy().toCompactId()) : null);
-                    gwtEndpointList.add(gwtEndpoint);
-
-                }
+            totalLength = (int) ENDPOINT_INFO_SERVICE.count(endpointQuery);
+            for (EndpointInfo ei : endpoints.getItems()) {
+                GwtEndpoint gwtEndpoint = KapuaGwtEndpointModelConverter.convertEndpoint(ei);
+                gwtEndpoint.setCreatedByName(ei.getCreatedBy() != null ? usernameMap.get(ei.getCreatedBy().toCompactId()) : null);
+                gwtEndpoint.setModifiedByName(ei.getModifiedBy() != null ? usernameMap.get(ei.getModifiedBy().toCompactId()) : null);
+                gwtEndpointList.add(gwtEndpoint);
             }
         } catch (Exception e) {
             KapuaExceptionHandler.handle(e);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
@@ -77,9 +77,6 @@ public class JobGrid extends EntityGrid<GwtJob> {
     protected List<ColumnConfig> getColumns() {
         List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
 
-        //        ColumnConfig columnConfig = new ColumnConfig("status", MSGS.gridJobColumnHeaderStatus(), 50);
-        //        columnConfigs.add(columnConfig);
-
         ColumnConfig columnConfig = new ColumnConfig("id", MSGS.gridJobColumnHeaderId(), 100);
         columnConfig.setHidden(true);
         columnConfigs.add(columnConfig);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
@@ -93,10 +93,9 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
 
     @Override
     protected KapuaDialog getDeleteDialog() {
-        GwtJob selectedJob = gridSelectionModel.getSelectedItem();
         JobDeleteDialog dialog = null;
-        if (selectedJob != null) {
-            dialog = new JobDeleteDialog(selectedJob);
+        if (selectedEntity != null) {
+            dialog = new JobDeleteDialog(selectedEntity);
         }
         return dialog;
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -69,6 +69,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
 
             // query
             JobListResult jobs = jobService.query(jobQuery);
+            totalLength = Long.valueOf(jobService.count(jobQuery)).intValue();
 
             // If there are results
             if (!jobs.isEmpty()) {
@@ -85,8 +86,6 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
                 for (User user : userListResult.getItems()) {
                     usernameMap.put(user.getId().toCompactId(), user.getName());
                 }
-                // count
-                totalLength = Long.valueOf(jobService.count(jobQuery)).intValue();
 
                 // Converto to GWT entity
                 for (Job j : jobs.getItems()) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -69,7 +69,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
 
             // query
             JobListResult jobs = jobService.query(jobQuery);
-            totalLength = Long.valueOf(jobService.count(jobQuery)).intValue();
+            totalLength = (int) jobService.count(jobQuery);
 
             // If there are results
             if (!jobs.isEmpty()) {

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -137,14 +137,11 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
                 usernameMap.put(user.getId().toCompactId(), user.getName());
             }
             TagListResult tags = tagService.query(tagQuery);
-            totalLength = Long.valueOf(tagService.count(tagQuery)).intValue();
-            if (!tags.isEmpty()) {
-                for (Tag g : tags.getItems()) {
-                    GwtTag gwtTag = KapuaGwtTagModelConverter.convertTag(g);
-                    gwtTag.setUserName(usernameMap.get(g.getCreatedBy().toCompactId()));
-                    gwtTagList.add(gwtTag);
-
-                }
+            totalLength = (int) tagService.count(tagQuery);
+            for (Tag g : tags.getItems()) {
+                GwtTag gwtTag = KapuaGwtTagModelConverter.convertTag(g);
+                gwtTag.setUserName(usernameMap.get(g.getCreatedBy().toCompactId()));
+                gwtTagList.add(gwtTag);
             }
         } catch (Exception e) {
             KapuaExceptionHandler.handle(e);

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -137,8 +137,8 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
                 usernameMap.put(user.getId().toCompactId(), user.getName());
             }
             TagListResult tags = tagService.query(tagQuery);
+            totalLength = Long.valueOf(tagService.count(tagQuery)).intValue();
             if (!tags.isEmpty()) {
-                totalLength = Long.valueOf(tagService.count(tagQuery)).intValue();
                 for (Tag g : tags.getItems()) {
                     GwtTag gwtTag = KapuaGwtTagModelConverter.convertTag(g);
                     gwtTag.setUserName(usernameMap.get(g.getCreatedBy().toCompactId()));

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
@@ -277,7 +277,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
             // query
             UserListResult users = userService.query(userQuery);
-            totalLength = Long.valueOf(userService.count(userQuery)).intValue();
+            totalLength = (int) userService.count(userQuery);
 
             // If there are results
             if (!users.isEmpty()) {

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
@@ -277,6 +277,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
             // query
             UserListResult users = userService.query(userQuery);
+            totalLength = Long.valueOf(userService.count(userQuery)).intValue();
 
             // If there are results
             if (!users.isEmpty()) {
@@ -291,8 +292,6 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
                 for (User user : allUsers.getItems()) {
                     usernameMap.put(user.getId().toCompactId(), user.getName());
                 }
-                // count
-                totalLength = Long.valueOf(userService.count(userQuery)).intValue();
 
                 // Convert to GWT entity
                 for (User u : users.getItems()) {


### PR DESCRIPTION
Grid was not refreshing correctly if last item was deleted on last page
of grid. Problem was that count of items was not placed correctly on most
of grids except device grid.

All grids are now fixed.

This fixes issue #1611

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>