### PR TITLE
Fix for "BAD REQUEST" error when updating assets

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
@@ -133,9 +133,6 @@ public class DeviceAssetsPanel extends LayoutContainer {
 
     private String getUpdatedChannel(GwtDeviceAssetChannel channel, Field<?> field) {
         try {
-            if (!field.isDirty()) {
-                return null;
-            }
             switch (channel.getTypeEnum()) {
             case BOOLEAN:
                 RadioGroup radioGroup = (RadioGroup) field;


### PR DESCRIPTION
Brief description of the PR.
Fix for "BAD REQUEST" error when updating assets

**Related Issue**
This PR fixes/closes #1797 

**Description of the solution adopted**
Removed the unnecessary _if block_ that set the updatedChannel value to null, causing the _BAD REQUEST_ error. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>