### PR TITLE
Generic Driver Name in Device Configuration fix

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -298,8 +298,7 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
                         gwtConfig.setId(config.getId());
                         if(config.getId().indexOf('.') == -1){
                             gwtConfig.setName(config.getId());
-                        }
-                        else{
+                        } else {
                             gwtConfig.setName(ocd.getName());
                         }
                         gwtConfig.setDescription(ocd.getDescription());

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -296,7 +296,12 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
                     if (ocd != null) {
                         GwtConfigComponent gwtConfig = new GwtConfigComponent();
                         gwtConfig.setId(config.getId());
-                        gwtConfig.setName(ocd.getName());
+                        if(config.getId().indexOf('.') == -1){
+                            gwtConfig.setName(config.getId());
+                        }
+                        else{
+                            gwtConfig.setName(ocd.getName());
+                        }
                         gwtConfig.setDescription(ocd.getDescription());
                         if (ocd.getIcon() != null && !ocd.getIcon().isEmpty()) {
                             KapuaTicon icon = ocd.getIcon().get(0);


### PR DESCRIPTION
Changed the findDeviceConfigurations() method so that ServicePID is
shown instead of generic name for drivers and assets.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>