### PR TITLE
Synchronized min and max values for Endpoint port field

### DIFF
--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
@@ -75,8 +75,8 @@ public class EndpointAddDialog extends EntityAddEditDialog {
         endpointPortField.setAllowNegative(false);
         endpointPortField.setAllowDecimals(false);
         endpointPortField.setMaxLength(5);
-        endpointPortField.setMinValue(0);
-        endpointPortField.setMaxValue(65536);
+        endpointPortField.setMinValue(1);
+        endpointPortField.setMaxValue(65535);
         endpointFormPanel.add(endpointPortField);
 
         endpointSercureCheckbox = new CheckBox();

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -111,7 +111,7 @@ public class EndpointInfoServiceImpl
         ArgumentValidator.lengthRange(endpointInfo.getDns(), 3L, 1024L, "endpointInfo.dns");
 
         ArgumentValidator.notNegative(endpointInfo.getPort(), "endpointInfo.port");
-        ArgumentValidator.numRange(endpointInfo.getPort(), 0, 65535, "endpointInfo.port");
+        ArgumentValidator.numRange(endpointInfo.getPort(), 1, 65535, "endpointInfo.port");
 
         //
         // Check Access


### PR DESCRIPTION
Brief description of the PR.
Synchronized min and max values for Endpoint port field.

**Related Issue**
This PR fixes #1822

**Description of the solution adopted**
Set min and max values for port field to 1 and 65535 respectively. These values were already used in the create() method of _EndPointInfoServiceImpl_ class, now the same values are also used in the update method of the same class and _EndpointAddDialog's_ createBody() method. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

