### PR TITLE
Place DeviceBundlePropertyKeys in correct package

### DIFF
--- a/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStartTargetProcessor.java
+++ b/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStartTargetProcessor.java
@@ -16,7 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
-import org.eclipse.kapua.service.device.management.command.job.definition.DeviceBundlePropertyKeys;
+import org.eclipse.kapua.service.device.management.bundle.job.definition.DeviceBundlePropertyKeys;
 import org.eclipse.kapua.service.job.operation.TargetOperation;
 import org.eclipse.kapua.service.job.targets.JobTarget;
 

--- a/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStopTargetProcessor.java
+++ b/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStopTargetProcessor.java
@@ -16,7 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
-import org.eclipse.kapua.service.device.management.command.job.definition.DeviceBundlePropertyKeys;
+import org.eclipse.kapua.service.device.management.bundle.job.definition.DeviceBundlePropertyKeys;
 import org.eclipse.kapua.service.job.operation.TargetOperation;
 import org.eclipse.kapua.service.job.targets.JobTarget;
 

--- a/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundlePropertyKeys.java
+++ b/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundlePropertyKeys.java
@@ -9,7 +9,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.service.device.management.command.job.definition;
+package org.eclipse.kapua.service.device.management.bundle.job.definition;
 
 import org.eclipse.kapua.service.job.step.definition.JobPropertyKey;
 

--- a/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStartStepDefinition.java
+++ b/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStartStepDefinition.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.device.management.bundle.job.definition;
 import org.eclipse.kapua.job.engine.commons.step.definition.AbstractTargetJobStepDefinition;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.bundle.job.DeviceBundleStartTargetProcessor;
-import org.eclipse.kapua.service.device.management.command.job.definition.DeviceBundlePropertyKeys;
+import org.eclipse.kapua.service.device.management.bundle.job.definition.DeviceBundlePropertyKeys;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionFactory;
 import org.eclipse.kapua.service.job.step.definition.JobStepProperty;

--- a/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStopStepDefinition.java
+++ b/service/device/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStopStepDefinition.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.device.management.bundle.job.definition;
 import org.eclipse.kapua.job.engine.commons.step.definition.AbstractTargetJobStepDefinition;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.bundle.job.DeviceBundleStopTargetProcessor;
-import org.eclipse.kapua.service.device.management.command.job.definition.DeviceBundlePropertyKeys;
+import org.eclipse.kapua.service.device.management.bundle.job.definition.DeviceBundlePropertyKeys;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionFactory;
 import org.eclipse.kapua.service.job.step.definition.JobStepProperty;


### PR DESCRIPTION
The classe `DeviceBundlePropertyKeys` is incorrectly placed in package `org.eclipse.kapua.service.device.management.command.job.definition`. I moved it in the correct package and fixed all the references.