### PR TITLE
Long (integer) value validation in NumberField

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -59,6 +59,11 @@ public class JobStepAddDialog extends EntityAddEditDialog {
      */
     protected static final String KAPUA_ID_CLASS_NAME = "org.eclipse.kapua.model.id.KapuaId";
 
+    /**
+     * Limitation of double value as max integer 2^52.
+     */
+    public static final long MAX_SAFE_INTEGER = 4503599627370496L;
+
     private final String jobId;
 
     protected final TextField<String> jobStepName;
@@ -220,7 +225,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
                 numberField.setData(PROPERTY_TYPE, property.getPropertyType());
                 numberField.setData(PROPERTY_NAME, property.getPropertyName());
                 if (propertyType.equals(Long.class.getName())) {
-                    numberField.setMaxValue(Long.MAX_VALUE);
+                    numberField.setMaxValue(MAX_SAFE_INTEGER);
                 } else if (propertyType.equals(Integer.class.getName())) {
                     numberField.setMaxValue(Integer.MAX_VALUE);
                 } else if (propertyType.equals(Float.class.getName())) {


### PR DESCRIPTION
While validating Long that is 64 bit values for integers there is wrong
validation of max value. Value is not validated correctly because
value is converted to Double before validating. This problem occurs because
Double can have mantisa which is 2^52 (signed). This brings validation to
that value.
To solve issue, max value is not set to Long.MAX_VALUE but to
4.503.599.627.370.496. If this is not good enough, NumberField provided
by GXT can not be used, as its validator uses Double for storing its values.

Other types should function correctly, as there is no limitation with conversion
to Double.

This solves issue #1634

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>