### PR TITLE
Return a modifiable list in KapuaListResult.getItems()

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/KapuaListResultImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/KapuaListResultImpl.java
@@ -13,7 +13,6 @@ package org.eclipse.kapua.commons.model.query;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -75,7 +74,7 @@ public class KapuaListResultImpl<E extends KapuaEntity> implements KapuaListResu
 
     @Override
     public List<E> getItems() {
-        return Collections.unmodifiableList(items);
+        return items;
     }
 
     @Override


### PR DESCRIPTION
Theoretically speaking, since KapuaListResult represents the result of a query, the result set should not be modifiable after the query has been executed. However, returning an unmodifiable list causes an exception when trying to unmarshal a JSON string representing a KapuaListResult; additionally, regardless of the object returned in KapuaListResult.getItems(), the list is not unmodifiable anyway given the presence of various methods (e.g. addItems(), clearItems(), etc.) that act directly on the items property and allows for modifications on the list.

**Related Issue**
This PR fixes #1921 

**Description of the solution adopted**
`KapuaListResult.getItems()` will return an `ArrayList` instead of an `UnmodifiableList`
