### PR TITLE
Datastore Indexing Window is now a System Setting

### DIFF
--- a/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DataStoreServiceSteps.java
@@ -52,7 +52,6 @@ import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.ClientInfoField;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreChannel;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreMediator;
-import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfiguration;
 import org.eclipse.kapua.service.datastore.internal.mediator.MetricInfoField;
 import org.eclipse.kapua.service.datastore.internal.model.DataIndexBy;
@@ -1356,28 +1355,13 @@ public class DataStoreServiceSteps extends AbstractKapuaSteps {
         checkListOrder(metLst, getNamedMetricOrdering());
     }
 
-    @Given("^Dataservice config enabled (.*), dataTTL (\\d+), rxByteLimit (\\d+), dataIndexBy \"(.*)\", indexWindow \"(.*)\"$")
-    public void configureDatastoreService(String enabled, int dataTTL, int rxByteLimit, String dataIndexBy, String indexWindow) throws Exception {
+    @Given("^Dataservice config enabled (.*), dataTTL (\\d+), rxByteLimit (\\d+), dataIndexBy \"(.*)\"$")
+    public void configureDatastoreService(String enabled, int dataTTL, int rxByteLimit, String dataIndexBy) throws Exception {
         Map<String, Object> settings = new HashMap<>();
         settings.put("enabled", enabled.equalsIgnoreCase("TRUE"));
         settings.put("dataTTL", dataTTL);
         settings.put("rxByteLimit", rxByteLimit);
         settings.put("dataIndexBy", dataIndexBy);
-        String indexingWindow;
-
-        switch (indexWindow) {
-        default:
-        case DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK:
-            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK;
-            break;
-        case DatastoreUtils.INDEXING_WINDOW_OPTION_DAY:
-            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_DAY;
-            break;
-        case DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR:
-            indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR;
-            break;
-        }
-        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, indexingWindow);
         messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
     }
 

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -46,7 +46,8 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "DAY"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    And System property "datastore.index.window" with value "day"
     When All indices are deleted
     And Account for "kapua-sys"
     Given The device "test-device-1"
@@ -64,7 +65,8 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "HOUR"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    And System property "datastore.index.window" with value "hour"
     When All indices are deleted
     And Account for "kapua-sys"
     Given The device "test-device-1"
@@ -81,7 +83,8 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "WEEK"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    And System property "datastore.index.window" with value "week"
     When All indices are deleted
     And Account for "kapua-sys"
     Given The device "test-device-1"
@@ -101,7 +104,8 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "DAY"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    And System property "datastore.index.window" with value "day"
     When All indices are deleted
     And Account for "kapua-sys"
     Given The device "test-device-1"
@@ -121,7 +125,8 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "HOUR"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    And System property "datastore.index.window" with value "hour"
     When All indices are deleted
     And Account for "kapua-sys"
     Given The device "test-device-1"
@@ -140,7 +145,8 @@ Feature: Datastore tests
 
     Given Server with host "127.0.0.1" on port "9200"
     And I login as user with name "kapua-sys" and password "kapua-password"
-    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP", indexWindow "WEEK"
+    Given Dataservice config enabled "true", dataTTL 30, rxByteLimit 0, dataIndexBy "DEVICE_TIMESTAMP"
+    And System property "datastore.index.window" with value "week"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -74,7 +74,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
     protected final AccountService accountService = LOCATOR.getService(AccountService.class);
     protected final AuthorizationService authorizationService = LOCATOR.getService(AuthorizationService.class);
     protected final PermissionFactory permissionFactory = LOCATOR.getFactory(PermissionFactory.class);
-    protected static final Integer MAX_ENTRIES_ON_DELETE = DatastoreSettings.getInstance().get(Integer.class, DatastoreSettingKey.CONFIG_MAX_ENTRIES_ON_DELETE);
+    protected static final Integer MAX_ENTRIES_ON_DELETE = DatastoreSettings.getInstance().getInt(DatastoreSettingKey.CONFIG_MAX_ENTRIES_ON_DELETE);
 
     protected final MessageStoreFacade messageStoreFacade;
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -65,7 +65,8 @@ public class Schema {
             throws ClientException {
         String dataIndexName;
         try {
-            dataIndexName = DatastoreUtils.getDataIndexName(scopeId, time);
+            String indexingWindowOption = DatastoreSettings.getInstance().getString(DatastoreSettingKey.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
+            dataIndexName = DatastoreUtils.getDataIndexName(scopeId, time, indexingWindowOption);
         } catch (KapuaException kaex) {
             throw new ClientException(DatastoreErrorCodes.CONFIGURATION_ERROR, "Error while generating index name", kaex);
         }
@@ -130,7 +131,8 @@ public class Schema {
         }
         String newIndex;
         try {
-            newIndex = DatastoreUtils.getDataIndexName(scopeId, time);
+            String indexingWindowOption = DatastoreSettings.getInstance().getString(DatastoreSettingKey.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
+            newIndex = DatastoreUtils.getDataIndexName(scopeId, time, indexingWindowOption);
         } catch (KapuaException kaex) {
             throw new ClientException(DatastoreErrorCodes.CONFIGURATION_ERROR, "Error while generating index name", kaex);
         }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
@@ -65,7 +65,11 @@ public enum DatastoreSettingKey implements SettingKey {
     /**
      * Elasticsearch index name system-wide prefix
      */
-    INDEX_PREFIX("datastore.index.prefix");
+    INDEX_PREFIX("datastore.index.prefix"),
+    /**
+     * Elasticsearch index width. Allowed values: "week", "day", "hour"
+     */
+    INDEXING_WINDOW_OPTION("datastore.index.window");
 
     private String key;
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettings.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettings.java
@@ -15,14 +15,14 @@ import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
 
 /**
  * Datastore settings implementation
- * 
+ *
  * @since 1.0
  */
 public class DatastoreSettings extends AbstractKapuaSetting<DatastoreSettingKey> {
 
     private static final String DATASTORE_CONFIG_RESOURCE = "kapua-datastore-setting.properties";
 
-    private static final DatastoreSettings INSTANCE = new DatastoreSettings();
+    private static DatastoreSettings instance = new DatastoreSettings();
 
     private DatastoreSettings() {
         super(DATASTORE_CONFIG_RESOURCE);
@@ -30,10 +30,14 @@ public class DatastoreSettings extends AbstractKapuaSetting<DatastoreSettingKey>
 
     /**
      * Get the datastore setting instance
-     * 
+     *
      * @return
      */
     public static DatastoreSettings getInstance() {
-        return INSTANCE;
+        return instance;
+    }
+
+    public static void refresh() {
+        instance = new DatastoreSettings();
     }
 }

--- a/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
@@ -26,17 +26,6 @@
             description="Message store enable.">
         </AD>
 
-        <AD id="indexingWindow"
-            name="indexingWindow"
-            type="String"
-            required="true"
-            default="WEEK"
-            description="Message retention period in days.">
-            <Option label="HOUR" value="HOUR" />
-            <Option label="DAY" value="DAY" />
-            <Option label="WEEK" value="WEEK" />
-        </AD>
-
         <AD id="dataTTL"
             name="dataTTL"
             type="Integer"
@@ -44,7 +33,7 @@
             required="true"
             default="30"
             min="0"
-            description="Message retention period, according to the selected indexingWindow." />
+            description="Message retention period, in days." />
 
         <AD id="rxByteLimit"
             name="rxByteLimit"

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/IndexCalculatorTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/IndexCalculatorTest.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.client.ClientException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
+import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettingKey;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -30,9 +31,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.TimeZone;
 
 public class IndexCalculatorTest extends AbstractMessageStoreServiceTest {
@@ -105,33 +104,21 @@ public class IndexCalculatorTest extends AbstractMessageStoreServiceTest {
 
     @Test
     public void dataIndexNameByScopeIdAndTimestamp() throws KapuaException, ParseException {
-        Map<String, Object> settings = new HashMap<>();
-        settings.put("enabled", true);
-        settings.put("dataTTL", 30);
-        settings.put("rxByteLimit", 0);
-        settings.put("dataIndexBy", "DEVICE_TIMESTAMP");
 
         // Index by Week
-        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
-        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
-        String weekIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime());
+        String weekIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime(), DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
         assertEquals("1-2017-01", weekIndexName);
 
         // Index by Day
-        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_DAY);
-        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
-        String dayIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime());
+        String dayIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime(), DatastoreUtils.INDEXING_WINDOW_OPTION_DAY);
         assertEquals("1-2017-01-02", dayIndexName);
 
-        // Index by Day
-        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR);
-        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
-        String hourIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime());
+        // Index by Hour
+        String hourIndexName = DatastoreUtils.getDataIndexName(KapuaId.ONE, sdf.parse("02/01/2017 13:12 +0100").getTime(), DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR);
         assertEquals("1-2017-01-02-12", hourIndexName);     // Index Hour is UTC!
 
         // Reset config for other tests; provide new tests where needed
-        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
-        messageStoreService.setConfigValues(KapuaId.ONE, null, settings);
+        System.setProperty(DatastoreSettingKey. INDEXING_WINDOW_OPTION.key(), DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
     }
 
     @Test

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceSslTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceSslTest.java
@@ -77,7 +77,7 @@ public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest 
      * The method deletes all indices and resets the Kapua internal singleton state.
      * This is required to ensure that each unit test, as it currently expects, starts with an empty ES setup
      * </p>
-     * 
+     *
      * @throws Exception
      *             any case anything goes wrong
      */

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
@@ -62,6 +62,8 @@ import org.eclipse.kapua.service.datastore.internal.schema.ChannelInfoSchema;
 import org.eclipse.kapua.service.datastore.internal.schema.ClientInfoSchema;
 import org.eclipse.kapua.service.datastore.internal.schema.MessageSchema;
 import org.eclipse.kapua.service.datastore.internal.schema.MetricInfoSchema;
+import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettingKey;
+import org.eclipse.kapua.service.datastore.internal.setting.DatastoreSettings;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
@@ -181,29 +183,22 @@ public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
 
     @Test
     public void deleteByDate() throws InterruptedException, KapuaException, ParseException {
-        Map<String, Object> settings = new HashMap<>();
-        settings.put("enabled", true);
-        settings.put("dataTTL", 30);
-        settings.put("rxByteLimit", 0);
-        settings.put("dataIndexBy", "DEVICE_TIMESTAMP");
-        String indexingWindow;
-
         // Delete by Week
-        indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK;
-        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, indexingWindow);
-        MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, settings);
+        String indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK;
+        System.setProperty(DatastoreSettingKey.INDEXING_WINDOW_OPTION.key(), indexingWindow);
+        DatastoreSettings.refresh();
         internalDeleteByDate(indexingWindow);
 
-        // Index by Day
+        // Delete by Day
         indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_DAY;
-        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, indexingWindow);
-        MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, settings);
+        System.setProperty(DatastoreSettingKey.INDEXING_WINDOW_OPTION.key(), indexingWindow);
+        DatastoreSettings.refresh();
         internalDeleteByDate(indexingWindow);
 
         // Delete by Hour
         indexingWindow = DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR;
-        settings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, indexingWindow);
-        MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, settings);
+        System.setProperty(DatastoreSettingKey.INDEXING_WINDOW_OPTION.key(), indexingWindow);
+        DatastoreSettings.refresh();
         internalDeleteByDate(indexingWindow);
     }
 

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsIndexNameTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsIndexNameTest.java
@@ -15,8 +15,6 @@ import java.math.BigInteger;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
@@ -27,7 +25,6 @@ import org.eclipse.kapua.service.datastore.internal.AbstractMessageStoreServiceT
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ClientUtilsIndexNameTest extends AbstractMessageStoreServiceTest {
@@ -36,34 +33,18 @@ public class ClientUtilsIndexNameTest extends AbstractMessageStoreServiceTest {
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
     private static final MessageStoreService MESSAGE_STORE_SERVICE = LOCATOR.getService(MessageStoreService.class);
 
-    public static Map<String, Object> serviceSettings = new HashMap<>();
-
-    @BeforeClass
-    public static void setupConfig() {
-        serviceSettings.put("enabled", true);
-        serviceSettings.put("dataTTL", 30);
-        serviceSettings.put("rxByteLimit", 0);
-        serviceSettings.put("dataIndexBy", "DEVICE_TIMESTAMP");
-    }
-
     @Test
     public void test1() {
         final Instant instant = ZonedDateTime.of(2017, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
         try {
             // Index by Week
-            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
-            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
-            Assert.assertEquals("1-2017-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+            Assert.assertEquals("1-2017-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli(), DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK));
 
             // Index by Day
-            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_DAY);
-            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
-            Assert.assertEquals("1-2017-01-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+            Assert.assertEquals("1-2017-01-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli(), DatastoreUtils.INDEXING_WINDOW_OPTION_DAY));
 
             // Index by Hour
-            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR);
-            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
-            Assert.assertEquals("1-2017-01-01-00", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+            Assert.assertEquals("1-2017-01-01-00", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli(), DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR));
         } catch (KapuaException kaex) {
             Assert.fail("Error while generating index name");
         }
@@ -74,19 +55,13 @@ public class ClientUtilsIndexNameTest extends AbstractMessageStoreServiceTest {
         final Instant instant = ZonedDateTime.of(2017, 1, 8, 0, 0, 0, 0, ZoneOffset.UTC).toInstant();
         try {
             // Index by Week
-            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK);
-            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
-            Assert.assertEquals("1-2017-02", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+            Assert.assertEquals("1-2017-02", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli(), DatastoreUtils.INDEXING_WINDOW_OPTION_WEEK));
 
             // Index by Day
-            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_DAY);
-            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
-            Assert.assertEquals("1-2017-02-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+            Assert.assertEquals("1-2017-02-01", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli(), DatastoreUtils.INDEXING_WINDOW_OPTION_DAY));
 
             // Index by Hour
-            serviceSettings.put(DatastoreUtils.INDEXING_WINDOW_OPTION, DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR);
-            MESSAGE_STORE_SERVICE.setConfigValues(KapuaId.ONE, null, serviceSettings);
-            Assert.assertEquals("1-2017-02-01-00", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli()));
+            Assert.assertEquals("1-2017-02-01-00", DatastoreUtils.getDataIndexName(ONE, instant.toEpochMilli(), DatastoreUtils.INDEXING_WINDOW_OPTION_HOUR));
         } catch (KapuaException kaex) {
             Assert.fail("Error while generating index name");
         }

--- a/service/datastore/internal/src/test/resources/kapua-datastore-setting.properties
+++ b/service/datastore/internal/src/test/resources/kapua-datastore-setting.properties
@@ -35,3 +35,6 @@ datastore.delete.max_entries_on_delete=100
 datastore.cache.local.expire.after=60
 datastore.cache.local.size.maximum=1000
 datastore.cache.metadata.local.size.maximum=1000
+
+# Allowed values are "week", "day" or "hour"; any other different value will be treated as "week".
+datastore.index.window=week


### PR DESCRIPTION
Brief description of the PR.
With this PR, Datastore Indexing Window (e.g. having indexes grouped by week, day or hour -- introduced in #1845) is now a Setting (per deployment) and not a Configuration (per account) anymore. The related key in kapua-datastore-setting.property is named datastore.index.window. Allowed values are week, day or hour; any other different value will be treated as week.

**Related Issue**
This PR builds upon #1845

**Description of the solution adopted**
The Indexing Window service configuration has been moved to a system property. Every piece of code who accessed it via service now accesses it via system property; the other semantics of the code are left untouched.
