### PR TITLE
Set maxLength() property for fields

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -573,6 +573,7 @@ public class AccountConfigPanel extends LayoutContainer {
         field.setAllowBlank(true);
         field.setFieldLabel(param.getName());
         field.addPlugin(dirtyPlugin);
+        field.setMaxLength(255);
         if (validator != null) {
             field.setValidator(validator);
         }

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTable.java
@@ -18,6 +18,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingToolBar;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.SwappableListStore;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
@@ -40,7 +41,6 @@ import com.extjs.gxt.ui.client.event.SelectionChangedListener;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.widget.ContentPanel;
 import com.extjs.gxt.ui.client.widget.LayoutContainer;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.extjs.gxt.ui.client.widget.grid.ColumnModel;
 import com.extjs.gxt.ui.client.widget.grid.Grid;
@@ -63,7 +63,7 @@ public class DeviceTable extends LayoutContainer {
     private ContentPanel tableContainer;
     private List<SelectionChangedListener<GwtDatastoreDevice>> listeners = new ArrayList<SelectionChangedListener<GwtDatastoreDevice>>();
     private KapuaPagingToolBar pagingToolBar;
-    private TextField<String> filterField;
+    private KapuaTextField<String> filterField;
 
     public DeviceTable(GwtSession currentSession) {
         this.currentSession = currentSession;
@@ -108,7 +108,8 @@ public class DeviceTable extends LayoutContainer {
         tableContainer.setLayout(new FitLayout());
         tableContainer.add(deviceGrid);
 
-        filterField = new TextField<String>();
+        filterField = new KapuaTextField<String>();
+        filterField.setMaxLength(255);
         filterField.setEmptyText(DATA_MSGS.deviceInfoTableFilter());
         ToolBar tb = new ToolBar();
         tb.add(filterField);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -13,7 +13,6 @@ package org.eclipse.kapua.app.console.module.job.client.schedule;
 
 import com.extjs.gxt.ui.client.widget.form.DateField;
 import com.extjs.gxt.ui.client.widget.form.MultiField;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.extjs.gxt.ui.client.widget.form.TimeField;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.DateTimeFormat;
@@ -54,7 +53,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
     protected final DateField endsOn;
     protected final TimeField endsOnTime;
     protected final KapuaNumberField retryInterval;
-    protected final TextField<String> cronExpression;
+    protected final KapuaTextField<String> cronExpression;
 
     public JobScheduleAddDialog(GwtSession currentSession, String jobId) {
         super(currentSession);
@@ -70,7 +69,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         endsOnTime = new TimeField();
         endsOnTime.setEditable(false);
         retryInterval = new KapuaNumberField();
-        cronExpression = new TextField<String>();
+        cronExpression = new KapuaTextField<String>();
 
         DialogUtils.resizeDialog(this, 400, 250);
     }
@@ -125,6 +124,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         mainPanel.add(retryInterval);
 
         cronExpression.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleCronScheduleLabel());
+        cronExpression.setMaxLength(255);
         mainPanel.add(cronExpression);
 
         bodyPanel.add(mainPanel);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -66,7 +66,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
 
     private final String jobId;
 
-    protected final TextField<String> jobStepName;
+    protected final KapuaTextField<String> jobStepName;
     protected final KapuaTextField<String> jobStepDescription;
     protected final ComboBox<GwtJobStepDefinition> jobStepDefinitionCombo;
     protected final FieldSet jobStepPropertiesFieldSet;
@@ -85,7 +85,8 @@ public class JobStepAddDialog extends EntityAddEditDialog {
 
         this.jobId = jobId;
 
-        jobStepName = new TextField<String>();
+        jobStepName = new KapuaTextField<String>();
+        jobStepName.setMaxLength(255);
         jobStepDescription = new KapuaTextField<String>();
         jobStepDefinitionCombo = new ComboBox<GwtJobStepDefinition>();
         jobStepPropertiesFieldSet = new FieldSet();

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -16,7 +16,6 @@ import com.extjs.gxt.ui.client.widget.form.FieldSet;
 import com.extjs.gxt.ui.client.widget.form.LabelField;
 import com.extjs.gxt.ui.client.widget.form.NumberField;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
-import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.extjs.gxt.ui.client.widget.layout.FormData;
 import com.extjs.gxt.ui.client.widget.layout.FormLayout;
 import com.google.gwt.core.client.GWT;
@@ -54,9 +53,9 @@ public class UserAddDialog extends EntityAddEditDialog {
     protected KapuaTextField<String> password;
     protected KapuaTextField<String> confirmPassword;
     protected LabelField passwordTooltip;
-    protected TextField<String> displayName;
-    protected TextField<String> email;
-    protected TextField<String> phoneNumber;
+    protected KapuaTextField<String> displayName;
+    protected KapuaTextField<String> email;
+    protected KapuaTextField<String> phoneNumber;
     protected SimpleComboBox<GwtUser.GwtUserStatus> userStatus;
     protected KapuaDateField expirationDate;
     protected NumberField optlock;
@@ -150,20 +149,20 @@ public class UserAddDialog extends EntityAddEditDialog {
             passwordTooltip.setStyleAttribute("font-size", "10px");
             infoFieldSet.add(passwordTooltip);
         }
-        displayName = new TextField<String>();
+        displayName = new KapuaTextField<String>();
         displayName.setName("displayName");
         displayName.setFieldLabel(USER_MSGS.dialogAddFieldDisplayName());
         displayName.setMaxLength(255);
         infoFieldSet.add(displayName, subFieldsetFormData);
 
-        email = new TextField<String>();
+        email = new KapuaTextField<String>();
         email.setName("userEmail");
         email.setFieldLabel(USER_MSGS.dialogAddFieldEmail());
         email.setValidator(new TextFieldValidator(email, FieldType.EMAIL));
         email.setMaxLength(255);
         infoFieldSet.add(email, subFieldsetFormData);
 
-        phoneNumber = new TextField<String>();
+        phoneNumber = new KapuaTextField<String>();
         phoneNumber.setName("phoneNumber");
         phoneNumber.setFieldLabel(USER_MSGS.dialogAddFieldPhoneNumber());
         phoneNumber.setValidator(new TextFieldValidator(phoneNumber, FieldType.PHONE));


### PR DESCRIPTION
Brief description of the PR.
Set maxLength() property for fields in Job/Data/User/Account tab

**Related Issue**
This PR fixes #1782

**Description of the solution adopted**
Set maxLenght() property, and changed relevant fields from regular TextField to KapuaTextField .

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>