### PR TITLE
wireGraph configuration not marked as invalid anymore

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -457,7 +457,7 @@ public class DeviceConfigPanel extends LayoutContainer {
             field.setMaxLength(1);
             field.setValidator((CharValidator) validator);
         }
-        if (validator != null && validator instanceof StringValidator && field.getId().equals("WireGraph")) {
+        if (validator != null && validator instanceof StringValidator && !param.getId().equals("WireGraph")) {
             field.setValidator((StringValidator) validator);
         }
         return field;

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -433,6 +433,9 @@ public class DeviceConfigPanel extends LayoutContainer {
         field.setAllowBlank(true);
         field.setFieldLabel(param.getName());
         field.addPlugin(dirtyPlugin);
+        if (param.getId().equals("WireGraph")) {
+            field.setMaxLength(32768);
+        }
 
         if (param.isRequired()) {
             field.setAllowBlank(false);
@@ -454,7 +457,7 @@ public class DeviceConfigPanel extends LayoutContainer {
             field.setMaxLength(1);
             field.setValidator((CharValidator) validator);
         }
-        if (validator != null && validator instanceof StringValidator) {
+        if (validator != null && validator instanceof StringValidator && field.getId().equals("WireGraph")) {
             field.setValidator((StringValidator) validator);
         }
         return field;


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

value for max length in WireGraph field changed

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
PR for increasing max length in field for WireGraph input.

**Related Issue**
This PR fixes issue #1800 

**Description of the solution adopted**
Added check if parametar id is "wireGraph" and if it is then max length for field is increased to 32768

**Screenshots**
/

**Any side note on the changes made**
/
