### PR TITLE
Disabled Paging Toolbars fix

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -162,11 +162,7 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
 
         //
         // Grid Data Load Listener
-        if (EntityFilterPanel.getSearchButton() != null && EntityFilterPanel.getResetButton() != null) {
-            entityGridLoadListener = new EntityGridLoadListener<M>(this, entityStore, EntityFilterPanel.getSearchButton(), EntityFilterPanel.getResetButton());
-        } else {
-            entityGridLoadListener = new EntityGridLoadListener<M>(this, entityStore);
-        }
+        entityGridLoadListener = new EntityGridLoadListener<M>(this, entityStore, EntityFilterPanel.getSearchButton(), EntityFilterPanel.getResetButton());
         entityGridLoadListener.setKeepSelectedOnLoad(keepSelectedItemsAfterLoad);
 
         entityLoader.addLoadListener(entityGridLoadListener);

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -65,6 +65,7 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     protected SelectionMode selectionMode = SelectionMode.SINGLE;
     protected boolean keepSelectedItemsAfterLoad = true;
     protected boolean entityGridConfigured;
+    private EntityGridLoadListener<M> entityGridLoadListener;
 
     protected EntityGrid(AbstractEntityView<M> entityView, GwtSession currentSession) {
         super(new FitLayout());
@@ -161,7 +162,11 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
 
         //
         // Grid Data Load Listener
-        EntityGridLoadListener<M> entityGridLoadListener = new EntityGridLoadListener<M>(this, entityStore);
+        if (EntityFilterPanel.getSearchButton() != null && EntityFilterPanel.getResetButton() != null) {
+            entityGridLoadListener = new EntityGridLoadListener<M>(this, entityStore, EntityFilterPanel.getSearchButton(), EntityFilterPanel.getResetButton());
+        } else {
+            entityGridLoadListener = new EntityGridLoadListener<M>(this, entityStore);
+        }
         entityGridLoadListener.setKeepSelectedOnLoad(keepSelectedItemsAfterLoad);
 
         entityLoader.addLoadListener(entityGridLoadListener);

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridLoadListener.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridLoadListener.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.app.console.module.api.client.ui.grid;
 import com.extjs.gxt.ui.client.data.LoadEvent;
 import com.extjs.gxt.ui.client.data.Loader;
 import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.button.Button;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaLoadListener;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtEntityModel;
 
@@ -23,6 +24,8 @@ public class EntityGridLoadListener<M extends GwtEntityModel> extends KapuaLoadL
 
     private EntityGrid<M> entityGrid;
     private ListStore<M> entityStore;
+    private Button searchButton;
+    private Button resetButton;
 
     private List<M> selectedEntities;
     private boolean keepSelectedOnLoad = true;
@@ -30,6 +33,13 @@ public class EntityGridLoadListener<M extends GwtEntityModel> extends KapuaLoadL
     public EntityGridLoadListener(EntityGrid<M> entityGrid, ListStore<M> entityStore) {
         this.entityGrid = entityGrid;
         this.entityStore = entityStore;
+    }
+
+    public EntityGridLoadListener(EntityGrid<M> entityGrid, ListStore<M> entityStore, Button searchButton, Button resetButton) {
+        this.entityGrid = entityGrid;
+        this.entityStore = entityStore;
+        this.searchButton = searchButton;
+        this.resetButton = resetButton;
     }
 
     /**
@@ -40,6 +50,10 @@ public class EntityGridLoadListener<M extends GwtEntityModel> extends KapuaLoadL
     @Override
     public void loaderBeforeLoad(LoadEvent le) {
         selectedEntities = entityGrid.getSelectionModel().getSelectedItems();
+        if (searchButton != null && resetButton != null) {
+            searchButton.disable();
+            resetButton.disable();
+        }
     }
 
     /**
@@ -61,6 +75,10 @@ public class EntityGridLoadListener<M extends GwtEntityModel> extends KapuaLoadL
             }
         }
 
+        if (searchButton != null && resetButton != null) {
+            searchButton.enable();
+            resetButton.enable();
+        }
         entityGrid.loaded();
     }
 
@@ -68,6 +86,10 @@ public class EntityGridLoadListener<M extends GwtEntityModel> extends KapuaLoadL
     public void loaderLoadException(LoadEvent le) {
         entityGrid.loaded();
 
+        if (searchButton != null && resetButton != null) {
+            searchButton.enable();
+            resetButton.enable();
+        }
         super.loaderLoadException(le);
     }
 

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/EntityFilterPanel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/EntityFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -34,8 +34,8 @@ import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 public abstract class EntityFilterPanel<M extends GwtEntityModel> extends ContentPanel {
 
     private final VerticalPanel fieldsPanel;
-    private final Button searchButton;
-    private final Button resetButton;
+    private static Button searchButton;
+    private static Button resetButton;
 
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
     private static final int WIDTH = 200;
@@ -106,4 +106,12 @@ public abstract class EntityFilterPanel<M extends GwtEntityModel> extends Conten
     public abstract void resetFields();
 
     public abstract void doFilter();
+
+    public static Button getSearchButton() {
+        return searchButton;
+    }
+
+    public static Button getResetButton() {
+        return resetButton;
+    }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
@@ -118,6 +118,7 @@ public class GroupSubjectGrid extends EntityGrid<GwtDevice> {
             query.setPredicates(predicates);
         }
         refresh();
+        entityPagingToolbar.enable();
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
@@ -130,6 +130,7 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
         initialized = true;
 
         loader.load();
+        pagingToolBar.enable();
     }
 
     private void initToolBar() {
@@ -150,6 +151,7 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
 
                     refreshProcess = false;
                     refreshButton.setEnabled(true);
+                    pagingToolBar.enable();
                 }
             }
         });

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/TagSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/TagSubjectGrid.java
@@ -114,6 +114,7 @@ public class TagSubjectGrid extends EntityGrid<GwtDevice> {
             query.setPredicates(predicates);
         }
         refresh();
+        entityPagingToolbar.enable();
     }
 
     @Override


### PR DESCRIPTION
Brief description of the PR.
Paging Toolbars are no longer disabled after grid load/refresh

**Related Issue**
This PR fixes/closes #1775 

**Description of the solution adopted**
Added new constructor for `EntityGridLoadListener` class, with refresh and reset buttons as parameters. Depending on the grid loading stage these buttons are enabled/disabled.  This new constructor is then used in the `EntityGrid` class if these buttons from `EntityFilterPanel` are passed as parameters. 
Also Paging Toolbars from Device Events and Assigned Devices tabs, which were disabled by default or after grid refresh are now enabled as well.
**Screenshots**
_None_

**Any side note on the changes made**
_None_
