### PR TITLE
Set automatic reload on Date Range change in Events tab

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
@@ -185,7 +185,8 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
 
             @Override
             public void onUpdate() {
-                refresh();
+                grid.getView().refresh(true);
+                reload();
             }
         });
 


### PR DESCRIPTION
Brief description of the PR.
Set automatic reload on Date Range change in Events tab

**Related Issue**
This PR fixes #1804 

**Description of the solution adopted**
Set `refresh(true)` for grid view, and made a call to already created `reload()` function in `onUpdate()` method of dateRangeSelector listener.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>