### PR TITLE
Added "null" check for selected bundle od the grid

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
@@ -341,6 +341,9 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
                         stopButton.disable();
                         startButton.enable();
                     }
+                } else {
+                    startButton.disable();
+                    stopButton.disable();
                 }
             }
         });


### PR DESCRIPTION
Solves issues: #1719, #1720

Added a "null" check in the SelectionChangedListener on the grid's
SelectionModel. If this check returns true, startButton and stopButton
will be disabled.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>