### PR TITLE
Require ScopeId when reading Configuration Metadata

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableService.java
@@ -17,7 +17,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
 import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.service.internal.ServiceDAO;
 import org.eclipse.kapua.commons.util.ResourceUtils;
@@ -230,13 +229,12 @@ public abstract class AbstractKapuaConfigurableService extends AbstractKapuaServ
     }
 
     @Override
-    public KapuaTocd getConfigMetadata()
+    public KapuaTocd getConfigMetadata(KapuaId scopeId)
             throws KapuaException {
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
 
-        KapuaId scopeId = KapuaSecurityUtils.getSession().getScopeId();
         authorizationService.checkPermission(permissionFactory.newPermission(domain, Actions.read, scopeId));
 
         try {
@@ -276,7 +274,7 @@ public abstract class AbstractKapuaConfigurableService extends AbstractKapuaServ
             properties = result.getFirstItem().getConfigurations();
         }
 
-        KapuaTocd ocd = getConfigMetadata();
+        KapuaTocd ocd = getConfigMetadata(scopeId);
         return toValues(ocd, properties);
     }
 
@@ -288,7 +286,7 @@ public abstract class AbstractKapuaConfigurableService extends AbstractKapuaServ
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(domain, Actions.write, scopeId));
 
-        KapuaTocd ocd = getConfigMetadata();
+        KapuaTocd ocd = getConfigMetadata(scopeId);
         validateConfigurations(pid, ocd, values, scopeId, parentId);
 
         ServiceConfigQueryImpl query = new ServiceConfigQueryImpl(scopeId);

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionServiceImpl.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionServiceImpl.java
@@ -81,7 +81,7 @@ public class CollisionServiceImpl extends AbstractKapuaConfigurableService imple
     }
 
     @Override
-    public KapuaTocd getConfigMetadata() throws KapuaException {
+    public KapuaTocd getConfigMetadata(KapuaId scopeId) throws KapuaException {
         // TODO Auto-generated method stub
         return null;
     }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
@@ -42,6 +42,7 @@ import com.extjs.gxt.ui.client.widget.treepanel.TreePanelSelectionModel;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountService;
 import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountServiceAsync;
@@ -124,7 +125,7 @@ public class AccountConfigComponents extends LayoutContainer {
     };
 
     AccountConfigComponents(GwtSession currentSession,
-            AccountTabConfiguration tabConfig) {
+                            AccountTabConfiguration tabConfig) {
         this.currentSession = currentSession;
         this.tabConfig = tabConfig;
         dirty = false;
@@ -543,6 +544,7 @@ public class AccountConfigComponents extends LayoutContainer {
             if (le.exception != null) {
                 FailureHandler.handle(le.exception);
             }
+            tree.setAutoSelect(!((List) le.getData()).isEmpty());
             tree.unmask();
             refreshButton.setEnabled(true);
         }
@@ -567,7 +569,7 @@ public class AccountConfigComponents extends LayoutContainer {
         }
     }
 
-    public void removeApplyAndResetButtons(){
+    public void removeApplyAndResetButtons() {
         if (toolBar != null) {
             toolBar.remove(apply);
             toolBar.remove(reset);

--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
@@ -650,7 +650,7 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @Then("^The account has metadata$")
     public void checkMetadataExistence()
             throws KapuaException {
-        KapuaTocd metaData = accountService.getConfigMetadata();
+        KapuaTocd metaData = accountService.getConfigMetadata(accountId);
 
         assertNotNull(metaData);
     }

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/KapuaConfigurableService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/KapuaConfigurableService.java
@@ -27,10 +27,11 @@ public interface KapuaConfigurableService {
     /**
      * Return the service configuration metadata
      *
+     * @param scopeId
      * @return
      * @throws KapuaException
      */
-    KapuaTocd getConfigMetadata() throws KapuaException;
+    KapuaTocd getConfigMetadata(KapuaId scopeId) throws KapuaException;
 
     /**
      * Return a map of configuration values associated with the provided scope id

--- a/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/UserServiceSteps.java
+++ b/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/UserServiceSteps.java
@@ -502,9 +502,10 @@ public class UserServiceSteps extends AbstractKapuaSteps {
         }
     }
 
-    @When("^I retrieve metadata$")
-    public void getMetadata() throws KapuaException {
-        metadata = userService.getConfigMetadata();
+    @When("^I retrieve metadata in scope (\\d+)$")
+    public void getMetadata(int scopeId) throws KapuaException {
+        KapuaEid scpId = new KapuaEid(BigInteger.valueOf(scopeId));
+        metadata = userService.getConfigMetadata(scpId);
     }
 
     @Then("^I have metadata$")

--- a/service/user/internal/src/test/resources/features/UserService.feature
+++ b/service/user/internal/src/test/resources/features/UserService.feature
@@ -307,5 +307,5 @@ Scenario: Find multiple users
 Scenario: Get metadata
     Query for service specific metadata.
 
-    When I retrieve metadata
+    When I retrieve metadata in scope 1
     Then I have metadata

--- a/test/src/main/java/org/eclipse/kapua/test/account/AccountServiceMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/account/AccountServiceMock.java
@@ -106,7 +106,7 @@ public class AccountServiceMock implements AccountService {
     }
 
     @Override
-    public KapuaTocd getConfigMetadata()
+    public KapuaTocd getConfigMetadata(KapuaId scopeId)
             throws KapuaException {
         throw KapuaException.internalError("Not implemented");
     }

--- a/test/src/main/java/org/eclipse/kapua/test/device/DeviceRegistryServiceMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/device/DeviceRegistryServiceMock.java
@@ -97,7 +97,7 @@ public class DeviceRegistryServiceMock implements DeviceRegistryService {
     }
 
     @Override
-    public KapuaTocd getConfigMetadata() throws KapuaException {
+    public KapuaTocd getConfigMetadata(KapuaId scopeId) throws KapuaException {
         return null;
     }
 

--- a/test/src/main/java/org/eclipse/kapua/test/user/UserServiceMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/user/UserServiceMock.java
@@ -129,7 +129,7 @@ public class UserServiceMock implements UserService {
     }
 
     @Override
-    public KapuaTocd getConfigMetadata()
+    public KapuaTocd getConfigMetadata(KapuaId scopeId)
             throws KapuaException {
         // TODO Auto-generated method stub
         return null;


### PR DESCRIPTION
This PR adds a new requested parameter (`scopeId`) when fetching Service Configuration Metadata, so that the request is always scoped to the account whose configuration metadata are required.

**Related Issue**
This PR fixes #1912
