### PR TITLE
fixes all problems with selecting and deselecting targets on refresh …

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,7 @@ public class AccountChildUserToolbar extends EntityCRUDToolbar<GwtUser> {
     public void setSelectedAccountId(String accountId) {
         this.accountId = accountId;
         updateToolBarButtons();
+        setRefreshAndDeselectVisible(false);
     }
 
     public void updateToolBarButtons() {

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
@@ -29,6 +29,7 @@ public class AccountGridToolbar extends EntityCRUDToolbar<GwtAccount> {
         super.onRender(target, index);
         super.getEditEntityButton().disable();
         super.getDeleteEntityButton().disable();
+        super.getRefreshAndDeselectButton().hide();
         getAddEntityButton().setEnabled(currentSession.hasPermission(AccountSessionPermission.write()));
     }
 

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -195,8 +195,7 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     }
 
     public void refresh() {
-        if (entityCRUDToolbar.getRefreshEntityButton() != null) {
-            entityCRUDToolbar.getRefreshEntityButton().setEnabled(false);
+        entityCRUDToolbar.getRefreshEntityButton().setEnabled(false);
         entityLoader.setReuseLoadConfig(true);
         entityLoader.load();
     }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.api.client.ui.grid;
 
+import java.util.ArrayList;
+import com.extjs.gxt.ui.client.Style;
 import com.extjs.gxt.ui.client.Style.SelectionMode;
 import com.extjs.gxt.ui.client.data.BasePagingLoader;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
@@ -18,6 +20,7 @@ import com.extjs.gxt.ui.client.data.RpcProxy;
 import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
 import com.extjs.gxt.ui.client.event.SelectionChangedListener;
 import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.extjs.gxt.ui.client.widget.grid.ColumnModel;
 import com.extjs.gxt.ui.client.widget.grid.GridSelectionModel;
@@ -55,7 +58,9 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     protected ListStore<M> entityStore;
     protected PagingToolBar entityPagingToolbar;
     protected EntityFilterPanel<M> filterPanel;
-
+    protected final EntityGridCheckBoxSelectionModel<M> selectionModel = new EntityGridCheckBoxSelectionModel<M>();
+    private List<SelectionChangedListener<M>> listeners = new ArrayList<SelectionChangedListener<M>>();
+    protected CheckBoxSelectionModel<M> selectionModels = new EntityGridCheckBoxSelectionModel<M>();
     /* Some grids (most notably "slave" grids, i.e. the ones that depends from the entity *
      * selected in another grid) should not be refreshed on render, otherwise they would be *
      * refreshed twice and the paging toolbar may be disabled because of this */
@@ -122,7 +127,6 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
         // Grid view options
         GridView gridView = entityGrid.getView();
         gridView.setEmptyText(MSGS.gridEmptyResult());
-
         //
         // Do first load
         if (refreshOnRender) {
@@ -169,10 +173,15 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
         //
         // Configure columns
         ColumnModel columnModel = new ColumnModel(getColumns());
-
+        selectionModel.setSelectionMode(Style.SelectionMode.SIMPLE);
+        for (SelectionChangedListener<M> listener : listeners) {
+            selectionModel.addSelectionChangedListener(listener);
+        }
         //
         // Set grid
         entityGrid = new KapuaGrid<M>(entityStore, columnModel);
+        entityGrid.addPlugin(selectionModel);
+        entityGrid.setSelectionModel(selectionModel);
         add(entityGrid);
 
         entityGridConfigured = true;
@@ -186,7 +195,8 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     }
 
     public void refresh() {
-        entityCRUDToolbar.getRefreshEntityButton().setEnabled(false);
+        if (entityCRUDToolbar.getRefreshEntityButton() != null) {
+            entityCRUDToolbar.getRefreshEntityButton().setEnabled(false);
         entityLoader.setReuseLoadConfig(true);
         entityLoader.load();
     }
@@ -235,6 +245,11 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
      * Method is called when grid is loaded.
      */
     public void loaded() {
-        entityCRUDToolbar.getRefreshEntityButton().setEnabled(true);
+        if (entityCRUDToolbar.getRefreshEntityButton() != null) {
+            entityCRUDToolbar.getRefreshEntityButton().setEnabled(true);
+        }
+        if (!entityGrid.getSelectionModel().getSelectedItems().isEmpty()) {
+            entityGrid.getSelectionModel().deselectAll();
+        }
     }
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
@@ -64,7 +64,9 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
     private boolean deleteEntityButtonShow = true;
 
     protected RefreshButton refreshEntityButton;
+    protected RefreshButton refreshAndDeselectEntityButton;
     private boolean refreshEntityButtonShow = true;
+    private boolean refreshAndClearGridShow = true;
 
     protected ToggleButton filterButton;
     private boolean filterButtonShow = true;
@@ -111,6 +113,10 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
             add(refreshEntityButton);
         }
 
+        if (refreshAndClearGridShow) {
+            refreshAndDeselectEntityButton = new RefreshButton(getRefreshAndDeselectButtonSelectionListener());
+            add(refreshAndDeselectEntityButton);
+        }
         // Check on extra buttons defined in the implemented Toolbar
         for (Component button : getExtraButtons()) {
             add(new SeparatorToolItem());
@@ -242,6 +248,10 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
         this.deleteEntityButtonShow = show;
     }
 
+    public void setRefreshAndDeselectVisible(boolean show) {
+        this.refreshAndClearGridShow = show;
+    }
+
     //
     // Refresh button methods
     //
@@ -250,6 +260,17 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
 
             @Override
             public void componentSelected(ButtonEvent ce) {
+                entityGrid.refresh();
+            }
+        };
+    }
+
+    protected SelectionListener<ButtonEvent> getRefreshAndDeselectButtonSelectionListener() {
+        return new SelectionListener<ButtonEvent>() {
+
+            @Override
+            public void componentSelected(ButtonEvent ce) {
+                entityGrid.getSelectionModel().deselectAll();
                 entityGrid.refresh();
             }
         };
@@ -332,7 +353,23 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
         return filterButton;
     }
 
+    public RefreshButton getRefreshAndDeselectButton() {
+        if (refreshEntityButton == null) {
+            refreshEntityButton = new RefreshButton(getRefreshAndDeselectButtonSelectionListener());
+        }
+
+        return refreshEntityButton;
+    }
+
     public void setFilterPanel(EntityFilterPanel<M> filterPanel) {
         this.filterPanel = filterPanel;
+    }
+
+    public RefreshButton getRefreshButton() {
+        if (refreshEntityButton == null) {
+            refreshEntityButton = new RefreshButton(getRefreshAndDeselectButtonSelectionListener());
+        }
+
+        return refreshEntityButton;
     }
 }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
@@ -214,6 +214,7 @@ public class CredentialGrid extends EntityGrid<GwtCredential> {
     }
 
     private void updateToolbarButtons() {
+        getToolbar().getRefreshAndDeselectButton().hide();
         getToolbar().getAddEntityButton().setEnabled(selectedUserId != null && currentSession.hasPermission(CredentialSessionPermission.write()));
         getToolbar().getEditEntityButton().setEnabled(getSelectionModel().getSelectedItem() != null && currentSession.hasPermission(CredentialSessionPermission.write()));
         getToolbar().getDeleteEntityButton().setEnabled(getSelectionModel().getSelectedItem() != null && currentSession.hasPermission(CredentialSessionPermission.delete()));

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupToolbarGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupToolbarGrid.java
@@ -35,6 +35,7 @@ public class GroupToolbarGrid extends EntityCRUDToolbar<GwtGroup> {
     @Override
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
+        getRefreshAndDeselectButton().hide();
         getAddEntityButton().setEnabled(currentSession.hasPermission(GroupSessionPermission.write()));
     }
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
@@ -58,6 +58,7 @@ public class RolePermissionGrid extends EntityGrid<GwtRolePermission> {
     protected EntityCRUDToolbar<GwtRolePermission> getToolbar() {
         if (rolePermissionToolBar == null) {
             rolePermissionToolBar = new RolePermissionToolbar(currentSession, this);
+            rolePermissionToolBar.setRefreshAndDeselectVisible(false);
         }
 
         return rolePermissionToolBar;

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
@@ -47,6 +47,7 @@ public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         getAddEntityButton().setEnabled(currentSession.hasPermission(RoleSessionPermission.write()));
+        getRefreshAndDeselectButton().hide();
     }
 
     @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionToolbar.java
@@ -62,6 +62,7 @@ public class UserTabPermissionToolbar extends EntityCRUDToolbar<GwtAccessPermiss
                 currentSession.hasPermission(DomainSessionPermission.read()) && currentSession.hasPermission(DomainSessionPermission.write()));
         deleteEntityButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null);
         refreshEntityButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null);
+        getRefreshAndDeselectButton().hide();
     }
 
     @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
@@ -120,6 +120,7 @@ public class UserTabAccessRoleGrid extends EntityGrid<GwtAccessRole> {
         if (toolbar == null) {
             toolbar = new UserTabAccessRoleToolbar(currentSession);
             toolbar.setEditButtonVisible(false);
+            toolbar.setRefreshAndDeselectVisible(false);
             toolbar.setBorders(true);
         }
         return toolbar;

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,6 +25,7 @@ public class ConnectionGridToolbar extends EntityCRUDToolbar<GwtDeviceConnection
         setAddButtonVisible(false);
         setEditButtonVisible(true);
         setDeleteButtonVisible(false);
+        setRefreshAndDeselectVisible(false);
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
@@ -34,6 +34,7 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         getAddEntityButton().setEnabled(currentSession.hasPermission(DeviceSessionPermission.write()));
+        getRefreshAndDeselectButton().hide();
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
@@ -104,6 +104,8 @@ public class GroupSubjectGrid extends EntityGrid<GwtDevice> {
         toolbar.setEditButtonVisible(false);
         toolbar.setDeleteButtonVisible(false);
         toolbar.setFilterButtonVisible(false);
+        toolbar.setRefreshAndDeselectVisible(false);
+        toolbar.getRefreshAndDeselectButton().hide();
         toolbar.setBorders(true);
 
         return toolbar;

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
@@ -71,6 +71,7 @@ public class DeviceTagToolbar extends TagToolbarGrid {
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         setBorders(true);
+        refreshAndDeselectEntityButton.hide();
         addEntityButton.setText(DEVICE_MSGS.tabTagsAddButton());
         deleteEntityButton.setText(DEVICE_MSGS.tabTagsDeleteButton());
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/TagSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/TagSubjectGrid.java
@@ -101,6 +101,8 @@ public class TagSubjectGrid extends EntityGrid<GwtDevice> {
         toolbar.setEditButtonVisible(false);
         toolbar.setDeleteButtonVisible(false);
         toolbar.setFilterButtonVisible(false);
+        toolbar.setRefreshAndDeselectVisible(false);
+        toolbar.getRefreshAndDeselectButton().hide();
         toolbar.setBorders(true);
 
         return toolbar;

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
@@ -146,6 +146,11 @@ public class GwtKapuaDeviceModelConverter {
             deviceQuery.setOffset(loadConfig.getOffset());
 
             String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? DevicePredicates.CLIENT_ID : loadConfig.getSortField();
+            if (sortField.equals("clientId")) {
+                sortField = DevicePredicates.CLIENT_ID;
+            } else if (sortField.equals("displayName")) {
+                sortField = DevicePredicates.DISPLAY_NAME;
+            }
             SortOrder sortOrder = loadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
             FieldSortCriteria sortCriteria = new FieldSortCriteria(sortField, sortOrder);
             deviceQuery.setSortCriteria(sortCriteria);
@@ -203,10 +208,7 @@ public class GwtKapuaDeviceModelConverter {
         }
 
         if (predicates.getSortAttribute() != null) {
-            SortOrder sortOrder = SortOrder.ASCENDING;
-            if (predicates.getSortOrder().equals(SortOrder.DESCENDING.name())) {
-                sortOrder = SortOrder.DESCENDING;
-            }
+            SortOrder sortOrder = loadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
 
         } else {
             deviceQuery.setSortCriteria(new FieldSortCriteria(DevicePredicates.CLIENT_ID, SortOrder.ASCENDING));

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointToolbarGrid.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointToolbarGrid.java
@@ -55,7 +55,7 @@ public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
     @Override
     protected void updateButtonEnablement() {
         super.updateButtonEnablement();
-
+        getRefreshAndDeselectButton().hide();
         //
         // Force disabled if entity is inherited from parent scopes
         addEntityButton.setEnabled(currentSession.hasPermission(EndpointSessionPermission.writeAll()));

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
@@ -73,6 +73,7 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
 
         getEditEntityButton().disable();
         getDeleteEntityButton().disable();
+        refreshAndDeselectEntityButton.hide();
         getAddEntityButton().setEnabled(currentSession.hasPermission(JobSessionPermission.write()));
     }
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -37,6 +37,7 @@ public class JobTabExecutionsToolbar extends EntityCRUDToolbar<GwtExecution> {
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         checkButtons();
+        refreshAndDeselectEntityButton.hide();
     }
 
     private void checkButtons() {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesToolbar.java
@@ -43,6 +43,7 @@ public class JobTabSchedulesToolbar extends EntityCRUDToolbar<GwtTrigger> {
             addEntityButton.setEnabled(false);
             refreshEntityButton.setEnabled(false);
         }
+        refreshAndDeselectEntityButton.hide();
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsToolbar.java
@@ -70,6 +70,7 @@ public class JobTabStepsToolbar extends EntityCRUDToolbar<GwtJobStep> {
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         checkButtons();
+        refreshAndDeselectEntityButton.hide();
     }
 
     private void checkButtons() {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -83,6 +83,7 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
         super.onRender(target, index);
 
         checkButtons();
+        getRefreshAndDeselectButton().hide();
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
@@ -12,23 +12,17 @@
 package org.eclipse.kapua.app.console.module.job.client.targets;
 
 import com.extjs.gxt.ui.client.Style.SelectionMode;
-import com.extjs.gxt.ui.client.data.ModelData;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
-import com.extjs.gxt.ui.client.store.ListStore;
-import com.extjs.gxt.ui.client.util.Format;
+import com.extjs.gxt.ui.client.event.SelectionChangedListener;
 import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
-import com.extjs.gxt.ui.client.widget.grid.ColumnData;
-import com.extjs.gxt.ui.client.widget.grid.Grid;
-import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.extjs.gxt.ui.client.widget.toolbar.PagingToolBar;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
-import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGridCheckBoxSelectionModel;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingToolBar;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -48,7 +42,7 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     private static final GwtDeviceServiceAsync GWT_DEVICE_SERVICE = GWT.create(GwtDeviceService.class);
     private static final ConsoleDeviceMessages DVC_MSGS = GWT.create(ConsoleDeviceMessages.class);
 
-    private final EntityGridCheckBoxSelectionModel<GwtDevice> selectionModel = new EntityGridCheckBoxSelectionModel<GwtDevice>();
+    private List<SelectionChangedListener<GwtDevice>> listeners = new ArrayList<SelectionChangedListener<GwtDevice>>();
 
     private static final int ENTITY_PAGE_SIZE = 10;
 
@@ -79,7 +73,6 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
                         query,
                         callback);
             }
-
         };
     }
 
@@ -94,26 +87,25 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
         toolbar.setAddButtonVisible(false);
         toolbar.setEditButtonVisible(false);
         toolbar.setDeleteButtonVisible(false);
-        toolbar.setRefreshButtonVisible(true);
+        toolbar.setRefreshButtonVisible(false);
+        toolbar.getRefreshButton().hide();
+        toolbar.setRefreshAndDeselectVisible(true);
         return toolbar;
     }
 
     @Override
     protected List<ColumnConfig> getColumns() {
         List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
-
-        ColumnConfig column = selectionModel.getColumn();
-        columnConfigs.add(column);
+        columnConfigs.add(selectionModel.getColumn());
+        ColumnConfig column;
 
         column = new ColumnConfig("clientId", DVC_MSGS.deviceTableClientID(), 175);
         column.setSortable(true);
         columnConfigs.add(column);
-        column.setRenderer(gridCellRenderer);
 
         column = new ColumnConfig("displayName", DVC_MSGS.deviceTableDisplayName(), 150);
         column.setSortable(true);
         columnConfigs.add(column);
-        column.setRenderer(gridCellRenderer);
 
         return columnConfigs;
     }
@@ -121,9 +113,6 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     @Override
     protected void onRender(Element target, int index) {
         configureEntityGrid(SelectionMode.SIMPLE);
-        entityGrid.addPlugin(selectionModel);
-        entityGrid.setSelectionModel(selectionModel);
-
         super.onRender(target, index);
     }
 
@@ -136,17 +125,5 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     public void setFilterQuery(GwtQuery filterQuery) {
         this.query = (GwtDeviceQuery) filterQuery;
     }
-
-    GridCellRenderer<ModelData> gridCellRenderer = new GridCellRenderer<ModelData>() {
-        @Override
-        public Object render(ModelData model, String property, ColumnData config, int rowIndex, int colIndex,
-                ListStore<ModelData> store, Grid<ModelData> grid) {
-            String value = model.get(property);
-            if (value != null) {
-                return "<tpl for=\".\"><div title=" + Format.htmlEncode(value) + ">" + Format.htmlEncode(value) + "</div></tpl>";
-            }
-            return value;
-        }
-    };
 
 }

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagToolbarGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagToolbarGrid.java
@@ -37,6 +37,7 @@ public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         getAddEntityButton().setEnabled(currentSession.hasPermission(TagSessionPermission.write()));
+        getRefreshAndDeselectButton().hide();
     }
 
     @Override

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGridToolbar.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGridToolbar.java
@@ -55,6 +55,7 @@ public class UserGridToolbar extends EntityCRUDToolbar<GwtUser> {
     @Override
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
+        getRefreshAndDeselectButton().hide();
         getEditEntityButton().disable();
         getDeleteEntityButton().disable();
         getAddEntityButton().setEnabled(currentSession.hasPermission(UserSessionPermission.write()));

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/RoleSubjectGrid.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/RoleSubjectGrid.java
@@ -99,6 +99,7 @@ public class RoleSubjectGrid extends EntityGrid<GwtUser> {
         toolbar.setEditButtonVisible(false);
         toolbar.setDeleteButtonVisible(false);
         toolbar.setFilterButtonVisible(false);
+        toolbar.setRefreshAndDeselectVisible(false);
         toolbar.setBorders(true);
 
         return toolbar;


### PR DESCRIPTION
…and sorting

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added some new methods for Refresh button with another listener(also new made) in constructor, then hide that button in all other views, also added some if's is GwtKapuaDeviceModelConverter for sorting.

**Related Issue**
This PR fixes issue #1597 

**Description of the solution adopted**
New Refresh button which not only refresh grid, also deselect all checked items if they are checked. Also when User wants to sort columns, all selected items become unchecked.

**Screenshots**
No screenshots.

**Any side note on the changes made**
No description.
