### PR TITLE
Password and confirmPassword validation update

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -120,6 +120,7 @@ public class CredentialAddDialog extends EntityAddEditDialog {
         password.setValidator(new PasswordFieldValidator(password));
         password.setPassword(true);
         password.setVisible(false);
+        password.setAutoValidate(true);
         credentialFormPanel.add(password);
 
         confirmPassword = new TextField<String>();
@@ -129,6 +130,7 @@ public class CredentialAddDialog extends EntityAddEditDialog {
         confirmPassword.setValidator(new ConfirmPasswordFieldValidator(confirmPassword, password));
         confirmPassword.setPassword(true);
         confirmPassword.setVisible(false);
+        confirmPassword.setAutoValidate(true);
         confirmPassword.disable();
         credentialFormPanel.add(confirmPassword);
 
@@ -138,6 +140,7 @@ public class CredentialAddDialog extends EntityAddEditDialog {
             public void handleEvent(BaseEvent be) {
                 if (password.getValue() != null) {
                     confirmPassword.enable();
+                    confirmPassword.validate();
                 } else {
                     confirmPassword.disable();
                     confirmPassword.clear();


### PR DESCRIPTION
Brief description of the PR.
Password and confirmPassword validation update

**Related Issue**
This PR fixes/closes #1894 

**Description of the solution adopted**
Set `autoValidate(true)` property on password and confirmPassword fields. 
Made call to validate() method on the confirmPassword field in the keyUp listener of the password field, to trigger validation of the confirmPassword with every change made on the password field.

**Screenshots**
None

**Any side note on the changes made**
None

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>
