### PR TITLE
Moved AccountJAXBContextProvider to src/test/resources

### DIFF
--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountsJAXBContextProvider.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountsJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 public class AccountsJAXBContextProvider implements JAXBContextProvider {
 
-    private static final Logger logger = LoggerFactory.getLogger(AccountsJAXBContextProvider.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AccountsJAXBContextProvider.class);
 
     private JAXBContext context;
 
@@ -60,7 +60,7 @@ public class AccountsJAXBContextProvider implements JAXBContextProvider {
             try {
                 context = JAXBContextFactory.createContext(classes, null);
             } catch (JAXBException jaxbException) {
-                logger.warn("Error creating JAXBContext, tests will fail!");
+                LOG.warn("Error creating JAXBContext, tests will fail!");
             }
         }
         return context;


### PR DESCRIPTION
This PR moves `AccountsJAXBContextProvider.java` from `src/main/java` to `src/test/java`.

**Related Issue**
This PR closes #175 

**Description of the solution adopted**
Moved the class,

**Screenshots**
_None_

**Any side note on the changes made**
Fixed name of `private static final` variable