### PR TITLE
login disabled when User insert blank space in username or password f…

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -114,6 +114,7 @@ public class LoginDialog extends Dialog {
         username = new TextField<String>();
         username.setFieldLabel(CORE_MSGS.loginUsername());
         username.addKeyListener(keyListener);
+        username.setAllowBlank(false);
         username.addListener(Events.OnBlur, changeListener);
 
         add(username);
@@ -122,6 +123,7 @@ public class LoginDialog extends Dialog {
         password.setPassword(true);
         password.setFieldLabel(CORE_MSGS.loginPassword());
         password.addKeyListener(keyListener);
+        password.setAllowBlank(false);
         password.addListener(Events.OnBlur, changeListener);
 
         add(password);
@@ -268,7 +270,7 @@ public class LoginDialog extends Dialog {
 
     protected boolean hasValue(TextField<String> field) {
         return field.getValue() != null &&
-                !field.getValue().isEmpty();
+                !field.getValue().trim().isEmpty();
     }
 
     protected void validate() {


### PR DESCRIPTION
…ield

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added trim check in validate method

**Related Issue**
This PR fixes issue #1914 

**Description of the solution adopted**
Just added trim check in username and password fields, so when User insert blank space in username or password field, login button is disabled

**Screenshots**
/

**Any side note on the changes made**
/
