### PR TITLE
Null value error when editing Users fix

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -128,6 +128,7 @@ public class UserEditDialog extends UserAddDialog {
         if (passwordTooltip != null) {
             passwordTooltip.hide();
         }
+        username.setValue(gwtUser.getUsername());
         displayName.setValue(gwtUser.getDisplayName());
         email.setValue(gwtUser.getEmail());
         phoneNumber.setValue(gwtUser.getPhoneNumber());


### PR DESCRIPTION
Set username value to gwtUser.getUsername().
Solves issue: #1701

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>