### PR TITLE
Device Call account find wrapped in privileged action

### DIFF
--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.service.device.call.kura;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
@@ -87,7 +88,7 @@ public class KuraDeviceCallImpl implements DeviceCall<KuraRequestMessage, KuraRe
         KuraResponseMessage response = null;
         TransportFacade transportFacade = null;
         try {
-            Account account = accountService.findByName(requestMessage.getChannel().getScope());
+            Account account = KapuaSecurityUtils.doPrivileged(() -> accountService.findByName(requestMessage.getChannel().getScope()));
             Device device = deviceRegistryService.findByClientId(account.getId(), requestMessage.getChannel().getClientId());
             String serverIp = device.getConnection().getServerIp();
 


### PR DESCRIPTION
Device call actions require account id, this needs to be found by
account name. This requires account service to perform action, but user
otherwise doesn't need account permissions.

That is why this single account operation was wrapped in doPriviledged.

This solves issue #1673

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>