### PR TITLE
Add method to get current context provider

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlUtil.java
@@ -63,6 +63,10 @@ public class XmlUtil {
         jaxbContextProvider = provider;
     }
 
+    public static JAXBContextProvider getContextProvider() {
+        return jaxbContextProvider;
+    }
+
     /**
      * Marshal the object to a String
      *


### PR DESCRIPTION
This adds a method to get the current JAXB context provider, making it possible to replace then restore the current context provider.

**Related Issue**
N/A

**Description of the solution adopted**
N/A

**Screenshots**
N/A

**Any side note on the changes made**
N/A
