### PR TITLE
Changed the message displayed when the selected device has no available assets

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -514,7 +514,7 @@ public class DeviceAssetsValues extends LayoutContainer {
         public void loaderLoadException(LoadEvent le) {
 
             if (le.exception != null) {
-                ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
+                ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.assetNoAssetsErrorMessage());
             }
 
             List<ModelData> assets = new ArrayList<ModelData>();

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -37,6 +37,7 @@ configurationTabItem=Configuration
 assetNameLabel=Asset Name: {0}
 assetValuesTab=Values
 assetNoAssets=No Available Assets
+assetNoAssetsErrorMessage=The selected device has no available assets.
 deviceAssetConfirmation=Are you sure you want to apply the new channels values to asset {0}?
 
 deviceTableStatus=Connection Status


### PR DESCRIPTION
Brief description of the PR.
Changed the message displayed when the selected device has no available assets.

**Related Issue**
This PR fixes/closes #1757 

**Description of the solution adopted**
Added new message to the ConsoleDeviceMessages, to be displayed when the selected device has no available assets.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>
