### PR TITLE
Disabled buttons on Events tab while loading is in progress

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
@@ -144,14 +144,11 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
             @Override
             public void componentSelected(ButtonEvent ce) {
                 if (!refreshProcess) {
-                    refreshButton.setEnabled(false);
                     refreshProcess = true;
 
                     reload();
 
                     refreshProcess = false;
-                    refreshButton.setEnabled(true);
-                    pagingToolBar.enable();
                 }
             }
         });
@@ -346,6 +343,16 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
             }
 
             toolBar.enable();
+            pagingToolBar.enable();
+            export.enable();
+            refreshButton.enable();
+        }
+
+        @Override
+        public void loaderBeforeLoad(LoadEvent le) {
+            super.loaderBeforeLoad(le);
+            export.disable();
+            refreshButton.disable();
         }
     }
 }


### PR DESCRIPTION
Brief description of the PR.
Disabled buttons on Events tab while loading is in progress.

**Related Issue**
This PR fixes/closes #1895 

**Description of the solution adopted**
Disabled refresh, export and paging buttons on the Events tab while loading of the grid is in progress. This is done using `loaderBeforeLoad()` and `loaderLoad()` methods, where the buttons in question are disabled/enabled.  

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>
