### PR TITLE
Cleanup JobEngine Data when deleting Job

### DIFF
--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
@@ -74,4 +74,13 @@ public interface JobEngineService extends KapuaService, KapuaDomainService<JobDo
      */
     void stopJob(KapuaId scopeId, KapuaId jobId) throws KapuaException;
 
+    /**
+     * Cleans all the Job related data from the data structures supporting the {@link JobEngineService}
+     *
+     * @param scopeId The scopeId of the {@link org.eclipse.kapua.service.job.Job}
+     * @param jobId   The id of the {@link org.eclipse.kapua.service.job.Job}
+     * @throws KapuaException if something goes bad when checking the status of the job
+     * @since 1.0.0
+     */
+    void cleanJobData(KapuaId scopeId, KapuaId jobId) throws KapuaException;
 }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
@@ -189,4 +189,9 @@ public class JobEngineServiceJbatch implements JobEngineService {
             throw new JobStopppingException(e, scopeId, jobId);
         }
     }
+
+    @Override
+    public void cleanJobData(KapuaId scopeId, KapuaId jobId) throws KapuaException {
+        JbatchDriver.cleanJobData(scopeId, jobId);
+    }
 }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.job.engine.jbatch.driver;
 import com.google.common.collect.Lists;
 import com.ibm.jbatch.container.jsl.ExecutionElement;
 import com.ibm.jbatch.container.jsl.ModelSerializerFactory;
+import com.ibm.jbatch.container.servicesmanager.ServicesManagerImpl;
 import com.ibm.jbatch.jsl.model.JSLJob;
 import com.ibm.jbatch.jsl.model.Step;
 import org.apache.commons.io.IOUtils;
@@ -32,6 +33,7 @@ import org.eclipse.kapua.job.engine.jbatch.driver.exception.JobExecutionIsRunnin
 import org.eclipse.kapua.job.engine.jbatch.driver.exception.JobStartingDriverException;
 import org.eclipse.kapua.job.engine.jbatch.driver.utils.JbatchUtil;
 import org.eclipse.kapua.job.engine.jbatch.driver.utils.JobDefinitionBuildUtils;
+import org.eclipse.kapua.job.engine.jbatch.persistence.KapuaJDBCPersistenceManagerImpl;
 import org.eclipse.kapua.job.engine.jbatch.setting.KapuaJobEngineSetting;
 import org.eclipse.kapua.job.engine.jbatch.setting.KapuaJobEngineSettingKeys;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -262,6 +264,11 @@ public class JbatchDriver {
      */
     public static boolean isRunningJob(@NotNull KapuaId scopeId, @NotNull KapuaId jobId) {
         return getRunningJobExecution(scopeId, jobId) != null;
+    }
+
+    public static void cleanJobData(@NotNull KapuaId scopeId, @NotNull KapuaId jobId) {
+        String jobName = getJbatchJobName(scopeId, jobId);
+        ((KapuaJDBCPersistenceManagerImpl)ServicesManagerImpl.getInstance().getPersistenceManagerService()).purgeByName(jobName);
     }
 
     //

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/KapuaJDBCPersistenceManagerImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/KapuaJDBCPersistenceManagerImpl.java
@@ -13,22 +13,29 @@ package org.eclipse.kapua.job.engine.jbatch.persistence;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.logging.Logger;
 
 import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 
+import com.ibm.jbatch.container.exception.PersistenceException;
 import com.ibm.jbatch.container.services.IPersistenceManagerService;
 import com.ibm.jbatch.container.services.impl.JDBCPersistenceManagerImpl;
 
 public class KapuaJDBCPersistenceManagerImpl extends JDBCPersistenceManagerImpl implements IPersistenceManagerService {
+
+    private static final String CLASSNAME = KapuaJDBCPersistenceManagerImpl.class.getName();
 
     private static final String JDBC_CONNECTION_URL = JdbcConnectionUrlResolvers.resolveJdbcUrl();
 
     private static final SystemSetting CONFIG = SystemSetting.getInstance();
     private static final String USERNAME = CONFIG.getString(SystemSettingKey.DB_USERNAME);
     private static final String PASSWORD = CONFIG.getString(SystemSettingKey.DB_PASSWORD);
+
+    private final static Logger logger = Logger.getLogger(CLASSNAME);
 
     protected Connection getConnectionToDefaultSchema() throws SQLException {
         return getConnection();
@@ -38,4 +45,40 @@ public class KapuaJDBCPersistenceManagerImpl extends JDBCPersistenceManagerImpl 
     protected Connection getConnection() throws SQLException {
         return DriverManager.getConnection(JDBC_CONNECTION_URL, USERNAME, PASSWORD);
     }
+
+    public void purgeByName(String jobName) {
+        logger.entering(CLASSNAME, "purgeByName", jobName);
+        String deleteJobs = "DELETE FROM jobinstancedata WHERE name = ?";
+        String deleteJobExecutions = "DELETE FROM executioninstancedata "
+                + "WHERE jobexecid IN ("
+                + "SELECT B.jobexecid FROM jobinstancedata A INNER JOIN executioninstancedata B "
+                + "ON A.jobinstanceid = B.jobinstanceid "
+                + "WHERE A.name = ?)";
+        String deleteStepExecutions = "DELETE FROM stepexecutioninstancedata "
+                + "WHERE stepexecid IN ("
+                + "SELECT C.stepexecid FROM jobinstancedata A INNER JOIN executioninstancedata B "
+                + "ON A.jobinstanceid = B.jobinstanceid INNER JOIN stepexecutioninstancedata C "
+                + "ON B.jobexecid = C.jobexecid "
+                + "WHERE A.name = ?)";
+
+        try (Connection conn = getConnection()) {
+            try(PreparedStatement statement = conn.prepareStatement(deleteStepExecutions)) {
+                statement.setString(1, jobName);
+                statement.executeUpdate();
+            }
+
+            try(PreparedStatement statement = conn.prepareStatement(deleteJobExecutions)) {
+                statement.setString(1, jobName);
+                statement.executeUpdate();
+            }
+            try(PreparedStatement statement = conn.prepareStatement(deleteJobs)) {
+                statement.setString(1, jobName);
+                statement.executeUpdate();
+            }
+        } catch (SQLException e) {
+            throw new PersistenceException(e);
+        }
+        logger.exiting(CLASSNAME, "purge");
+    }
+
 }

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -85,6 +85,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-engine-api</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResource
 import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.job.engine.JobEngineService;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -47,6 +48,7 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
     private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
     private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+    private static final JobEngineService JOB_ENGINE_SERVICE = LOCATOR.getService(JobEngineService.class);
 
     public JobServiceImpl() {
         super(JobService.class.getName(), JOB_DOMAIN, JobEntityManagerFactory.getInstance(), JobService.class, JobFactory.class);
@@ -187,6 +189,8 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
         //
         // Do delete
+
+        JOB_ENGINE_SERVICE.cleanJobData(scopeId, jobId);
         entityManagerSession.onTransactedAction(em -> JobDAO.delete(em, jobId));
     }
 


### PR DESCRIPTION
Hi all,

This PR adds some cleanup in the JBatch Job Engine implementation when a Job gets deleted, deleting rows in JBatch tables that are related to the job that is going to be deleted.