### PR TITLE
Group Permission Problem fix

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermissionDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermissionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,6 +14,8 @@ package org.eclipse.kapua.app.console.module.user.client.tabs.permission;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.AbstractEntityTabDescriptor;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.DomainSessionPermission;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.GroupSessionPermission;
 import org.eclipse.kapua.app.console.module.user.client.UserView;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
 
@@ -36,6 +38,8 @@ public class UserTabItemPermissionDescriptor extends AbstractEntityTabDescriptor
 
     @Override
     public Boolean isEnabled(GwtSession currentSession) {
-        return currentSession.hasPermission(AccessInfoSessionPermission.read());
+        return currentSession.hasPermission(AccessInfoSessionPermission.read()) 
+            && currentSession.hasPermission(DomainSessionPermission.read()) 
+            && currentSession.hasPermission(GroupSessionPermission.read());
     }
 }


### PR DESCRIPTION
Brief description of the PR.
Group Permission Problem fix

**Related Issue**
This PR fixes/closes #1910 

**Description of the solution adopted**
Updated _UserTabItemPermissionDescriptor_ class's `isEnabled()` method() with permissions needed for displaying the Permissions tab in Users.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>
