### PR TITLE
Added query-ability of Certificate.signature field

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ByteArrayParam.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ByteArrayParam.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources.model;
+
+import org.eclipse.kapua.model.xml.BinaryXmlAdapter;
+
+import javax.annotation.Nullable;
+import java.util.Base64;
+
+/**
+ * This class is used to deserialize a {@link Byte}[] {@link javax.ws.rs.QueryParam} from a {@link Base64} encoded {@link String} to a {@link Byte[]}
+ *
+ * @since 1.0.0
+ */
+public class ByteArrayParam extends BinaryXmlAdapter {
+
+    private byte[] value;
+
+    /**
+     * This converts a {@link Base64} encoded {@link String} to a {@link Byte}[]
+     *
+     * @param base64encoded The {@link Base64} encoded  {@link String} representation of the {@link Byte}[].
+     * @since 1.0.0
+     */
+    public ByteArrayParam(@Nullable String base64encoded) {
+        value = super.unmarshal(base64encoded);
+    }
+
+    /**
+     * Gets the converted {@link Byte}[]
+     *
+     * @return the converted {@link Byte}[]
+     */
+    public byte[] getValue() {
+        return value;
+    }
+}

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/BinaryXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/BinaryXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,9 @@ import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
@@ -30,25 +32,7 @@ import java.util.Set;
 
 @XmlRootElement(name = "certificate")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "certificate",
-        "version",
-        "serial",
-        "algorithm",
-        "subject",
-        "issuer",
-        "notBefore",
-        "notAfter",
-        "status",
-        "signature",
-        "privateKey",
-        "ca",
-        "caId",
-        "password",
-        "certificateUsages",
-        "keyUsageSettings",
-        "forwardable"
-}, factoryClass = CertificateXmlRegistry.class, factoryMethod = "newCertificate")
+@XmlType(factoryClass = CertificateXmlRegistry.class, factoryMethod = "newCertificate")
 public interface Certificate extends KapuaNamedEntity {
 
     String TYPE = "certificate";
@@ -58,43 +42,25 @@ public interface Certificate extends KapuaNamedEntity {
         return TYPE;
     }
 
+    @XmlElement(name = "certificate")
     String getCertificate();
 
     void setCertificate(String certificate);
 
+    @XmlElement(name = "version")
     Integer getVersion();
 
     void setVersion(Integer version);
 
+    @XmlElement(name = "serial")
     String getSerial();
 
     void setSerial(String serial);
 
+    @XmlElement(name = "algorithm")
     String getAlgorithm();
 
     void setAlgorithm(String algorithm);
-
-    String getSubject();
-
-    void setSubject(String subject);
-
-    String getIssuer();
-
-    void setIssuer(String issuer);
-
-    @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    Date getNotBefore();
-
-    void setNotBefore(Date notBefore);
-
-    @XmlJavaTypeAdapter(DateXmlAdapter.class)
-    Date getNotAfter();
-
-    void setNotAfter(Date notAfter);
-
-    CertificateStatus getStatus();
-
-    void setStatus(CertificateStatus status);
 
     @XmlElement(name = "signature")
     @XmlJavaTypeAdapter(BinaryXmlAdapter.class)
@@ -102,24 +68,57 @@ public interface Certificate extends KapuaNamedEntity {
 
     void setSignature(byte[] signature);
 
+    @XmlElement(name = "subject")
+    String getSubject();
+
+    void setSubject(String subject);
+
+    @XmlElement(name = "issuer")
+    String getIssuer();
+
+    void setIssuer(String issuer);
+
+    @XmlElement(name = "notBefore")
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
+    Date getNotBefore();
+
+    void setNotBefore(Date notBefore);
+
+    @XmlElement(name = "notAfter")
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
+    Date getNotAfter();
+
+    void setNotAfter(Date notAfter);
+
+    @XmlElement(name = "status")
+    CertificateStatus getStatus();
+
+    void setStatus(CertificateStatus status);
+
+    @XmlElement(name = "privateKey")
     String getPrivateKey();
 
     void setPrivateKey(String privateKey);
 
+    @XmlElement(name = "ca")
     Boolean getCa();
 
     void setCa(Boolean isCa);
 
+    @XmlElement(name = "caId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
     KapuaId getCaId();
 
     void setCaId(KapuaId caId);
 
+    @XmlTransient
     String getPassword();
 
     void setPassword(String password);
 
+    @XmlElementWrapper(name = "keyUsageSettings")
+    @XmlElement(name = "keyUsageSetting")
     <K extends KeyUsageSetting> Set<K> getKeyUsageSettings();
 
     void setKeyUsageSettings(Set<KeyUsageSetting> keyUsages);
@@ -128,6 +127,8 @@ public interface Certificate extends KapuaNamedEntity {
 
     void removeKeyUsageSetting(KeyUsageSetting keyUsage);
 
+    @XmlElementWrapper(name = "certificateUsages")
+    @XmlElement(name = "certificateUsage")
     <C extends CertificateUsage> Set<C> getCertificateUsages();
 
     void setCertificateUsages(Set<CertificateUsage> certificateUsages);
@@ -136,6 +137,7 @@ public interface Certificate extends KapuaNamedEntity {
 
     void removeCertificateUsage(CertificateUsage certificateUsage);
 
+    @XmlElement(name = "forwardable")
     Boolean getForwardable();
 
     void setForwardable(Boolean forwardable);

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,8 @@ import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -31,43 +33,43 @@ import java.util.Set;
  */
 @XmlRootElement(name = "certificateCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "certificate",
-        "status",
-        "privateKey",
-        "caId",
-        "password",
-        "certificateUsages",
-        "forwardable"
-}, factoryClass = CertificateXmlRegistry.class, factoryMethod = "newCreator")
+@XmlType(factoryClass = CertificateXmlRegistry.class, factoryMethod = "newCreator")
 public interface CertificateCreator extends KapuaNamedEntityCreator<Certificate> {
 
+    @XmlElement(name = "certificate")
     String getCertificate();
 
     void setCertificate(String certificate);
 
+    @XmlElement(name = "status")
     CertificateStatus getStatus();
 
     void setStatus(CertificateStatus status);
 
+    @XmlElement(name = "privateKey")
     String getPrivateKey();
 
     void setPrivateKey(String privateKey);
 
+    @XmlElement(name = "caId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
     KapuaId getCaId();
 
     void setCaId(KapuaId caId);
 
+    @XmlElement(name = "password")
     String getPassword();
 
     void setPassword(String password);
 
+    @XmlElementWrapper(name = "certificateUsages")
+    @XmlElement(name = "certificateUsage")
     <C extends CertificateUsage> Set<C> getCertificateUsages();
 
     void setCertificateUsages(Set<CertificateUsage> certificateUsages);
 
+    @XmlElement(name = "forwardable")
     Boolean getForwardable();
 
     void setForwardable(Boolean forwardable);

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificatePredicates.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificatePredicates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,14 +15,16 @@ import org.eclipse.kapua.model.KapuaNamedEntityPredicates;
 
 public interface CertificatePredicates extends KapuaNamedEntityPredicates {
 
-    String USAGE = "certificateUsages";
-
-    String USAGE_NAME = USAGE + ".name";
-
-    String STATUS = "status";
+    String CA_ID = "caId";
 
     String FORWARDABLE = "forwardable";
 
-    String CA_ID = "caId";
+    String SIGNATURE = "signature";
+
+    String STATUS = "status";
+
+    String USAGE = "certificateUsages";
+
+    String USAGE_NAME = USAGE + ".name";
 
 }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -197,7 +197,7 @@ public class CertificateImpl extends AbstractKapuaUpdatableEntity implements Cer
     public void setKeyUsageSettings(Set<KeyUsageSetting> keyUsageSettings) {
         this.keyUsageSettings = new HashSet<>();
 
-        keyUsageSettings.stream().forEach((k) -> this.keyUsageSettings.add(KeyUsageSettingImpl.parse(k)));
+        keyUsageSettings.forEach(k -> this.keyUsageSettings.add(KeyUsageSettingImpl.parse(k)));
     }
 
     @Override
@@ -223,7 +223,7 @@ public class CertificateImpl extends AbstractKapuaUpdatableEntity implements Cer
     public void setCertificateUsages(Set<CertificateUsage> certificateUsages) {
         this.certificateUsages = new HashSet<>();
 
-        certificateUsages.stream().forEach((k) -> this.certificateUsages.add(CertificateUsageImpl.parse(k)));
+        certificateUsages.forEach(k -> this.certificateUsages.add(CertificateUsageImpl.parse(k)));
     }
 
     @Override
@@ -238,9 +238,11 @@ public class CertificateImpl extends AbstractKapuaUpdatableEntity implements Cer
 
     @Override
     public Boolean getForwardable() {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public void setForwardable(Boolean forwardable) { }
+    public void setForwardable(Boolean forwardable) {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
Added small modification to allow to query the `signature` field of the `Certificate` entity

**Related Issue**
This PR closes #1881 

**Description of the solution adopted**
Added new `CertificatePredicate` and fixed JAXB annotations

**Screenshots**
_None_

**Any side note on the changes made**
Fixed some code style issues.