### PR TITLE
Login button disabled after reset

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -281,10 +281,10 @@ public class LoginDialog extends Dialog {
         username.reset();
         password.reset();
 
-        validate();
         username.focus();
         status.hide();
         getButtonBar().enable();
+        login.disable();
     }
 
 }


### PR DESCRIPTION
Brief description of the PR.
Login button disabled in `reset()` method of the _LoginDialog_.

**Related Issue**
This PR fixes/closes #1893 

**Description of the solution adopted**
_None_ 

**Screenshots**
_None_

**Any side note on the changes made**
Removed unnecessary call to the `validate()` function from inside of the `reset()` function in the _LoginDialog_ . 

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>
