### PR TITLE
Duplicate count of batch job properties

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -433,7 +433,7 @@ public class ServiceDAO {
 
         //
         // SELECT
-        criteriaSelectQuery.select(cb.count(entityRoot));
+        criteriaSelectQuery.select(cb.countDistinct(entityRoot));
 
         //
         // WHERE

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerServiceImpl.java
@@ -65,11 +65,7 @@ public class GwtTriggerServiceImpl extends KapuaRemoteServiceServlet implements 
 
             // query
             TriggerListResult triggerListResult = TRIGGER_SERVICE.query(triggerQuery);
-            if ((triggerListResult != null) && (!triggerListResult.isEmpty())) {
-                totalLength = triggerListResult.getSize();
-            } else {
-                totalLength = 0;
-            }
+            totalLength = (int) TRIGGER_SERVICE.count(triggerQuery);
 
             // Converto to GWT entity
             for (Trigger trigger : triggerListResult.getItems()) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerServiceImpl.java
@@ -65,7 +65,11 @@ public class GwtTriggerServiceImpl extends KapuaRemoteServiceServlet implements 
 
             // query
             TriggerListResult triggerListResult = TRIGGER_SERVICE.query(triggerQuery);
-            totalLength = (int) TRIGGER_SERVICE.count(triggerQuery);
+            if ((triggerListResult != null) && (!triggerListResult.isEmpty())) {
+                totalLength = triggerListResult.getSize();
+            } else {
+                totalLength = 0;
+            }
 
             // Converto to GWT entity
             for (Trigger trigger : triggerListResult.getItems()) {


### PR DESCRIPTION
Duplicate records for job schedules caused wrong paging of schedules.
Count method doesn't work and was replaced by using size of returned list of schedules instead.

**Related Issue**
This PR fixes/closes _1760_

**Description of the solution adopted**
Count on properties of job doesn't work as expected. This caused wrong
paging on job schedules. Count method was removed and replaced by list
getSize method. That method already has info about number of records, this
is also more efficient approach.

Count method doesn't work because it does cartesian product on schdl_trigger_properties
multiple times while combining AND predicates. It works on query because
query is using DISTINCT on selected results.

**Screenshots**
Not applicable.

**Any side note on the changes made**
Count method should be investigated, as it doesn't work as expected.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>