### PR TITLE
Dialog window closes after invalid selection fix

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -22,8 +22,10 @@ import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.validator.ConfirmPasswordFieldValidator;
 import org.eclipse.kapua.app.console.module.api.client.util.validator.PasswordFieldValidator;
@@ -40,6 +42,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaDateField;
 public class CredentialAddDialog extends EntityAddEditDialog {
 
     protected static final ConsoleCredentialMessages MSGS = GWT.create(ConsoleCredentialMessages.class);
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
 
     protected FormPanel credentialFormPanel;
     private String selectedUserId;
@@ -187,9 +190,9 @@ public class CredentialAddDialog extends EntityAddEditDialog {
                 status.hide();
 
                 exitStatus = false;
-                exitMessage = MSGS.dialogAddError(cause.getLocalizedMessage());
-
-                hide();
+                exitMessage = cause.getLocalizedMessage();
+                credentialType.markInvalid(exitMessage);
+                ConsoleInfo.display(CMSGS.error(), exitMessage);
             }
         });
     }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -19,13 +19,16 @@ import com.extjs.gxt.ui.client.widget.form.CheckBoxGroup;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
+import com.extjs.gxt.ui.client.widget.form.SimpleComboValue;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsolePermissionMessages;
@@ -50,6 +53,7 @@ import java.util.List;
 public class PermissionAddDialog extends EntityAddEditDialog {
 
     private static final ConsolePermissionMessages MSGS = GWT.create(ConsolePermissionMessages.class);
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
 
     private static final GwtDomainRegistryServiceAsync GWT_DOMAIN_SERVICE = GWT.create(GwtDomainRegistryService.class);
     private static final GwtAccessPermissionServiceAsync GWT_ACCESS_PERMISSION_SERVICE = GWT.create(GwtAccessPermissionService.class);
@@ -156,6 +160,7 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                         actionsCombo.add(result);
                         actionsCombo.setSimpleValue(allAction);
                         actionsCombo.enable();
+                        groupsCombo.clearInvalid();
 
                         if (allDomain.equals(selectedDomain)) {
                             groupsCombo.setEnabled(true);
@@ -184,6 +189,15 @@ public class PermissionAddDialog extends EntityAddEditDialog {
         actionsCombo.setFieldLabel(MSGS.dialogAddPermissionAction());
         actionsCombo.setTriggerAction(TriggerAction.ALL);
         actionsCombo.setEmptyText(MSGS.dialogAddPermissionLoading());
+
+        actionsCombo.addSelectionChangedListener(new SelectionChangedListener<SimpleComboValue<GwtAction>>() {
+
+            public void selectionChanged(SelectionChangedEvent<SimpleComboValue<GwtAction>> se) {
+                domainsCombo.clearInvalid();
+                actionsCombo.clearInvalid();
+                groupsCombo.clearInvalid();
+            }
+        });
 
         permissionFormPanel.add(actionsCombo);
 
@@ -215,6 +229,16 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                 groupsCombo.getStore().add(result);
                 groupsCombo.setValue(allGroup);
                 groupsCombo.enable();
+            }
+        });
+
+        groupsCombo.addSelectionChangedListener(new SelectionChangedListener<GwtGroup>() {
+
+            @Override
+            public void selectionChanged(SelectionChangedEvent<GwtGroup> se) {
+                domainsCombo.clearInvalid();
+                actionsCombo.clearInvalid();
+                groupsCombo.clearInvalid();
             }
         });
         permissionFormPanel.add(groupsCombo);
@@ -274,7 +298,12 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                     exitMessage = MSGS.dialogAddError(MSGS.dialogAddPermissionError(cause.getLocalizedMessage()));
                 }
 
-                hide();
+                domainsCombo.markInvalid(exitMessage);
+                actionsCombo.markInvalid(exitMessage);
+                if (groupsCombo.isEnabled()){
+                    groupsCombo.markInvalid(exitMessage);
+                }
+                ConsoleInfo.display(CMSGS.error(), exitMessage);
             }
         });
     }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -21,8 +21,10 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsolePermissionMessages;
@@ -40,6 +42,7 @@ import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRole
 public class AccessRoleAddDialog extends EntityAddEditDialog {
 
     private static final ConsolePermissionMessages MSGS = GWT.create(ConsolePermissionMessages.class);
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
 
     private static final GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
     private static final GwtAccessRoleServiceAsync GWT_ACCESS_ROLE_SERVICE = GWT.create(GwtAccessRoleService.class);
@@ -105,7 +108,8 @@ public class AccessRoleAddDialog extends EntityAddEditDialog {
                     exitMessage = MSGS.dialogAddError(MSGS.dialogAddRoleError(cause.getLocalizedMessage()));
                 }
 
-                hide();
+                rolesCombo.markInvalid(exitMessage);
+                ConsoleInfo.display(CMSGS.error(), exitMessage);
             }
         });
     }

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
@@ -149,7 +149,7 @@ dialogAddRoleInfo=Select a Role to assign to the User
 dialogAddRoleComboName=Role
 dialogAddRoleError=Error assigning role: {0}
 dialogAddRoleErrorAccessInfo=Error retrieving AccessInfo: {0}
-dialogAddRoleDuplicateError=Error when associating role: An entity with the same value for field already exists.
+dialogAddRoleDuplicateError=Error when assigning role: An entity with the same value for field already exists.
 
 #
 # User view - Delete role dialog

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -17,9 +17,12 @@ import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
@@ -71,9 +74,14 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
                 cancelButton.enable();
                 status.hide();
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeviceTagAddError(cause.getLocalizedMessage());
 
-                hide();
+                FailureHandler.handleFormException(formPanel, cause);
+                if (cause instanceof GwtKapuaException) {
+                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                        tagsCombo.markInvalid(gwtCause.getMessage());
+                    }
+                }
             }
         });
     }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/KapuaExistingCredentialException.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/KapuaExistingCredentialException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,12 +23,12 @@ import org.eclipse.kapua.KapuaException;
 public class KapuaExistingCredentialException extends KapuaException {
 
     private static final long serialVersionUID = -2761138212317761216L;
-    private static final String MESSAGE_FORMAT = "Credential of type %s for user id %s already exists";
+    private static final String MESSAGE_FORMAT = "Credential of type %s already exists for this user.";
 
     /**
      * Constructor for the {@link KapuaExistingCredentialException} taking in the duplicated name.
      */
-    public KapuaExistingCredentialException(CredentialType credentialType, String userId) {
-        super(KapuaErrorCodes.ENTITY_ALREADY_EXISTS, String.format(MESSAGE_FORMAT, credentialType, userId));
+    public KapuaExistingCredentialException(CredentialType credentialType) {
+        super(KapuaErrorCodes.ENTITY_ALREADY_EXISTS, String.format(MESSAGE_FORMAT, credentialType));
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -82,7 +82,7 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
             CredentialListResult existingCredentials = findByUserId(credentialCreator.getScopeId(), credentialCreator.getUserId());
             for (Credential credential : existingCredentials.getItems()) {
                 if (credential.getCredentialType().equals(CredentialType.PASSWORD)) {
-                    throw new KapuaExistingCredentialException(CredentialType.PASSWORD, credential.getUserId().toCompactId());
+                    throw new KapuaExistingCredentialException(CredentialType.PASSWORD);
                 }
             }
         }


### PR DESCRIPTION
Brief description of the PR.
Changed behaviour after invalid selection for some of the dialogs.

**Releted issue**
This PR fixes #1753

**Description of the solution adopted**
Made changes to the affected dialogs, so that they stay open, invalid
inputs selected and error messages are shown. Changes were made to the
KapuaExistingCredentialException class, so that the returned error
message and the constructor no longer contain the userId. This change
affected CredentialServiceImpl class, which was updated as well. Added
new SelectionChangedListeners for some of the comboBoxes, and updated
some of the existing listeners.

**Screenshots**
None

**Any side note on the changes made**
Handled a nullPoinerException when setting groupId in submit() method of
RolePermissionAddDialog class.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
[e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue**
This PR fixes/closes _{issue number}_

**Description of the solution adopted**
A more detailed description of the changes made to solve/close one or more issues.
If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
