### PR TITLE
Added tooltip on combo box for adding tags to device

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -105,6 +105,7 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
         tagsCombo.setFieldLabel("* " + MSGS.dialogDeviceTagAddFieldTag());
         tagsCombo.setTriggerAction(TriggerAction.ALL);
         tagsCombo.setDisplayField("tagName");
+        tagsCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={tagName}>{tagName}</div></tpl>");
 
         GWT_TAG_SERVICE.findAll(selectedDevice.getScopeId(), new AsyncCallback<List<GwtTag>>() {
 


### PR DESCRIPTION
Template for combo box item was added, and this template includes
title attribute that displays tooltip on selected drop down item.
This is issue, when name of item is clipped and it is hard for user
to distinguish items with similar begining.

This solves issue #1638

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>