### PR TITLE
Cleanup of job schedules at job deletion

### DIFF
--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-job-engine-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-scheduler-api</artifactId>
+        </dependency>
 
         <!-- Internal dependencies -->
         <dependency>
@@ -94,7 +98,11 @@
             <artifactId>kapua-job-engine-jbatch</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-scheduler-quartz</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/sql/H2/trigger_drop.sql
+++ b/service/job/internal/src/main/sql/H2/trigger_drop.sql
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *  
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/sql/H2/trigger_drop.sql
+++ b/service/job/internal/src/main/sql/H2/trigger_drop.sql
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
  *  
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/sql/H2/trigger_drop.sql
+++ b/service/job/internal/src/main/sql/H2/trigger_drop.sql
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *  
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+
+DROP TABLE IF EXISTS schdl_trigger;
+DROP TABLE IF EXISTS schdl_trigger_properties;
+
+DROP TABLE IF EXISTS schdl_qrtz_blob_triggers;
+DROP TABLE IF EXISTS schdl_qrtz_calendars;
+DROP TABLE IF EXISTS schdl_qrtz_cron_triggers;
+DROP TABLE IF EXISTS schdl_qrtz_fired_triggers;
+DROP TABLE IF EXISTS schdl_qrtz_job_details;
+DROP TABLE IF EXISTS schdl_qrtz_locks;
+DROP TABLE IF EXISTS schdl_qrtz_paused_trigger_grps;
+DROP TABLE IF EXISTS schdl_qrtz_scheduler_state;
+DROP TABLE IF EXISTS schdl_qrtz_simple_triggers;
+DROP TABLE IF EXISTS schdl_qrtz_simprop_triggers;
+DROP TABLE IF EXISTS schdl_qrtz_triggers;
+
+DROP TABLE IF EXISTS DATABASECHANGELOG;

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
@@ -45,9 +45,10 @@ import org.eclipse.kapua.service.job.common.TestConfig;
 import org.eclipse.kapua.service.job.step.JobStep;
 import org.eclipse.kapua.service.job.step.StepData;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
+import org.eclipse.kapua.service.scheduler.trigger.quartz.TriggerFactoryImpl;
+import org.eclipse.kapua.service.scheduler.trigger.quartz.TriggerServiceImpl;
 import org.eclipse.kapua.test.MockedLocator;
 import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
-
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -123,7 +124,7 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
 
         // Inject mocked Authorization Service method checkPermission
         AuthorizationService mockedAuthorization = Mockito.mock(AuthorizationService.class);
-        // TODO: Check why does this line needs an explicit cast!
+        // TODO: Check why does this line need an explicit cast!
         Mockito.doNothing().when(mockedAuthorization).checkPermission(
                 (org.eclipse.kapua.service.authorization.permission.Permission) Matchers.any(Permission.class));
         mockLocator.setMockedService(org.eclipse.kapua.service.authorization.AuthorizationService.class,
@@ -142,6 +143,8 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
 
         // Inject the implementations of the depending services
         mockLocator.setMockedService(JobEngineService.class, new JobEngineServiceJbatch());
+        mockLocator.setMockedFactory(org.eclipse.kapua.service.scheduler.trigger.TriggerFactory.class, new TriggerFactoryImpl());
+        mockLocator.setMockedService(org.eclipse.kapua.service.scheduler.trigger.TriggerService.class, new TriggerServiceImpl());
 
         // Set KapuaMetatypeFactory for Metatype configuration
         mockLocator.setMockedFactory(org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory.class, new KapuaMetatypeFactoryImpl());

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
@@ -77,6 +77,7 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
     private static final String DEFAULT_COMMONS_PATH = "../../../commons";
     private static final String DROP_JOB_TABLES = "job_drop.sql";
     private static final String DROP_JOB_ENGINE_TABLES = "job_engine_drop.sql";
+    private static final String DROP_TRIGGER_TABLES = "trigger_drop.sql";
 
     private static final KapuaId ROOT_ID = new KapuaEid(BigInteger.ONE);
 
@@ -164,6 +165,7 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
         // Drop the Job Service tables
         scriptSession(JobEntityManagerFactory.getInstance(), DROP_JOB_TABLES);
         scriptSession(JobEntityManagerFactory.getInstance(), DROP_JOB_ENGINE_TABLES);
+        scriptSession(JobEntityManagerFactory.getInstance(), DROP_TRIGGER_TABLES);
         KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
         KapuaSecurityUtils.clearSession();
     }

--- a/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
+++ b/service/job/internal/src/test/java/org/eclipse/kapua/service/job/internal/JobServiceTestSteps.java
@@ -30,6 +30,7 @@ import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.job.engine.JobEngineService;
 import org.eclipse.kapua.job.engine.jbatch.JobEngineServiceJbatch;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
@@ -45,6 +46,8 @@ import org.eclipse.kapua.service.job.common.TestConfig;
 import org.eclipse.kapua.service.job.step.JobStep;
 import org.eclipse.kapua.service.job.step.StepData;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerService;
 import org.eclipse.kapua.service.scheduler.trigger.quartz.TriggerFactoryImpl;
 import org.eclipse.kapua.service.scheduler.trigger.quartz.TriggerServiceImpl;
 import org.eclipse.kapua.test.MockedLocator;
@@ -128,27 +131,25 @@ public class JobServiceTestSteps extends AbstractKapuaSteps {
         // TODO: Check why does this line need an explicit cast!
         Mockito.doNothing().when(mockedAuthorization).checkPermission(
                 (org.eclipse.kapua.service.authorization.permission.Permission) Matchers.any(Permission.class));
-        mockLocator.setMockedService(org.eclipse.kapua.service.authorization.AuthorizationService.class,
-                mockedAuthorization);
+        mockLocator.setMockedService(AuthorizationService.class, mockedAuthorization);
 
         // Inject mocked Permission Factory
         PermissionFactory mockedPermissionFactory = Mockito.mock(PermissionFactory.class);
-        mockLocator.setMockedFactory(org.eclipse.kapua.service.authorization.permission.PermissionFactory.class,
-                mockedPermissionFactory);
+        mockLocator.setMockedFactory(PermissionFactory.class, mockedPermissionFactory);
 
         // Inject actual service implementations
         jobFactory = new JobFactoryImpl();
-        mockLocator.setMockedFactory(org.eclipse.kapua.service.job.JobFactory.class, jobFactory);
+        mockLocator.setMockedFactory(JobFactory.class, jobFactory);
         jobService = new JobServiceImpl();
-        mockLocator.setMockedService(org.eclipse.kapua.service.job.JobService.class, jobService);
+        mockLocator.setMockedService(JobService.class, jobService);
 
         // Inject the implementations of the depending services
         mockLocator.setMockedService(JobEngineService.class, new JobEngineServiceJbatch());
-        mockLocator.setMockedFactory(org.eclipse.kapua.service.scheduler.trigger.TriggerFactory.class, new TriggerFactoryImpl());
-        mockLocator.setMockedService(org.eclipse.kapua.service.scheduler.trigger.TriggerService.class, new TriggerServiceImpl());
+        mockLocator.setMockedFactory(TriggerFactory.class, new TriggerFactoryImpl());
+        mockLocator.setMockedService(TriggerService.class, new TriggerServiceImpl());
 
         // Set KapuaMetatypeFactory for Metatype configuration
-        mockLocator.setMockedFactory(org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory.class, new KapuaMetatypeFactoryImpl());
+        mockLocator.setMockedFactory(KapuaMetatypeFactory.class, new KapuaMetatypeFactoryImpl());
 
         // All operations on database are performed using system user.
         KapuaSession kapuaSession = new KapuaSession(null, ROOT_ID, ROOT_ID);

--- a/service/job/internal/src/test/resources/locator.xml
+++ b/service/job/internal/src/test/resources/locator.xml
@@ -23,8 +23,9 @@
         <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
-
-        <!-- 
+        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
+        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
+        <!--
         <provide>
             <api></api>
             <with></with>

--- a/service/job/internal/src/test/resources/locator.xml
+++ b/service/job/internal/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -48,7 +49,6 @@ import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.quartz.impl.StdSchedulerFactory;
 
-import javax.inject.Inject;
 import java.util.TimeZone;
 
 /**
@@ -60,11 +60,10 @@ import java.util.TimeZone;
 public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Trigger, TriggerCreator, TriggerService, TriggerListResult, TriggerQuery, TriggerFactory>
         implements TriggerService {
 
-    @Inject
-    private AuthorizationService authorizationService;
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
-    @Inject
-    private PermissionFactory permissionFactory;
+    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
+    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     /**
      * Constructor.
@@ -85,7 +84,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.write, triggerCreator.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.write, triggerCreator.getScopeId()));
 
         //
         // Check duplicate name
@@ -174,7 +173,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.write, trigger.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.write, trigger.getScopeId()));
 
         //
         // Check existence
@@ -210,7 +209,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.delete, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.delete, scopeId));
 
         //
         // Check existence
@@ -246,7 +245,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.read, scopeId));
 
         //
         // Do find
@@ -262,7 +261,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.read, query.getScopeId()));
 
         //
         // Do query
@@ -278,7 +277,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(SCHEDULER_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(SCHEDULER_DOMAIN, Actions.read, query.getScopeId()));
 
         //
         // Do count

--- a/service/scheduler/quartz/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.schedule.trigger.TriggerService.xml
+++ b/service/scheduler/quartz/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.schedule.trigger.TriggerService.xml
@@ -13,32 +13,32 @@
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kapua.service.account.AccountService"
          name="AccountService" 
-         description="This is the configuration for the kapua AccountService. ">
+         description="This is the configuration for the kapua TriggerService. ">
         
-        <Icon resource="OSGI-INF/account-service.png" size="32"/>
+        <Icon resource="OSGI-INF/trigger-service.png" size="32"/>
 
         <AD id="infiniteChildEntities"
-            name="infiniteChildAccounts"
+            name="infiniteChildSchedules"
             type="Boolean"
             cardinality="0"
             required="true"
             default="false"
-            description="Whether to allow infinite child accounts for this account.">
+            description="Whether to allow infinite schedules for this account.">
         </AD>
 
         <AD id="maxNumberChildEntities"  
-            name="maxNumberChildAccounts"
+            name="maxNumberChildSchedules"
             type="Integer"
             cardinality="0" 
             required="true"
             default="0" 
             min="0"
-            description="Maximum number of child accounts that are allowed to be created for this account.">
+            description="Maximum number of child schedules that are allowed to be created for this account.">
         </AD>
 
     </OCD>
     
-    <Designate pid="org.eclipse.kapua.service.account.AccountService">
-        <Object ocdref="org.eclipse.kapua.service.account.AccountService"/>
+    <Designate pid="org.eclipse.kapua.service.scheduler.trigger.TriggerService">
+        <Object ocdref="org.eclipse.kapua.service.scheduler.trigger.TriggerService"/>
     </Designate>
 </MetaData>

--- a/service/scheduler/quartz/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.schedule.trigger.TriggerService.xml
+++ b/service/scheduler/quartz/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.schedule.trigger.TriggerService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.0.0/scheduler-domain.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.0.0/scheduler-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,13 @@
         logicalFilePath="KapuaDB/changelog-scheduler-1.0.0.xml">
 
     <changeSet id="changelog-scheduler-domain-1.0.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_domain"/>
+                <tableExists tableName="athz_domain_actions"/>
+            </and>
+        </preConditions>
+
         <update tableName="athz_domain">
             <column name="serviceName" value="org.eclipse.kapua.service.scheduler.SchedulerService"/>
             <where>serviceName = 'schedulerService'</where>


### PR DESCRIPTION
Signed-off-by: Andrej Nussdorfer andrej.nussdorfer@comtrade.com

All the job related schedules are automatically deleted when the job is deleted.

**Related Issue**
This PR sddresses issue _1643_

**Description of the solution adopted**
At job deletion, the Job service first queries for all the schedules related to this job item and deletes them. Next it continues with the regular job deletion.

**Screenshots**
/

**Any side note on the changes made**
The job deletion is now a multi-step procedure (Quartz table cleanup, Kapua schedule cleanup, job deletion). If any of the steps fail the database will be left in an inconsistent state, possibly leading to unpredictable behavior.
