### PR TITLE
Feature account expiration date

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountGrid.java
@@ -112,6 +112,12 @@ public class AccountGrid extends EntityGrid<GwtAccount> {
         column.setSortable(false);
         configs.add(column);
 
+        column = new ColumnConfig("expirationDateFormatted", 120);
+        column.setHeader(ACCOUNT_MSGS.accountTableExpirationDate());
+        column.setWidth(150);
+        column.setSortable(false);
+        configs.add(column);
+
         column = new ColumnConfig("modifiedOnFormatted", ACCOUNT_MSGS.accountTableModifiedOn(), 130);
         column.setAlignment(HorizontalAlignment.CENTER);
         configs.add(column);

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -140,6 +140,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
             accountCreator.setOrganizationZipPostCode(gwtAccountCreator.getOrganizationZipPostCode());
             accountCreator.setOrganizationStateProvinceCounty(gwtAccountCreator.getOrganizationStateProvinceCounty());
             accountCreator.setOrganizationCountry(gwtAccountCreator.getOrganizationCountry());
+            accountCreator.setExpirationDate(gwtAccountCreator.getExpirationDate());
 
             //
             // Create the Account
@@ -320,6 +321,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
             account.getOrganization().setCity(gwtAccount.getGwtOrganization().getCity());
             account.getOrganization().setStateProvinceCounty(gwtAccount.getGwtOrganization().getStateProvinceCounty());
             account.getOrganization().setCountry(gwtAccount.getGwtOrganization().getCountry());
+            account.setExpirationDate(gwtAccount.getExpirationDate());
             account.setOptlock(gwtAccount.getOptlock());
 
             account = ACCOUNT_SERVICE.update(account);

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -223,6 +223,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
                 }
             });
 
+            accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "expirationDate", account.getExpirationDate() != null ? account.getExpirationDate() : "Never"));
             accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountCreatedOn", account.getCreatedOn()));
             accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountCreatedBy", userCreatedBy != null ? userCreatedBy.getName() : null));
             accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountModifiedOn", account.getModifiedOn()));

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccount.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccount.java
@@ -12,10 +12,12 @@
 package org.eclipse.kapua.app.console.module.account.shared.model;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.List;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
 
+import org.eclipse.kapua.app.console.module.api.client.util.DateUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityModel;
 
 public class GwtAccount extends GwtUpdatableEntityModel implements Serializable {
@@ -61,6 +63,20 @@ public class GwtAccount extends GwtUpdatableEntityModel implements Serializable 
 
     public GwtAccount() {
         super();
+    }
+
+    @Override
+    @SuppressWarnings({ "unchecked" })
+    public <X> X get(String property) {
+        if ("expirationDateFormatted".equals(property)) {
+            if (getExpirationDate() != null) {
+                return (X) ((DateUtils.formatDateTime(getExpirationDate())));
+            } else {
+                return (X) "N/A";
+            }
+        } else {
+            return super.get(property);
+        }
     }
 
     public String getName() {
@@ -113,5 +129,17 @@ public class GwtAccount extends GwtUpdatableEntityModel implements Serializable 
 
     public void setChildAccounts(List<GwtAccount> childAccounts) {
         set("childAccounts", childAccounts);
+    }
+
+    public Date getExpirationDate() {
+        return get("expirationDate");
+    }
+
+    public String getExpirationDateFormatted() {
+        return get("expirationDateFormatted");
+    }
+
+    public void setExpirationDate(Date expirationDate) {
+        set("expirationDate", expirationDate);
     }
 }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccount.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccount.java
@@ -72,7 +72,7 @@ public class GwtAccount extends GwtUpdatableEntityModel implements Serializable 
             if (getExpirationDate() != null) {
                 return (X) ((DateUtils.formatDateTime(getExpirationDate())));
             } else {
-                return (X) "N/A";
+                return (X) "Never";
             }
         } else {
             return super.get(property);

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccountCreator.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccountCreator.java
@@ -14,7 +14,6 @@ package org.eclipse.kapua.app.console.module.account.shared.model;
 import java.util.Date;
 
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtEntityCreator;
-import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceConnection.GwtConnectionUserCouplingMode;
 
 public class GwtAccountCreator extends GwtEntityCreator {
 
@@ -22,12 +21,7 @@ public class GwtAccountCreator extends GwtEntityCreator {
 
     private String accountName;
     private String accountPassword;
-    private Long brokerClusterId;
-    private Long vpnServerId;
-    private Boolean lockoutPolicyEnabled;
-    private Integer lockoutPolicyMaxFailures;
-    private Integer lockoutPolicyResetAfter;
-    private Integer lockoutPolicyLockDuration;
+    private String parentAccountId;
     private String organizationName;
     private String organizationPersonName;
     private String organizationEmail;
@@ -39,36 +33,6 @@ public class GwtAccountCreator extends GwtEntityCreator {
     private String organizationStateProvinceCounty;
     private String organizationCountry;
     private Date expirationDate;
-
-    // Health check monitor
-    private long healthCheckInterval;
-    private long mqttThreshold;
-    private long restThreshold;
-    private long restCommandThreshold;
-
-    // Tight Coupling
-    private boolean deviceNewAllowUnprovisioned;
-    private GwtConnectionUserCouplingMode deviceDefaultCredentialsTight;
-
-    // Service plan
-    private int maxNumberOfDevices;
-    private String parentAccountId;
-    private int maxNumberChildAccounts;
-    private int maxNumberProvisionRequests;
-    private int maxNumberDeviceJobs;
-    private int maxNumberVpnConnections;
-    private long txByteLimit;
-    private long rxByteLimit;
-    private boolean dataStorageEnabled;
-    private int dataTimeToLive;
-    private String dataIndexBy;
-    private String metricsIndexBy;
-    private int maxNumberOfRules;
-
-    // SSL Auth
-    private boolean simpleConnection;
-    private boolean sslConnection;
-    private boolean mutualSslConnection;
 
     public GwtAccountCreator() {
     }
@@ -169,78 +133,6 @@ public class GwtAccountCreator extends GwtEntityCreator {
         this.organizationCountry = organizationCountry;
     }
 
-    public Boolean getLockoutPolicyEnabled() {
-        return lockoutPolicyEnabled;
-    }
-
-    public void setLockoutPolicyEnabled(Boolean lockoutPolicyEnabled) {
-        this.lockoutPolicyEnabled = lockoutPolicyEnabled;
-    }
-
-    public Integer getLockoutPolicyMaxFailures() {
-        return lockoutPolicyMaxFailures;
-    }
-
-    public void setLockoutPolicyMaxFailures(Integer lockoutPolicyMaxFailures) {
-        this.lockoutPolicyMaxFailures = lockoutPolicyMaxFailures;
-    }
-
-    public Integer getLockoutPolicyResetAfter() {
-        return lockoutPolicyResetAfter;
-    }
-
-    public void setLockoutPolicyResetAfter(Integer lockoutPolicyResetAfter) {
-        this.lockoutPolicyResetAfter = lockoutPolicyResetAfter;
-    }
-
-    public Integer getLockoutPolicyLockDuration() {
-        return lockoutPolicyLockDuration;
-    }
-
-    public void setLockoutPolicyLockDuration(Integer lockoutPolicyLockDuration) {
-        this.lockoutPolicyLockDuration = lockoutPolicyLockDuration;
-    }
-
-    public Long getBrokerClusterId() {
-        return brokerClusterId;
-    }
-
-    public void setBrokerClusterId(Long brokerClusterId) {
-        this.brokerClusterId = brokerClusterId;
-    }
-
-    public Long getVpnServerId() {
-        return vpnServerId;
-    }
-
-    public void setVpnServerId(Long vpnServerId) {
-        this.vpnServerId = vpnServerId;
-    }
-
-    public Date getExpirationDate() {
-        return expirationDate;
-    }
-
-    public void setExpirationDate(Date expirationDate) {
-        this.expirationDate = expirationDate;
-    }
-
-    public long getHealthCheckInterval() {
-        return healthCheckInterval;
-    }
-
-    public void setHealthCheckInterval(long healthCheckInterval) {
-        this.healthCheckInterval = healthCheckInterval;
-    }
-
-    public int getMaxNumberOfDevices() {
-        return maxNumberOfDevices;
-    }
-
-    public void setMaxNumberOfDevices(int maxNumberOfDevices) {
-        this.maxNumberOfDevices = maxNumberOfDevices;
-    }
-
     public String getParentAccountId() {
         return parentAccountId;
     }
@@ -249,160 +141,11 @@ public class GwtAccountCreator extends GwtEntityCreator {
         this.parentAccountId = parentAccountId;
     }
 
-    public int getMaxNumberChildAccounts() {
-        return maxNumberChildAccounts;
+    public Date getExpirationDate() {
+        return expirationDate;
     }
 
-    public void setMaxNumberChildAccounts(int maxNumberChildAccounts) {
-        this.maxNumberChildAccounts = maxNumberChildAccounts;
-    }
-
-    public int getMaxNumberProvisionRequests() {
-        return maxNumberProvisionRequests;
-    }
-
-    public int getMaxNumberDeviceJobs() {
-        return maxNumberDeviceJobs;
-    }
-
-    public void setMaxNumberDeviceJobs(int maxNumberDeviceJobs) {
-        this.maxNumberDeviceJobs = maxNumberDeviceJobs;
-    }
-
-    public void setMaxNumberProvisionRequest(int maxNumberProvisionRequests) {
-        this.maxNumberProvisionRequests = maxNumberProvisionRequests;
-    }
-
-    public int getMaxNumberVpnConnections() {
-        return maxNumberVpnConnections;
-    }
-
-    public void setMaxNumberVpnConnections(int maxNumberVpnConnections) {
-        this.maxNumberVpnConnections = maxNumberVpnConnections;
-    }
-
-    public long getTxByteLimit() {
-        return txByteLimit;
-    }
-
-    public void setTxByteLimit(long txByteLimit) {
-        this.txByteLimit = txByteLimit;
-    }
-
-    public long getRxByteLimit() {
-        return rxByteLimit;
-    }
-
-    public void setRxByteLimit(long rxByteLimit) {
-        this.rxByteLimit = rxByteLimit;
-    }
-
-    public boolean getDataStorageEnabled() {
-        return dataStorageEnabled;
-    }
-
-    public void setDataStorageEnabled(boolean dataStorageEnabled) {
-        this.dataStorageEnabled = dataStorageEnabled;
-    }
-
-    public int getDataTimeToLive() {
-        return dataTimeToLive;
-    }
-
-    public void setDataTimeToLive(int dataTimeToLive) {
-        this.dataTimeToLive = dataTimeToLive;
-    }
-
-    public String getDataIndexBy() {
-        return dataIndexBy;
-    }
-
-    public void setDataIndexBy(String dataIndexBy) {
-        this.dataIndexBy = dataIndexBy;
-    }
-
-    public int getMaxNumberOfRules() {
-        return maxNumberOfRules;
-    }
-
-    public void setMaxNumberOfRules(int maxNumberOfRules) {
-        this.maxNumberOfRules = maxNumberOfRules;
-    }
-
-    public String getMetricsIndexBy() {
-        return metricsIndexBy;
-    }
-
-    public void setMetricsIndexBy(String metricsIndexBy) {
-        this.metricsIndexBy = metricsIndexBy;
-    }
-
-    public boolean isSimpleConnection() {
-        return simpleConnection;
-    }
-
-    public void setSimpleConnection(boolean simpleConnection) {
-        this.simpleConnection = simpleConnection;
-    }
-
-    public boolean isSslConnection() {
-        return sslConnection;
-    }
-
-    public void setSslConnection(boolean sslConnection) {
-        this.sslConnection = sslConnection;
-    }
-
-    public boolean isMutualSslConnection() {
-        return mutualSslConnection;
-    }
-
-    public void setMutualSslConnection(boolean mutualSslConnection) {
-        this.mutualSslConnection = mutualSslConnection;
-    }
-
-    public long getMqttThreshold() {
-        return mqttThreshold;
-    }
-
-    public void setMqttThreshold(long mqttThreshold) {
-        this.mqttThreshold = mqttThreshold;
-    }
-
-    public long getRestThreshold() {
-        return restThreshold;
-    }
-
-    public void setRestThreshold(long restThreshold) {
-        this.restThreshold = restThreshold;
-    }
-
-    public long getRestCommandThreshold() {
-        return restCommandThreshold;
-    }
-
-    public void setRestCommandThreshold(long restCommandThreshold) {
-        this.restCommandThreshold = restCommandThreshold;
-    }
-
-    // Tight Coupling
-    public boolean getDeviceNewAllowUnprovisioned() {
-        return deviceNewAllowUnprovisioned;
-    }
-
-    public void setDeviceNewAllowUnprovisioned(boolean deviceNewAllowUnprovisioned) {
-        this.deviceNewAllowUnprovisioned = deviceNewAllowUnprovisioned;
-    }
-
-    public GwtConnectionUserCouplingMode getDeviceDefaultCredentialsTight() {
-        return deviceDefaultCredentialsTight;
-    }
-
-    public void setDeviceDefaultCredentialsTight(String deviceDefaultCredentialsTight) {
-        setDeviceDefaultCredentialsTight(GwtConnectionUserCouplingMode.getEnumFromLabel(deviceDefaultCredentialsTight));
-    }
-
-    public void setDeviceDefaultCredentialsTight(GwtConnectionUserCouplingMode deviceDefaultCredentialsTight) {
-        this.deviceDefaultCredentialsTight = deviceDefaultCredentialsTight;
+    public void setExpirationDate(Date expirationDate) {
+        this.expirationDate = expirationDate;
     }
 }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/KapuaGwtAccountModelConverter.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/KapuaGwtAccountModelConverter.java
@@ -49,6 +49,7 @@ public class KapuaGwtAccountModelConverter {
         gwtAccount.set("orgName", account.getOrganization().getName());
         gwtAccount.set("orgEmail", account.getOrganization().getEmail());
         gwtAccount.setChildAccounts(convertChildAccounts(account.getChildAccounts()));
+        gwtAccount.setExpirationDate(account.getExpirationDate());
         //
         // Return converted entity
         return gwtAccount;

--- a/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/client/messages/ConsoleAccountMessages.properties
+++ b/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/client/messages/ConsoleAccountMessages.properties
@@ -18,6 +18,7 @@ settings=Settings
 #
 # Account Table column headers
 accountTableName=Account Name
+accountTableExpirationDate=Expiration Date
 accountTableModifiedOn=Modified On
 accountTableModifiedBy=Modified By
 accountTableOrgName=Organization Name
@@ -50,6 +51,8 @@ accountFormCreatedBy=Created By
 accountFormButtonChildCreationDisabled=This account cannot have child accounts
 accountFormBrokerCluster=Broker Cluster
 accountFormDeploymentInformation=Deployment Information
+accountFormExpirationDate=Expiration Date
+accountFormNoExpiration=No Expiration
 
 accountFormOrgInformation=Organization Information
 accountFormOrgName=Organization Name
@@ -87,3 +90,5 @@ filterHeader=Account Filter
 accountFilterNameLabel=Account Name
 accountFilterOrgNameLabel=Organization Name
 accountFilterOrgEmailLabel=Organization Email
+
+conflictingExpirationDate=The expiration date conflicts with either its parent expiration date or one of its children expiration date

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/user/steps/TestAccount.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/user/steps/TestAccount.java
@@ -12,6 +12,12 @@
 package org.eclipse.kapua.service.user.steps;
 
 import java.math.BigInteger;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
 
 /**
  * Data object used in Gherkin to transfer Account data.
@@ -21,6 +27,8 @@ public class TestAccount {
     private String name;
 
     private BigInteger scopeId;
+
+    private String expirationDate;
 
     public String getName() {
         return name;
@@ -36,5 +44,39 @@ public class TestAccount {
 
     public void setScopeId(BigInteger scopeId) {
         this.scopeId = scopeId;
+    }
+
+    public void setExpirationDate(String date) {
+        this.expirationDate = date;
+    }
+
+    public Date getExpirationDate() {
+        DateFormat df = new SimpleDateFormat("dd/mm/yyyy");
+        Date expDate = null;
+        Instant now = Instant.now();
+
+        if (expirationDate == null) {
+            return null;
+        }
+        // Special keywords for date
+        switch (expirationDate.trim().toLowerCase()) {
+            case "yesterday":
+                expDate = Date.from(now.minus(Duration.ofDays(1)));
+                break;
+            case "today":
+                expDate = Date.from(now);
+                break;
+            case "tomorrow":
+                expDate = Date.from(now.plus(Duration.ofDays(1)));
+                break;
+        }
+        // Just parse date
+        try {
+            expDate = df.parse(expirationDate.trim().toLowerCase());
+        } catch (ParseException | NullPointerException e) {
+            // skip, leave date null
+        }
+
+        return expDate;
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/account/expiration/RunAccountServiceI9nTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/account/expiration/RunAccountServiceI9nTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.service.account.expiration;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = "classpath:features/account/AccountExpirationI9n.feature",
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps"
+               },
+        plugin = {"pretty", 
+                  "html:target/cucumber/AccountServiceI9n",
+                  "json:target/AccountServiceI9n_cucumber.json"
+                 },
+        monochrome=true)
+public class RunAccountServiceI9nTest {}

--- a/qa/src/test/resources/features/account/AccountExpirationI9n.feature
+++ b/qa/src/test/resources/features/account/AccountExpirationI9n.feature
@@ -1,0 +1,508 @@
+###############################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@user
+Feature: Account expiration features
+    Accounts have an expiration date. From this date onward the accounts are considered disabled
+    and cannot be logged into anymore.
+
+  Scenario: Account with future expiration date
+    Set the expiration date of an account in the future. It must be possible to log into such
+    account.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 20     |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | tomorrow       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Account with no expiration date
+  Do not set the expiration date of an account. Such an account should never expire.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 20     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Account past its expiration date
+    Set the expiration date of the account in the past. Te account should be expired and should
+    not be possible to log in with it.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 30    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | yesterday      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | false   |
+    And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Account exactly on its expiration date
+  Set the expiration date of the account to the current date. Te account should be expired and should
+  not be possible to log in with it.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 30    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | today          |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | false   |
+    And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then An exception was thrown
+    And I logout
+
+    Scenario: Child account expires before parent
+    Create a chain of accounts. Each child account expires before its parent.
+      When I login as user with name "kapua-sys" and password "kapua-password"
+      And I configure account service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 50    |
+      Given Account
+        | name      | scopeId | expirationDate |
+        | account-a | 1       | 20/7/2018      |
+      And I configure account service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 40    |
+      Given I select account "account-a"
+      And Account
+        | name      | expirationDate |
+        | account-b | 19/7/2018      |
+      And I configure account service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 40    |
+      Given I select account "account-b"
+      And Account
+        | name      | expirationDate |
+        | account-c | 18/7/2018      |
+      And I logout
+
+  Scenario: Both the parent and child accounts have the same expiration date
+  Create a chain of accounts. All accounts have the same expiration dates. This should be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      | expirationDate |
+      | account-b | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      | expirationDate |
+      | account-c | 20/7/2018      |
+    And I logout
+
+  Scenario: Both the parent and child accounts do not expire
+  Create a chain of accounts. All accounts have null expiration dates. This should be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      |
+      | account-b |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      |
+      | account-c |
+    And I logout
+
+  Scenario: Child account expires after parent
+  Create a chain of two accounts. An attempt to create an account with an expiration date past the
+  parents should be impossible.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "argument expirationDate"
+    And Account
+      | name      | expirationDate |
+      | account-b | 21/7/2018      |
+    Then An exception was thrown
+
+  Scenario: Child account has null expiration date
+  Create a chain of two accounts. An attempt to create a child account with a null expiration date.
+  This should not be possible.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "argument expirationDate"
+    And Account
+      | name      |
+      | account-b |
+    Then An exception was thrown
+
+  Scenario: Modify parent expiration so that it still expires after child
+  Create a chain of accounts. Modify the expiration date of the parent so that it is still later than
+  the child expiration date. Regular case. Should be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      | expirationDate |
+      | account-b | 19/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      | expirationDate |
+      | account-c | 18/7/2018      |
+    Given I select account "account-a"
+    When I change the current account expiration date to "25/7/2018"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Delete parent expiration
+  Create a chain of accounts. Set the expiration date of the parent to null. Regular case. Should be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      |expirationDate |
+      | account-b |19/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      | expirationDate |
+      | account-c | 18/7/2018      |
+    Given I select account "account-a"
+    When I change the current account expiration date to "null"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Modify parent expiration to before child expiration
+  Create a chain of accounts. Modify the expiration date of the parent so that it expires before childs.
+  Should not be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      | expirationDate |
+      | account-b | 19/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      | expirationDate |
+      | account-c | 18/7/2018      |
+    Given I select account "account-a"
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "argument expirationDate"
+    When I change the current account expiration date to "15/7/2018"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Modify middle child expiration so that it still expires before parent
+  Create a chain of accounts. Modify the expiration date of the middle child so that it is still before the
+  parents expiration date. Regular case. Should be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      | expirationDate |
+      | account-b | 19/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      | expirationDate |
+      | account-c | 10/7/2018      |
+    Given I select account "account-b"
+    When I change the current account expiration date to "15/7/2018"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Modify last child expiration so that it still expires before parent
+  Create a chain of accounts. Modify the expiration date of the last child so that it is still before the
+  parents expiration date. Regular case. Should be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      | expirationDate |
+      | account-b | 19/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      | expirationDate |
+      | account-c | 10/7/2018      |
+    Given I select account "account-c"
+    When I change the current account expiration date to "15/7/2018"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Modify middle child expiration to outlive parent
+  Create a chain of accounts. Modify the expiration date of the middle child so that it expires after its parent.
+  Should not be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      | expirationDate |
+      | account-b | 19/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      | expirationDate |
+      | account-c | 18/7/2018      |
+    Given I select account "account-b"
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "argument expirationDate"
+    When I change the current account expiration date to "25/7/2018"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Delete middle child expiration
+  Create a chain of accounts. Set the expiration date of the middle child to null.
+  Should not be allowed.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | 20/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-a"
+    And Account
+      | name      | expirationDate |
+      | account-b | 19/7/2018      |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 40    |
+    Given I select account "account-b"
+    And Account
+      | name      | expirationDate |
+      | account-c | 18/7/2018      |
+    Given I select account "account-b"
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "argument expirationDate"
+    When I change the current account expiration date to "null"
+    Then An exception was thrown
+    And I logout

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
@@ -12,12 +12,15 @@
 package org.eclipse.kapua.service.account;
 
 import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -70,4 +73,21 @@ public interface Account extends KapuaNamedEntity {
     void setParentAccountPath(String parentAccountPath);
 
     List<Account> getChildAccounts();
+
+    /**
+     * Gets the current Account expiration date
+     *
+     * @return the current Account expiration date
+     */
+    @XmlElement(name = "expirationDate")
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
+    Date getExpirationDate();
+
+    /**
+     * Sets the current Account expiration date
+     *
+     * @param expirationDate the current Account expiration date
+     */
+    void setExpirationDate(Date expirationDate);
+
 }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
@@ -12,12 +12,15 @@
 package org.eclipse.kapua.service.account;
 
 import org.eclipse.kapua.model.KapuaNamedEntityCreator;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Date;
 
 /**
  * AccountCreator encapsulates all the information needed to create a new Account in the system.<br>
@@ -36,7 +39,8 @@ import javax.xml.bind.annotation.XmlType;
         "organizationCity",
         "organizationZipPostCode",
         "organizationStateProvinceCounty",
-        "organizationCountry" }, factoryClass = AccountXmlRegistry.class, factoryMethod = "newAccountCreator")
+        "organizationCountry",
+        "expirationDate" }, factoryClass = AccountXmlRegistry.class, factoryMethod = "newAccountCreator")
 public interface AccountCreator extends KapuaNamedEntityCreator<Account> {
 
     /**
@@ -188,4 +192,20 @@ public interface AccountCreator extends KapuaNamedEntityCreator<Account> {
      * @param organizationCountry
      */
     void setOrganizationCountry(String organizationCountry);
+
+    /**
+     * Get the expiration date
+     *
+     * @return the current Account expiration date
+     */
+    @XmlElement(name = "expirationDate")
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
+    Date getExpirationDate();
+
+    /**
+     * Set the expiration date
+     *
+     * @param expirationDate the current Account expiration date
+     */
+    void setExpirationDate(Date expirationDate);
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountCreatorImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountCreatorImpl.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account.internal;
 
+import java.util.Date;
+
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.Account;
@@ -47,6 +49,8 @@ public class AccountCreatorImpl extends AbstractKapuaNamedEntityCreator<Account>
     private String organizationStateProvinceCounty;
 
     private String organizationCountry;
+
+    private Date expirationDate;
 
     /**
      * Constructor
@@ -175,5 +179,15 @@ public class AccountCreatorImpl extends AbstractKapuaNamedEntityCreator<Account>
     @Override
     public void setOrganizationCountry(String organizationCountry) {
         this.organizationCountry = organizationCountry;
+    }
+
+    @Override
+    public Date getExpirationDate() {
+        return expirationDate;
+    }
+
+    @Override
+    public void setExpirationDate(Date expirationDate) {
+        this.expirationDate = expirationDate;
     }
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDAO.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDAO.java
@@ -59,6 +59,7 @@ public class AccountDAO {
 
         AccountImpl accountImpl = new AccountImpl(accountCreator.getScopeId(), accountCreator.getName());
         accountImpl.setOrganization(organizationImpl);
+        accountImpl.setExpirationDate(accountCreator.getExpirationDate());
 
         return ServiceDAO.create(em, accountImpl);
     }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
@@ -29,7 +29,10 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -72,6 +75,10 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
     @JoinColumn(name = "scope_id", referencedColumnName = "id", insertable = false, updatable = false)
     @OrderBy("name ASC")
     private List<AccountImpl> childAccounts;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "expiration_date")
+    protected Date expirationDate;
 
     /**
      * Constructor
@@ -127,5 +134,16 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
         list.addAll(childAccounts);
         return list;
     }
+
+    @Override
+    public Date getExpirationDate() {
+        return expirationDate;
+    }
+
+    @Override
+    public void setExpirationDate(Date expirationDate) {
+        this.expirationDate = expirationDate;
+    }
+
 
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -173,7 +173,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
             // if parent account never expires no check is needed
             if (account.getExpirationDate() == null || parentAccount.getExpirationDate().before(account.getExpirationDate())) {
                 // if current account expiration date is null it will be obviously after parent expiration date
-                throw new KapuaIllegalArgumentException("expirationDate", account.getExpirationDate().toString() != null ? account.getExpirationDate().toString() : "no expiration date set");
+                throw new KapuaIllegalArgumentException("expirationDate", account.getExpirationDate() != null ? account.getExpirationDate().toString() : "no expiration date set");
             }
         }
 
@@ -185,7 +185,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
                 // if child account expiration date is null it will be obviously after current account expiration date
                 return childAccount.getExpirationDate() == null || childAccount.getExpirationDate().after(account.getExpirationDate());
             })) {
-                throw new KapuaIllegalArgumentException("expirationDate", account.getExpirationDate().toString() != null ? account.getExpirationDate().toString() : "no expiration date set");
+                throw new KapuaIllegalArgumentException("expirationDate", account.getExpirationDate() != null ? account.getExpirationDate().toString() : "no expiration date set");
             }
         }
 

--- a/service/account/internal/src/main/resources/liquibase/1.0.0/account-expiration-date.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.0.0/account-expiration-date.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -15,10 +15,17 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-account-1.0.0.xml">
+        logicalFilePath="KapuaDB/changelog-expiration-date-1.0.0.xml">
 
-    <include relativeToChangelogFile="true" file="./account-sys-housekeeper-run-seed.xml"/>
-    <include relativeToChangelogFile="true" file="./account-domain.xml"/>
-    <include relativeToChangelogFile="true" file="./account-expiration-date.xml"/>
+    <changeSet id="changelog-account-expiration-date-1.0.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <tableExists tableName="act_account" />
+        </preConditions>
+
+        <addColumn tableName="act_account">
+            <column name="expiration_date" type="timestamp(3)" />
+        </addColumn>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
@@ -22,6 +22,7 @@ import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
+
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalNullArgumentException;
@@ -52,12 +53,16 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
 import org.eclipse.kapua.test.MockedLocator;
 import org.eclipse.kapua.test.steps.AbstractKapuaSteps;
+
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,11 +70,10 @@ import java.util.Properties;
 
 /**
  * Implementation of Gherkin steps used in AccountService.feature scenarios.
- *
+ * <p>
  * MockedLocator is used for Location Service. Mockito is used to mock other
  * services that the Account services dependent on. Dependent services are:
  * - Authorization Service
- *
  */
 @ScenarioScoped
 public class AccountServiceTestSteps extends AbstractKapuaSteps {
@@ -221,6 +225,22 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
         }
     }
 
+    @Given("^An existing account that expires on \"(.*)\" with the name \"(.*)\"$")
+    public void createTestAccountWithName(String expirationDateStr, String name)
+            throws Exception {
+
+        Date expirationDate = new SimpleDateFormat("yyyy-MM-dd").parse(expirationDateStr);
+        accountCreator = prepareRegularAccountCreator(rootScopeId, name);
+        accountCreator.setExpirationDate(expirationDate);
+        try {
+            primeException();
+            account = accountService.create(accountCreator);
+            accountId = account.getId();
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
+    }
+
     @Given("^I create (\\d+) childs for account with Id (\\d+)$")
     public void createANumberOfAccounts(int num, int parentId)
             throws Exception {
@@ -253,6 +273,26 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
             }
         }
     }
+
+    @Given("^I create (\\d+) childs for account with expiration date \"(.*)\" and name \"(.*)\"$")
+    public void createANumberOfChildrenForAccountWithName(int num, String expirationDateStr, String name)
+            throws Exception {
+
+        Account tmpAcc = accountService.findByName(name);
+        for (int i = 0; i < num; i++) {
+            Date expirationDate = new SimpleDateFormat("yyyy-MM-dd").parse(expirationDateStr);
+            accountCreator = prepareRegularAccountCreator(tmpAcc.getId(), "tmp_acc_" + String.format("%d", i));
+            accountCreator.setExpirationDate(expirationDate);
+            try {
+                primeException();
+                accountService.create(accountCreator);
+            } catch (KapuaException ex) {
+                verifyException(ex);
+                break;
+            }
+        }
+    }
+
 
     @Given("^I create (\\d+) accounts with organization name \"(.*)\"$")
     public void createANumberOfChildrenForAccountWithOrganizationName(int num, String name)
@@ -340,6 +380,26 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
         Account tmpAcc = accountService.findByName(accName);
         tmpAcc.setName(name);
 
+        try {
+            primeException();
+            accountService.update(tmpAcc);
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
+    }
+
+    @When("^I change the expiration date of the account \"(.*)\" to \"(.*)\"$")
+    public void changeAccountExpirationDate(String accName, String expirationDateStr)
+            throws Exception {
+
+        Account tmpAcc = accountService.findByName(accName);
+        Date expirationDate;
+        if (expirationDateStr.equals("never")) {
+            expirationDate = null;
+        } else {
+            expirationDate = new SimpleDateFormat("yyyy-DD-mm").parse(expirationDateStr);
+        }
+        tmpAcc.setExpirationDate(expirationDate);
         try {
             primeException();
             accountService.update(tmpAcc);
@@ -456,14 +516,14 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
         Map<String, Object> valueMap = new HashMap<>();
 
         switch (type) {
-        case "integer":
-            valueMap.put(name, Integer.valueOf(value));
-            break;
-        case "string":
-            valueMap.put(name, value);
-            break;
-        default:
-            break;
+            case "integer":
+                valueMap.put(name, Integer.valueOf(value));
+                break;
+            case "string":
+                valueMap.put(name, value);
+                break;
+            default:
+                break;
         }
         valueMap.put("infiniteChildEntities", true);
 
@@ -489,6 +549,14 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
         AccountQuery query = new AccountQueryImpl(rootScopeId);
         KapuaListResult<Account> accList = accountService.query(query);
         intVal = accList.getSize();
+    }
+
+    @When("^I set the expiration date to (.*)$")
+    public void setExpirationDate(String expirationDateStr)
+            throws KapuaException, ParseException {
+        Date expirationDate = new SimpleDateFormat("yyyy-MM-dd").parse(expirationDateStr);
+        account.setExpirationDate(expirationDate);
+        account = accountService.update(account);
     }
 
     @Then("^The account matches the creator settings$")
@@ -630,10 +698,8 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     /**
      * Create a user creator object. The creator is pre-filled with default data.
      *
-     * @param parentId
-     *            Id of the parent account
-     * @param name
-     *            The name of the account
+     * @param parentId Id of the parent account
+     * @param name     The name of the account
      * @return The newly created account creator object.
      */
     private AccountCreator prepareRegularAccountCreator(KapuaId parentId, String name) {

--- a/service/account/internal/src/test/resources/features/AccountService.feature
+++ b/service/account/internal/src/test/resources/features/AccountService.feature
@@ -207,3 +207,30 @@ Scenario: Account name must not be mutable
     When I change the account "test_acc" name to "test_acc_new"
     Then An exception is caught
     And Account "test_acc" exists
+
+Scenario: Account expiration date test - Parent expiration set, child expiration null
+    Given An existing account with the name "exp-acc"
+    And I set the expiration date to 2018-07-11
+    And I configure "integer" item "maxNumberChildEntities" to "5"
+    And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument"
+    When I create 1 childs for account with name "exp-acc"
+
+Scenario: Account expiration date test - Parent expiration set, child expiration before father expiration
+    Given An existing account that expires on "2018-07-11" with the name "exp-acc"
+    And I configure "integer" item "maxNumberChildEntities" to "5"
+    When I create 1 childs for account with expiration date "2018-07-10" and name "exp-acc"
+    Then Account "exp-acc" has 1 children
+
+Scenario: Account expiration date test - Parent expiration set, child expiration after father expiration
+    Given An existing account that expires on "2018-07-11" with the name "exp-acc"
+    And I configure "integer" item "maxNumberChildEntities" to "5"
+    And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument"
+    When I create 1 childs for account with expiration date "2018-07-12" and name "exp-acc"
+    And Account "exp-acc" has 0 children
+
+Scenario: Account expiration date test - Parent and child expiration set, then parent expiration date changed to before child expiration date
+    Given An existing account that expires on "2018-07-11" with the name "exp-acc"
+    And I configure "integer" item "maxNumberChildEntities" to "5"
+    And I create 1 childs for account with expiration date "2018-07-10" and name "exp-acc"
+    And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument"
+    When I change the expiration date of the account "exp-acc" to "2018-07-09"

--- a/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/SimpleRegistrationProcessor.java
+++ b/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/SimpleRegistrationProcessor.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.security.registration.RegistrationProcessor;
+import org.eclipse.kapua.security.registration.simple.setting.SimpleSetting;
 import org.eclipse.kapua.security.registration.simple.setting.SimpleSettingKeys;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountCreator;
@@ -52,6 +53,9 @@ import org.jose4j.jwt.consumer.JwtContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -212,6 +216,7 @@ public class SimpleRegistrationProcessor implements RegistrationProcessor {
         AccountCreator accountCreator = accountFactory.newCreator(settings.getRootAccount(), name);
         accountCreator.setOrganizationEmail(email);
         accountCreator.setOrganizationName(name);
+        accountCreator.setExpirationDate(Date.from(Instant.now().plus(SimpleSetting.getInstance().getInt(SimpleSettingKeys.ACCOUNT_EXPIRATION_DATE_DAYS, 30), ChronoUnit.DAYS)));
 
         // create account
 

--- a/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/setting/SimpleSettingKeys.java
+++ b/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/setting/SimpleSettingKeys.java
@@ -18,7 +18,8 @@ import org.eclipse.kapua.commons.setting.SettingKey;
  */
 public enum SimpleSettingKeys implements SettingKey {
     SIMPLE_ROOT_ACCOUNT("auto.registration.simple.rootAccount"), //
-    SIMPLE_MAX_NUMBER_OF_CHILD_USERS("auto.registration.simple.maximumNumberOfChildUsers");
+    SIMPLE_MAX_NUMBER_OF_CHILD_USERS("auto.registration.simple.maximumNumberOfChildUsers"),
+    ACCOUNT_EXPIRATION_DATE_DAYS("auto.registration.simple.accountExpirationDate.days");
 
     private String key;
 

--- a/service/security/registration/simple/src/main/resources/kapua-security-registration-simple-setting.properties
+++ b/service/security/registration/simple/src/main/resources/kapua-security-registration-simple-setting.properties
@@ -19,3 +19,4 @@
 # Currently there are at least two required. The main user and the device user.
 #
 # auto.registration.simple.maximumNumberOfChildUsers=2
+auto.registration.simple.accountExpirationDate.days=30

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/ExpiredAccountException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/ExpiredAccountException.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.exceptions;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import org.apache.shiro.authc.DisabledAccountException;
+
+public class ExpiredAccountException extends DisabledAccountException {
+
+    public ExpiredAccountException(final Date expirationDate) {
+        super("This credential has been locked out until " + (expirationDate != null ? DateTimeFormatter.ISO_INSTANT.format(expirationDate.toInstant()) : "<null>"));
+
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
@@ -29,6 +29,7 @@ import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
 import org.eclipse.kapua.service.authentication.shiro.AccessTokenCredentialsImpl;
+import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.authentication.token.AccessTokenService;
 import org.eclipse.kapua.service.user.User;
@@ -137,6 +138,11 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         // Check existence
         if (account == null) {
             throw new UnknownAccountException();
+        }
+
+        // Check account expired
+        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
+            throw new ExpiredAccountException(account.getExpirationDate());
         }
 
         //

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
@@ -34,6 +34,7 @@ import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialService;
 import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.shiro.ApiKeyCredentialsImpl;
+import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
 import org.eclipse.kapua.service.authentication.shiro.exceptions.TemporaryLockedAccountException;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
@@ -158,6 +159,11 @@ public class ApiKeyAuthenticatingRealm extends AuthenticatingRealm {
         // Check existence
         if (account == null) {
             throw new UnknownAccountException();
+        }
+
+        // Check account expired
+        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
+            throw new ExpiredAccountException(account.getExpirationDate());
         }
 
         // Check credential disabled

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -36,6 +36,7 @@ import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
 import org.eclipse.kapua.service.authentication.credential.shiro.CredentialImpl;
 import org.eclipse.kapua.service.authentication.shiro.JwtCredentialsImpl;
+import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
 import org.eclipse.kapua.service.authentication.shiro.utils.JwtProcessors;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
@@ -149,6 +150,11 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
             throw e;
         } catch (Exception e) {
             throw new ShiroException("Error while find account!", e);
+        }
+
+        // Check account expired
+        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
+            throw new ExpiredAccountException(account.getExpirationDate());
         }
 
         // Check account existence

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
@@ -36,6 +36,7 @@ import org.eclipse.kapua.service.authentication.credential.CredentialService;
 import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
 import org.eclipse.kapua.service.authentication.shiro.UsernamePasswordCredentialsImpl;
+import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
 import org.eclipse.kapua.service.authentication.shiro.exceptions.TemporaryLockedAccountException;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
@@ -131,6 +132,11 @@ public class UserPassAuthenticatingRealm extends AuthenticatingRealm {
         // Check existence
         if (account == null) {
             throw new UnknownAccountException();
+        }
+
+        // Check account expired
+        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
+            throw new ExpiredAccountException(account.getExpirationDate());
         }
 
         //

--- a/test/src/main/java/org/eclipse/kapua/test/account/AccountCreatorMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/account/AccountCreatorMock.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.test.account;
 
+import java.util.Date;
 import java.util.Properties;
 
 import org.eclipse.kapua.KapuaException;
@@ -171,4 +172,14 @@ public class AccountCreatorMock implements AccountCreator {
 
     }
 
+    @Override
+    public Date getExpirationDate() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void setExpirationDate(Date expirationDate) {
+        // TODO Auto-generated method stub
+    }
 }

--- a/test/src/main/java/org/eclipse/kapua/test/account/AccountMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/account/AccountMock.java
@@ -162,4 +162,14 @@ public class AccountMock implements Account {
 
     }
 
+    @Override
+    public Date getExpirationDate() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public void setExpirationDate(Date expirationDate) {
+        // TODO Auto-generated method stub
+    }
 }


### PR DESCRIPTION
This PR introduces expiration date for the Account entity. When an account is expired, none of its users can login in the system. An account can have a `null` expiration date, meaning that it will never expire; also, a parent account cannot expire before any of its children (thus, an account cannot expire later than its parent).

**Related Issue**
This PR closes #1860 

**Description of the solution adopted**
A new field `expirationDate` has been added in the `Account` entity, and is checked against current date at login
