### PR TITLE
Added doPrivileged call on DeviceEvent creation

### DIFF
--- a/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
+++ b/service/device/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
@@ -84,7 +84,7 @@ public class DeviceBundleManagementServiceImpl extends AbstractDeviceManagementS
         //
         // Do get
         DeviceCallExecutor<BundleRequestChannel, BundleRequestPayload, BundleRequestMessage, BundleResponseMessage> deviceApplicationCall = new DeviceCallExecutor<>(bundleRequestMessage, timeout);
-        BundleResponseMessage responseMessage = (BundleResponseMessage) deviceApplicationCall.send();
+        BundleResponseMessage responseMessage = deviceApplicationCall.send();
 
         //
         // Create event
@@ -102,7 +102,7 @@ public class DeviceBundleManagementServiceImpl extends AbstractDeviceManagementS
             try {
                 body = new String(responsePayload.getBody(), charEncoding);
             } catch (Exception e) {
-                throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, responsePayload.getBody());
+                throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, (Object) responsePayload.getBody());
             }
 
             DeviceBundles deviceBundleList = null;

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
@@ -12,16 +12,21 @@
 package org.eclipse.kapua.service.device.management.commons;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.ThrowingRunnable;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.device.management.message.request.KapuaRequestChannel;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessage;
-import org.eclipse.kapua.service.device.management.message.request.KapuaRequestPayload;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
 
+/**
+ * Utility {@code abstract} {@link Class} used to provide utility methods to all implementation of {@link org.eclipse.kapua.service.device.management.DeviceManagementService}s.
+ *
+ * @since 1.0.0
+ */
 public abstract class AbstractDeviceManagementServiceImpl {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
@@ -29,7 +34,20 @@ public abstract class AbstractDeviceManagementServiceImpl {
     private static final DeviceEventService DEVICE_EVENT_SERVICE = LOCATOR.getService(DeviceEventService.class);
     private static final DeviceEventFactory DEVICE_EVENT_FACTORY = LOCATOR.getFactory(DeviceEventFactory.class);
 
-    protected <C extends KapuaRequestChannel, P extends KapuaRequestPayload> void createDeviceEvent(KapuaId scopeId, KapuaId deviceId, KapuaRequestMessage<C, P> requestMessage,
+    /**
+     * Creates a {@link org.eclipse.kapua.service.device.registry.event.DeviceEvent} extracting data from the given {@link KapuaRequestMessage} and {@link KapuaResponseMessage}.
+     * <p>
+     * This operation is performed using {@link KapuaSecurityUtils#doPrivileged(ThrowingRunnable)} since {@link org.eclipse.kapua.service.device.registry.event.DeviceEventDomain} isn't a required
+     * permission to use any of the {@link org.eclipse.kapua.service.device.management.DeviceManagementService}s.
+     *
+     * @param scopeId         The scopeId in which to create the {@link org.eclipse.kapua.service.device.registry.event.DeviceEvent}
+     * @param deviceId        The {@link org.eclipse.kapua.service.device.registry.Device} id for which the {@link org.eclipse.kapua.service.device.registry.event.DeviceEvent} is created
+     * @param requestMessage  The {@link KapuaRequestMessage} of the {@link org.eclipse.kapua.service.device.management.DeviceManagementService} operation from which to extract data.
+     * @param responseMessage The {@link KapuaResponseMessage} of the {@link org.eclipse.kapua.service.device.management.DeviceManagementService} operation from which to extract data.
+     * @throws KapuaException If the creation of the {@link org.eclipse.kapua.service.device.registry.event.DeviceEvent} fails for some reasons
+     * @since 1.0.0
+     */
+    protected void createDeviceEvent(KapuaId scopeId, KapuaId deviceId, KapuaRequestMessage<?, ?> requestMessage,
             KapuaResponseMessage responseMessage) throws KapuaException {
 
         DeviceEventCreator deviceEventCreator =
@@ -45,6 +63,6 @@ public abstract class AbstractDeviceManagementServiceImpl {
         deviceEventCreator.setResponseCode(responseMessage.getResponseCode());
         deviceEventCreator.setEventMessage(responseMessage.getPayload().toDisplayString());
 
-        DEVICE_EVENT_SERVICE.create(deviceEventCreator);
+        KapuaSecurityUtils.doPrivileged(() -> DEVICE_EVENT_SERVICE.create(deviceEventCreator));
     }
 }

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -112,8 +112,7 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
                 try {
                     body = new String(responsePayload.getBody(), charEncoding);
                 } catch (Exception e) {
-                    throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, responsePayload.getBody());
-
+                    throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, (Object) responsePayload.getBody());
                 }
 
                 try {
@@ -211,7 +210,6 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
                     XmlUtil.unmarshal(xmlDeviceConfig, DeviceConfigurationImpl.class),
                     timeout);
         } catch (JAXBException | XMLStreamException | FactoryConfigurationError | SAXException e) {
-            // FIXME: rethrow or log this exception
             throw new KapuaIllegalArgumentException(xmlDeviceConfig, xmlDeviceConfig);
         }
     }

--- a/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
+++ b/service/device/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
@@ -100,18 +100,14 @@ public class DeviceSnapshotManagementServiceImpl extends AbstractDeviceManagemen
             try {
                 body = new String(responsePayload.getBody(), charEncoding);
             } catch (Exception e) {
-                throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION,
-                        e,
-                        responsePayload.getBody());
+                throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, (Object) responsePayload.getBody());
             }
 
             DeviceSnapshots deviceSnapshots = null;
             try {
                 deviceSnapshots = XmlUtil.unmarshal(body, DeviceSnapshotsImpl.class);
             } catch (Exception e) {
-                throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION,
-                        e,
-                        body);
+                throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, body);
             }
 
             return deviceSnapshots;

--- a/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -127,8 +127,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
                 try {
                     body = new String(responsePayload.getBody(), charEncoding);
                 } catch (Exception e) {
-                    throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, responsePayload.getBody());
-
+                    throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, (Object) responsePayload.getBody());
                 }
 
                 try {
@@ -581,7 +580,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
             try {
                 body = new String(responsePayload.getBody(), charEncoding);
             } catch (Exception e) {
-                throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, responsePayload.getBody());
+                throw new DeviceManagementException(DeviceManagementErrorCodes.RESPONSE_PARSE_EXCEPTION, e, (Object) responsePayload.getBody());
 
             }
 


### PR DESCRIPTION
This PR fixes #1690 

Added `KapuaSecurityUtils.doPrivileged(...)` on `DeviceEventService.create(...)`.
Also updated javadoc for class and method.
Small clean up of Sonar issue on `DeviceManagementService`s implementations.

Regards, 

_Alberto_