### PR TITLE
Optional Datastore indexing window by hour, day or week

### DIFF
--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/BasicSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/BasicSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2018 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -87,5 +87,10 @@ public class BasicSteps extends Assert {
     @Then("^I get the text \"(.+)\"$")
     public void checkStringResult(String text) {
         assertEquals(text, (String) stepData.get("Text"));
+    }
+
+    @Given("^System property \"(.*)\" with value \"(.*)\"$")
+    public void setSystemProperty(String key, String value) {
+        System.setProperty(key, value);
     }
 }

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -25,14 +25,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
 import java.net.URL;
 
 import org.junit.Assert;
 
 @ScenarioScoped
-public class RestClientSteps extends Assert {
+public class RestClientSteps extends BaseQATests {
 
     private static final Logger logger = LoggerFactory.getLogger(RestClientSteps.class);
 
@@ -53,7 +51,7 @@ public class RestClientSteps extends Assert {
     }
 
     @When("^REST call at \"(.*)\"")
-    public void restCallStatusOfIndex(String resource) {
+    public void restCallStatusOfIndex(String resource) throws Exception {
 
         String host = (String) stepData.get("host");
         String port = (String) stepData.get("port");
@@ -61,7 +59,7 @@ public class RestClientSteps extends Assert {
             URL url = new URL("http://" + host + ":" + port + resource);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
-            assertFalse("Wrong response.", conn.getResponseCode() != 200);
+            Assert.assertFalse("Wrong response.", conn.getResponseCode() != 200);
             BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
             String output;
             StringBuilder sb = new StringBuilder();
@@ -70,12 +68,9 @@ public class RestClientSteps extends Assert {
             }
             conn.disconnect();
             stepData.put("restResponse", sb.toString());
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        } catch (ProtocolException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch ( IOException ioe) {
+            logger.error("Exception on REST call execution: " + resource);
+            throw ioe;
         }
     }
 
@@ -83,7 +78,7 @@ public class RestClientSteps extends Assert {
     public void restResponseContaining(String checkStr) {
 
         String restResponse = (String) stepData.get("restResponse");
-        assertTrue(String.format("Response %s doesn't include %s.", restResponse, checkStr),
+        Assert.assertTrue(String.format("Response %s doesn't include %s.", restResponse, checkStr),
                 restResponse.contains(checkStr));
     }
 
@@ -92,7 +87,7 @@ public class RestClientSteps extends Assert {
 
         String restResponse = (String) stepData.get("restResponse");
         Account account = (Account) stepData.get(var);
-        assertTrue(String.format("Response %s doesn't include %s.", restResponse, account.getId() + checkStr),
+        Assert.assertTrue(String.format("Response %s doesn't include %s.", restResponse, account.getId() + checkStr),
                 restResponse.contains(account.getId() + checkStr));
     }
 

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -51,13 +51,13 @@ public class RestClientSteps extends Assert {
         stepData.put("port", port);
     }
 
-    @When("^REST call at \"(.*)\" and \"(.*)\"")
-    public void restCallStatusOfIndex(String resource, String resourceApndx) {
+    @When("^REST call at \"(.*)\"")
+    public void restCallStatusOfIndex(String resource) {
 
         String host = (String) stepData.get("host");
         String port = (String) stepData.get("port");
         try {
-            URL url = new URL("http://" + host + ":" + port + resource + resourceApndx);
+            URL url = new URL("http://" + host + ":" + port + resource);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             assertFalse("Wrong response.", conn.getResponseCode() != 200);

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.qa.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.eclipse.kapua.service.StepData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+
+import org.junit.Assert;
+
+@ScenarioScoped
+public class RestClientSteps extends Assert {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestClientSteps.class);
+
+    /**
+     * Scenario scoped step data.
+     */
+    private StepData stepData;
+
+    @Inject
+    public RestClientSteps(StepData stepData) {
+        this.stepData = stepData;
+    }
+
+    @Given("^Server with host \"(.+)\" on port \"(.+)\"$")
+    public void setHostPort(String host, String port) {
+        stepData.put("host", host);
+        stepData.put("port", port);
+    }
+
+    @When("^REST call at \"(.*)\" and \"(.*)\"")
+    public void restCallStatusOfIndex(String resource, String resourceApndx) {
+
+        String host = (String) stepData.get("host");
+        String port = (String) stepData.get("port");
+        try {
+            URL url = new URL("http://" + host + ":" + port + resource + resourceApndx);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            assertFalse("Wrong response.", conn.getResponseCode() != 200);
+            BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
+            String output;
+            StringBuilder sb = new StringBuilder();
+            while ((output = br.readLine()) != null) {
+                sb.append(output);
+            }
+            conn.disconnect();
+            stepData.put("restResponse", sb.toString());
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        } catch (ProtocolException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Then("^REST response containing \"(.*)\"")
+    public void restResponseStatusOfIndex(String checkStr) {
+
+        String restResponse = (String) stepData.get("restResponse");
+        assertTrue(String.format("Response %s doesn't include %s.", restResponse, checkStr),
+                restResponse.contains(checkStr));
+    }
+}

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -16,6 +16,7 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
 import org.eclipse.kapua.service.StepData;
+import org.eclipse.kapua.service.account.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,11 +79,21 @@ public class RestClientSteps extends Assert {
         }
     }
 
-    @Then("^REST response containing \"(.*)\"")
-    public void restResponseStatusOfIndex(String checkStr) {
+    @Then("^REST response containing text \"(.*)\"$")
+    public void restResponseContaining(String checkStr) {
 
         String restResponse = (String) stepData.get("restResponse");
         assertTrue(String.format("Response %s doesn't include %s.", restResponse, checkStr),
                 restResponse.contains(checkStr));
     }
+
+    @Then("^REST response containing \"(.*)\" with prefix account \"(.*)\"")
+    public void restResponseContainingPrefixVar(String checkStr, String var) {
+
+        String restResponse = (String) stepData.get("restResponse");
+        Account account = (Account) stepData.get(var);
+        assertTrue(String.format("Response %s doesn't include %s.", restResponse, account.getId() + checkStr),
+                restResponse.contains(account.getId() + checkStr));
+    }
+
 }

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -52,6 +52,7 @@ import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.ClientInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreChannel;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfiguration;
 import org.eclipse.kapua.service.datastore.internal.mediator.MetricInfoField;
 import org.eclipse.kapua.service.datastore.internal.model.DataIndexBy;
@@ -1353,6 +1354,31 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
 
         MetricInfoListResult metLst = (MetricInfoListResult) stepData.get(lstKey);
         checkListOrder(metLst, getNamedMetricOrdering());
+    }
+
+    @Given("^Dataservice config enabled (.*), dataTTL (\\d+), rxByteLimit (\\d+), dataIndexBy \"(.*)\", indexWindow \"(.*)\"$")
+    public void configureDatastoreService(String enabled, int dataTTL, int rxByteLimit, String dataIndexBy, String indexWindow) throws Exception {
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("enabled", enabled.equalsIgnoreCase("TRUE"));
+        settings.put("dataTTL", dataTTL);
+        settings.put("rxByteLimit", rxByteLimit);
+        settings.put("dataIndexBy", dataIndexBy);
+        String indexingWindow;
+
+        switch (indexWindow) {
+        default:
+        case DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK:
+            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK;
+            break;
+        case DatastoreUtils.INDEXING_WINDOW_OPTION_DAY:
+            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_DAY;
+            break;
+        case DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR:
+            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR;
+            break;
+        }
+        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, indexingWindow);
+        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
     }
 
     // Private helper functions

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -209,6 +209,16 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
                 ((Device) stepData.get("LastDevice")).getId(),
                 ((Device) stepData.get("LastDevice")).getClientId(),
                 null, null);
+        stepData.put(msgKey, tmpMessage);
+    }
+
+    @Given("^I prepare a random message with capture date \"(.*)\" and save it as \"(.*)\"$")
+    public void prepareAndRememberARandomMessage(String captureDate, String msgKey) throws Exception {
+
+        KapuaDataMessage tmpMessage = createTestMessage(((Account) stepData.get("LastAccount")).getId(),
+                ((Device) stepData.get("LastDevice")).getId(),
+                ((Device) stepData.get("LastDevice")).getClientId(),
+                null, captureDate);
         stepData.put(msgKey, tmpMessage);
     }
 

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -165,6 +165,11 @@ public class UserServiceSteps extends BaseQATests {
     @Given("^Permissions$")
     public void givenPermissions(List<TestPermission> permissionList) throws Exception {
         createPermissions(permissionList, (ComparableUser) stepData.get("LastUser"), (Account) stepData.get("LastAccount"));
+    }
+
+    @Given("^Full permissions$")
+    public void givenFullPermissions() throws Exception {
+        createPermissions(null, (ComparableUser) stepData.get("LastUser"), (Account) stepData.get("LastAccount"));
     }
 
     @Given("^User A$")
@@ -561,15 +566,20 @@ public class UserServiceSteps extends BaseQATests {
         accessInfoCreator.setUserId(user.getUser().getId());
         accessInfoCreator.setScopeId(user.getUser().getScopeId());
         Set<Permission> permissions = new HashSet<>();
-        for (TestPermission testPermission : permissionList) {
-            Actions action = testPermission.getAction();
-            KapuaEid targetScopeId = testPermission.getTargetScopeId();
-            if (targetScopeId == null) {
-                targetScopeId = (KapuaEid) account.getId();
+        if (permissionList != null) {
+            for (TestPermission testPermission : permissionList) {
+                Actions action = testPermission.getAction();
+                KapuaEid targetScopeId = testPermission.getTargetScopeId();
+                if (targetScopeId == null) {
+                    targetScopeId = (KapuaEid) account.getId();
+                }
+                Domain domain = new UserDomain();
+                Permission permission = permissionFactory.newPermission(domain,
+                        action, targetScopeId);
+                permissions.add(permission);
             }
-            Domain domain = new UserDomain();
-            Permission permission = permissionFactory.newPermission(domain,
-                    action, targetScopeId);
+        } else {
+            Permission permission = permissionFactory.newPermission(null, null, null);
             permissions.add(permission);
         }
         accessInfoCreator.setPermissions(permissions);

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexCustomPrefixTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexCustomPrefixTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.integration;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = "classpath:features/datastore/DatastoreNewIndexCustomPrefix.feature",
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps",
+                "org.eclipse.kapua.service.datastore.steps" },
+        plugin = {"pretty",
+                "html:target/cucumber/DatastoreNewIndex",
+                "json:target/DatastoreNewIndex_cucumber.json" },
+        monochrome = true)
+@CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+@CucumberProperty(key="broker.ip", value="192.168.33.10")
+@CucumberProperty(key="kapua.config.url", value="")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="2")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="2")
+@CucumberProperty(key="datastore.index.prefix", value="custom-prefix")
+public class RunDatastoreNewIndexCustomPrefixTest {
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexCustomPrefixTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexCustomPrefixTest.java
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
 @CucumberProperty(key="broker.ip", value="192.168.33.10")
 @CucumberProperty(key="kapua.config.url", value="")
-@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="2")
-@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="2")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="5")
 @CucumberProperty(key="datastore.index.prefix", value="custom-prefix")
 public class RunDatastoreNewIndexCustomPrefixTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.integration;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = "classpath:features/datastore/DatastoreNewIndex.feature",
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps",
+                "org.eclipse.kapua.service.datastore.steps" },
+        plugin = {"pretty",
+                "html:target/cucumber/DatastoreNewIndex",
+                "json:target/DatastoreNewIndex_cucumber.json" },
+        monochrome = true)
+@CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+@CucumberProperty(key="broker.ip", value="192.168.33.10")
+@CucumberProperty(key="kapua.config.url", value="")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="2")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="2")
+public class RunDatastoreNewIndexTest {
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexTest.java
@@ -30,7 +30,8 @@ import org.junit.runner.RunWith;
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
 @CucumberProperty(key="broker.ip", value="192.168.33.10")
 @CucumberProperty(key="kapua.config.url", value="")
-@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="2")
-@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="2")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="5")
+@CucumberProperty(key="datastore.index.prefix", value="")
 public class RunDatastoreNewIndexTest {
 }

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -36,7 +36,7 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    Then REST response containing text "green open 1-2018-01"
+    Then REST response containing text "1-2018-01"
     And All indices are deleted
 
   Scenario: Simple positive scenario for creating daily index
@@ -54,7 +54,7 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01-02"
+    And REST response containing text "1-2018-01-02"
     And All indices are deleted
 
   Scenario: Simple positive scenario for creating hourly index
@@ -72,7 +72,7 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01-02-10"
+    And REST response containing text "1-2018-01-02-10"
     And All indices are deleted
 
   Scenario: Creating two indexes with weekly index
@@ -91,8 +91,8 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01"
-    And REST response containing text "green open 1-2018-02"
+    And REST response containing text "1-2018-01"
+    And REST response containing text "1-2018-02"
     And All indices are deleted
 
   Scenario: Creating two indexes with daily index
@@ -111,8 +111,8 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01-02"
-    And REST response containing text "green open 1-2018-01-03"
+    And REST response containing text "1-2018-01-02"
+    And REST response containing text "1-2018-01-03"
     And All indices are deleted
 
   Scenario: Creating two indexes with hourly index
@@ -131,8 +131,8 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01-02-10"
-    And REST response containing text "green open 1-2018-01-02-15"
+    And REST response containing text "1-2018-01-02-10"
+    And REST response containing text "1-2018-01-02-15"
     And All indices are deleted
 
   Scenario: Creating index with regular user

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -1,0 +1,85 @@
+###############################################################################
+# Copyright (c) 2018 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+@datastore
+Feature: Datastore tests
+
+  @StartEventBroker
+  Scenario: Start event broker for all scenarios
+
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
+  Scenario: Simple positive scenario for creating default - weekly index
+  Create elasticsearch index with default setting for index creation which is weekly
+  index creation. Index gets created when user publishes data. Index is based on
+  capture date, which is set to specific value, this value determines index name.
+
+    Given Server with host "127.0.0.1" on port "9200"
+    When All indices are deleted
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    Given The device "test-device-1"
+    When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When REST call at "/_cat/indices/"
+    Then REST response containing "green open 1-2018-01"
+    And All indices are deleted
+
+  Scenario: Simple positive scenario for creating daily index
+  Create elasticsearch index with setting for daily index creation. Index gets created when
+  user publishes data. Index is based on capture date, which is set to specific value, this
+  value determines index name.
+
+    Given Server with host "127.0.0.1" on port "9200"
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "DAY"
+    When All indices are deleted
+    And Account for "kapua-sys"
+    Given The device "test-device-1"
+    When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When REST call at "/_cat/indices/"
+    And REST response containing "green open 1-2018-01-02"
+    And All indices are deleted
+
+  Scenario: Simple positive scenario for creating hourly index
+  Create elasticsearch index with setting for hour index creation. Index gets created when
+  user publishes data. Index is based on capture date, which is set to specific value, this
+  value determines index name.
+
+    Given Server with host "127.0.0.1" on port "9200"
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "HOUR"
+    When All indices are deleted
+    And Account for "kapua-sys"
+    Given The device "test-device-1"
+    When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When REST call at "/_cat/indices/"
+    And REST response containing "green open 1-2018-01-02-10"
+    And All indices are deleted
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios
+
+  @StopEventBroker
+  Scenario: Stop event broker for all scenarios

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
@@ -1,0 +1,49 @@
+###############################################################################
+# Copyright (c) 2018 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+@datastore
+Feature: Datastore tests
+
+  @StartEventBroker
+  Scenario: Start event broker for all scenarios
+
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
+  Scenario: Create index with specific prefix
+  Create elasticsearch index with specific prefix set by system property.
+  Index gets created when user publishes data.
+
+    Given Server with host "127.0.0.1" on port "9200"
+    When All indices are deleted
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    Given The device "test-device-1"
+    When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When REST call at "/_cat/indices/" and "custom-prefix-1-2018-01"
+    Then REST response containing "green open"
+    And REST response containing "custom-prefix-1-2018-01"
+    And All indices are deleted
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios
+
+  @StopEventBroker
+  Scenario: Stop event broker for all scenarios

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
@@ -34,9 +34,9 @@ Feature: Datastore tests
     When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
-    When REST call at "/_cat/indices/" and "custom-prefix-1-2018-01"
-    Then REST response containing "green open"
-    And REST response containing "custom-prefix-1-2018-01"
+    When REST call at "/_cat/indices/"
+    Then REST response containing text "green open"
+    And REST response containing text "custom-prefix-1-2018-01"
     And All indices are deleted
 
   @StopBroker

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/RestDatastoreClient.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/RestDatastoreClient.java
@@ -571,7 +571,7 @@ public class RestDatastoreClient implements org.eclipse.kapua.service.datastore.
                         getFindIndexPath(indexRequest.getIndex()),
                         Collections.singletonMap("pretty", "true"));
             }
-        }, "*", "INDEX EXIST");
+        }, indexRequest.getIndex(), "INDEX EXIST");
         if (isIndexExistsResponse != null && isIndexExistsResponse.getStatusLine() != null) {
             if (isIndexExistsResponse.getStatusLine().getStatusCode() == 200) {
                 try {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -354,22 +354,6 @@ public final class MessageStoreFacade {
         client.deleteByQuery(typeDescriptor, query);
     }
 
-//    /**
-//     * Delete the data messages by date range.<br>
-//     * Date range must be valid (so no null dates and start date before end date).<br>
-//     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
-//     * It just deletes the messages that matching the date range without checking the consistency of the registries.</b>
-//     *
-//     * @param scopeId
-//     * @param startDate
-//     * @param endDate
-//     * @throws ClientException
-//     * @throws DatastoreException
-//     */
-//    public void deleteByDate(KapuaId scopeId, Date startDate, Date endDate) throws ClientException, DatastoreException {
-//        client.deleteIndexes(DatastoreUtils.convertToDataIndexes(scopeId, startDate.toInstant(), endDate.toInstant()));
-//    }
-
     // TODO cache will not be reset from the client code it should be automatically reset
     // after some time.
     private void resetCache(KapuaId scopeId, KapuaId deviceId, String channel, String clientId)
@@ -553,22 +537,11 @@ public final class MessageStoreFacade {
         return datastoreMessage;
     }
 
-//    public List<String> findIndexes(String prefix) throws ClientException {
-//        return Arrays.asList(client.findIndexes(new IndexRequest(prefix)).getIndexes());
-//    }
-
     private List<String> getDataIndexesByAccount(KapuaId scopeId) throws ClientException {
         List<String> result = new ArrayList<>();
         result.addAll(Arrays.asList(client.findIndexes(new IndexRequest(scopeId.toStringId() + "-*")).getIndexes()));
         return result;
     }
-
-//    public List<String> getAllIndexesByAccount(KapuaId scopeId) throws ClientException {
-//        List<String> result = new ArrayList<>();
-//        result.addAll(Arrays.asList(client.findIndexes(new IndexRequest("." + scopeId.toStringId())).getIndexes()));
-//        result.addAll(getDataIndexesByAccount(scopeId));
-//        return result;
-//    }
 
     public void refreshAllIndexes() throws ClientException {
         client.refreshAllIndexes();

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.service.datastore.internal;
 
 import com.codahale.metrics.Counter;
+
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.cache.LocalCache;
 import org.eclipse.kapua.commons.metric.MetricServiceFactory;
@@ -26,6 +27,7 @@ import org.eclipse.kapua.service.datastore.client.ClientException;
 import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
 import org.eclipse.kapua.service.datastore.client.DatastoreClient;
 import org.eclipse.kapua.service.datastore.client.QueryMappingException;
+import org.eclipse.kapua.service.datastore.client.model.IndexRequest;
 import org.eclipse.kapua.service.datastore.client.model.InsertRequest;
 import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.client.model.ResultList;
@@ -33,7 +35,6 @@ import org.eclipse.kapua.service.datastore.client.model.TypeDescriptor;
 import org.eclipse.kapua.service.datastore.internal.client.DatastoreClientFactory;
 import org.eclipse.kapua.service.datastore.internal.mediator.ConfigurationException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreChannel;
-import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageInfo;
@@ -64,11 +65,15 @@ import org.eclipse.kapua.service.datastore.model.MetricInfo;
 import org.eclipse.kapua.service.datastore.model.StorableId;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -349,21 +354,21 @@ public final class MessageStoreFacade {
         client.deleteByQuery(typeDescriptor, query);
     }
 
-    /**
-     * Delete the data messages by date range.<br>
-     * Date range must be valid (so no null dates and start date before end date).<br>
-     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
-     * It just deletes the messages that matching the date range without checking the consistency of the registries.</b>
-     *
-     * @param scopeId
-     * @param startDate
-     * @param endDate
-     * @throws ClientException
-     * @throws DatastoreException
-     */
-    public void deleteByDate(KapuaId scopeId, Date startDate, Date endDate) throws ClientException, DatastoreException {
-        client.deleteIndexes(DatastoreUtils.convertToDataIndexes(scopeId, startDate.toInstant(), endDate.toInstant()));
-    }
+//    /**
+//     * Delete the data messages by date range.<br>
+//     * Date range must be valid (so no null dates and start date before end date).<br>
+//     * <b>Be careful using this function since it doesn't guarantee the datastore consistency.<br>
+//     * It just deletes the messages that matching the date range without checking the consistency of the registries.</b>
+//     *
+//     * @param scopeId
+//     * @param startDate
+//     * @param endDate
+//     * @throws ClientException
+//     * @throws DatastoreException
+//     */
+//    public void deleteByDate(KapuaId scopeId, Date startDate, Date endDate) throws ClientException, DatastoreException {
+//        client.deleteIndexes(DatastoreUtils.convertToDataIndexes(scopeId, startDate.toInstant(), endDate.toInstant()));
+//    }
 
     // TODO cache will not be reset from the client code it should be automatically reset
     // after some time.
@@ -547,6 +552,23 @@ public final class MessageStoreFacade {
         datastoreMessage.setDatastoreId(new StorableIdImpl(messageId));
         return datastoreMessage;
     }
+
+//    public List<String> findIndexes(String prefix) throws ClientException {
+//        return Arrays.asList(client.findIndexes(new IndexRequest(prefix)).getIndexes());
+//    }
+
+    private List<String> getDataIndexesByAccount(KapuaId scopeId) throws ClientException {
+        List<String> result = new ArrayList<>();
+        result.addAll(Arrays.asList(client.findIndexes(new IndexRequest(scopeId.toStringId() + "-*")).getIndexes()));
+        return result;
+    }
+
+//    public List<String> getAllIndexesByAccount(KapuaId scopeId) throws ClientException {
+//        List<String> result = new ArrayList<>();
+//        result.addAll(Arrays.asList(client.findIndexes(new IndexRequest("." + scopeId.toStringId())).getIndexes()));
+//        result.addAll(getDataIndexesByAccount(scopeId));
+//        return result;
+//    }
 
     public void refreshAllIndexes() throws ClientException {
         client.refreshAllIndexes();

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
@@ -61,7 +61,11 @@ public enum DatastoreSettingKey implements SettingKey {
     /**
      * Elasticsearch index refresh interval (the data is available for a search operation only if it is indexed)
      */
-    CONFIG_MAX_ENTRIES_ON_DELETE("datastore.delete.max_entries_on_delete");
+    CONFIG_MAX_ENTRIES_ON_DELETE("datastore.delete.max_entries_on_delete"),
+    /**
+     * Elasticsearch index name system-wide prefix
+     */
+    INDEX_PREFIX("datastore.index.prefix");
 
     private String key;
 

--- a/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
@@ -15,7 +15,7 @@
          name="MessageStoreService"
          description="This is the configuration for the kapua MessageStoreService ">
 
-        <Icon resource="OSGI-INF/message-store-service.png" size="32"/>
+        <Icon resource="OSGI-INF/message-store-service.png" size="32" />
 
         <AD id="enabled"
             name="messageStore.enabled"
@@ -26,6 +26,17 @@
             description="Message store enable.">
         </AD>
 
+        <AD id="indexingWindow"
+            name="indexingWindow"
+            type="String"
+            required="true"
+            default="WEEK"
+            description="Message retention period in days.">
+            <Option label="HOUR" value="HOUR" />
+            <Option label="DAY" value="DAY" />
+            <Option label="WEEK" value="WEEK" />
+        </AD>
+
         <AD id="dataTTL"
             name="dataTTL"
             type="Integer"
@@ -33,7 +44,7 @@
             required="true"
             default="30"
             min="0"
-            description="Message retention period in days."/>
+            description="Message retention period, according to the selected indexingWindow." />
 
         <AD id="rxByteLimit"
             name="rxByteLimit"
@@ -42,7 +53,7 @@
             required="true"
             default="0"
             min="0"
-            description="Total data usage per month."/>
+            description="Total data usage per month." />
 
         <AD id="dataIndexBy"
             name="dataIndexBy"
@@ -58,6 +69,6 @@
     </OCD>
 
     <Designate pid="org.eclipse.kapua.service.datastore.MessageStoreService">
-        <Object ocdref="org.eclipse.kapua.service.datastore.MessageStoreService"/>
+        <Object ocdref="org.eclipse.kapua.service.datastore.MessageStoreService" />
     </Designate>
 </MetaData>

--- a/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
@@ -35,3 +35,6 @@ datastore.delete.max_entries_on_delete=100
 datastore.cache.local.expire.after=60
 datastore.cache.local.size.maximum=1000
 datastore.cache.metadata.local.size.maximum=1000
+
+# Datastore index prefix
+datastore.index.prefix=

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/AbstractMessageStoreServiceTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/AbstractMessageStoreServiceTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.kapua.service.datastore.internal;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtils;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.test.KapuaTest;
 import org.junit.AfterClass;
@@ -26,12 +25,12 @@ public abstract class AbstractMessageStoreServiceTest extends KapuaTest {
     @BeforeClass
     public static void tearUpGlobal()
             throws KapuaException {
-        KapuaConfigurableServiceSchemaUtils.createSchemaObjects(DEFAULT_COMMONS_PATH);
+//        KapuaConfigurableServiceSchemaUtils.createSchemaObjects(DEFAULT_COMMONS_PATH);
         XmlUtil.setContextProvider(new DatastoreJAXBContextProvider());
     }
 
     @AfterClass
     public static void tearDownGlobal() {
-        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
+//        KapuaConfigurableServiceSchemaUtils.dropSchemaObjects(DEFAULT_COMMONS_PATH);
     }
 }

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/IndexCalculatorTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/IndexCalculatorTest.java
@@ -14,9 +14,13 @@ package org.eclipse.kapua.service.datastore.internal;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.client.ClientException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
-import org.eclipse.kapua.test.KapuaTest;
+
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,17 +30,21 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 
-public class IndexCalculatorTest extends KapuaTest {
+public class IndexCalculatorTest extends AbstractMessageStoreServiceTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(IndexCalculatorTest.class);
 
+    private final MessageStoreService messageStoreService = KapuaLocator.getInstance().getService(MessageStoreService.class);
+    private final SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy HH:mm Z");
+
     @Test
     public void testIndex() throws KapuaException, ParseException, InterruptedException {
-        SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy HH:mm");
-        // performTest(sdf.parse("01/01/2000 13:12"), sdf.parse("01/01/2020 13:12"), buildExpectedResult("1", 1, 2000, 1, 2020, new int[] {
+        // performTest(sdf.parse("01/01/2000 13:12 +0100"), sdf.parse("01/01/2020 13:12 +0100"), buildExpectedResult("1", 1, 2000, 1, 2020, new int[] {
         // 53,// 2000 for locale us - 52 for locale "Europe"
         // 52,// 2001
         // 52,// 2002
@@ -60,31 +68,119 @@ public class IndexCalculatorTest extends KapuaTest {
         // 53// 2020 for locale us - 52 for locale "Europe"
         //
         // }));
-        performTest(sdf.parse("02/01/2017 13:12"), sdf.parse("02/07/2017 13:12"), buildExpectedResult("1", 2, 2017, 26, 2017, null));
-        performTest(sdf.parse("02/01/2017 13:12"), sdf.parse("01/07/2017 13:12"), buildExpectedResult("1", 2, 2017, 26, 2017, null));
-        performTest(sdf.parse("01/01/2017 13:12"), sdf.parse("02/07/2017 13:12"), buildExpectedResult("1", 1, 2017, 26, 2017, null));
-        performTest(sdf.parse("31/12/2016 13:12"), sdf.parse("02/07/2017 13:12"), buildExpectedResult("1", 1, 2017, 26, 2017, null));
-        performTest(sdf.parse("01/01/2017 13:12"), sdf.parse("01/07/2017 13:12"), buildExpectedResult("1", 1, 2017, 26, 2017, null));
+        performTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("02/07/2017 13:12 +0100"), buildExpectedResult("1", 2, 2017, 25, 2017, null));
+        performTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("01/07/2017 13:12 +0100"), buildExpectedResult("1", 2, 2017, 25, 2017, null));
+        performTest(sdf.parse("01/01/2017 13:12 +0100"), sdf.parse("02/07/2017 13:12 +0100"), buildExpectedResult("1", 1, 2017, 25, 2017, null));
+        performTest(sdf.parse("31/12/2016 13:12 +0100"), sdf.parse("02/07/2017 13:12 +0100"), buildExpectedResult("1", 1, 2017, 25, 2017, null));
+        performTest(sdf.parse("01/01/2017 13:12 +0100"), sdf.parse("01/07/2017 13:12 +0100"), buildExpectedResult("1", 1, 2017, 25, 2017, null));
+        performTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("03/07/2017 13:12 +0100"), buildExpectedResult("1", 2, 2017, 26, 2017, null));
+        performTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("03/07/2017 13:12 +0100"), buildExpectedResult("1", 2, 2017, 26, 2017, null));
+        performTest(sdf.parse("01/01/2017 13:12 +0100"), sdf.parse("03/07/2017 13:12 +0100"), buildExpectedResult("1", 1, 2017, 26, 2017, null));
 
-        performTest(sdf.parse("01/01/2017 13:12"), sdf.parse("08/01/2017 13:12"), buildExpectedResult("1", 1, 2017, 1, 2017, null));
-        performTest(sdf.parse("01/01/2017 13:12"), sdf.parse("07/01/2017 13:12"), buildExpectedResult("1", 1, 2017, 1, 2017, null));
-        performTest(sdf.parse("01/01/2017 13:12"), sdf.parse("06/01/2017 13:12"), null);
+        performTest(sdf.parse("31/12/2016 13:12 +0100"), sdf.parse("09/01/2017 13:12 +0100"), buildExpectedResult("1", 1, 2017, 1, 2017, null));
+        performTest(sdf.parse("01/01/2017 13:12 +0100"), sdf.parse("09/01/2017 13:12 +0100"), buildExpectedResult("1", 1, 2017, 1, 2017, null));
+        performTest(sdf.parse("01/01/2017 13:12 +0100"), sdf.parse("06/01/2017 13:12 +0100"), null);
+        performTest(sdf.parse("01/01/2017 13:12 +0100"), sdf.parse("08/01/2017 13:12 +0100"), null);
+        performTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("08/01/2017 13:12 +0100"), null);
+        performTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("09/01/2017 13:12 +0100"), null);
+        performTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("09/01/2017 13:12 +0100"), null);
+
+        performTest(null, sdf.parse("09/04/2015 13:12 +0100"), buildExpectedResult("1", 1, 2015, 14, 2015, null));
+        performTest(null, sdf.parse("06/04/2015 13:12 +0100"), buildExpectedResult("1", 1, 2015, 14, 2015, null));
+        performTest(null, sdf.parse("05/04/2015 13:12 +0100"), buildExpectedResult("1", 1, 2015, 13, 2015, null));
+        performTest(null, sdf.parse("13/04/2015 13:12 +0100"), buildExpectedResult("1", 1, 2015, 15, 2015, null));
+
+        performTest(sdf.parse("09/12/2018 13:12 +0100"), null, buildExpectedResult("1", 50, 2018, 52, 2018, null));
+        performTest(sdf.parse("10/12/2018 13:12 +0100"), null, buildExpectedResult("1", 51, 2018, 52, 2018, null));
+        performTest(sdf.parse("08/12/2018 13:12 +0100"), null, buildExpectedResult("1", 50, 2018, 52, 2018, null));
+        performTest(sdf.parse("17/12/2018 13:12 +0100"), null, buildExpectedResult("1", 52, 2018, 52, 2018, null));
+
+        performNullIndexTest(sdf.parse("02/01/2017 13:12 +0100"), sdf.parse("09/01/2017 13:12 +0100"));
     }
 
-    private void performTest(Date startDate, Date endDate, String[] expectedIndexes) throws DatastoreException {
-        Calendar calStartDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"), KapuaDateUtils.getLocale());
-        calStartDate.setTimeInMillis(startDate.getTime());
-        Calendar calEndDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"), KapuaDateUtils.getLocale());
-        calEndDate.setTimeInMillis(endDate.getTime());
+    @Test
+    public void dataIndexNameByScopeId() {
+        assertEquals("1-*", DatastoreUtils.getDataIndexName(KapuaId.ONE));
+    }
+
+    @Test
+    public void dataIndexNameByScopeIdAndTimestamp() throws KapuaException, ParseException {
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("enabled", true);
+        settings.put("dataTTL", 30);
+        settings.put("rxByteLimit", 0);
+        settings.put("dataIndexBy", "DEVICE_TIMESTAMP");
+
+        // Index by Week
+        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
+        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
+        String weekIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime());
+        assertEquals("1-2017-01", weekIndexName);
+
+        // Index by Day
+        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_DAY);
+        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
+        String dayIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime());
+        assertEquals("1-2017-01-02", dayIndexName);
+
+        // Index by Day
+        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR);
+        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
+        String hourIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime());
+        assertEquals("1-2017-01-02-12", hourIndexName);     // Index Hour is UTC!
+
+        // Reset config for other tests; provide new tests where needed
+        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
+        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
+    }
+
+    @Test
+    public void registryIndexNameByScopeId() {
+        assertEquals(".1", DatastoreUtils.getRegistryIndexName(KapuaId.ONE));
+    }
+
+    private void performTest(Date startDate, Date endDate, String[] expectedIndexes) throws DatastoreException, ClientException {
+        Calendar calStartDate = null;
+        Calendar calEndDate = null;
+        if (startDate != null) {
+            calStartDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"), KapuaDateUtils.getLocale());
+            calStartDate.setTimeInMillis(startDate.getTime());
+        }
+        if (endDate != null) {
+            calEndDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"), KapuaDateUtils.getLocale());
+            calEndDate.setTimeInMillis(endDate.getTime());
+        }
 
         LOG.info("StartDate week {} - day {} *** EndDate week {} - day {}",
-                calStartDate.get(Calendar.WEEK_OF_YEAR),
-                calStartDate.get(Calendar.DAY_OF_WEEK),
-                calEndDate.get(Calendar.WEEK_OF_YEAR),
-                calEndDate.get(Calendar.DAY_OF_WEEK));
+                calStartDate != null ? calStartDate.get(Calendar.WEEK_OF_YEAR) : "Infinity",
+                calStartDate != null ? calStartDate.get(Calendar.DAY_OF_WEEK) : "Infinity",
+                calEndDate != null ? calEndDate.get(Calendar.WEEK_OF_YEAR) : "Infinity",
+                calEndDate != null ? calEndDate.get(Calendar.DAY_OF_WEEK) : "Infinity");
 
-        String[] index = DatastoreUtils.convertToDataIndexes(KapuaEid.ONE, startDate.toInstant(), endDate.toInstant());
+        String[] index = DatastoreUtils.convertToDataIndexes(getDataIndexesByAccount(KapuaEid.ONE), startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null);
         compareResult(expectedIndexes, index);
+    }
+
+    private void performNullIndexTest(Date startDate, Date endDate) throws DatastoreException, ClientException {
+        Calendar calStartDate = null;
+        Calendar calEndDate = null;
+        if (startDate != null) {
+            calStartDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"), KapuaDateUtils.getLocale());
+            calStartDate.setTimeInMillis(startDate.getTime());
+        }
+        if (endDate != null) {
+            calEndDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"), KapuaDateUtils.getLocale());
+            calEndDate.setTimeInMillis(endDate.getTime());
+        }
+
+        LOG.info("StartDate week {} - day {} *** EndDate week {} - day {}",
+                calStartDate != null ? calStartDate.get(Calendar.WEEK_OF_YEAR) : "Infinity",
+                calStartDate != null ? calStartDate.get(Calendar.DAY_OF_WEEK) : "Infinity",
+                calEndDate != null ? calEndDate.get(Calendar.WEEK_OF_YEAR) : "Infinity",
+                calEndDate != null ? calEndDate.get(Calendar.DAY_OF_WEEK) : "Infinity");
+
+        String[] index = DatastoreUtils.convertToDataIndexes(new String[]{ null, null }, startDate != null ? startDate.toInstant() : null, endDate != null ? endDate.toInstant() : null);
+        compareResult(null, index);
     }
 
     private String[] buildExpectedResult(String scopeId, int startWeek, int startYear, int endWeek, int endYear, int[] weekCountByYear) {
@@ -109,11 +205,14 @@ public class IndexCalculatorTest extends KapuaTest {
         if (result != null) {
             assertEquals("Wrong result size!", (expected != null ? expected.length : 0), result.length);
             for (int i = 0; i < result.length; i++) {
-                assertEquals("Wrong result!", expected[i], result[i]);
+                assertEquals(String.format("Wrong result at position {0}!", i), expected[i], result[i]);
             }
         } else {
             assertTrue("Wrong result size!", expected == null || expected.length <= 0);
         }
     }
 
+    private String[] getDataIndexesByAccount(KapuaId scopeId) throws ClientException {
+        return buildExpectedResult("1", 1, 2015, 52, 2018, new int[]{ 53, 52, 52, 52 });
+    }
 }

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsConvertDateTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsConvertDateTest.java
@@ -16,10 +16,12 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 
 import org.assertj.core.api.Assertions;
+
+import org.eclipse.kapua.service.datastore.internal.AbstractMessageStoreServiceTest;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.junit.Test;
 
-public class ClientUtilsConvertDateTest {
+public class ClientUtilsConvertDateTest extends AbstractMessageStoreServiceTest {
 
     @Test(expected = java.lang.IllegalArgumentException.class)
     public void convertNullString() {

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsIndexNameTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsIndexNameTest.java
@@ -15,28 +15,80 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.internal.AbstractMessageStoreServiceTest;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
+
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class ClientUtilsIndexNameTest {
+public class ClientUtilsIndexNameTest extends AbstractMessageStoreServiceTest {
 
     private static final KapuaId ONE = new KapuaEid(BigInteger.ONE);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final MessageStoreService MESSAGE_STORE_SERVICE = LOCATOR.getService(MessageStoreService.class);
+
+    public static Map<String, Object> serviceSettings = new HashMap<>();
+
+    @BeforeClass
+    public static void setupConfig() {
+        serviceSettings.put("enabled", true);
+        serviceSettings.put("dataTTL", 30);
+        serviceSettings.put("rxByteLimit", 0);
+        serviceSettings.put("dataIndexBy", "DEVICE_TIMESTAMP");
+    }
 
     @Test
     public void test1() {
         final Instant instant = ZonedDateTime.of(2017, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
-        final String name = DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli());
-        Assert.assertEquals("1-2017-01", name);
+        try {
+            // Index by Week
+            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
+            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
+            Assert.assertEquals("1-2017-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+
+            // Index by Day
+            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_DAY);
+            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
+            Assert.assertEquals("1-2017-01-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+
+            // Index by Hour
+            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR);
+            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
+            Assert.assertEquals("1-2017-01-01-00", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+        } catch (KapuaException kaex) {
+            Assert.fail("Error while generating index name");
+        }
     }
 
     @Test
     public void test2() {
         final Instant instant = ZonedDateTime.of(2017, 1, 8, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
-        final String name = DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli());
-        Assert.assertEquals("1-2017-02", name);
+        try {
+            // Index by Week
+            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
+            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
+            Assert.assertEquals("1-2017-02", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+
+            // Index by Day
+            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_DAY);
+            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
+            Assert.assertEquals("1-2017-02-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+
+            // Index by Hour
+            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR);
+            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
+            Assert.assertEquals("1-2017-02-01-00", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+        } catch (KapuaException kaex) {
+            Assert.fail("Error while generating index name");
+        }
     }
 }

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/MessageStoreConfigurationTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/MessageStoreConfigurationTest.java
@@ -18,11 +18,12 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.kapua.service.datastore.internal.AbstractMessageStoreServiceTest;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class MessageStoraConfigurationTest {
+public class MessageStoreConfigurationTest extends AbstractMessageStoreServiceTest {
 
     @Test
     public void test1() {


### PR DESCRIPTION
This PR introduces two new features in the Datastore:

1- Now the Datastore indexes can have a common prefix, configurable per-deployment via the `datastore.index.prefix` system property. The prefix will be prepended to all the indexes within the deployment
2- `MessageStoreService` now has an option to configure indexes width per week, day or hour, in order to have a control on how many messages will be contained in a single index. Such configuration is available per account among the other services configurations.

**Description of the solution adopted**
All the methods that have an access in the index name have been reworked according the the new implementations
