### PR TITLE
Added the @jobs tag to the Job service tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,10 @@ jobs:
       script:
         - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcucumber.options="--tags @security" verify
         - bash <(curl -s https://codecov.io/bash)
+    - stage: test
+      script:
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcucumber.options="--tags @jobs" verify
+        - bash <(curl -s https://codecov.io/bash)
 
 # The following upgrades Java during the build in
 # order to work around an older Java 8 compiler issue

--- a/service/job/internal/src/test/resources/features/JobExecutionService.feature
+++ b/service/job/internal/src/test/resources/features/JobExecutionService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/test/resources/features/JobExecutionService.feature
+++ b/service/job/internal/src/test/resources/features/JobExecutionService.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@jobs
 Feature: Job Execution service CRUD tests
     The Job service is responsible for maintaining the status of the target step executions.
 

--- a/service/job/internal/src/test/resources/features/JobService.feature
+++ b/service/job/internal/src/test/resources/features/JobService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/test/resources/features/JobService.feature
+++ b/service/job/internal/src/test/resources/features/JobService.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@jobs
 Feature: Job service CRUD tests
   The Job service is responsible for executing scheduled actions on various targets.
 

--- a/service/job/internal/src/test/resources/features/JobStepDefinitionService.feature
+++ b/service/job/internal/src/test/resources/features/JobStepDefinitionService.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@jobs
 Feature: Job step definition service CRUD tests
     The Job Step Definition service is responsible for maintaining job step definitions.
     During regular runtime the step definitions are automatically extracted from the various

--- a/service/job/internal/src/test/resources/features/JobStepDefinitionService.feature
+++ b/service/job/internal/src/test/resources/features/JobStepDefinitionService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/test/resources/features/JobStepService.feature
+++ b/service/job/internal/src/test/resources/features/JobStepService.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@jobs
 Feature: Job step service CRUD tests
     The Job Step service is responsible for maintaining job steps.
 

--- a/service/job/internal/src/test/resources/features/JobStepService.feature
+++ b/service/job/internal/src/test/resources/features/JobStepService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/test/resources/features/JobTargetsService.feature
+++ b/service/job/internal/src/test/resources/features/JobTargetsService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/test/resources/features/JobTargetsService.feature
+++ b/service/job/internal/src/test/resources/features/JobTargetsService.feature
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
+@jobs
 Feature: Job Target service CRUD tests
     The Job service is responsible for maintaining a list of job targets.
 


### PR DESCRIPTION
Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>

The Job service unit tests are now tagged with the @jobs tag.

**Related Issue**
None.

**Description of the solution adopted**
The Job service unit tests are now tagged with the @jobs tag. A new section was added to the travis.yml file for this new test tag. 

**Screenshots**
None.

**Any side note on the changes made**
None.
