### PR TITLE
Query button is disabled during query operation

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -139,6 +139,7 @@ public class AssetTabItem extends TabItem {
             }
         });
         queryButton.disable();
+
         TableLayout queryButtonTL = new TableLayout();
         queryButtonTL.setCellPadding(0);
         LayoutContainer queryButtonContainer = new LayoutContainer(queryButtonTL);
@@ -154,7 +155,7 @@ public class AssetTabItem extends TabItem {
         resultsTabPanel.setBorders(false);
         resultsTabPanel.setBodyBorder(false);
 
-        resultsTable = new ResultsTable(currentSession);
+        resultsTable = new ResultsTable(currentSession, queryButton);
         TabItem resultsTableTabItem = new TabItem(MSGS.resultsTableTabItemTitle(), new KapuaIcon(IconSet.TABLE));
         resultsTableTabItem.setLayout(new FitLayout());
         resultsTableTabItem.add(resultsTable);

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
@@ -118,8 +118,8 @@ public class DeviceTabItem extends TabItem {
                 resultsTable.refresh(gwtDevice, metricsInfo);
             }
         });
-
         queryButton.disable();
+
         TableLayout queryButtonTL = new TableLayout();
         queryButtonTL.setCellPadding(0);
         LayoutContainer queryButtonContainer = new LayoutContainer(queryButtonTL);
@@ -135,7 +135,7 @@ public class DeviceTabItem extends TabItem {
         resultsTabPanel.setBorders(false);
         resultsTabPanel.setBodyBorder(false);
 
-        resultsTable = new ResultsTable(currentSession);
+        resultsTable = new ResultsTable(currentSession, queryButton);
         TabItem resultsTableTabItem = new TabItem(MSGS.resultsTableTabItemTitle(), new KapuaIcon(IconSet.TABLE));
         resultsTableTabItem.setLayout(new FitLayout());
         resultsTableTabItem.add(resultsTable);

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -42,6 +42,7 @@ import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.ExportButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.DateRangeSelector;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.DateRangeSelectorListener;
@@ -89,9 +90,11 @@ public class ResultsTable extends LayoutContainer {
     private Date endDate;
     private ExportButton exportButton;
     private DateRangeSelector dateRangeSelector;
+    private Button queryButton;
 
-    public ResultsTable(GwtSession currentSession) {
+    public ResultsTable(GwtSession currentSession, Button queryButton) {
         this.currentSession = currentSession;
+        this.queryButton = queryButton;
     }
 
     @Override
@@ -167,6 +170,34 @@ public class ResultsTable extends LayoutContainer {
                 }
             }
         });
+        loader.addListener(Loader.BeforeLoad, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent baseEvent) {
+                if (queryButton != null) {
+                    queryButton.disable();
+                }
+            }
+        } );
+        loader.addListener(Loader.Load, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent baseEvent) {
+                if (queryButton != null) {
+                    queryButton.enable();
+                }
+            }
+        } );
+        loader.addListener(Loader.LoadException, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent baseEvent) {
+                if (queryButton != null) {
+                    queryButton.enable();
+                }
+            }
+        } );
+
         loader.setSortField("timestampFormatted");
         loader.setSortDir(SortDir.DESC);
         loader.setRemoteSort(true);

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
@@ -117,6 +117,8 @@ public class TopicsTabItem extends TabItem {
                 resultsTable.refresh(topic, metrics);
             }
         });
+        queryButton.disable();
+
         TableLayout queryButtonTL = new TableLayout();
         queryButtonTL.setCellPadding(0);
         LayoutContainer queryButtonContainer = new LayoutContainer(queryButtonTL);
@@ -132,7 +134,7 @@ public class TopicsTabItem extends TabItem {
         resultsTabPanel.setBorders(false);
         resultsTabPanel.setBodyBorder(false);
 
-        resultsTable = new ResultsTable(currentSession);
+        resultsTable = new ResultsTable(currentSession, queryButton);
         TabItem resultsTableTabItem = new TabItem(MSGS.resultsTableTabItemTitle(), new KapuaIcon(IconSet.TABLE));
         resultsTableTabItem.setLayout(new FitLayout());
         resultsTableTabItem.add(resultsTable);


### PR DESCRIPTION
Issue was showing if Query button was pressed so fast that query operation
didn't finish before next was triggered. That confused paging toolbar.
Solution was to disable button during query operation, so that user is
not able to trigger too many queries.

This solves issue #1628

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>