### PR TITLE
Show proper message on timestamp when a row has no available data

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTimestampCellRenderer.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTimestampCellRenderer.java
@@ -107,6 +107,8 @@ public class DeviceTimestampCellRenderer implements GridCellRenderer<GwtDatastor
             public void onSuccess(List<GwtDatastoreDevice> gwtDatastoreDevices) {
                 if (gwtDatastoreDevices != null && gwtDatastoreDevices.size() == 1) {
                     gwtDevice.setTimestamp(gwtDatastoreDevices.get(0).getTimestamp());
+                } else {
+                    cellText.setText(DATA_MSGS.topicInfoTableNoLastPostDate());
                 }
                 grid.getView().refresh(false);
                 cellText.unmask();

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTimestampCellRenderer.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTimestampCellRenderer.java
@@ -11,17 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.data.client;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
-import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
-import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
-import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMessages;
-import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreDevice;
-import org.eclipse.kapua.app.console.module.data.shared.service.GwtDataService;
-import org.eclipse.kapua.app.console.module.data.shared.service.GwtDataServiceAsync;
-
 import com.extjs.gxt.ui.client.event.IconButtonEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.store.ListStore;
@@ -37,12 +26,21 @@ import com.google.gwt.event.dom.client.MouseOutHandler;
 import com.google.gwt.event.dom.client.MouseOverEvent;
 import com.google.gwt.event.dom.client.MouseOverHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMessages;
+import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreDevice;
+import org.eclipse.kapua.app.console.module.data.shared.service.GwtDataService;
+import org.eclipse.kapua.app.console.module.data.shared.service.GwtDataServiceAsync;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class DeviceTimestampCellRenderer implements GridCellRenderer<GwtDatastoreDevice> {
 
-    private static final GwtDataServiceAsync DATA_SERVICE = GWT.create(GwtDataService.class);
-    private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private static final ConsoleDataMessages DATA_MSGS = GWT.create(ConsoleDataMessages.class);
+
+    private static final GwtDataServiceAsync DATA_SERVICE = GWT.create(GwtDataService.class);
 
     private final GwtSession currentSession;
 
@@ -54,9 +52,17 @@ public class DeviceTimestampCellRenderer implements GridCellRenderer<GwtDatastor
     public Object render(final GwtDatastoreDevice gwtDevice, String s, ColumnData columnData, int i, int i1, ListStore<GwtDatastoreDevice> listStore, final Grid<GwtDatastoreDevice> grid) {
         final HorizontalPanel hp = new HorizontalPanel();
         hp.setHeight(15);
+
         // Timestamp text
-        final Text cellText = new Text(gwtDevice.getTimestamp() != null ? gwtDevice.getTimestampFormatted() : DATA_MSGS.topicInfoTableCalculatingLastPostDate());
+        final Text cellText = new Text();
         cellText.setStyleName("x-grid3-cell");
+
+        if (GwtDatastoreDevice.NO_TIMESTAMP.equals(gwtDevice.getTimestamp())) {
+            cellText.setText(DATA_MSGS.topicInfoTableNoLastPostDate());
+        } else {
+            cellText.setText(gwtDevice.getTimestamp() != null ? gwtDevice.getTimestampFormatted() : DATA_MSGS.topicInfoTableCalculatingLastPostDate());
+        }
+
         hp.add(cellText);
 
         // Refresh button
@@ -72,6 +78,7 @@ public class DeviceTimestampCellRenderer implements GridCellRenderer<GwtDatastor
 
         // Show refresh button on mouse over
         hp.addDomHandler(new MouseOverHandler() {
+
             @Override
             public void onMouseOver(MouseOverEvent arg0) {
                 refreshButton.show();
@@ -80,6 +87,7 @@ public class DeviceTimestampCellRenderer implements GridCellRenderer<GwtDatastor
 
         // Hide refresh button on mouse out
         hp.addDomHandler(new MouseOutHandler() {
+
             @Override
             public void onMouseOut(MouseOutEvent arg0) {
                 refreshButton.hide();
@@ -94,6 +102,7 @@ public class DeviceTimestampCellRenderer implements GridCellRenderer<GwtDatastor
 
         List<GwtDatastoreDevice> gwtDevices = new ArrayList<GwtDatastoreDevice>();
         gwtDevices.add(gwtDevice);
+
         // Refresh timestamp for selected topic
         DATA_SERVICE.updateDeviceTimestamps(currentSession.getSelectedAccountId(), gwtDevices, new AsyncCallback<List<GwtDatastoreDevice>>() {
 
@@ -104,12 +113,13 @@ public class DeviceTimestampCellRenderer implements GridCellRenderer<GwtDatastor
             }
 
             @Override
-            public void onSuccess(List<GwtDatastoreDevice> gwtDatastoreDevices) {
-                if (gwtDatastoreDevices != null && gwtDatastoreDevices.size() == 1) {
-                    gwtDevice.setTimestamp(gwtDatastoreDevices.get(0).getTimestamp());
+            public void onSuccess(List<GwtDatastoreDevice> list) {
+                if (!list.isEmpty() && list.get(0).getTimestamp() != null) {
+                    gwtDevice.setTimestamp(list.get(0).getTimestamp());
                 } else {
-                    cellText.setText(DATA_MSGS.topicInfoTableNoLastPostDate());
+                    gwtDevice.setTimestamp(GwtDatastoreDevice.NO_TIMESTAMP);
                 }
+
                 grid.getView().refresh(false);
                 cellText.unmask();
             }

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/GwtTopic.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/GwtTopic.java
@@ -11,17 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.data.client;
 
-import java.io.Serializable;
-import java.util.Date;
-
 import com.google.gwt.user.client.rpc.IsSerializable;
-
 import org.eclipse.kapua.app.console.module.api.client.util.DateUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.KapuaBaseTreeModel;
+
+import java.io.Serializable;
+import java.util.Date;
 
 public class GwtTopic extends KapuaBaseTreeModel implements Serializable, IsSerializable {
 
     private static final long serialVersionUID = 7519496938895060911L;
+
+    static final Date NO_TIMESTAMP = new Date(0);
 
     public GwtTopic() {
         super();
@@ -65,7 +66,6 @@ public class GwtTopic extends KapuaBaseTreeModel implements Serializable, IsSeri
     }
 
     @Override
-    @SuppressWarnings({ "unchecked" })
     public <X> X get(String property) {
         if ("timestampFormatted".equals(property)) {
             return (X) (DateUtils.formatDateTime(getTimestamp()));
@@ -103,7 +103,7 @@ public class GwtTopic extends KapuaBaseTreeModel implements Serializable, IsSeri
     }
 
     public String[] getTopicFragments() {
-        return ((String)get("semanticTopic")).split("/");
+        return ((String) get("semanticTopic")).split("/");
     }
 
     @Override

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicTimestampCellRenderer.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicTimestampCellRenderer.java
@@ -82,6 +82,8 @@ public class TopicTimestampCellRenderer implements GridCellRenderer<GwtTopic> {
                     public void onSuccess(List<GwtTopic> list) {
                         if (list != null && list.size() == 1) {
                             gwtTopic.setTimestamp(list.get(0).getTimestamp());
+                        } else {
+                            cellText.setText(DATA_MSGS.topicInfoTableNoLastPostDate());
                         }
                         grid.getView().refresh(false);
                         cellText.unmask();

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
@@ -36,7 +36,6 @@ import com.extjs.gxt.ui.client.widget.treegrid.TreeGridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
@@ -178,11 +177,6 @@ public class TopicsTable extends LayoutContainer {
         });
     }
 
-    // --------------------------------------------------------------------------------------
-    //
-    // Unload of the GXT Component
-    //
-    // --------------------------------------------------------------------------------------
     @Override
     public void onUnload() {
         super.onUnload();
@@ -195,6 +189,7 @@ public class TopicsTable extends LayoutContainer {
 
     private void updateTimestamps(List<ModelData> topics) {
         dataService.updateTopicTimestamps(currentSession.getSelectedAccountId(), topics, new AsyncCallback<List<GwtTopic>>() {
+
             @Override
             public void onFailure(Throwable caught) {
                 FailureHandler.handle(caught);
@@ -203,7 +198,7 @@ public class TopicsTable extends LayoutContainer {
             @Override
             public void onSuccess(List<GwtTopic> result) {
                 for (GwtTopic topic : result) {
-                    store.findModel(topic).setTimestamp(topic.getTimestamp());
+                    store.findModel(topic).setTimestamp(topic.getTimestamp() != null ? topic.getTimestamp() : GwtTopic.NO_TIMESTAMP);
                 }
                 topicInfoGrid.getTreeView().refresh(false);
             }

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
@@ -11,14 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.data.server;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.extjs.gxt.ui.client.Style;
+import com.extjs.gxt.ui.client.data.BaseListLoadResult;
+import com.extjs.gxt.ui.client.data.BasePagingLoadResult;
+import com.extjs.gxt.ui.client.data.ListLoadResult;
+import com.extjs.gxt.ui.client.data.LoadConfig;
+import com.extjs.gxt.ui.client.data.ModelData;
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
@@ -75,16 +77,13 @@ import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DeviceQuery;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 
-import com.extjs.gxt.ui.client.Style;
-import com.extjs.gxt.ui.client.data.BaseListLoadResult;
-import com.extjs.gxt.ui.client.data.BasePagingLoadResult;
-import com.extjs.gxt.ui.client.data.ListLoadResult;
-import com.extjs.gxt.ui.client.data.LoadConfig;
-import com.extjs.gxt.ui.client.data.ModelData;
-import com.extjs.gxt.ui.client.data.PagingLoadConfig;
-import com.extjs.gxt.ui.client.data.PagingLoadResult;
-import com.google.common.base.Strings;
-import org.apache.commons.lang3.StringUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements GwtDataService {
 
@@ -125,6 +124,7 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
             KapuaExceptionHandler.handle(e);
         }
         Collections.sort(channelInfoList, new Comparator<GwtTopic>() {
+
             @Override
             public int compare(GwtTopic o1, GwtTopic o2) {
                 return o1.getSemanticTopic().compareTo(o2.getSemanticTopic());
@@ -164,7 +164,7 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
                 messageQuery.setPredicate(predicate);
 
                 MessageListResult messageList = messageStoreService.query(messageQuery);
-                if (messageList.getSize() == 1) {
+                if (messageList.getFirstItem() != null) {
                     topic.setTimestamp(messageList.getFirstItem().getTimestamp());
                 }
                 updatedTopics.add(topic);
@@ -192,7 +192,8 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
                 query.setFetchAttributes(Collections.singletonList(ClientInfoField.TIMESTAMP.field()));
                 query.setPredicate(new TermPredicateImpl(ClientInfoField.CLIENT_ID, device.getClientId()));
                 ClientInfoListResult result = clientInfoRegistryService.query(query);
-                if (result.getSize() == 1) {
+
+                if (result.getFirstItem() != null) {
                     updatedDevice = KapuaGwtDataModelConverter.convertToDatastoreDevice(result.getFirstItem());
                     updatedDevices.add(updatedDevice);
                 }
@@ -297,6 +298,7 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
                         clientIdsMap.put(device.getClientId(), device.getDisplayName());
                     }
                 }
+
                 for (ClientInfo client : result.getItems()) {
                     GwtDatastoreDevice gwtDatastoreDevice = KapuaGwtDataModelConverter.convertToDatastoreDevice(client);
                     String clientId = client.getClientId();
@@ -361,8 +363,7 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
     }
 
     @Override
-    public ListLoadResult<GwtHeader> findHeaders(LoadConfig config, String accountName,
-                                                 GwtDatastoreAsset gwtDatastoreAsset) throws GwtKapuaException {
+    public ListLoadResult<GwtHeader> findHeaders(LoadConfig config, String accountName, GwtDatastoreAsset gwtDatastoreAsset) throws GwtKapuaException {
         ChannelMatchPredicate predicate = STORABLE_PREDICATE_FACTORY.newChannelMatchPredicate(gwtDatastoreAsset.getTopick());
         return findHeaders(accountName, predicate);
     }

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDatastoreDevice.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDatastoreDevice.java
@@ -11,16 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.data.shared.model;
 
-import java.io.Serializable;
-import java.util.Date;
-
 import org.eclipse.kapua.app.console.module.api.client.util.DateUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.KapuaBaseModel;
 
+import java.io.Serializable;
+import java.util.Date;
+
 public class GwtDatastoreDevice extends KapuaBaseModel implements Serializable {
+
     private static final long serialVersionUID = 5756712401178232349L;
 
+    public static final Date NO_TIMESTAMP = new Date(0);
+
     public GwtDatastoreDevice() {
+        super();
     }
 
     public GwtDatastoreDevice(String device, Date timestamp) {
@@ -29,7 +33,6 @@ public class GwtDatastoreDevice extends KapuaBaseModel implements Serializable {
     }
 
     @Override
-    @SuppressWarnings({"unchecked"})
     public <X> X get(String property) {
         if ("timestampFormatted".equals(property)) {
             return (X) (DateUtils.formatDateTime(getTimestamp()));

--- a/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/client/messages/ConsoleDataMessages.properties
+++ b/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/client/messages/ConsoleDataMessages.properties
@@ -26,6 +26,7 @@ topicInfoTableHeader=Available Topics
 topicInfoTableTopicHeader=Topic
 topicInfoTableLastPostedHeader=Last Post Date
 topicInfoTableCalculatingLastPostDate=Calculating...
+topicInfoTableNoLastPostDate=No Messages
 topicInfoGridEmptyText=No Topics
 
 deviceInfoTableHeader=Available Devices


### PR DESCRIPTION
A string is now shown on Data View when a row (topic, device or asset) has no available data

**Related Issue**
This PR fixes/closes #1759 

**Description of the solution adopted**
A message is now shown if the topic, device or asset has no messages
