### PR TITLE
Tests for variable datastore index width

### DIFF
--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/BasicSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/BasicSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2018 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -87,5 +87,10 @@ public class BasicSteps extends Assert {
     @Then("^I get the text \"(.+)\"$")
     public void checkStringResult(String text) {
         assertEquals(text, (String) stepData.get("Text"));
+    }
+
+    @Given("^System property \"(.*)\" with value \"(.*)\"$")
+    public void setSystemProperty(String key, String value) {
+        System.setProperty(key, value);
     }
 }

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -25,14 +25,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
 import java.net.URL;
 
 import org.junit.Assert;
 
 @ScenarioScoped
-public class RestClientSteps extends Assert {
+public class RestClientSteps extends BaseQATests {
 
     private static final Logger logger = LoggerFactory.getLogger(RestClientSteps.class);
 
@@ -53,7 +51,7 @@ public class RestClientSteps extends Assert {
     }
 
     @When("^REST call at \"(.*)\"")
-    public void restCallStatusOfIndex(String resource) {
+    public void restCallStatusOfIndex(String resource) throws Exception {
 
         String host = (String) stepData.get("host");
         String port = (String) stepData.get("port");
@@ -61,7 +59,7 @@ public class RestClientSteps extends Assert {
             URL url = new URL("http://" + host + ":" + port + resource);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
-            assertFalse("Wrong response.", conn.getResponseCode() != 200);
+            Assert.assertFalse("Wrong response.", conn.getResponseCode() != 200);
             BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
             String output;
             StringBuilder sb = new StringBuilder();
@@ -70,12 +68,9 @@ public class RestClientSteps extends Assert {
             }
             conn.disconnect();
             stepData.put("restResponse", sb.toString());
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        } catch (ProtocolException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch ( IOException ioe) {
+            logger.error("Exception on REST call execution: " + resource);
+            throw ioe;
         }
     }
 
@@ -83,7 +78,7 @@ public class RestClientSteps extends Assert {
     public void restResponseContaining(String checkStr) {
 
         String restResponse = (String) stepData.get("restResponse");
-        assertTrue(String.format("Response %s doesn't include %s.", restResponse, checkStr),
+        Assert.assertTrue(String.format("Response %s doesn't include %s.", restResponse, checkStr),
                 restResponse.contains(checkStr));
     }
 
@@ -92,7 +87,7 @@ public class RestClientSteps extends Assert {
 
         String restResponse = (String) stepData.get("restResponse");
         Account account = (Account) stepData.get(var);
-        assertTrue(String.format("Response %s doesn't include %s.", restResponse, account.getId() + checkStr),
+        Assert.assertTrue(String.format("Response %s doesn't include %s.", restResponse, account.getId() + checkStr),
                 restResponse.contains(account.getId() + checkStr));
     }
 

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -51,13 +51,13 @@ public class RestClientSteps extends Assert {
         stepData.put("port", port);
     }
 
-    @When("^REST call at \"(.*)\" and \"(.*)\"")
-    public void restCallStatusOfIndex(String resource, String resourceApndx) {
+    @When("^REST call at \"(.*)\"")
+    public void restCallStatusOfIndex(String resource) {
 
         String host = (String) stepData.get("host");
         String port = (String) stepData.get("port");
         try {
-            URL url = new URL("http://" + host + ":" + port + resource + resourceApndx);
+            URL url = new URL("http://" + host + ":" + port + resource);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             assertFalse("Wrong response.", conn.getResponseCode() != 200);

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.qa.steps;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.eclipse.kapua.service.StepData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+
+import org.junit.Assert;
+
+@ScenarioScoped
+public class RestClientSteps extends Assert {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestClientSteps.class);
+
+    /**
+     * Scenario scoped step data.
+     */
+    private StepData stepData;
+
+    @Inject
+    public RestClientSteps(StepData stepData) {
+        this.stepData = stepData;
+    }
+
+    @Given("^Server with host \"(.+)\" on port \"(.+)\"$")
+    public void setHostPort(String host, String port) {
+        stepData.put("host", host);
+        stepData.put("port", port);
+    }
+
+    @When("^REST call at \"(.*)\" and \"(.*)\"")
+    public void restCallStatusOfIndex(String resource, String resourceApndx) {
+
+        String host = (String) stepData.get("host");
+        String port = (String) stepData.get("port");
+        try {
+            URL url = new URL("http://" + host + ":" + port + resource + resourceApndx);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            assertFalse("Wrong response.", conn.getResponseCode() != 200);
+            BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
+            String output;
+            StringBuilder sb = new StringBuilder();
+            while ((output = br.readLine()) != null) {
+                sb.append(output);
+            }
+            conn.disconnect();
+            stepData.put("restResponse", sb.toString());
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        } catch (ProtocolException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Then("^REST response containing \"(.*)\"")
+    public void restResponseStatusOfIndex(String checkStr) {
+
+        String restResponse = (String) stepData.get("restResponse");
+        assertTrue(String.format("Response %s doesn't include %s.", restResponse, checkStr),
+                restResponse.contains(checkStr));
+    }
+}

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -16,6 +16,7 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
 import org.eclipse.kapua.service.StepData;
+import org.eclipse.kapua.service.account.Account;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,11 +79,21 @@ public class RestClientSteps extends Assert {
         }
     }
 
-    @Then("^REST response containing \"(.*)\"")
-    public void restResponseStatusOfIndex(String checkStr) {
+    @Then("^REST response containing text \"(.*)\"$")
+    public void restResponseContaining(String checkStr) {
 
         String restResponse = (String) stepData.get("restResponse");
         assertTrue(String.format("Response %s doesn't include %s.", restResponse, checkStr),
                 restResponse.contains(checkStr));
     }
+
+    @Then("^REST response containing \"(.*)\" with prefix account \"(.*)\"")
+    public void restResponseContainingPrefixVar(String checkStr, String var) {
+
+        String restResponse = (String) stepData.get("restResponse");
+        Account account = (Account) stepData.get(var);
+        assertTrue(String.format("Response %s doesn't include %s.", restResponse, account.getId() + checkStr),
+                restResponse.contains(account.getId() + checkStr));
+    }
+
 }

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -52,6 +52,7 @@ import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.ClientInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreChannel;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfiguration;
 import org.eclipse.kapua.service.datastore.internal.mediator.MetricInfoField;
 import org.eclipse.kapua.service.datastore.internal.model.DataIndexBy;
@@ -1353,6 +1354,31 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
 
         MetricInfoListResult metLst = (MetricInfoListResult) stepData.get(lstKey);
         checkListOrder(metLst, getNamedMetricOrdering());
+    }
+
+    @Given("^Dataservice config enabled (.*), dataTTL (\\d+), rxByteLimit (\\d+), dataIndexBy \"(.*)\", indexWindow \"(.*)\"$")
+    public void configureDatastoreService(String enabled, int dataTTL, int rxByteLimit, String dataIndexBy, String indexWindow) throws Exception {
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("enabled", enabled.equalsIgnoreCase("TRUE"));
+        settings.put("dataTTL", dataTTL);
+        settings.put("rxByteLimit", rxByteLimit);
+        settings.put("dataIndexBy", dataIndexBy);
+        String indexingWindow;
+
+        switch (indexWindow) {
+        default:
+        case DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK:
+            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK;
+            break;
+        case DatastoreUtils.INDEXING_WINDOW_OPTION_DAY:
+            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_DAY;
+            break;
+        case DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR:
+            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR;
+            break;
+        }
+        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, indexingWindow);
+        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
     }
 
     // Private helper functions

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -209,6 +209,16 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
                 ((Device) stepData.get("LastDevice")).getId(),
                 ((Device) stepData.get("LastDevice")).getClientId(),
                 null, null);
+        stepData.put(msgKey, tmpMessage);
+    }
+
+    @Given("^I prepare a random message with capture date \"(.*)\" and save it as \"(.*)\"$")
+    public void prepareAndRememberARandomMessage(String captureDate, String msgKey) throws Exception {
+
+        KapuaDataMessage tmpMessage = createTestMessage(((Account) stepData.get("LastAccount")).getId(),
+                ((Device) stepData.get("LastDevice")).getId(),
+                ((Device) stepData.get("LastDevice")).getClientId(),
+                null, captureDate);
         stepData.put(msgKey, tmpMessage);
     }
 

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -165,6 +165,11 @@ public class UserServiceSteps extends BaseQATests {
     @Given("^Permissions$")
     public void givenPermissions(List<TestPermission> permissionList) throws Exception {
         createPermissions(permissionList, (ComparableUser) stepData.get("LastUser"), (Account) stepData.get("LastAccount"));
+    }
+
+    @Given("^Full permissions$")
+    public void givenFullPermissions() throws Exception {
+        createPermissions(null, (ComparableUser) stepData.get("LastUser"), (Account) stepData.get("LastAccount"));
     }
 
     @Given("^User A$")
@@ -561,15 +566,20 @@ public class UserServiceSteps extends BaseQATests {
         accessInfoCreator.setUserId(user.getUser().getId());
         accessInfoCreator.setScopeId(user.getUser().getScopeId());
         Set<Permission> permissions = new HashSet<>();
-        for (TestPermission testPermission : permissionList) {
-            Actions action = testPermission.getAction();
-            KapuaEid targetScopeId = testPermission.getTargetScopeId();
-            if (targetScopeId == null) {
-                targetScopeId = (KapuaEid) account.getId();
+        if (permissionList != null) {
+            for (TestPermission testPermission : permissionList) {
+                Actions action = testPermission.getAction();
+                KapuaEid targetScopeId = testPermission.getTargetScopeId();
+                if (targetScopeId == null) {
+                    targetScopeId = (KapuaEid) account.getId();
+                }
+                Domain domain = new UserDomain();
+                Permission permission = permissionFactory.newPermission(domain,
+                        action, targetScopeId);
+                permissions.add(permission);
             }
-            Domain domain = new UserDomain();
-            Permission permission = permissionFactory.newPermission(domain,
-                    action, targetScopeId);
+        } else {
+            Permission permission = permissionFactory.newPermission(null, null, null);
             permissions.add(permission);
         }
         accessInfoCreator.setPermissions(permissions);

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexCustomPrefixTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexCustomPrefixTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.integration;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = "classpath:features/datastore/DatastoreNewIndexCustomPrefix.feature",
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps",
+                "org.eclipse.kapua.service.datastore.steps" },
+        plugin = {"pretty",
+                "html:target/cucumber/DatastoreNewIndex",
+                "json:target/DatastoreNewIndex_cucumber.json" },
+        monochrome = true)
+@CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+@CucumberProperty(key="broker.ip", value="192.168.33.10")
+@CucumberProperty(key="kapua.config.url", value="")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="2")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="2")
+@CucumberProperty(key="datastore.index.prefix", value="custom-prefix")
+public class RunDatastoreNewIndexCustomPrefixTest {
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexCustomPrefixTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexCustomPrefixTest.java
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
 @CucumberProperty(key="broker.ip", value="192.168.33.10")
 @CucumberProperty(key="kapua.config.url", value="")
-@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="2")
-@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="2")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="5")
 @CucumberProperty(key="datastore.index.prefix", value="custom-prefix")
 public class RunDatastoreNewIndexCustomPrefixTest {
 }

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.integration;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.test.cucumber.CucumberProperty;
+import org.eclipse.kapua.test.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = "classpath:features/datastore/DatastoreNewIndex.feature",
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.steps",
+                "org.eclipse.kapua.service.datastore.steps" },
+        plugin = {"pretty",
+                "html:target/cucumber/DatastoreNewIndex",
+                "json:target/DatastoreNewIndex_cucumber.json" },
+        monochrome = true)
+@CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+@CucumberProperty(key="broker.ip", value="192.168.33.10")
+@CucumberProperty(key="kapua.config.url", value="")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="2")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="2")
+public class RunDatastoreNewIndexTest {
+}

--- a/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/service/datastore/integration/RunDatastoreNewIndexTest.java
@@ -30,7 +30,8 @@ import org.junit.runner.RunWith;
 @CucumberProperty(key="datastore.client.class", value="org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
 @CucumberProperty(key="broker.ip", value="192.168.33.10")
 @CucumberProperty(key="kapua.config.url", value="")
-@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="2")
-@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="2")
+@CucumberProperty(key="org.eclipse.kapua.qa.datastore.extraStartupDelay", value="5")
+@CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="5")
+@CucumberProperty(key="datastore.index.prefix", value="")
 public class RunDatastoreNewIndexTest {
 }

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -36,7 +36,7 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    Then REST response containing text "green open 1-2018-01"
+    Then REST response containing text "1-2018-01"
     And All indices are deleted
 
   Scenario: Simple positive scenario for creating daily index
@@ -54,7 +54,7 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01-02"
+    And REST response containing text "1-2018-01-02"
     And All indices are deleted
 
   Scenario: Simple positive scenario for creating hourly index
@@ -72,7 +72,7 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01-02-10"
+    And REST response containing text "1-2018-01-02-10"
     And All indices are deleted
 
   Scenario: Creating two indexes with weekly index
@@ -91,8 +91,8 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01"
-    And REST response containing text "green open 1-2018-02"
+    And REST response containing text "1-2018-01"
+    And REST response containing text "1-2018-02"
     And All indices are deleted
 
   Scenario: Creating two indexes with daily index
@@ -111,8 +111,8 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01-02"
-    And REST response containing text "green open 1-2018-01-03"
+    And REST response containing text "1-2018-01-02"
+    And REST response containing text "1-2018-01-03"
     And All indices are deleted
 
   Scenario: Creating two indexes with hourly index
@@ -131,8 +131,8 @@ Feature: Datastore tests
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
     When REST call at "/_cat/indices/"
-    And REST response containing text "green open 1-2018-01-02-10"
-    And REST response containing text "green open 1-2018-01-02-15"
+    And REST response containing text "1-2018-01-02-10"
+    And REST response containing text "1-2018-01-02-15"
     And All indices are deleted
 
   Scenario: Creating index with regular user

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -1,0 +1,85 @@
+###############################################################################
+# Copyright (c) 2018 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+@datastore
+Feature: Datastore tests
+
+  @StartEventBroker
+  Scenario: Start event broker for all scenarios
+
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
+  Scenario: Simple positive scenario for creating default - weekly index
+  Create elasticsearch index with default setting for index creation which is weekly
+  index creation. Index gets created when user publishes data. Index is based on
+  capture date, which is set to specific value, this value determines index name.
+
+    Given Server with host "127.0.0.1" on port "9200"
+    When All indices are deleted
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    Given The device "test-device-1"
+    When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When REST call at "/_cat/indices/"
+    Then REST response containing "green open 1-2018-01"
+    And All indices are deleted
+
+  Scenario: Simple positive scenario for creating daily index
+  Create elasticsearch index with setting for daily index creation. Index gets created when
+  user publishes data. Index is based on capture date, which is set to specific value, this
+  value determines index name.
+
+    Given Server with host "127.0.0.1" on port "9200"
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "DAY"
+    When All indices are deleted
+    And Account for "kapua-sys"
+    Given The device "test-device-1"
+    When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When REST call at "/_cat/indices/"
+    And REST response containing "green open 1-2018-01-02"
+    And All indices are deleted
+
+  Scenario: Simple positive scenario for creating hourly index
+  Create elasticsearch index with setting for hour index creation. Index gets created when
+  user publishes data. Index is based on capture date, which is set to specific value, this
+  value determines index name.
+
+    Given Server with host "127.0.0.1" on port "9200"
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "HOUR"
+    When All indices are deleted
+    And Account for "kapua-sys"
+    Given The device "test-device-1"
+    When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When REST call at "/_cat/indices/"
+    And REST response containing "green open 1-2018-01-02-10"
+    And All indices are deleted
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios
+
+  @StopEventBroker
+  Scenario: Stop event broker for all scenarios

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
@@ -1,0 +1,49 @@
+###############################################################################
+# Copyright (c) 2018 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+@datastore
+Feature: Datastore tests
+
+  @StartEventBroker
+  Scenario: Start event broker for all scenarios
+
+  @StartBroker
+  Scenario: Start broker for all scenarios
+
+  @StartDatastore
+  Scenario: Start datastore for all scenarios
+
+  Scenario: Create index with specific prefix
+  Create elasticsearch index with specific prefix set by system property.
+  Index gets created when user publishes data.
+
+    Given Server with host "127.0.0.1" on port "9200"
+    When All indices are deleted
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And Account for "kapua-sys"
+    Given The device "test-device-1"
+    When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
+    And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
+    And I refresh all database indices
+    When REST call at "/_cat/indices/" and "custom-prefix-1-2018-01"
+    Then REST response containing "green open"
+    And REST response containing "custom-prefix-1-2018-01"
+    And All indices are deleted
+
+  @StopBroker
+  Scenario: Stop broker after all scenarios
+
+  @StopDatastore
+  Scenario: Stop datastore after all scenarios
+
+  @StopEventBroker
+  Scenario: Stop event broker for all scenarios

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
@@ -34,9 +34,9 @@ Feature: Datastore tests
     When I prepare a random message with capture date "2018-01-01T10:21:32.123Z" and save it as "RandomDataMessage"
     And I store the message "RandomDataMessage" and remember its ID as "RandomDataMessageId"
     And I refresh all database indices
-    When REST call at "/_cat/indices/" and "custom-prefix-1-2018-01"
-    Then REST response containing "green open"
-    And REST response containing "custom-prefix-1-2018-01"
+    When REST call at "/_cat/indices/"
+    Then REST response containing text "green open"
+    And REST response containing text "custom-prefix-1-2018-01"
     And All indices are deleted
 
   @StopBroker


### PR DESCRIPTION
Added integration tests for variable datastore index

Tests are written in Gherkin with Cucumber.

**Related Issue**
I am not aware of issue regarding this pull request as it is only providing tests for feature branch
with PR 1845.

**Description of the solution adopted**
Implementation of integration tests in Cucumber. These tests are exercising fully functional integration environment with running services and running embedded ES instance.
Indexes are created for weekly, daily and hourly indexing. Multiple index creation is checked.
Also creation of index, as a non-kapua-sys user,  is tested.

**Screenshots**
No screenshots are applicable.

**Any side note on the changes made**
Some user service cucumber steps were changed to support adding full set of permissions to user.
Common REST service steps were added to common qa steps.
