### PR TITLE
Cleared automatic invalid state on inputs

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -99,6 +99,8 @@ public class CredentialAddDialog extends EntityAddEditDialog {
                 password.setAllowBlank(selectionChangedEvent.getSelectedItem().getValue() != GwtCredentialType.PASSWORD);
                 confirmPassword.setVisible(selectionChangedEvent.getSelectedItem().getValue() == GwtCredentialType.PASSWORD);
                 confirmPassword.setAllowBlank(selectionChangedEvent.getSelectedItem().getValue() != GwtCredentialType.PASSWORD);
+                password.clearInvalid();
+                confirmPassword.clearInvalid();
             }
         });
         credentialFormPanel.add(credentialType);


### PR DESCRIPTION
Brief description of the PR.
Cleared automatic invalid state on inputs

**Related Issue**
This PR fixes/closes  #1848 

**Description of the solution adopted**
If the user tries submit of CredentialAddDialog without choosing value for Credential Type, this field is marked as invalid. But this invalid state is no longer automatically passed to the password and confirm password fields reveled if Password is chosen as credential type.   

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>