### PR TITLE
Solved problem with adding targets in Jobs

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
@@ -215,7 +215,7 @@ public class GwtKapuaDeviceModelConverter {
         if(predicates.getTagId() != null) {
             andPred = andPred.and(new AttributePredicateImpl<KapuaId[]>(DevicePredicates.TAG_IDS, new KapuaId[] { GwtKapuaCommonsModelConverter.convertKapuaId(predicates.getTagId()) }));
         }
-        if (predicates.getSortAttribute() != null) {
+        if (predicates.getSortAttribute() != null && loadConfig != null) {
             String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? DevicePredicates.CLIENT_ID : loadConfig.getSortField();
             SortOrder sortOrder = loadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
             if (sortField.equals("lastEventOnFormatted")) {


### PR DESCRIPTION
Brief description of the PR.
Solved problem with adding targets in Jobs.

**Related Issue**
This PR fixes/closes #1902 

**Description of the solution adopted**
Added `loadConfig` null check for one of the if statements in the `convertDeviceQuery()` method of `GwtKapuaDeviceModelConverter` class.

**Screenshots**
_None_.

**Any side note on the changes made**
_None_.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>