### PR TITLE
Fixed setting view permissions

### DIFF
--- a/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/client/about/AboutView.java
+++ b/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/client/about/AboutView.java
@@ -49,11 +49,8 @@ import org.eclipse.kapua.app.console.module.api.client.util.Years;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Logger;
 
 public class AboutView extends AbstractView implements View {
-
-    private static final Logger logger = Logger.getLogger("AboutView");
 
     private static final ConsoleAboutMessages MSGS = GWT.create(ConsoleAboutMessages.class);
 
@@ -157,6 +154,7 @@ public class AboutView extends AbstractView implements View {
         northBorder.setMargins(new Margins(0, -3, 0, 0));
         centerBorder.setSplit(true);
         centerBorder.setMargins(new Margins(10, -3, 0, 1));
+
         final LayoutContainer mainPanel = new LayoutContainer(borderLayout);
         mainPanel.setHeight("100%");
         mainPanel.add(blurb, northBorder);
@@ -187,8 +185,6 @@ public class AboutView extends AbstractView implements View {
     }
 
     protected void applyAboutInformation(final GwtAboutInformation about, final Grid<BeanModel> grid, final ListStore<BeanModel> store) {
-        logger.info("Entries: " + about.getDependencies().size());
-
         final BeanModelFactory factory = BeanModelLookup.get().getFactory(GwtAboutDependency.class);
         store.add(factory.createModel(about.getDependencies()));
         grid.getView().refresh(false);

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -226,16 +226,18 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
             accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountCreatedBy", userCreatedBy != null ? userCreatedBy.getName() : null));
             accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountModifiedOn", account.getModifiedOn()));
             accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountModifiedBy", userModifiedBy != null ? userModifiedBy.getName() : null));
+
+            if (account.getScopeId() != null) {
+                Account parentAccount = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
+
+                    @Override
+                    public Account call() throws Exception {
+                        return ACCOUNT_SERVICE.find(account.getScopeId());
+                    }
+                });
+                accountPropertiesPairs.add(new GwtGroupedNVPair("accountInfo", "accountParent", parentAccount != null ? parentAccount.getName() : null));
+            }
             accountPropertiesPairs.add(new GwtGroupedNVPair("accountInfo", "accountName", account.getName()));
-
-            Account parentAccount = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
-
-                @Override
-                public Account call() throws Exception {
-                    return ACCOUNT_SERVICE.find(account.getScopeId());
-                }
-            });
-            accountPropertiesPairs.add(new GwtGroupedNVPair("accountInfo", "accountParent", parentAccount != null ? parentAccount.getName() : null));
 
             EndpointInfoListResult endpointInfos = KapuaSecurityUtils.doPrivileged(new Callable<EndpointInfoListResult>() {
 

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -227,7 +227,14 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
             accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountModifiedOn", account.getModifiedOn()));
             accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountModifiedBy", userModifiedBy != null ? userModifiedBy.getName() : null));
             accountPropertiesPairs.add(new GwtGroupedNVPair("accountInfo", "accountName", account.getName()));
-            Account parentAccount = ACCOUNT_SERVICE.find(account.getScopeId());
+
+            Account parentAccount = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
+
+                @Override
+                public Account call() throws Exception {
+                    return ACCOUNT_SERVICE.find(account.getScopeId());
+                }
+            });
             accountPropertiesPairs.add(new GwtGroupedNVPair("accountInfo", "accountParent", parentAccount != null ? parentAccount.getName() : null));
 
             EndpointInfoListResult endpointInfos = KapuaSecurityUtils.doPrivileged(new Callable<EndpointInfoListResult>() {


### PR DESCRIPTION
Brief description of the PR.
Added `doPrivileged` on `AccountService.find()` of the parent account. 
Not only it is `null` if the current account is `kapua-sys` but also user don't have permission to find their parent account.

**Related Issue**
This PR fixes #1833 

**Description of the solution adopted**
_None_

**Screenshots**
_None_

**Any side note on the changes made**
_None_