### PR TITLE
Fixed handling of selected item on multi-selectable grids

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridLoadListener.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridLoadListener.java
@@ -12,42 +12,80 @@
 package org.eclipse.kapua.app.console.module.api.client.ui.grid;
 
 import com.extjs.gxt.ui.client.data.LoadEvent;
+import com.extjs.gxt.ui.client.data.Loader;
 import com.extjs.gxt.ui.client.store.ListStore;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaLoadListener;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtEntityModel;
 
+import java.util.List;
+
 public class EntityGridLoadListener<M extends GwtEntityModel> extends KapuaLoadListener {
 
     private EntityGrid<M> entityGrid;
-    private M selectedEntity;
     private ListStore<M> entityStore;
+
+    private List<M> selectedEntities;
+    private boolean keepSelectedOnLoad = true;
 
     public EntityGridLoadListener(EntityGrid<M> entityGrid, ListStore<M> entityStore) {
         this.entityGrid = entityGrid;
         this.entityStore = entityStore;
     }
 
+    /**
+     * Keeps track of the selected item in the {@link EntityGrid} before the invocation of {@link Loader#load()}.
+     *
+     * @param le The {@link LoadEvent}
+     */
     @Override
     public void loaderBeforeLoad(LoadEvent le) {
-        selectedEntity = entityGrid.getSelectionModel().getSelectedItem();
+        selectedEntities = entityGrid.getSelectionModel().getSelectedItems();
     }
 
+    /**
+     * If {@link #keepSelectedOnLoad} is {@code true}, selects all entities which where selected before {@link Loader#load()}
+     * invocation if they are present in the new result set.
+     *
+     * @param le The {@link LoadEvent}.
+     */
     @Override
     public void loaderLoad(LoadEvent le) {
-        if (selectedEntity != null) {
+        if (isKeepSelectedOnLoad() && !selectedEntities.isEmpty()) {
             for (M e : entityStore.getModels()) {
-                if (selectedEntity.getId().equals(e.getId())) {
-                    entityGrid.getSelectionModel().select(e, true);
+                for (M se : selectedEntities) {
+                    if (se.getId().equals(e.getId())) {
+                        entityGrid.getSelectionModel().select(e, true);
+                        break;
+                    }
                 }
             }
         }
+
         entityGrid.loaded();
     }
 
     @Override
     public void loaderLoadException(LoadEvent le) {
         entityGrid.loaded();
+
         super.loaderLoadException(le);
     }
 
+    /**
+     * Returns whether or not the currently selected entities will be kept selected after the {@link Loader#load()}
+     *
+     * @return {@code true} if enabled,{@code false} otherwise.
+     */
+    public boolean isKeepSelectedOnLoad() {
+        return keepSelectedOnLoad;
+    }
+
+    /**
+     * Enables or disables the feature of remembering the selected items after the {@link Loader#load()} event.
+     *
+     * @param keepSelectedOnLoad {@code true} to enable, {@code false} to disable.
+     */
+    public void setKeepSelectedOnLoad(boolean keepSelectedOnLoad) {
+        this.keepSelectedOnLoad = keepSelectedOnLoad;
+    }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddGrid.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.targets;
 
-import com.extjs.gxt.ui.client.Style.SelectionMode;
+import com.extjs.gxt.ui.client.Style;
 import com.extjs.gxt.ui.client.data.ModelData;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
@@ -62,6 +62,10 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
 
         query = new GwtDeviceQuery();
         query.setScopeId(currentSession.getSelectedAccountId());
+
+        // Configure grid options
+        selectionMode = Style.SelectionMode.SIMPLE;
+        keepSelectedItemsAfterLoad = false;
     }
 
     @Override
@@ -75,9 +79,7 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
 
             @Override
             protected void load(Object loadConfig, AsyncCallback<PagingLoadResult<GwtDevice>> callback) {
-                GWT_DEVICE_SERVICE.query((PagingLoadConfig) loadConfig,
-                        query,
-                        callback);
+                GWT_DEVICE_SERVICE.query((PagingLoadConfig) loadConfig, query, callback);
             }
 
         };
@@ -95,6 +97,7 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
         toolbar.setEditButtonVisible(false);
         toolbar.setDeleteButtonVisible(false);
         toolbar.setRefreshButtonVisible(true);
+
         return toolbar;
     }
 
@@ -120,7 +123,8 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
 
     @Override
     protected void onRender(Element target, int index) {
-        configureEntityGrid(SelectionMode.SIMPLE);
+        configureEntityGrid();
+
         entityGrid.addPlugin(selectionModel);
         entityGrid.setSelectionModel(selectionModel);
 
@@ -138,6 +142,7 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     }
 
     GridCellRenderer<ModelData> gridCellRenderer = new GridCellRenderer<ModelData>() {
+
         @Override
         public Object render(ModelData model, String property, ColumnData config, int rowIndex, int colIndex,
                 ListStore<ModelData> store, Grid<ModelData> grid) {


### PR DESCRIPTION
Brief description of the PR.
Managed properly selected item before and after load.

**Related Issue**
This PR fixes #1597 

**Description of the solution adopted**
The `KapuaLoadListener` was designed to work with only single selected items. So the problem was that the `KapuaLoadListener` was keeping the selection of the last selected item, instead of all of them. 

Changed the single `selectedEntity` into a `List` of `selectedItems` so all items are tracked. 
Added a parameter which can configure if "remember selected item" feature is disabled or not.

**Screenshots**
_None_

**Any side note on the changes made**
Reordered a bit field in classes and added some javadocs