### PR TITLE
Command field validation and error message fix

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -39,6 +39,7 @@ import com.extjs.gxt.ui.client.widget.layout.FormLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Node;
 import com.google.gwt.dom.client.NodeList;
+import com.google.gwt.dom.client.StyleInjector;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
@@ -218,10 +219,10 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
                     if (UNDEFINED_ERROR.equals(errorMessage)) {
                         errorMessage = DEVICE_MSGS.deviceConnectionError();
                     } else if (errorMessage.contains(INTERNAL_ERROR)) {
-                        errorMessage = errorMessage.substring(errorMessage.indexOf(INTERNAL_ERROR) + INTERNAL_ERROR.length() + 1,
-                                errorMessage.indexOf(": error="));
+                        errorMessage = DEVICE_MSGS.deviceCommandExecutionErrorMessage();
                     }
-                    MessageBox.alert(MSGS.error(), MSGS.commandExecutionFailure() + ":<br/>" + errorMessage, null);
+                    StyleInjector.inject(".x-window-dlg .ext-mb-icon {width: 50px; height: 50px;}"); 
+                    MessageBox.alert(MSGS.error(), MSGS.commandExecutionFailure() + ":<br/>" + errorMessage, null).getDialog().addStyleName("x-window-dlg .ext-mb-icon" );
                     commandInput.unmask();
                 } else {
                     int outputMessageStartIndex = htmlResult.indexOf("<pre");
@@ -260,6 +261,8 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
         commandField = new TextField<String>();
         commandField.setName("command");
         commandField.setAllowBlank(false);
+        commandField.setMaxLength(1024);
+        commandField.getMessages().setMaxLengthText(DEVICE_MSGS.deviceCommandMaxLengthErrorMessage());
         commandField.setFieldLabel("* " + DEVICE_MSGS.deviceCommandExecute());
         commandField.setLayoutData(layout);
         fieldSet.add(commandField, formData);

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -244,6 +244,8 @@ deviceCommandPasswordTooltip=This is the password set in the device command serv
 deviceCommandExecute=Execute
 deviceCommandNoOutput=No Output
 deviceCommandExecuting=Executing Command...
+deviceCommandMaxLengthErrorMessage=The limit for this field is 1024 characters. Longer commands should be put in .sh files, zipped, uploaded and executed using the file field.
+deviceCommandExecutionErrorMessage=The entered command can not be executed. Please check the command and try again.
 
 deviceConfigComponents=Services
 deviceConfigSnapshots=Snapshots


### PR DESCRIPTION
Brief description of the PR.
Command field validation and error message fix

**Related Issue**
This PR fixes #1715 

**Description of the solution adopted**
Added maxLength() property to the command field, set maxLengthText to custom message. Changed text for the error message thrown when invalid command is entered with another custom message. Added these messages to ConsoleDeviceMessages class.

**Screenshots**
None

**Any side note on the changes made**
None

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>