### PR TITLE
Added OnClick listener for the export button

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
@@ -22,7 +22,10 @@ import com.extjs.gxt.ui.client.data.LoadEvent;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.MenuEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.store.ListStore;
@@ -157,7 +160,7 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
         toolBar.add(refreshButton);
         toolBar.add(new SeparatorToolItem());
 
-        Menu menu = new Menu();
+        final Menu menu = new Menu();
         menu.add(new KapuaMenuItem(MSGS.exportToExcel(), IconSet.FILE_EXCEL_O,
                 new SelectionListener<MenuEvent>() {
 
@@ -175,6 +178,13 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
                     }
                 }));
         export = new ExportButton();
+        export.addListener(Events.OnClick, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                export.showMenu();
+            }
+        });
         export.setMenu(menu);
 
         toolBar.add(export);


### PR DESCRIPTION
Brief description of the PR.
Added OnClick listener for the export button in DeviceTabHistory class.

**Related Issue**
This PR fixes #1781 

**Description of the solution adopted**
In handleEvent method of the listener, export button's showMenu() function is called.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>