### PR TITLE
Special characters problem in Jobs fix

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
@@ -70,7 +70,7 @@ public class JobStepEditDialog extends JobStepAddDialog {
 
             @Override
             public void onSuccess(GwtJobStepDefinition result) {
-                jobStepName.setValue(gwtJobStep.getJobStepName());
+                jobStepName.setValue(gwtJobStep.getUnescapedJobStepName());
                 jobStepDescription.setValue(gwtJobStep.getUnescapedDescription());
                 jobStepDefinitionCombo.setValue(result);
 
@@ -96,7 +96,7 @@ public class JobStepEditDialog extends JobStepAddDialog {
 
     @Override
     public void submit() {
-        selectedJobStep.setJobStepName(jobStepName.getValue());
+        selectedJobStep.setJobStepName(KapuaSafeHtmlUtils.htmlUnescape(jobStepName.getValue()));
         selectedJobStep.setDescription(KapuaSafeHtmlUtils.htmlUnescape(jobStepDescription.getValue()));
         selectedJobStep.setJobStepDefinitionId(jobStepDefinitionCombo.getValue().getId());
         selectedJobStep.setStepProperties(readStepProperties());

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
@@ -17,7 +17,6 @@ import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
 import com.extjs.gxt.ui.client.store.ListStore;
-import com.extjs.gxt.ui.client.util.Format;
 import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.extjs.gxt.ui.client.widget.grid.ColumnData;
@@ -31,6 +30,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGridCheckBoxSelectionModel;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingToolBar;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
@@ -141,9 +141,9 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
         @Override
         public Object render(ModelData model, String property, ColumnData config, int rowIndex, int colIndex,
                 ListStore<ModelData> store, Grid<ModelData> grid) {
-            String value = model.get(property);
+            String value = model.get(KapuaSafeHtmlUtils.htmlUnescape(property));
             if (value != null) {
-                return "<tpl for=\".\"><div title=" + Format.htmlEncode(value) + ">" + Format.htmlEncode(value) + "</div></tpl>";
+                return "<tpl for=\".\"><div title=" + value + ">" + value + "</div></tpl>";
             }
             return value;
         }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
@@ -174,7 +174,7 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
 
                 //
                 // Update job step
-                jobStep.setName(gwtJobStep.getJobStepName());
+                jobStep.setName(gwtJobStep.getUnescapedJobStepName());
                 jobStep.setDescription(gwtJobStep.getUnescapedDescription());
                 jobStep.setJobStepDefinitionId(GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobStep.getJobStepDefinitionId()));
                 jobStep.setStepProperties(GwtKapuaJobModelConverter.convertJobStepProperties(gwtJobStep.getStepProperties()));

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStep.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStep.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,10 @@ public class GwtJobStep extends GwtUpdatableEntityModel implements IsSerializabl
 
     public String getJobStepName() {
         return get("jobStepName");
+    }
+
+    public String getUnescapedJobStepName() {
+        return (String) getUnescaped("jobStepName");
     }
 
     public void setJobStepName(String jobStepName) {


### PR DESCRIPTION
Solves issue: #1756
Added method to get unescaped value of JobStepName propery in GwtJobStep class, used in GwtJobStep update method. Made change in JobStepEditDialog, so that so that value of jobStepName is unescaped when populating the dialog. Updated JobTargetGrid so that the values on the grid and tooltips are unescaped as well.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>