### PR TITLE
Group field not validated correctly on edit

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,6 +35,8 @@ public class DeviceEditDialog extends DeviceAddDialog {
 
         // hide fields used for add
         clientIdField.hide();
+        // this protects against odd issue https://github.com/eclipse/kapua/issues/1631
+        groupCombo.setAllowBlank(true);
 
         loadDevice();
     }


### PR DESCRIPTION
This removes mandatory group field on edit dialog for device. This removes
condition that resulted in false negative validation of group field.
As group field is mandatory, that means that device can not be created
without group, it is at least No Group. That means that when user edits
device, it will always have group field set and it doesn't have to check
for empty field.
This should resolve this odd issue. I hope.

This solves issue #1631

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>