### PR TITLE
Inactive buttons in Kapua fix

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/ExportButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/ExportButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/ExportButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/ExportButton.java
@@ -15,6 +15,10 @@ import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.EventType;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.google.gwt.core.client.GWT;
 
 public class ExportButton extends SplitButton {
@@ -23,5 +27,16 @@ public class ExportButton extends SplitButton {
 
     public ExportButton() {
         super(MSGS.buttonExport(), new KapuaIcon(IconSet.DOWNLOAD));
+    }
+
+    @Override
+    public void addListener(EventType eventType, Listener<? extends BaseEvent> listener) {
+        super.addListener(Events.OnClick, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                showMenu();
+            }
+        });
     }
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelector.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelector.java
@@ -13,7 +13,10 @@ package org.eclipse.kapua.app.console.module.api.client.ui.widget;
 
 import java.util.Date;
 
+import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.MenuEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.widget.Dialog;
@@ -106,6 +109,13 @@ public class DateRangeSelector extends LayoutContainer {
                 }));
 
         dateRange.setMenu(menu);
+        dateRange.addListener(Events.OnClick, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                dateRange.showMenu();
+            }
+        });
 
         // initialize with the last 24 hours
         onMenuItemSelected(2, null);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
@@ -22,10 +22,7 @@ import com.extjs.gxt.ui.client.data.LoadEvent;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
-import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
-import com.extjs.gxt.ui.client.event.Events;
-import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.MenuEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.store.ListStore;
@@ -160,7 +157,7 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
         toolBar.add(refreshButton);
         toolBar.add(new SeparatorToolItem());
 
-        final Menu menu = new Menu();
+        Menu menu = new Menu();
         menu.add(new KapuaMenuItem(MSGS.exportToExcel(), IconSet.FILE_EXCEL_O,
                 new SelectionListener<MenuEvent>() {
 
@@ -178,13 +175,6 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
                     }
                 }));
         export = new ExportButton();
-        export.addListener(Events.OnClick, new Listener<BaseEvent>() {
-
-            @Override
-            public void handleEvent(BaseEvent be) {
-                export.showMenu();
-            }
-        });
         export.setMenu(menu);
 
         toolBar.add(export);


### PR DESCRIPTION
Brief description of the PR.
Added OnClick listeners to ExportButton and DateRangeSelector classes.

**Related Issue**
This PR fixes/closes #1793 

**Description of the solution adopted**
In the handleEvent() method of the listener showMenu() function is called. 

**Screenshots**
None

**Any side note on the changes made**
Removed the unneeded listener on the export button in the DeviceTabHistory class. It's now implemented in the ExportButton class.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>