### PR TITLE
Marked status and/or expirationDate fields invalid on exception

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -21,6 +21,7 @@ import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
+import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser.GwtUserStatus;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserService;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserServiceAsync;
 
@@ -99,6 +100,12 @@ public class UserEditDialog extends UserAddDialog {
                     } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.ILLEGAL_ARGUMENT)) {
                         if (gwtCause.getArguments().length == 2 && gwtCause.getArguments()[0].equals("status") && gwtCause.getArguments()[1].equals("DISABLED")) {
                             userStatus.markInvalid(gwtCause.getMessage());
+                        }
+                    } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.OPERATION_NOT_ALLOWED_ON_ADMIN_USER)) {
+                        if (userStatus.getValue().getValue().equals(GwtUserStatus.DISABLED)) {
+                            userStatus.markInvalid(USER_MSGS.dialogEditAdminUserStatusError());
+                        } if (expirationDate.getValue() != null) {
+                            expirationDate.markInvalid(USER_MSGS.dialogEditAdminExpirationDateError());
                         }
                     }
                 }

--- a/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
+++ b/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
@@ -64,6 +64,8 @@ dialogEditInfo=Edit user attributes.
 dialogEditLoadFailed=Cannot load user: {0}
 dialogEditConfirmation=User successfully updated.
 dialogEditError=User edit failed: {0}
+dialogEditAdminUserStatusError=Admin user cannot be disabled.
+dialogEditAdminExpirationDateError=Admin user cannot have an expiration date.
 
 dialogEditFieldName=Name
 dialogEditFieldNameTooltip=The name of the User. It must be unique.


### PR DESCRIPTION
Brief description of the PR.
Marked status and/or expirationDate fields invalid on OPERATION_NOT_ALLOWED_ON_ADMIN_USER exception.

**Related Issue**
This PR adds the needed validation for **fix-disable_admin_error** branch and **_PR 1942_.**

**Description of the solution adopted**
Marked status and/or expirationDate fields invalid on OPERATION_NOT_ALLOWED_ON_ADMIN_USER exception in UserEditDialog. Added new eror messages for user status and expirationDate  fields.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

