### PR TITLE
Fixed JSON serialization of generic request resource

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -15,6 +15,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
+import org.eclipse.kapua.app.api.resources.v1.resources.marker.JsonSerializationFixed;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.DateParam;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.MetricType;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
@@ -46,103 +47,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This is a JAX-RS resource that acts as a bridge for the JSON serialization of datastore objects.
- * <p>
- * The {@link org.eclipse.kapua.message.KapuaPayload} is marshalled with the following format:
- * <pre>
- * &lt;payload xsi:type=&quot;kapuaDataPayload&quot;&gt;
- *     &lt;metrics&gt;
- *         &lt;metric&gt;
- *              &lt;valueType&gt;float&lt;valueType/&gt;
- *              &lt;value&gt;5.0&lt;value/&gt;
- *              &lt;name&gt;temperatureExternal&lt;name/&gt;
- *         &lt;metric/&gt;
- *         &lt;metric&gt;
- *              &lt;valueType&gt;float&lt;valueType/&gt;
- *              &lt;value&gt;19.25&lt;value/&gt;
- *              &lt;name&gt;temperatureInternal&lt;name/&gt;
- *         &lt;metric/&gt;
- *         &lt;metric&gt;
- *              &lt;valueType&gt;float&lt;valueType/&gt;
- *              &lt;value&gt;30.00&lt;value/&gt;
- *              &lt;name&gt;temperatureExhaust&lt;name/&gt;
- *         &lt;metric/&gt;
- *         &lt;metric&gt;
- *              &lt;valueType&gt;integer&lt;valueType/&gt;
- *              &lt;value&gt;-1422687692&lt;value/&gt;
- *              &lt;name&gt;errorCode&lt;name/&gt;
- *         &lt;metric/&gt;
- *     &lt;metrics/&gt;
- *     &lt;body&gt;YXNk&lt;/body&gt;
- * &lt;/payload&gt;
- * </pre>
- * <p>
- * But the JSON has the following format:
- * <pre>
- * "payload": {
- *    "metrics": {
- *       "metric": [
- *           {
- *              "valueType" : "float",
- *              "value" : "5.0",
- *              "name" : "temperatureExternal"
- *           }, {
- *              "valueType" : "float",
- *              "value" : "19.25",
- *              "name" : "temperatureInternal"
- *           }, {
- *              "valueType" : "float",
- *              "value" : "30.0",
- *              "name" : "temperatureExhaust"
- *           }, {
- *              "valueType" : "integer",
- *              "value" : "-1422687692",
- *              "name" : "errorCode"
- *           }
- *       ]
- *    },
- *    "body": "YXNk"
- * }
- * </pre>
- * For some reasons in JSON format "metrics" is an object with "metric" array as a field.
- * <p>
- * Since we weren't able to fina JAXB mapping configuration to allow correct formatting of both XML and JSON,
- * this "bridge" class is introduced to allow a translation of the {@link org.eclipse.kapua.message.KapuaPayload}.
- * <p>
- * This resources then maps to the {@link DataMessages} class, just translating:
- * <ul>
- * <li>{@link KapuaDataMessage} to {@link JsonKapuaDataMessage}</li>
- * <li>{@link DatastoreMessage} to {@link JsonDatastoreMessage}</li>
- * </ul>
- * Final JSON output is:
- * <pre>
- * "payload": {
- *     "metrics": [
- *         {
- *             "valueType" : "float",
- *             "value" : "5.0",
- *             "name" : "temperatureExternal"
- *         }, {
- *             "valueType" : "float",
- *              "value" : "19.25",
- *              "name" : "temperatureInternal"
- *         }, {
- *              "valueType" : "float",
- *              "value" : "30.0",
- *              "name" : "temperatureExhaust"
- *         }, {
- *              "valueType" : "integer",
- *              "value" : "-1422687692",
- *              "name" : "errorCode"
- *         }
- *    ],
- *    "body": "YXNk"
- * }
- * </pre>
+ * @see JsonSerializationFixed
  */
-@Api(value = "Data Messages", authorizations = { @Authorization(value = "kapuaAccessToken") })
+@Api(value = "Data Messages", authorizations = {@Authorization(value = "kapuaAccessToken")})
 @Path("{scopeId}/data/messages")
-public class DataMessagesJson extends AbstractKapuaResource {
+public class DataMessagesJson extends AbstractKapuaResource implements JsonSerializationFixed {
 
     private static final DataMessages DATA_MESSAGES = new DataMessages();
 
@@ -162,23 +71,23 @@ public class DataMessagesJson extends AbstractKapuaResource {
      * @since 1.0.0
      */
     @ApiOperation(nickname = "dataMessageSimpleQuery",
-            value = "Gets the DatastoreMessage list in the scope", //
-            notes = "Returns the list of all the datastoreMessages associated to the current selected scope.", //
+            value = "Gets the DatastoreMessage list in the scope",
+            notes = "Returns the list of all the datastoreMessages associated to the current selected scope.",
             response = MessageListResult.class)
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
-    public <V extends Comparable<V>> JsonMessageListResult simpleQueryJson(  //
-            @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,//
-            @ApiParam(value = "The client id to filter results") @QueryParam("clientId") String clientId, //
+    @Produces({MediaType.APPLICATION_JSON})
+    public <V extends Comparable<V>> JsonMessageListResult simpleQueryJson(
+            @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The client id to filter results") @QueryParam("clientId") String clientId,
             @ApiParam(value = "The channel to filter results.") @QueryParam("channel") String channel,
             @ApiParam(value = "Restrict the search only to this channel ignoring its children. Only meaningful if channel is set.") @QueryParam("strictChannel") boolean strictChannel,
             @ApiParam(value = "The start date to filter the results. Must come before endDate parameter") @QueryParam("startDate") DateParam startDateParam,
             @ApiParam(value = "The end date to filter the results. Must come after startDate parameter") @QueryParam("endDate") DateParam endDateParam,
-            @ApiParam(value = "The metric name to filter results") @QueryParam("metricName") String metricName, //
-            @ApiParam(value = "The metric type to filter results") @QueryParam("metricType") MetricType<V> metricType, //
-            @ApiParam(value = "The min metric value to filter results") @QueryParam("metricMin") String metricMinValue, //
-            @ApiParam(value = "The max metric value to filter results") @QueryParam("metricMax") String metricMaxValue, //
-            @ApiParam(value = "The result set offset", defaultValue = "0") @QueryParam("offset") @DefaultValue("0") int offset,//
+            @ApiParam(value = "The metric name to filter results") @QueryParam("metricName") String metricName,
+            @ApiParam(value = "The metric type to filter results") @QueryParam("metricType") MetricType<V> metricType,
+            @ApiParam(value = "The min metric value to filter results") @QueryParam("metricMin") String metricMinValue,
+            @ApiParam(value = "The max metric value to filter results") @QueryParam("metricMax") String metricMaxValue,
+            @ApiParam(value = "The result set offset", defaultValue = "0") @QueryParam("offset") @DefaultValue("0") int offset,
             @ApiParam(value = "The result set limit", defaultValue = "50") @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
 
         MessageListResult result = DATA_MESSAGES.simpleQuery(
@@ -214,14 +123,14 @@ public class DataMessagesJson extends AbstractKapuaResource {
      *                   {@link KapuaService} exceptions.
      */
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON })
-    @Produces({ MediaType.APPLICATION_JSON })
+    @Consumes({MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON})
     @ApiOperation(nickname = "dataMessageStore",
-            value = "Stores a new KapuaDataMessage", //
-            notes = "Stores a new KapuaDataMessage under the account of the currently connected user. In this case, the provided message will only be stored in the back-end database and it will not be forwarded to the message broker.", //
+            value = "Stores a new KapuaDataMessage",
+            notes = "Stores a new KapuaDataMessage under the account of the currently connected user. In this case, the provided message will only be stored in the back-end database and it will not be forwarded to the message broker.",
             response = StorableId.class)
     public StorableEntityId storeMessageJson(
-            @ApiParam(value = "The ScopeId in which to store the message", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,//
+            @ApiParam(value = "The ScopeId in which to store the message", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
             @ApiParam(value = "The KapuaDataMessage to be stored") JsonKapuaDataMessage jsonKapuaDataMessage) throws Exception {
 
         KapuaDataMessage kapuaDataMessage = new KapuaDataMessageImpl();
@@ -263,14 +172,14 @@ public class DataMessagesJson extends AbstractKapuaResource {
      */
     @POST
     @Path("_query")
-    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-    @Produces({ MediaType.APPLICATION_JSON })
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON})
     @ApiOperation(nickname = "dataMessageQuery",
-            value = "Queries the DatastoreMessages", //
-            notes = "Queries the DatastoreMessages with the given DatastoreMessageQuery parameter returning all matching DatastoreMessages",  //
+            value = "Queries the DatastoreMessages",
+            notes = "Queries the DatastoreMessages with the given DatastoreMessageQuery parameter returning all matching DatastoreMessages",
             response = MessageListResult.class)
-    public JsonMessageListResult queryJson( //
-            @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId, //
+    public JsonMessageListResult queryJson(
+            @ApiParam(value = "The ScopeId in which to search results", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
             @ApiParam(value = "The DatastoreMessageQuery to use to filter results", required = true) MessageQuery query) throws Exception {
         query.setScopeId(scopeId);
 
@@ -294,12 +203,12 @@ public class DataMessagesJson extends AbstractKapuaResource {
      */
     @GET
     @Path("{datastoreMessageId}")
-    @Produces({ MediaType.APPLICATION_JSON })
+    @Produces({MediaType.APPLICATION_JSON})
     @ApiOperation(nickname = "dataMessageFind",
-            value = "Gets an DatastoreMessage", //
-            notes = "Gets the DatastoreMessage specified by the datastoreMessageId path parameter", //
+            value = "Gets an DatastoreMessage",
+            notes = "Gets the DatastoreMessage specified by the datastoreMessageId path parameter",
             response = DatastoreMessage.class)
-    public JsonDatastoreMessage findJson( //
+    public JsonDatastoreMessage findJson(
             @ApiParam(value = "The ScopeId of the requested DatastoreMessage.", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
             @ApiParam(value = "The id of the requested DatastoreMessage", required = true) @PathParam("datastoreMessageId") StorableEntityId datastoreMessageId) throws Exception {
         DatastoreMessage datastoreMessage = DATA_MESSAGES.find(scopeId, datastoreMessageId);

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequests.java
@@ -16,7 +16,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
-
 import org.eclipse.kapua.app.api.resources.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -35,7 +34,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
+@Api(value = "Devices", authorizations = {@Authorization(value = "kapuaAccessToken")})
 @Path("{scopeId}/devices/{deviceId}/requests")
 public class DeviceManagementRequests extends AbstractKapuaResource {
 
@@ -46,59 +45,17 @@ public class DeviceManagementRequests extends AbstractKapuaResource {
      * Sends a request message to a device.
      * This call is generally used to perform remote management of resources
      * attached to the device such sensors and registries.
-     * <p>
-     * <p>
-     * Example to send a request to the Kura Command application:
-     * <p>
-     * 
-     * <pre>
-     * {
-     *   "type": "genericRequestMessage",
-     *   "position": {
-     *     "type": "kapuaPosition"
-     *   },
-     *   "channel": {
-     *     "type": "genericRequestChannel",
-     *     "method": "EXECUTE",
-     *     "appName": "CMD",
-     *     "version": "V1",
-     *     "resources": ["command"]
-     *   },
-     *   "payload": {
-     *     "type": "genericRequestPayload",
-     *     "metrics": {
-     *       "metric": [
-     *         {
-     *           "valueType": "string",
-     *           "value": "ls",
-     *           "name": "command.command"
-     *         },
-     *         {
-     *           "valueType": "string",
-     *           "value": "-lisa",
-     *           "name": "command.argument0"
-     *         }
-     *       ]
-     *     }
-     *   }
-     * }
-     * </pre>
      *
-     * @param scopeId
-     *            The {@link ScopeId} of the {@link Device}.
-     * @param deviceId
-     *            The {@link Device} ID.
-     * @param timeout
-     *            The timeout of the request execution
-     * @param requestMessage
-     *            The input request
+     * @param scopeId        The {@link ScopeId} of the {@link Device}.
+     * @param deviceId       The {@link Device} ID.
+     * @param timeout        The timeout of the request execution
+     * @param requestMessage The input request
      * @return The response output.
-     * @throws Exception
-     *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
      */
     @POST
-    @Consumes({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
-    @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+    @Consumes({MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_XML})
     @ApiOperation(nickname = "deviceRequestSend", value = "Sends a request", notes = "Sends a request message to a device", response = DeviceCommandOutput.class)
     public GenericResponseMessage sendRequest(
             @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
@@ -107,6 +64,7 @@ public class DeviceManagementRequests extends AbstractKapuaResource {
             @ApiParam(value = "The input request", required = true) GenericRequestMessage requestMessage) throws Exception {
         requestMessage.setScopeId(scopeId);
         requestMessage.setDeviceId(deviceId);
+
         return requestService.exec(requestMessage, timeout);
     }
 }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequestsJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequestsJson.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
+import org.eclipse.kapua.app.api.resources.v1.resources.marker.JsonSerializationFixed;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.EntityId;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.device.management.JsonGenericRequestMessage;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.device.management.JsonGenericResponseMessage;
+import org.eclipse.kapua.model.type.ObjectValueConverter;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.device.management.command.DeviceCommandOutput;
+import org.eclipse.kapua.service.device.management.request.internal.message.request.GenericRequestMessageImpl;
+import org.eclipse.kapua.service.device.management.request.internal.message.request.GenericRequestPayloadImpl;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+import org.eclipse.kapua.service.device.registry.Device;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @see JsonSerializationFixed
+ */
+@Api(value = "Devices", authorizations = {@Authorization(value = "kapuaAccessToken")})
+@Path("{scopeId}/devices/{deviceId}/requests")
+public class DeviceManagementRequestsJson extends AbstractKapuaResource implements JsonSerializationFixed {
+
+    private static final DeviceManagementRequests DEVICE_MANAGEMENT_REQUESTS = new DeviceManagementRequests();
+
+    /**
+     * Sends a request message to a device.
+     * This call is generally used to perform remote management of resources
+     * attached to the device such sensors and registries.
+     *
+     * @param scopeId                   The {@link ScopeId} of the {@link Device}.
+     * @param deviceId                  The {@link Device} ID.
+     * @param timeout                   The timeout of the request execution
+     * @param jsonGenericRequestMessage The input request
+     * @return The response output.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     */
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON})
+    @ApiOperation(nickname = "deviceRequestSend", value = "Sends a request", notes = "Sends a request message to a device", response = DeviceCommandOutput.class)
+    public JsonGenericResponseMessage sendRequest(
+            @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
+            @ApiParam(value = "The id of the device", required = true) @PathParam("deviceId") EntityId deviceId,
+            @ApiParam(value = "The timeout of the request execution") @QueryParam("timeout") Long timeout,
+            @ApiParam(value = "The input request", required = true) JsonGenericRequestMessage jsonGenericRequestMessage) throws Exception {
+
+        GenericRequestMessage genericRequestMessage = new GenericRequestMessageImpl();
+
+        genericRequestMessage.setId(jsonGenericRequestMessage.getId());
+        genericRequestMessage.setScopeId(scopeId);
+        genericRequestMessage.setDeviceId(jsonGenericRequestMessage.getDeviceId());
+        genericRequestMessage.setClientId(jsonGenericRequestMessage.getClientId());
+        genericRequestMessage.setReceivedOn(jsonGenericRequestMessage.getReceivedOn());
+        genericRequestMessage.setSentOn(jsonGenericRequestMessage.getSentOn());
+        genericRequestMessage.setCapturedOn(jsonGenericRequestMessage.getCapturedOn());
+        genericRequestMessage.setPosition(jsonGenericRequestMessage.getPosition());
+        genericRequestMessage.setChannel(jsonGenericRequestMessage.getChannel());
+
+        GenericRequestPayload kapuaDataPayload = new GenericRequestPayloadImpl();
+        kapuaDataPayload.setBody(jsonGenericRequestMessage.getPayload().getBody());
+
+        jsonGenericRequestMessage.getPayload().getMetrics().forEach(
+                jsonMetric -> {
+                    String name = jsonMetric.getName();
+                    Object value = ObjectValueConverter.fromString(jsonMetric.getValue(), jsonMetric.getValueType());
+
+                    kapuaDataPayload.getMetrics().put(name, value);
+                });
+
+        genericRequestMessage.setPayload(kapuaDataPayload);
+
+        GenericResponseMessage genericResponseMessage = DEVICE_MANAGEMENT_REQUESTS.sendRequest(scopeId, deviceId, timeout, genericRequestMessage);
+
+        return new JsonGenericResponseMessage(genericResponseMessage);
+    }
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/StreamsJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/StreamsJson.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
+import org.eclipse.kapua.app.api.resources.v1.resources.marker.JsonSerializationFixed;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.data.JsonKapuaDataMessage;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
@@ -31,9 +32,12 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Api(value = "Streams", authorizations = { @Authorization(value = "kapuaAccessToken") })
+/**
+ * @see JsonSerializationFixed
+ */
+@Api(value = "Streams", authorizations = {@Authorization(value = "kapuaAccessToken")})
 @Path("{scopeId}/streams")
-public class StreamsJson extends AbstractKapuaResource {
+public class StreamsJson extends AbstractKapuaResource implements JsonSerializationFixed {
 
     private static final Streams STREAMS = new Streams();
 
@@ -86,7 +90,7 @@ public class StreamsJson extends AbstractKapuaResource {
      */
     @POST
     @Path("messages")
-    @Consumes({ MediaType.APPLICATION_JSON })
+    @Consumes({MediaType.APPLICATION_JSON})
     @ApiOperation(nickname = "streamPublish", value = "Publishes a fire-and-forget message", notes = "Publishes a fire-and-forget message to a topic composed of [account-name] / [client-id] / [semtantic-parts]")
     public Response publish(
             @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/marker/JsonSerializationFixed.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/marker/JsonSerializationFixed.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources.marker;
+
+import org.eclipse.kapua.app.api.resources.v1.resources.DataMessages;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.data.JsonDatastoreMessage;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.data.JsonKapuaDataMessage;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.device.management.JsonGenericRequestMessage;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.device.management.JsonGenericResponseMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+
+/**
+ * This is a marker interface to mark JAX-RS resources which do not map to any actual Kapua resource but they wrap existing resources.
+ * <p>
+ * Any JAX-RS resource marked with this {@code interface} that acts as a bridge for the JSON serialization of generic request objects.
+ * <p>
+ * The {@link org.eclipse.kapua.message.KapuaPayload} is marshalled with the following format:
+ * <pre>
+ * &lt;payload xsi:type=&quot;kapuaDataPayload&quot;&gt;
+ *     &lt;metrics&gt;
+ *         &lt;metric&gt;
+ *              &lt;valueType&gt;float&lt;valueType/&gt;
+ *              &lt;value&gt;5.0&lt;value/&gt;
+ *              &lt;name&gt;temperatureExternal&lt;name/&gt;
+ *         &lt;metric/&gt;
+ *         &lt;metric&gt;
+ *              &lt;valueType&gt;float&lt;valueType/&gt;
+ *              &lt;value&gt;19.25&lt;value/&gt;
+ *              &lt;name&gt;temperatureInternal&lt;name/&gt;
+ *         &lt;metric/&gt;
+ *         &lt;metric&gt;
+ *              &lt;valueType&gt;float&lt;valueType/&gt;
+ *              &lt;value&gt;30.00&lt;value/&gt;
+ *              &lt;name&gt;temperatureExhaust&lt;name/&gt;
+ *         &lt;metric/&gt;
+ *         &lt;metric&gt;
+ *              &lt;valueType&gt;integer&lt;valueType/&gt;
+ *              &lt;value&gt;-1422687692&lt;value/&gt;
+ *              &lt;name&gt;errorCode&lt;name/&gt;
+ *         &lt;metric/&gt;
+ *     &lt;metrics/&gt;
+ *     &lt;body&gt;YXNk&lt;/body&gt;
+ * &lt;/payload&gt;
+ * </pre>
+ * <p>
+ * But the JSON has the following format:
+ * <pre>
+ * "payload": {
+ *    "metrics": {
+ *       "metric": [
+ *           {
+ *              "valueType" : "float",
+ *              "value" : "5.0",
+ *              "name" : "temperatureExternal"
+ *           }, {
+ *              "valueType" : "float",
+ *              "value" : "19.25",
+ *              "name" : "temperatureInternal"
+ *           }, {
+ *              "valueType" : "float",
+ *              "value" : "30.0",
+ *              "name" : "temperatureExhaust"
+ *           }, {
+ *              "valueType" : "integer",
+ *              "value" : "-1422687692",
+ *              "name" : "errorCode"
+ *           }
+ *       ]
+ *    },
+ *    "body": "YXNk"
+ * }
+ * </pre>
+ * For some reasons in JSON format "metrics" is an object with "metric" array as a field.
+ * <p>
+ * Since we weren't able to fina JAXB mapping configuration to allow correct formatting of both XML and JSON,
+ * this "bridge" class is introduced to allow a translation of the {@link org.eclipse.kapua.message.KapuaPayload}.
+ * <p>
+ * This resources then maps to the {@link DataMessages} class, just translating:
+ * <ul>
+ * <li>{@link KapuaDataMessage} to {@link JsonKapuaDataMessage}</li>
+ * <li>{@link DatastoreMessage} to {@link JsonDatastoreMessage}</li>
+ * <li>{@link GenericRequestMessage} to {@link JsonGenericRequestMessage}</li>
+ * <li>{@link GenericResponseMessage} to {@link JsonGenericResponseMessage}</li>
+ * </ul>
+ * Final JSON output is:
+ * <pre>
+ * "payload": {
+ *     "metrics": [
+ *         {
+ *             "valueType" : "float",
+ *             "value" : "5.0",
+ *             "name" : "temperatureExternal"
+ *         }, {
+ *             "valueType" : "float",
+ *              "value" : "19.25",
+ *              "name" : "temperatureInternal"
+ *         }, {
+ *              "valueType" : "float",
+ *              "value" : "30.0",
+ *              "name" : "temperatureExhaust"
+ *         }, {
+ *              "valueType" : "integer",
+ *              "value" : "-1422687692",
+ *              "name" : "errorCode"
+ *         }
+ *    ],
+ *    "body": "YXNk"
+ * }
+ * </pre>
+ */
+public interface JsonSerializationFixed {
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/device/management/JsonGenericRequestMessage.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/device/management/JsonGenericRequestMessage.java
@@ -9,16 +9,16 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.api.resources.v1.resources.model.data;
+package org.eclipse.kapua.app.api.resources.v1.resources.model.device.management;
 
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.message.JsonKapuaPayload;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
-import org.eclipse.kapua.message.device.data.KapuaDataChannel;
-import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlTransient;
@@ -26,7 +26,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 import java.util.UUID;
 
-public class JsonKapuaDataMessage {
+public class JsonGenericRequestMessage {
 
     private UUID id;
 
@@ -39,26 +39,26 @@ public class JsonKapuaDataMessage {
     private Date capturedOn;
 
     private KapuaPosition position;
-    private KapuaDataChannel channel;
+    private GenericRequestChannel channel;
     private JsonKapuaPayload payload;
 
-    public JsonKapuaDataMessage() {
+    public JsonGenericRequestMessage() {
     }
 
-    public JsonKapuaDataMessage(KapuaDataMessage kapuaDataMessage) {
-        setId(kapuaDataMessage.getId());
+    public JsonGenericRequestMessage(GenericRequestMessage genericRequestMessage) {
+        setId(genericRequestMessage.getId());
 
-        setScopeId(kapuaDataMessage.getScopeId());
-        setDeviceId(kapuaDataMessage.getDeviceId());
-        setClientId(kapuaDataMessage.getClientId());
+        setScopeId(genericRequestMessage.getScopeId());
+        setDeviceId(genericRequestMessage.getDeviceId());
+        setClientId(genericRequestMessage.getClientId());
 
-        setReceivedOn(kapuaDataMessage.getReceivedOn());
-        setSentOn(kapuaDataMessage.getSentOn());
-        setCapturedOn(kapuaDataMessage.getCapturedOn());
+        setReceivedOn(genericRequestMessage.getReceivedOn());
+        setSentOn(genericRequestMessage.getSentOn());
+        setCapturedOn(genericRequestMessage.getCapturedOn());
 
-        setPosition(kapuaDataMessage.getPosition());
-        setChannel(kapuaDataMessage.getChannel());
-        setPayload(kapuaDataMessage.getPayload());
+        setPosition(genericRequestMessage.getPosition());
+        setChannel(genericRequestMessage.getChannel());
+        setPayload(genericRequestMessage.getPayload());
     }
 
     @XmlElement(name = "id")
@@ -138,11 +138,11 @@ public class JsonKapuaDataMessage {
     }
 
     @XmlElement(name = "channel")
-    public KapuaDataChannel getChannel() {
+    public GenericRequestChannel getChannel() {
         return channel;
     }
 
-    public void setChannel(KapuaDataChannel channel) {
+    public void setChannel(GenericRequestChannel channel) {
         this.channel = channel;
     }
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/device/management/JsonGenericResponseMessage.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/device/management/JsonGenericResponseMessage.java
@@ -9,16 +9,16 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.api.resources.v1.resources.model.data;
+package org.eclipse.kapua.app.api.resources.v1.resources.model.device.management;
 
 import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.message.JsonKapuaPayload;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
-import org.eclipse.kapua.message.device.data.KapuaDataChannel;
-import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlTransient;
@@ -26,7 +26,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 import java.util.UUID;
 
-public class JsonKapuaDataMessage {
+public class JsonGenericResponseMessage {
 
     private UUID id;
 
@@ -39,26 +39,26 @@ public class JsonKapuaDataMessage {
     private Date capturedOn;
 
     private KapuaPosition position;
-    private KapuaDataChannel channel;
+    private GenericResponseChannel channel;
     private JsonKapuaPayload payload;
 
-    public JsonKapuaDataMessage() {
+    public JsonGenericResponseMessage() {
     }
 
-    public JsonKapuaDataMessage(KapuaDataMessage kapuaDataMessage) {
-        setId(kapuaDataMessage.getId());
+    public JsonGenericResponseMessage(GenericResponseMessage genericResponseMessage) {
+        setId(genericResponseMessage.getId());
 
-        setScopeId(kapuaDataMessage.getScopeId());
-        setDeviceId(kapuaDataMessage.getDeviceId());
-        setClientId(kapuaDataMessage.getClientId());
+        setScopeId(genericResponseMessage.getScopeId());
+        setDeviceId(genericResponseMessage.getDeviceId());
+        setClientId(genericResponseMessage.getClientId());
 
-        setReceivedOn(kapuaDataMessage.getReceivedOn());
-        setSentOn(kapuaDataMessage.getSentOn());
-        setCapturedOn(kapuaDataMessage.getCapturedOn());
+        setReceivedOn(genericResponseMessage.getReceivedOn());
+        setSentOn(genericResponseMessage.getSentOn());
+        setCapturedOn(genericResponseMessage.getCapturedOn());
 
-        setPosition(kapuaDataMessage.getPosition());
-        setChannel(kapuaDataMessage.getChannel());
-        setPayload(kapuaDataMessage.getPayload());
+        setPosition(genericResponseMessage.getPosition());
+        setChannel(genericResponseMessage.getChannel());
+        setPayload(genericResponseMessage.getPayload());
     }
 
     @XmlElement(name = "id")
@@ -138,11 +138,11 @@ public class JsonKapuaDataMessage {
     }
 
     @XmlElement(name = "channel")
-    public KapuaDataChannel getChannel() {
+    public GenericResponseChannel getChannel() {
         return channel;
     }
 
-    public void setChannel(KapuaDataChannel channel) {
+    public void setChannel(GenericResponseChannel channel) {
         this.channel = channel;
     }
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
@@ -9,7 +9,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.api.resources.v1.resources.model.data;
+package org.eclipse.kapua.app.api.resources.v1.resources.model.message;
 
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.xml.XmlAdaptedMetric;

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -19,7 +19,9 @@ import org.eclipse.kapua.app.api.core.exception.model.ThrowableInfo;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.CountResult;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.StorableEntityId;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.data.JsonDatastoreMessage;
-import org.eclipse.kapua.app.api.resources.v1.resources.model.data.JsonKapuaPayload;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.device.management.JsonGenericRequestMessage;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.device.management.JsonGenericResponseMessage;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.message.JsonKapuaPayload;
 import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecordCreator;
 import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecordListResult;
 import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecordQuery;
@@ -194,7 +196,7 @@ import java.util.Map;
  * @since 1.0.0
  */
 @Provider
-@Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+@Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
 public class JaxbContextResolver implements ContextResolver<JAXBContext> {
 
     private JAXBContext jaxbContext;
@@ -204,7 +206,7 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
             Map<String, Object> properties = new HashMap<>(1);
             properties.put(MarshallerProperties.JSON_WRAPPER_AS_ARRAY_NAME, true);
 
-            jaxbContext = JAXBContextFactory.createContext(new Class[] {
+            jaxbContext = JAXBContextFactory.createContext(new Class[]{
 
                     // REST API utility models
                     CountResult.class,
@@ -252,6 +254,9 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
 
                     // Data Messages
                     KapuaDataMessage.class,
+                    KapuaDataChannel.class,
+                    KapuaDataPayload.class,
+
                     MessageListResult.class,
                     MessageQuery.class,
                     MessageXmlRegistry.class,
@@ -334,6 +339,8 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     KapuaResponseChannel.class,
                     KapuaRequestPayload.class,
                     RequestMessageXmlRegistry.class,
+
+                    // Device Generic Request
                     GenericRequestChannel.class,
                     GenericRequestPayload.class,
                     GenericRequestMessage.class,
@@ -341,10 +348,11 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     GenericResponsePayload.class,
                     GenericResponseMessage.class,
                     GenericRequestXmlRegistry.class,
-                    KapuaDataChannel.class,
-                    KapuaDataPayload.class,
-                    KapuaDataMessage.class,
 
+                    JsonGenericRequestMessage.class,
+                    JsonGenericResponseMessage.class,
+
+                    // Authentication
                     AuthenticationCredentials.class,
                     AuthenticationXmlRegistry.class,
                     AccessToken.class,

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/app/request/KuraRequestChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/app/request/KuraRequestChannel.java
@@ -66,6 +66,10 @@ public class KuraRequestChannel extends KuraAppChannel implements DeviceRequestC
 
     @Override
     public String[] getResources() {
+        if (resources == null) {
+            resources = new String[0];
+        }
+
         return resources;
     }
 

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestChannel.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestChannel.java
@@ -14,9 +14,11 @@ package org.eclipse.kapua.service.device.management.request.message.request;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestChannel;
 import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlType;
 
-@XmlType(propOrder = { "resources" }, factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newRequestChannel")
+@XmlType(factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newRequestChannel")
 public interface GenericRequestChannel extends KapuaRequestChannel {
 
     /**
@@ -24,6 +26,8 @@ public interface GenericRequestChannel extends KapuaRequestChannel {
      *
      * @return resources
      */
+    @XmlElementWrapper(name = "resources")
+    @XmlElement(name = "resource")
     String[] getResources();
 
     /**

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestMessage.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestMessage.java
@@ -14,8 +14,10 @@ package org.eclipse.kapua.service.device.management.request.message.request;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessage;
 import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
 
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+@XmlRootElement(name = "genericRequestMessage")
 @XmlType(factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newRequestMessage")
 public interface GenericRequestMessage extends KapuaRequestMessage<GenericRequestChannel, GenericRequestPayload> {
 

--- a/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseMessage.java
+++ b/service/device/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseMessage.java
@@ -14,8 +14,10 @@ package org.eclipse.kapua.service.device.management.request.message.response;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.management.request.GenericRequestXmlRegistry;
 
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+@XmlRootElement(name = "genericResponseMessage")
 @XmlType(factoryClass = GenericRequestXmlRegistry.class, factoryMethod = "newResponseMessage")
 public interface GenericResponseMessage extends KapuaResponseMessage<GenericResponseChannel, GenericResponsePayload> {
 


### PR DESCRIPTION
Fixed the serialization model of GenericRequestMessage and GenericResponseMessage on REST API like we did for DataMessages and Streams publish resources. 

**Related Issue**
This PR fixes #1883 

**Description of the solution adopted**
Same strategy adopted in #1790 

**Screenshots**
_None_

**Any side note on the changes made**
_None_