### PR TITLE
Fixed error when starting bundles in Devices tab

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
@@ -161,7 +161,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
             }
         });
 
-        refreshButton.setEnabled(true);
+        refreshButton.setEnabled(false);
         toolBar.add(refreshButton);
         toolBar.add(new SeparatorToolItem());
 
@@ -188,6 +188,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
             public void componentSelected(ButtonEvent ce) {
                 if (selectedEntity.isOnline()) {
                     toolBar.disable();
+                    disableButtons();
                     grid.mask(MSGS.loading());
 
                     //
@@ -204,12 +205,23 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
                             gwtDeviceManagementService.startBundle(token,
                                     selectedEntity,
                                     grid.getSelectionModel().getSelectedItem(),
-                                    callback);
+                                    new AsyncCallback<Void>() {
+
+                                        @Override
+                                        public void onFailure(Throwable caught) {
+                                            FailureHandler.handle(caught);
+                                            grid.unmask();
+                                            toolBar.enable();
+                                            stopButton.disable();
+                                        }
+
+                                        @Override
+                                        public void onSuccess(Void result) {
+                                            doRefresh();
+                                        }
+                                   });
                         }
                     });
-                    grid.unmask();
-                    toolBar.enable();
-                    stopButton.disable();
                 } else {
                     MessageBox.alert(MSGS.dialogAlerts(), DEVICE_MSGS.deviceOffline(),
                             new Listener<MessageBoxEvent>() {
@@ -361,8 +373,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
             if (selectedEntity != null) {
                 loader.load();
                 toolBar.enable();
-                startButton.disable();
-                stopButton.disable();
+                disableButtons();
             } else {
                 grid.getStore().removeAll();
                 toolBar.disable();
@@ -389,6 +400,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
 
         @Override
         public void loaderBeforeLoad(LoadEvent le) {
+            disableButtons();
             grid.mask(MSGS.loading());
         }
 
@@ -399,6 +411,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
             }
             startButton.disable();
             stopButton.disable();
+            refreshButton.enable();
             grid.unmask();
         }
 
@@ -412,5 +425,11 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
             stopButton.disable();
             grid.unmask();
         }
+    }
+
+    private void disableButtons() {
+        startButton.disable();
+        stopButton.disable();
+        refreshButton.disable();
     }
 }


### PR DESCRIPTION
Brief description of the PR.
Fixed error when starting bundles in Devices tab

**Related Issue**
This PR fixes/closes #1843

**Description of the solution adopted**
Changed the way _gwtDeviceManagementService.startBundle()_ callback is handled. Added _onSuccess()_ and _onFailure()_ methods and their implementation.
Disabled start, stop and refresh buttons on Bundles tab when loading is in progress.

**Screenshots**
None

**Any side note on the changes made**
None

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>