### PR TITLE
Quatation Marks Problem in Users and Jobs fix

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobService;
@@ -41,7 +42,7 @@ public class JobEditDialog extends JobAddDialog {
     @Override
     public void submit() {
         selectedJob.setJobName(name.getValue());
-        selectedJob.setDescription(description.getValue());
+        selectedJob.setDescription(KapuaSafeHtmlUtils.htmlUnescape(description.getValue()));
 
         gwtJobService.update(xsrfToken, selectedJob, new AsyncCallback<GwtJob>() {
 
@@ -84,6 +85,6 @@ public class JobEditDialog extends JobAddDialog {
 
     private void populateEditDialog(GwtJob gwtJob) {
         name.setValue(gwtJob.getJobName());
-        description.setValue(gwtJob.getDescription());
+        description.setValue(gwtJob.getUnescapedDescription());
     }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
@@ -20,6 +20,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobStep;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobStepDefinition;
@@ -70,7 +71,7 @@ public class JobStepEditDialog extends JobStepAddDialog {
             @Override
             public void onSuccess(GwtJobStepDefinition result) {
                 jobStepName.setValue(gwtJobStep.getJobStepName());
-                jobStepDescription.setValue(gwtJobStep.getDescription());
+                jobStepDescription.setValue(gwtJobStep.getUnescapedDescription());
                 jobStepDefinitionCombo.setValue(result);
 
                 Map<String, String> propertiesMap = new HashMap<String, String>();
@@ -91,7 +92,7 @@ public class JobStepEditDialog extends JobStepAddDialog {
     @Override
     public void submit() {
         selectedJobStep.setJobStepName(jobStepName.getValue());
-        selectedJobStep.setDescription(jobStepDescription.getValue());
+        selectedJobStep.setDescription(KapuaSafeHtmlUtils.htmlUnescape(jobStepDescription.getValue()));
         selectedJobStep.setJobStepDefinitionId(jobStepDefinitionCombo.getValue().getId());
         selectedJobStep.setStepProperties(readStepProperties());
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -162,7 +162,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
                 //
                 // Update job
                 job.setName(gwtJob.getJobName());
-                job.setDescription(gwtJob.getDescription());
+                job.setDescription(gwtJob.getUnescapedDescription());
 
                 // optlock
                 job.setOptlock(gwtJob.getOptlock());

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -175,7 +175,7 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
                 //
                 // Update job step
                 jobStep.setName(gwtJobStep.getJobStepName());
-                jobStep.setDescription(gwtJobStep.getDescription());
+                jobStep.setDescription(gwtJobStep.getUnescapedDescription());
                 jobStep.setJobStepDefinitionId(GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobStep.getJobStepDefinitionId()));
                 jobStep.setStepProperties(GwtKapuaJobModelConverter.convertJobStepProperties(gwtJobStep.getStepProperties()));
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJob.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,10 @@ public class GwtJob extends GwtUpdatableEntityModel implements IsSerializable {
 
     public String getDescription() {
         return get("description");
+    }
+
+    public String getUnescapedDescription() {
+        return (String) getUnescaped("description");
     }
 
     public void setDescription(String description) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStep.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStep.java
@@ -30,6 +30,10 @@ public class GwtJobStep extends GwtUpdatableEntityModel implements IsSerializabl
         return get("description");
     }
 
+    public String getUnescapedDescription() {
+        return (String) getUnescaped("description");
+    }
+
     public void setDescription(String description) {
         set("description", description);
     }

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -17,6 +17,7 @@ import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserService;
@@ -65,7 +66,7 @@ public class UserEditDialog extends UserAddDialog {
     @Override
     public void submit() {
         selectedUser.setUsername(username.getValue());
-        selectedUser.setDisplayName(displayName.getValue());
+        selectedUser.setDisplayName(KapuaSafeHtmlUtils.htmlUnescape(displayName.getValue()));
         selectedUser.setEmail(email.getValue());
         selectedUser.setPhoneNumber(phoneNumber.getValue());
         selectedUser.setStatus(userStatus.getValue().getValue().toString());
@@ -129,7 +130,7 @@ public class UserEditDialog extends UserAddDialog {
             passwordTooltip.hide();
         }
         username.setValue(gwtUser.getUsername());
-        displayName.setValue(gwtUser.getDisplayName());
+        displayName.setValue(gwtUser.getUnescapedDisplayName());
         email.setValue(gwtUser.getEmail());
         phoneNumber.setValue(gwtUser.getPhoneNumber());
         userStatus.setSimpleValue(gwtUser.getStatusEnum());


### PR DESCRIPTION
Added new getter methods to GwtJob and GwtJobStep, that return unescaped
values for description property. Those getters are than used in
JobEditDialog and JobStepEditDialog, as well as the already existing
KapuaSafeHtmlUtils.htmlUnEscape() method. Modified update methods on the service
side, so that they also set unescaped values for descriptions.
Solves issue: #1717

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>