### PR TITLE
Fix Liquibase Scripts Checksum

### DIFF
--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.post.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.post.xml
@@ -18,5 +18,6 @@
         logicalFilePath="KapuaDB/changelog-endpoint-1.0.0.xml">
 
     <include relativeToChangelogFile="true" file="./endpoint_info-domain.xml"/>
+    <include relativeToChangelogFile="true" file="./update-endpoint_info-domain.xml"/>
 
 </databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info-domain.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info-domain.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-endpoint_info-domain-1.0.0.xml">
 
-    <property name="selectEndpointDomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'endpoint_info')"/>
+    <property name="selectEndpointDomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'endpointInfo')"/>
 
     <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
@@ -34,8 +34,8 @@
         <insert tableName="athz_domain">
             <column name="created_on" valueComputed="${now}"/>
             <column name="created_by" value="1"/>
-            <column name="name" value="endpoint_info"/>
-            <column name="serviceName" value="org.eclipse.kapua.service.endpoint.EndpointInfoService"/>
+            <column name="name" value="endpointInfo"/>
+            <column name="serviceName" value="endpointInfoService"/>
         </insert>
 
         <insert tableName="athz_domain_actions">

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/update-endpoint_info-domain.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/update-endpoint_info-domain.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/update-endpoint_info-domain.xml">
+
+    <changeSet id="update-endpoint_info-domain"
+               author="eurotech">
+        <update tableName="athz_domain">
+            <column name="name" value="endpoint_info"/>
+            <where>name LIKE 'endpointInfo'</where>
+        </update>
+        <update tableName="athz_domain">
+            <column name="serviceName" value="org.eclipse.kapua.service.endpoint.EndpointInfoService"/>
+            <where>serviceName LIKE 'endpointInfoService'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-sys-housekeeper-run-seed.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-sys-housekeeper-run-seed.xml
@@ -11,33 +11,33 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-                   logicalFilePath="KapuaDB/changelog-authorization-1.0.0.xml">
+    logicalFilePath="KapuaDB/changelog-authorization-1.0.0.xml">
 
     <changeSet id="changelog-athz-sys-housekeeper-run-1.0.0-seed"
-               author="eurotech">
+        author="eurotech">
         <!-- Seed values -->
         <insert tableName="sys_housekeeper_run">
-            <column name="service" value="org.eclipse.kapua.service.authorization.access.AccessInfoService"/>
-            <column name="last_run_on" valueComputed="${now}"/>
-            <column name="version" value="1"/>
+            <column name="service" value="org.eclipse.kapua.service.authorization.access.AccessInfoService" />
+            <column name="last_run_on" valueComputed="${now}" />
+            <column name="version" value="1" />
         </insert>
         <insert tableName="sys_housekeeper_run">
-            <column name="service" value="org.eclipse.kapua.service.authorization.role.RoleService"/>
-            <column name="last_run_on" valueComputed="${now}"/>
-            <column name="version" value="1"/>
+            <column name="service" value="org.eclipse.kapua.service.authorization.role.RoleService" />
+            <column name="last_run_on" valueComputed="${now}" />
+            <column name="version" value="1" />
         </insert>
         <insert tableName="sys_housekeeper_run">
-            <column name="service" value="org.eclipse.kapua.service.authorization.group.GroupService"/>
-            <column name="last_run_on" valueComputed="${now}"/>
-            <column name="version" value="1"/>
+            <column name="service" value="org.eclipse.kapua.service.authorization.group.GroupService" />
+            <column name="last_run_on" valueComputed="${now}" />
+            <column name="version" value="1" />
         </insert>
         <insert tableName="sys_housekeeper_run">
-            <column name="service" value="org.eclipse.kapua.service.authorization.domain.DomainRegistryService"/>
-            <column name="last_run_on" valueComputed="${now}"/>
-            <column name="version" value="1"/>
+            <column name="service" value="org.eclipse.kapua.service.authorization.domain.DomainService" />
+            <column name="last_run_on" valueComputed="${now}" />
+            <column name="version" value="1" />
         </insert>
     </changeSet>
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-sys-housekeeper-update-domain-service.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-sys-housekeeper-update-domain-service.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/athz-sys-housekeeper-update-domain-service.xml">
+
+    <changeSet id="changelog-athz-sys-housekeeper-update-domain"
+               author="eurotech">
+        <update tableName="sys_housekeeper_run">
+            <column name="service" value="org.eclipse.kapua.service.authorization.domain.DomainRegistryService"/>
+            <where>service LIKE 'org.eclipse.kapua.service.authorization.domain.DomainService'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/changelog-authorization-1.0.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/changelog-authorization-1.0.0.xml
@@ -18,6 +18,7 @@
         logicalFilePath="KapuaDB/changelog-authorization-1.0.0.xml">
 
     <include relativeToChangelogFile="true" file="./athz-sys-housekeeper-run-seed.xml"/>
+    <include relativeToChangelogFile="true" file="./athz-sys-housekeeper-update-domain-service.xml"/>
 
     <include relativeToChangelogFile="true" file="./athz-access_info-domain.xml"/>
     <include relativeToChangelogFile="true" file="./athz-domain-domain.xml"/>


### PR DESCRIPTION
Hi all,

This PR refactors Liquibase scripts that are now failing due to a checksum error when upgrading from Kapua 1.0.0-M3 to 1.0.0-M5. This happens because the scripts themselves were changed between the two versions, while the right way to deal with database changes in Liquibase is to create new scripts that act incrementally.