### PR TITLE
fix sorting fields in Jobs and Devices

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
@@ -144,11 +144,6 @@ public class GwtKapuaDeviceModelConverter {
         if (loadConfig != null) {
             deviceQuery.setLimit(loadConfig.getLimit());
             deviceQuery.setOffset(loadConfig.getOffset());
-
-            String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? DevicePredicates.CLIENT_ID : loadConfig.getSortField();
-            SortOrder sortOrder = loadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
-            FieldSortCriteria sortCriteria = new FieldSortCriteria(sortField, sortOrder);
-            deviceQuery.setSortCriteria(sortCriteria);
         }
 
         GwtDeviceQueryPredicates predicates = gwtDeviceQuery.getPredicates();
@@ -201,13 +196,13 @@ public class GwtKapuaDeviceModelConverter {
         if(predicates.getTagId() != null) {
             andPred = andPred.and(new AttributePredicateImpl<KapuaId[]>(DevicePredicates.TAG_IDS, new KapuaId[] { GwtKapuaCommonsModelConverter.convertKapuaId(predicates.getTagId()) }));
         }
-
         if (predicates.getSortAttribute() != null) {
-            SortOrder sortOrder = SortOrder.ASCENDING;
-            if (predicates.getSortOrder().equals(SortOrder.DESCENDING.name())) {
-                sortOrder = SortOrder.DESCENDING;
+            String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? DevicePredicates.CLIENT_ID : loadConfig.getSortField();
+            SortOrder sortOrder = loadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
+            if (sortField.equals("lastEventOnFormatted")) {
+                sortField = DevicePredicates.LAST_EVENT_ON;
             }
-
+            deviceQuery.setSortCriteria(new FieldSortCriteria(sortField, sortOrder));
         } else {
             deviceQuery.setSortCriteria(new FieldSortCriteria(DevicePredicates.CLIENT_ID, SortOrder.ASCENDING));
         }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -279,11 +279,15 @@ public class GwtKapuaJobModelConverter {
     public static JobExecutionQuery convertJobExecutionQuery(PagingLoadConfig pagingLoadConfig, GwtExecutionQuery gwtExecutionQuery) {
         JobExecutionQuery query = JOB_EXECUTION_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtExecutionQuery.getScopeId()));
         query.setPredicate(new AttributePredicateImpl<KapuaId>(JobExecutionPredicates.JOB_ID, GwtKapuaCommonsModelConverter.convertKapuaId(gwtExecutionQuery.getJobId())));
-
-        if (pagingLoadConfig.getSortField() != null) {
-            query.setSortCriteria(new FieldSortCriteria(pagingLoadConfig.getSortField(), pagingLoadConfig.getSortDir() == SortDir.ASC ? SortOrder.ASCENDING : SortOrder.DESCENDING));
+        String sortField = StringUtils.isEmpty(pagingLoadConfig.getSortField()) ? JobPredicates.NAME : pagingLoadConfig.getSortField();
+        if (sortField.equals("startedOnFormatted")) {
+            sortField = JobPredicates.STARTED_ON;
+        } else if (sortField.equals("endedOnFormatted")) {
+            sortField = JobPredicates.ENDED_ON;
         }
-
+        SortOrder sortOrder = pagingLoadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
+        FieldSortCriteria sortCriteria = new FieldSortCriteria(sortField, sortOrder);
+        query.setSortCriteria(sortCriteria);
         query.setLimit(pagingLoadConfig.getLimit());
         query.setOffset(pagingLoadConfig.getOffset());
 

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobPredicates.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobPredicates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,4 +15,6 @@ import org.eclipse.kapua.model.KapuaNamedEntityPredicates;
 
 public interface JobPredicates extends KapuaNamedEntityPredicates {
 
+    String ENDED_ON = "endedOn";
+    String STARTED_ON = "startedOn";
 }


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
User now can sort Devices by Last Event and Jobs  by Started On and Ended On

**Related Issue**
This PR fixes issue #1879 

**Description of the solution adopted**
Added new Jobs Predicates and added some if statements in GwtKapuaDeviceModelConverter and in GwtKapuaJobModelConverter.

**Screenshots**
/

**Any side note on the changes made**
/