### PR TITLE
Replaced Tomcat with Jetty in Vagrant

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -40,25 +40,6 @@
 
         <!-- REST api dependency -->
         <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat</artifactId>
-            <version>${tomcat.version}</version>
-            <type>tar.gz</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.tomcat.extras</groupId>
-            <artifactId>tomcat-extras-juli</artifactId>
-            <version>${tomcat.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.tomcat.extras</groupId>
-            <artifactId>tomcat-extras-juli-adapters</artifactId>
-            <version>${tomcat.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-rest-api-web</artifactId>
             <version>${project.version}</version>
@@ -269,21 +250,6 @@
             <artifactId>log4j-over-slf4j</artifactId>
         </dependency>
 
-        <!--
-            Java APIs from Tomcat:
-            We stick to 8.0.38 because they are only APIs and we can
-            piggyback on this version.
-            -->
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-servlet-api</artifactId>
-            <version>8.0.38</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-websocket-api</artifactId>
-            <version>8.0.38</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -310,29 +276,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-tomcat</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.apache.tomcat</groupId>
-                                    <artifactId>tomcat</artifactId>
-                                    <type>tar.gz</type>
-                                    <outputDirectory>target/dependencies/tomcat</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -351,7 +294,6 @@
                         <configuration>
                             <environmentVariables>
                                 <KAPUA_VERSION>${project.version}</KAPUA_VERSION>
-                                <TOMCAT_VERSION>${tomcat.version}</TOMCAT_VERSION>
                                 <ACTIVEMQ_VERSION>${activemq.version}</ACTIVEMQ_VERSION>
                             </environmentVariables>
                         </configuration>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -36,25 +36,6 @@
 
         <!-- Console dependency -->
         <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat</artifactId>
-            <version>${tomcat.version}</version>
-            <type>tar.gz</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.tomcat.extras</groupId>
-            <artifactId>tomcat-extras-juli</artifactId>
-            <version>${tomcat.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.tomcat.extras</groupId>
-            <artifactId>tomcat-extras-juli-adapters</artifactId>
-            <version>${tomcat.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-console-web</artifactId>
             <version>${project.version}</version>
@@ -265,21 +246,6 @@
             <artifactId>log4j-over-slf4j</artifactId>
         </dependency>
 
-        <!--
-            Java APIs from Tomcat:
-            We stick to 8.0.38 because they are only APIs and we can
-            piggyback on this version.
-            -->
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-servlet-api</artifactId>
-            <version>8.0.38</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-websocket-api</artifactId>
-            <version>8.0.38</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/dev-tools/src/main/vagrant/README.md
+++ b/dev-tools/src/main/vagrant/README.md
@@ -4,7 +4,7 @@ This module provides script and configuration files to create 2 different Vagran
 * ActiveMQ
 * Elasticsearch
 * H2 Database
-* Tomcat
+* Jetty
 
 The 2 machine provided (through creation script) are:
 
@@ -69,7 +69,7 @@ Once the development machine has been created (or started manually as described 
 $ vagrant ssh
 ```
 
-***Note:*** to allow the database creation and seeding the broker and the Tomcat. Please run a full Kapua project build from the project root directory outside of the vagrant box (see the commands below)
+***Note:*** to allow the database creation and seeding the broker and the Jetty. Please run a full Kapua project build from the project root directory outside of the vagrant box (see the commands below)
 ```
 $ mvn clean install -f external/pom.xml
 $ mvn clean install -DskipTests -P console
@@ -91,16 +91,16 @@ To stop the broker type:
 bin/activemq stop
 ```
 
-The servlet container (Tomcat) directory is:
+The servlet container (Jetty) directory is:
 ```
-$ /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}
+$ /usr/local/jetty/jetty-distribution-${JETTY_VERSION}
 ```
-There is a script to start the Tomcat
+There is a script to start the Jetty container:
 ```
-$ ./start-tomcat.sh
+$ ./start-jetty.sh
 ```
 
-The script recreates the link between api and console wars inside the Kapua workspace and the webapps directory of Tomcat. To stop Tomcat call the standard stop script inside bin directory.
+The script recreates the link between api and console wars inside the Kapua workspace and the webapps directory of Jetty. To stop Jetty call the `stop-jetty.sh` script in the same directory.
 
 ## Verifying and accessing Kapua components
 
@@ -163,7 +163,7 @@ As for the development machine, once the demo machine has been created (or start
 $ vagrant ssh demo
 ```
 
-The fresh machine has both the ActiveMQ and Tomcat installed, but please don't use them, it's just due to the reuse of the base-box.
+The fresh machine has both the ActiveMQ and Jetty installed, but please don't use them, it's just due to the reuse of the base-box.
 To start ***using properly the demo machine*** run a full Kapua build as follow:
 
 ```
@@ -184,12 +184,12 @@ $ bin/activemq start
 
 To stop it follow the instructions for the develop machine.
 
-The api and console are properly installed in a Tomcat container in the directory
+The api and console are properly installed in a Jetty container in the directory
 ```
-$ /usr/local/kapua/apache-tomcat-${TOMCAT_VERSION}/webapps
+$ /usr/local/kapua/jetty-distribution-${JETTY_VERSION}/webapps
 ```
 
-To start and stop the Tomcat please use the standard scripts under the bin directory of the Tomcat installation.
+To start and stop the Jetty container please use the standard scripts under the root of the Jetty distribution.
 ```
 $ bin/startup.sh
 ```

--- a/dev-tools/src/main/vagrant/Vagrantfile
+++ b/dev-tools/src/main/vagrant/Vagrantfile
@@ -20,7 +20,7 @@ env_vars = {
   'H2DB_VERSION'          => '1.4.192',
   'ACTIVEMQ_VERSION'      => '5.14.5',
   'ARTEMIS_VERSION'       => '2.2.0',
-  'TOMCAT_VERSION'        => '8.0.41',
+  'JETTY_VERSION'         => '9.4.6.v20170531',
   'KAPUA_VERSION'         => '1.0.0-SNAPSHOT'
 }
 
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
     owner: "vagrant", group: "vagrant",
     mount_options: ["dmode=775", "fmode=664"]
 
-  config.vm.box = "kapua-dev-box/0.6"
+  config.vm.box = "kapua-dev-box/0.7"
   config.vm.box_check_update = false
 
   # DBMS
@@ -66,7 +66,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 9200, host: 9200
   config.vm.network "forwarded_port", guest: 9300, host: 9300
 
-  # Tomcat
+  # Jetty
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.network "forwarded_port", guest: 8443, host: 8443
@@ -88,6 +88,7 @@ Vagrant.configure("2") do |config|
 
     # Setup permanent environment vars
     sudo ln -sf /kapua/dev-tools/src/main/vagrant/develop/etc/profile.d/kapua_env.sh /etc/profile.d/kapua_env.sh
+    export JETTY_VERSION=${JETTY_VERSION}
 
     ###########################
     ### H2 database startup ###
@@ -132,12 +133,15 @@ Vagrant.configure("2") do |config|
       # Run the datastore engine
       su --login -c "/usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch -d" vagrant
 
-      # Changing ActiveMQ and Tomcat directories from those used by the develop machine
+      # Changing ActiveMQ and Jetty directories from those used by the develop machine
       sudo mkdir -p /usr/local/kapua
-      sudo mv /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION} /usr/local/kapua/
+      sudo mv /usr/local/jetty/jetty-distribution-${JETTY_VERSION} /usr/local/kapua/
       sudo mv /usr/local/activemq/apache-activemq-${ACTIVEMQ_VERSION} /usr/local/kapua/
-      sudo rm -rf /usr/local/tomcat
+      sudo rm -rf /usr/local/jetty
       sudo rm -rf /usr/local/activemq
+      cd /usr/local/kapua/jetty-distribution-${JETTY_VERSION}
+      cp /kapua/dev-tools/src/main/vagrant/develop/jetty/start-jetty.sh .
+      chmod 555 start-jetty.sh
       sudo chown -R vagrant:vagrant /usr/local/kapua
     SHELL
 
@@ -191,38 +195,22 @@ Vagrant.configure("2") do |config|
       sudo sed -i "s|localhost:8161|${BINDING_IP}:8161|g" etc/bootstrap.xml
       sudo chown -R vagrant:vagrant /usr/local/artemis/apache-artemis-${ARTEMIS_VERSION}
 
-      ###########################
-      ### Tomcat post install ###
-      ###########################
+      ##########################
+      ### Jetty post install ###
+      ##########################
 
-      # Allow remote manager application
-      cd /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}
-      echo 'configuring webapps/manager/META-INF/context.xml'
-      MANAGER_CONTEXT_LN=$(sudo wc -l < /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/webapps/manager/META-INF/context.xml)
-      TOMCAT_CONTEXT_L1='<Valve className=\"org.apache.catalina.valves.RemoteAddrValve\"'
-      TOMCAT_CONTEXT_L2='allow="\\\\d+\\\\.\\\\d+\\\\.\\\\d+\\\\.\\\\d+\\|::1\\|0:0:0:0:0:0:0:1" />'
-      sudo sed -i "$((MANAGER_CONTEXT_LN))i \\ \\ $TOMCAT_CONTEXT_L1" /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/webapps/manager/META-INF/context.xml
-      sudo sed -i "$((MANAGER_CONTEXT_LN+1))i \\ \\ \\ \\ \\ \\ $TOMCAT_CONTEXT_L2" /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/webapps/manager/META-INF/context.xml
-
-      echo 'configuring conf/tomcat-users.xml'
-      TOMCAT_USER_LN=$(sudo wc -l < /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/conf/tomcat-users.xml)
-      sudo sed -i "$((TOMCAT_USER_LN))i \\ \\ <role rolename=\\"manager-gui\\"/>" /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/conf/tomcat-users.xml
-      sudo sed -i "$((TOMCAT_USER_LN+1))i \\ \\ <role rolename=\\"manager-script\\"/>" /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/conf/tomcat-users.xml
-      sudo sed -i "$((TOMCAT_USER_LN+2))i \\ \\ <role rolename=\\"manager-jmx\\"/>" /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/conf/tomcat-users.xml
-      sudo sed -i "$((TOMCAT_USER_LN+3))i \\ \\ <role rolename=\\"manager-status\\"/>" /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/conf/tomcat-users.xml
-      sudo sed -i "$((TOMCAT_USER_LN+4))i \\ \\ <user username=\\"tomcat\\" password=\\"tomcat\\" roles=\\"manager-gui,manager-script,manager-jmx,manager-status\\"/>" /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/conf/tomcat-users.xml
-
-      cp /kapua/dev-tools/src/main/vagrant/develop/tomcat/*.sh .
-      chmod 555 start-tomcat.sh
+      cd /usr/local/jetty/jetty-distribution-${JETTY_VERSION}
+      cp /kapua/dev-tools/src/main/vagrant/develop/jetty/*.sh .
+      chmod 555 start-jetty.sh
       chmod 555 update-kapua-war.sh
       sudo sed -i 's/KAPUA_VERSION/'"$KAPUA_VERSION"'/g' update-kapua-war.sh
 
-      sudo chown -R vagrant /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}
     SHELL
 
     config.vm.provision "shell", env: env_vars, run: "always", inline: <<-SHELL
       setsid su --login -c "/usr/local/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch -d" vagrant
       setsid su --login -c "java -cp /usr/local/h2database/h2database-${H2DB_VERSION}/h2*.jar org.h2.tools.Server -baseDir /home/vagrant/H2/kapua -webAllowOthers -tcpAllowOthers -tcpPort 3306 &" vagrant
+      setsid su --login -c "/usr/local/artemis/apache-artemis-2.2.0/kapua/bin/artemis-service start" vagrant
     SHELL
 
   end

--- a/dev-tools/src/main/vagrant/baseBox/Vagrantfile
+++ b/dev-tools/src/main/vagrant/baseBox/Vagrantfile
@@ -36,6 +36,7 @@ Vagrant.configure(2) do |config|
     export ACTIVE_MQ_VERSION="5.14.5"
     export ARTEMIS_VERSION="2.2.0"
     export TOMCAT_VERSION="8.0.41"
+    export JETTY_VERSION="9.4.6.v20170531"
     export BINDING_IP="192.168.33.10"
 
     # Install OpenJDK 8
@@ -154,19 +155,25 @@ Vagrant.configure(2) do |config|
     sudo tar -xvf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
     sudo rm elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
 
-    # Install Tomcat8
-    sudo mkdir -p /usr/local/tomcat
-    cd /usr/local/tomcat
-    sudo curl -O https://archive.apache.org/dist/tomcat/tomcat-8/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
-    sudo tar zxvf apache-tomcat-${TOMCAT_VERSION}.tar.gz
-    sudo rm apache-tomcat-${TOMCAT_VERSION}.tar.gz
+    # Install Jetty
+    sudo mkdir -p /usr/local/jetty
+    cd /usr/local/jetty
+    curl -s https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${JETTY_VERSION}/jetty-distribution-${JETTY_VERSION}.tar.gz -o jetty-distribution.tar.gz
+    sudo tar zxvf jetty-distribution.tar.gz
+    sudo rm jetty-distribution.tar.gz
 
-    # Fix tomcat8 to provide slf4j and logback
-    cd /usr/local/tomcat/apache-tomcat-${TOMCAT_VERSION}/lib
-    sudo curl -O https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.24/slf4j-api-1.7.24.jar
-    sudo curl -O https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.1.8/logback-core-1.1.8.jar
-    sudo curl -O https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.1.8/logback-classic-1.1.8.jar
-    sudo curl -O http://central.maven.org/maven2/javax/mail/javax.mail-api/1.5.6/javax.mail-api-1.5.6.jar
+    cd /usr/local/jetty/jetty-distribution-${JETTY_VERSION}
+    mkdir -p /var/lib/jetty/lib/ext /var/lib/jetty/start.d /var/lib/jetty/modules
+
+    cd /var/lib/jetty/modules
+    curl -O https://raw.githubusercontent.com/jetty-project/logging-modules/master/capture-all/logging.mod
+    curl -O https://raw.githubusercontent.com/jetty-project/logging-modules/master/centralized/webapp-logging.mod
+
+    cd /usr/local/jetty/jetty-distribution-${JETTY_VERSION}
+    java -jar start.jar --approve-all-licenses --create-startd --add-to-start=http,jsp,jstl,websocket,deploy,logging,webapp-logging,jmx,stats -Djetty.base=/var/lib/jetty
+
+    sudo chown -R vagrant /usr/local/jetty/jetty-distribution-${JETTY_VERSION}
+    sudo chown -R vagrant /var/lib/jetty
 
     ############################
     ### System Configuration ###

--- a/dev-tools/src/main/vagrant/baseBox/create.sh
+++ b/dev-tools/src/main/vagrant/baseBox/create.sh
@@ -13,7 +13,7 @@
 #*******************************************************************************
 
 BASEDIR=$(dirname "$0")
-KAPUA_BOX_VERSION=0.6
+KAPUA_BOX_VERSION=0.7
 KAPUA_BOX_NAME="kapua-dev-box/${KAPUA_BOX_VERSION}"
 KAPUA_BOX_TMP_DIR="/tmp/kapua-dev-box"
 

--- a/dev-tools/src/main/vagrant/demo/deploy-apps.sh
+++ b/dev-tools/src/main/vagrant/demo/deploy-apps.sh
@@ -10,7 +10,7 @@
 #      Eurotech - initial API and implementation
 #*******************************************************************************
 vagrant ssh demo -c "echo 'deploying the Kapua broker'
-	cd /usr/local/kapua/apache-tomcat-${TOMCAT_VERSION}
+	cd /var/lib/jetty
 	sudo rm -rf webapp/admin*
 	sudo rm -rf webapp/api*
 	echo 'copying Kapua console web application'
@@ -18,4 +18,4 @@ vagrant ssh demo -c "echo 'deploying the Kapua broker'
 	echo 'copying Kapua api web application'
 	sudo cp /kapua/rest-api/web/target/api.war webapps/api.war
 	cd ..
-	sudo chown -R vagrant:vagrant apache-tomcat-${TOMCAT_VERSION}"
+	sudo chown -R vagrant:vagrant jetty"

--- a/dev-tools/src/main/vagrant/develop/broker/start-broker.sh
+++ b/dev-tools/src/main/vagrant/develop/broker/start-broker.sh
@@ -11,8 +11,6 @@
 #
 #*******************************************************************************
 # Kapua jars and activemq.xml need to be added before starting the activemq instance...
-cd /usr/local/artemis/apache-artemis-ARTEMIS_VERSION/kapua
-./bin/artemis-service start
 cd /usr/local/activemq/apache-activemq-ACTIVEMQ_VERSION
 ./update-kapua-jars-cfg.sh
 export ACTIVEMQ_OPTS="${ACTIVEMQ_OPTS} -Dorg.apache.activemq.SERIALIZABLE_PACKAGES=*"

--- a/dev-tools/src/main/vagrant/develop/etc/profile.d/kapua_env.sh
+++ b/dev-tools/src/main/vagrant/develop/etc/profile.d/kapua_env.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 export ACTIVEMQ_OPTS="-Dcommons.db.schema.update=true -Dcertificate.jwt.private.key=file:///home/vagrant/key.pk8 -Dcertificate.jwt.certificate=file:///home/vagrant/cert.pem"
 export CATALINA_OPTS="-Dcommons.db.schema.update=true -Dcertificate.jwt.private.key=file:///home/vagrant/key.pk8 -Dcertificate.jwt.certificate=file:///home/vagrant/cert.pem"
+export JETTY_OPTS="-Dcommons.db.schema.update=true -Dcertificate.jwt.private.key=file:///home/vagrant/key.pk8 -Dcertificate.jwt.certificate=file:///home/vagrant/cert.pem -Djetty.base=/var/lib/jetty"

--- a/dev-tools/src/main/vagrant/develop/jetty/start-jetty.sh
+++ b/dev-tools/src/main/vagrant/develop/jetty/start-jetty.sh
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -10,11 +10,6 @@
 #     Eurotech - initial API and implementation
 #
 #*******************************************************************************
-echo 'remove old symbolic link to console web application'
-rm webapps/admin.war
-echo 'remove old symbolic link to api web application'
-rm webapps/api.war
-echo 'create symbolic link to console web application'
-ln -s /kapua/console/web/target/admin.war webapps/admin.war
-echo 'create symbolic link to api web application'
-ln -s /kapua/rest-api/web/target/api.war webapps/api.war
+# Kapua jars and activemq.xml need to be added before starting the activemq instance...
+./update-kapua-war.sh
+java $JAVA_OPTS -jar start.jar $JETTY_OPTS "$@"

--- a/dev-tools/src/main/vagrant/develop/jetty/update-kapua-war.sh
+++ b/dev-tools/src/main/vagrant/develop/jetty/update-kapua-war.sh
@@ -10,6 +10,11 @@
 #     Eurotech - initial API and implementation
 #
 #*******************************************************************************
-# Kapua jars and activemq.xml need to be added before starting the activemq instance...
-./update-kapua-war.sh
-bin/startup.sh
+echo 'remove old symbolic link to console web application'
+rm /var/lib/jetty/webapps/admin.war
+echo 'remove old symbolic link to api web application'
+rm /var/lib/jetty/webapps/api.war
+echo 'create symbolic link to console web application'
+ln -s /kapua/console/web/target/admin.war /var/lib/jetty/webapps/admin.war
+echo 'create symbolic link to api web application'
+ln -s /kapua/rest-api/web/target/api.war /var/lib/jetty/webapps/api.war

--- a/dev-tools/src/main/vagrant/integrationTestScripts/startup.sh
+++ b/dev-tools/src/main/vagrant/integrationTestScripts/startup.sh
@@ -12,6 +12,6 @@
 #*******************************************************************************
 
 echo 'VARGRANT UP......'
-vagrant box list | grep -q kapua-dev-box/0.6 || ../start.sh base-box
+vagrant box list | grep -q kapua-dev-box/0.7 || ../start.sh base-box
 vagrant up
 echo 'VARGRANT UP...... DONE'


### PR DESCRIPTION
This PR replaces Tomcat with Jetty as the web application container within the Vagrant machines. 

**Description of the solution adopted**
Upon creation of the base Vagrant box, Jetty gets downloaded instead of Tomcat and properly setup as Tomcat was. A change worth noting is that to achieve a common, webapp-independent logging implementation, [Centralized Logging](https://www.eclipse.org/jetty/documentation/9.3.x/example-logging-logback-centralized.html) has been implemented; this needs an unofficial but documented Jetty module.

Also, now the Service broker is automatically started when the Vagrant gets created.