### PR TITLE
Validation of client-id to one character

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -59,7 +59,7 @@ public class TextFieldValidator implements Validator {
     public enum FieldType {
 
         SIMPLE_NAME("simple_name", "^[a-zA-Z0-9\\-]{3,}$"),
-        DEVICE_CLIENT_ID("device_client_id", "^[a-zA-Z0-9\\:\\_\\-]{3,}$"),
+        DEVICE_CLIENT_ID("device_client_id", "^[a-zA-Z0-9\\:\\_\\-]{1,}$"),
         NAME("name", "^[a-zA-Z0-9\\_\\-]{3,}$"),
         NAME_SPACE("name_space", "^[a-zA-Z0-9\\ \\_\\-]{3,}$"),
         PASSWORD("password", "^.*(?=.{12,})(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!\\~\\|]).*$"),

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -14,8 +14,8 @@ simple_nameRegexMsg=Name must be at least 3 characters and can contain alphanume
 simple_nameToolTipMsg=Must be at least 3 characters and can contain alphanumeric characters combined with dash.
 simple_nameRequiredMsg=Name is required.
 
-device_client_idRegexMsg=Name must be at least 3 characters and can contain alphanumeric characters combined with dash.
-device_client_idToolTipMsg=Must be at least 3 characters and can contain alphanumeric characters combined with dash.
+device_client_idRegexMsg=Name must be at least 1 character and can contain alphanumeric characters combined with dash.
+device_client_idToolTipMsg=Must be at least 1 character and can contain alphanumeric characters combined with dash.
 device_client_idRequiredMsg=Device Client ID is required
 
 nameRegexMsg=Name must be at least 3 characters and can contain alphanumeric characters combined with dash and/or underscore.


### PR DESCRIPTION
Validation of client-id field was changed from 3 to one character.
Tooltip and validation message was also changed accordingly.

This fixes issue #1595

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>