### PR TITLE
Changed EntityGrid's refresh() method

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -187,7 +187,8 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
 
     public void refresh() {
         entityCRUDToolbar.getRefreshEntityButton().setEnabled(false);
-        entityLoader.load(0, entityLoader.getLimit());
+        entityLoader.setReuseLoadConfig(true);
+        entityLoader.load();
     }
 
     public void refresh(GwtQuery query) {


### PR DESCRIPTION
Solves issue: #1724
Changed the way entityLoader's properties (offset and limit) are set in the refresh method. They are reused after refresh.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>