### PR TITLE
Repair the REST-API Credential JAXB conversion problem

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/GwtKapuaAuthenticationModelConverter.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/GwtKapuaAuthenticationModelConverter.java
@@ -141,7 +141,7 @@ public class GwtKapuaAuthenticationModelConverter {
         credential.setCredentialType(convertCredentialType(gwtCredential.getCredentialTypeEnum()));
         credential.setCredentialKey(gwtCredential.getCredentialKey());
         credential.setExpirationDate(gwtCredential.getExpirationDate());
-        credential.setCredentialStatus(convertCredentialStatus(gwtCredential.getCredentialStatusEnum()));
+        credential.setStatus(convertCredentialStatus(gwtCredential.getCredentialStatusEnum()));
         credential.setLoginFailures(gwtCredential.getLoginFailures());
         credential.setFirstLoginFailure(gwtCredential.getFirstLoginFailure());
         credential.setLoginFailuresReset(gwtCredential.getLoginFailuresReset());

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
@@ -110,7 +110,7 @@ public interface Credential extends KapuaUpdatableEntity {
      *
      * @param status The credential status
      */
-    void setCredentialStatus(CredentialStatus status);
+    void setStatus(CredentialStatus status);
 
     /**
      * Gets the current Credential expiration date

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialImpl.java
@@ -69,7 +69,7 @@ public class CredentialImpl extends AbstractKapuaUpdatableEntity implements Cred
 
     @Enumerated(EnumType.STRING)
     @Column(name = "credential_status", nullable = false)
-    private CredentialStatus credentialStatus;
+    private CredentialStatus status;
 
     @Basic
     @Column(name = "login_failures", nullable = false)
@@ -107,7 +107,7 @@ public class CredentialImpl extends AbstractKapuaUpdatableEntity implements Cred
         this.userId = (KapuaEid) userId;
         this.credentialType = credentialType;
         this.credentialKey = credentialKey;
-        this.credentialStatus = credentialStatus;
+        this.status = credentialStatus;
         this.expirationDate = expirationDate;
     }
 
@@ -148,12 +148,12 @@ public class CredentialImpl extends AbstractKapuaUpdatableEntity implements Cred
 
     @Override
     public CredentialStatus getStatus() {
-        return credentialStatus;
+        return status;
     }
 
     @Override
-    public void setCredentialStatus(CredentialStatus status) {
-        this.credentialStatus = status;
+    public void setStatus(CredentialStatus status) {
+        this.status = status;
     }
 
     @Override
@@ -170,9 +170,6 @@ public class CredentialImpl extends AbstractKapuaUpdatableEntity implements Cred
         this.userId = userId;
     }
 
-    public CredentialStatus getCredentialStatus() {
-        return credentialStatus;
-    }
 
     @Override
     public int getLoginFailures() {


### PR DESCRIPTION
Brief description of the PR. 
Change credentialStatus constructor parameter to status to make everything more consistent with the other parameters

Description of the solution adopted
Change credentialStatus constructor parameter to status to make everything more consistent with the other parameters