### PR TITLE
Added tooltips for Target grid and comboBoxes

### DIFF
--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -145,6 +145,7 @@ public class AccessRoleAddDialog extends EntityAddEditDialog {
         rolesCombo.setTriggerAction(TriggerAction.ALL);
         rolesCombo.setStore(roleStore);
         rolesCombo.setDisplayField("name");
+        rolesCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={name}>{name}</div></tpl>");
         rolesCombo.setValueField("id");
 
         roleFormPanel.add(rolesCombo);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -106,6 +106,7 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         reservedUserCombo.setTriggerAction(TriggerAction.ALL);
         reservedUserCombo.setStore(new ListStore<GwtUser>());
         reservedUserCombo.setDisplayField("username");
+        reservedUserCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={username}>{username}</div></tpl>");
         reservedUserCombo.setValueField("id");
 
         if (currentSession.hasPermission(UserSessionPermission.read())) {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -182,6 +182,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
             groupCombo.setAllowBlank(false);
             groupCombo.setEditable(false);
             groupCombo.setDisplayField("groupName");
+            groupCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={groupName}>{groupName}</div></tpl>");
             groupCombo.setValueField("id");
 
             gwtGroupService.findAll(currentSession.getSelectedAccountId(), new AsyncCallback<List<GwtGroup>>() {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceFilterPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceFilterPanel.java
@@ -279,6 +279,7 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
             groupsCombo.setAllowBlank(false);
             groupsCombo.setEmptyText(DEVICE_MSGS.deviceFilteringPanelLoading());
             groupsCombo.setDisplayField("groupName");
+            groupsCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={groupName}>{groupName}</div></tpl>");
             groupsCombo.setValueField("id");
             groupsCombo.setName("groupId");
             groupsCombo.setWidth(WIDTH);
@@ -329,6 +330,7 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
             tagsCombo.setAllowBlank(false);
             tagsCombo.setEmptyText(DEVICE_MSGS.deviceFilteringPanelLoading());
             tagsCombo.setDisplayField("tagName");
+            tagsCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={tagName}>{tagName}</div></tpl>");
             tagsCombo.setValueField("id");
             tagsCombo.setName("tagId");
             tagsCombo.setWidth(WIDTH);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
@@ -12,11 +12,17 @@
 package org.eclipse.kapua.app.console.module.job.client.targets;
 
 import com.extjs.gxt.ui.client.Style.SelectionMode;
+import com.extjs.gxt.ui.client.data.ModelData;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.util.Format;
 import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
+import com.extjs.gxt.ui.client.widget.grid.ColumnData;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.extjs.gxt.ui.client.widget.toolbar.PagingToolBar;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
@@ -102,10 +108,12 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
         column = new ColumnConfig("clientId", DVC_MSGS.deviceTableClientID(), 175);
         column.setSortable(true);
         columnConfigs.add(column);
+        column.setRenderer(gridCellRenderer);
 
         column = new ColumnConfig("displayName", DVC_MSGS.deviceTableDisplayName(), 150);
         column.setSortable(true);
         columnConfigs.add(column);
+        column.setRenderer(gridCellRenderer);
 
         return columnConfigs;
     }
@@ -128,5 +136,17 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     public void setFilterQuery(GwtQuery filterQuery) {
         this.query = (GwtDeviceQuery) filterQuery;
     }
+
+    GridCellRenderer<ModelData> gridCellRenderer = new GridCellRenderer<ModelData>() {
+        @Override
+        public Object render(ModelData model, String property, ColumnData config, int rowIndex, int colIndex,
+                ListStore<ModelData> store, Grid<ModelData> grid) {
+            String value = model.get(property);
+            if (value != null) {
+                return "<tpl for=\".\"><div title=" + Format.htmlEncode(value) + ">" + Format.htmlEncode(value) + "</div></tpl>";
+            }
+            return value;
+        }
+    };
 
 }


### PR DESCRIPTION
Solves issue: #1737
Added custom GridCellRenderer with defined tooltip for columns on JobTargetGrid.
Added templates with tooltips, like the already existing one used on the New Tag dialog, to other relevant comboBoxes.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>