### PR TITLE
Disabled Submit button if there are no changes on the dialog

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -92,6 +92,7 @@ public class AccountAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel accountFormPanel = new FormPanel(FORM_LABEL_WIDTH);
 
         // //////////////////////////////////////////
@@ -138,6 +139,13 @@ public class AccountAddDialog extends EntityAddEditDialog {
         expirationDateField.setFormatValue(true);
         expirationDateField.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         expirationDateField.setMaxLength(10);
+        expirationDateField.getDatePicker().addListener(Events.Select, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                formPanel.fireEvent(Events.OnClick);
+            }
+        });
         fieldSet.add(expirationDateField, accountFieldsetFormData);
 
         accountFormPanel.add(fieldSet);

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,8 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.api.client.ui.dialog;
 
+import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.ComponentEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.extjs.gxt.ui.client.util.KeyNav;
 import com.extjs.gxt.ui.client.widget.Status;
 import com.extjs.gxt.ui.client.widget.button.Button;
 import com.extjs.gxt.ui.client.widget.form.FormPanel;
@@ -21,6 +26,7 @@ import com.extjs.gxt.ui.client.widget.form.FormPanel.Method;
 import com.extjs.gxt.ui.client.widget.layout.FormLayout;
 import com.extjs.gxt.ui.client.widget.toolbar.FillToolItem;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
@@ -70,6 +76,25 @@ public abstract class ActionDialog extends KapuaDialog {
         addListeners();
 
         add(formPanel);
+        Listener<BaseEvent> listener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                setSubmitButtonState();
+            }
+        };
+
+        KeyNav<ComponentEvent> keyNav = new KeyNav<ComponentEvent>(formPanel) {
+            public void onKeyPress(ComponentEvent ce) {
+                if (ce.getKeyCode() == KeyCodes.KEY_TAB || ce.getKeyCode() == KeyCodes.KEY_ENTER ) {
+                    setSubmitButtonState();
+                }
+            }
+        };
+
+        formPanel.addListener(Events.OnMouseUp, listener);
+        formPanel.addListener(Events.OnClick, listener);
+        formPanel.addListener(Events.OnKeyUp, listener);
 
         //
         // Buttons setup
@@ -172,5 +197,13 @@ public abstract class ActionDialog extends KapuaDialog {
 
     public void unmaskDialog() {
         formPanel.unmask();
+    }
+
+    public void setSubmitButtonState() {
+        if (formPanel.isDirty()) {
+            submitButton.enable();
+        } else {
+            submitButton.disable();
+        }
     }
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import com.extjs.gxt.ui.client.Style.HorizontalAlignment;
 import com.extjs.gxt.ui.client.Style.Scroll;
+import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
 import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.FormEvent;
@@ -121,6 +122,17 @@ public class FileUploadDialog extends Dialog {
         fileUploadField.setName("uploadedFile");
         fileUploadField.setFieldLabel("File");
         fileUploadField.setInputStyleAttribute("style", "width:300");
+        fileUploadField.addListener(Events.OnChange, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                if (fileUploadField.isDirty()){
+                    submitButton.enable();
+                } else {
+                    submitButton.disable();
+                }
+            }
+        });
         FormData formData = new FormData("-20");
         fieldSet.add(fileUploadField, formData);
 
@@ -188,6 +200,7 @@ public class FileUploadDialog extends Dialog {
             }
         });
 
+        submitButton.disable();
         addButton(cancelButton);
         addButton(submitButton);
     }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaDateField.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaDateField.java
@@ -14,16 +14,17 @@ package org.eclipse.kapua.app.console.module.api.client.ui.widget;
 import com.extjs.gxt.ui.client.widget.form.DateField;
 import com.google.gwt.user.client.Element;
 
-public class KapuaDateField extends DateField{
-@Override
-public void setMaxLength(int maxLength) {
-    super.setMaxLength(maxLength);
-    if (rendered) {
-        getInputEl().setElementAttribute("maxLength", maxLength);
-    }
-}
+public class KapuaDateField extends DateField {
 
-@Override
+    @Override
+    public void setMaxLength(int maxLength) {
+        super.setMaxLength(maxLength);
+        if (rendered) {
+            getInputEl().setElementAttribute("maxLength", maxLength);
+        }
+    }
+
+    @Override
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         getInputEl().setElementAttribute("maxLength", getMaxLength());

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -71,6 +71,7 @@ public class CredentialAddDialog extends EntityAddEditDialog {
     @Override
     public void createBody() {
 
+        submitButton.disable();
         credentialFormPanel = new FormPanel(FORM_LABEL_WIDTH);
 
         subject = new LabelField();
@@ -156,6 +157,14 @@ public class CredentialAddDialog extends EntityAddEditDialog {
         expirationDate.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         expirationDate.setToolTip(MSGS.dialogAddFieldExpirationDateTooltip());
         expirationDate.setMaxLength(10);
+        expirationDate.getDatePicker().addListener(Events.Select, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                formPanel.fireEvent(Events.OnClick);
+            }
+        });
+
         credentialFormPanel.add(expirationDate);
 
         credentialStatus = new SimpleComboBox<GwtCredentialStatus>();
@@ -179,6 +188,7 @@ public class CredentialAddDialog extends EntityAddEditDialog {
         optlock.setName("optlock");
         optlock.setEditable(false);
         optlock.setVisible(false);
+        optlock.setPropertyEditorType(Integer.class);
         credentialFormPanel.add(optlock);
 
         bodyPanel.add(credentialFormPanel);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
@@ -44,6 +44,7 @@ public class GroupAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel groupFormPanel = new FormPanel(FORM_LABEL_WIDTH);
         groupNameField = new KapuaTextField<String>();
         groupNameField.setAllowBlank(false);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -84,7 +84,7 @@ public class GroupEditDialog extends GroupAddDialog {
 
     private void populateEditDialog(GwtGroup gwtGroup) {
         groupNameField.setValue(gwtGroup.getGroupName());
-
+        formPanel.clearDirtyFields();
     }
 
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
@@ -90,6 +90,7 @@ public class RoleAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel roleFormPanel = new FormPanel(FORM_LABEL_WIDTH);
 
         //

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -70,6 +70,7 @@ public class RoleEditDialog extends RoleAddDialog {
 
     private void populateEditDialog(GwtRole gwtRole) {
         roleNameField.setValue(gwtRole.getName());
+        roleNameField.setOriginalValue(roleNameField.getValue());
     }
 
     @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -11,6 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authorization.client.tabs.role;
 
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
@@ -57,7 +60,6 @@ public class AccessRoleAddDialog extends EntityAddEditDialog {
             @Override
             public void onSuccess(GwtAccessInfo result) {
                 accessInfoId = result.getId();
-                submitButton.enable();
             }
 
             @Override
@@ -140,6 +142,13 @@ public class AccessRoleAddDialog extends EntityAddEditDialog {
         rolesCombo.setDisplayField("name");
         rolesCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={name}>{name}</div></tpl>");
         rolesCombo.setValueField("id");
+        rolesCombo.addListener(Events.Select, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                formPanel.fireEvent(Events.OnClick);
+                }
+        });
 
         GWT_ROLE_SERVICE.findAll(currentSession.getAccountId(), new AsyncCallback<List<GwtRole>>() {
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -67,6 +67,7 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel groupFormPanel = new FormPanel(FORM_LABEL_WIDTH);
         FormLayout layoutSecurityOptions = new FormLayout();
         layoutSecurityOptions.setLabelWidth(Constants.LABEL_WIDTH_DEVICE_FORM);
@@ -214,6 +215,7 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         }
         couplingModeCombo.setSimpleValue(gwtConnectionUserCouplingMode != null ? gwtConnectionUserCouplingMode.getLabel() : "N/A");
         allowUserChangeCheckbox.setValue(gwtDeviceConnection.getAllowUserChange());
+        formPanel.clearDirtyFields();
     }
 
     private void setReservedUser() {
@@ -226,6 +228,7 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
                 reservedUserCombo.setValue(gwtUser);
             }
         }
+        formPanel.clearDirtyFields();
     }
 
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -107,6 +107,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
     @Override
     public void createBody() {
         generateBody();
+        submitButton.disable();
 
         // hide fields used for edit
         clientIdLabel.hide();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -32,6 +32,7 @@ public class DeviceEditDialog extends DeviceAddDialog {
     @Override
     public void createBody() {
         generateBody();
+        submitButton.disable();
 
         // hide fields used for add
         clientIdField.hide();
@@ -149,5 +150,6 @@ public class DeviceEditDialog extends DeviceAddDialog {
             // Other data
             optlock.setValue(device.getOptlock());
         }
+        formPanel.clearDirtyFields();
     }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
@@ -73,6 +73,7 @@ public class PackageInstallDialog extends TabbedDialog {
     public void createTabItems() {
         // Deployment package info tab content
         {
+            submitButton.disable();
             FormData formData = new FormData("-15");
 
             FormLayout formLayout = new FormLayout();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -98,6 +98,7 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
 
         FormPanel formPanel = new FormPanel(FORM_LABEL_WIDTH);
 

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
@@ -49,6 +49,7 @@ public class EndpointAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel endpointFormPanel = new FormPanel(FORM_LABEL_WIDTH);
 
         endpointSchemaField = new KapuaTextField<String>();
@@ -77,6 +78,7 @@ public class EndpointAddDialog extends EntityAddEditDialog {
         endpointPortField.setMaxLength(5);
         endpointPortField.setMinValue(1);
         endpointPortField.setMaxValue(65535);
+        endpointPortField.setPropertyEditorType(Integer.class);
         endpointFormPanel.add(endpointPortField);
 
         endpointSercureCheckbox = new CheckBox();

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
@@ -45,6 +45,7 @@ public class JobAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel jobFormPanel = new FormPanel(FORM_LABEL_WIDTH);
 
         name = new KapuaTextField<String>();

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobEditDialog.java
@@ -37,6 +37,7 @@ public class JobEditDialog extends JobAddDialog {
     public void createBody() {
         super.createBody();
         populateEditDialog(selectedJob);
+        submitButton.disable();
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -11,8 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.schedule;
 
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.widget.HorizontalPanel;
+import com.extjs.gxt.ui.client.widget.Label;
 import com.extjs.gxt.ui.client.widget.form.DateField;
-import com.extjs.gxt.ui.client.widget.form.MultiField;
 import com.extjs.gxt.ui.client.widget.form.TimeField;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.DateTimeFormat;
@@ -54,6 +58,8 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
     protected final TimeField endsOnTime;
     protected final KapuaNumberField retryInterval;
     protected final KapuaTextField<String> cronExpression;
+    private Label startsOnLabel;
+    private Label endsOnLabel;
 
     public JobScheduleAddDialog(GwtSession currentSession, String jobId) {
         super(currentSession);
@@ -68,6 +74,8 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         endsOn.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         endsOnTime = new TimeField();
         endsOnTime.setEditable(false);
+        startsOnLabel = new Label();
+        endsOnLabel = new Label();
         retryInterval = new KapuaNumberField();
         cronExpression = new KapuaTextField<String>();
 
@@ -76,13 +84,11 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel mainPanel = new FormPanel(150);
-        MultiField<?> multiFieldStartsOn=new MultiField<Object>();
-        MultiField<?> multiFieldEndsOn=new MultiField<Object>();
-        multiFieldStartsOn.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleStartsOnLabel());
-        multiFieldStartsOn.setSpacing(20);
-        multiFieldEndsOn.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleEndsOnLabel());
-        multiFieldEndsOn.setSpacing(20);
+        HorizontalPanel startsOnPanel = new HorizontalPanel();
+        HorizontalPanel endsOnPanel = new HorizontalPanel();
+        endsOnPanel.setStyleAttribute("padding", "4px 0px 4px 0px");
 
         triggerName.setAllowBlank(false);
         triggerName.setMaxLength(255);
@@ -92,35 +98,59 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
 
         startsOn.setFormatValue(true);
         startsOn.setAllowBlank(false);
-        startsOn.setWidth(90);
+        startsOn.setWidth(95);
         startsOn.setEmptyText(JOB_MSGS.dialogAddScheduleDatePlaceholder());
         startsOn.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         startsOn.setToolTip(JOB_MSGS.dialogAddScheduleStartsOnTooltip());
-        multiFieldStartsOn.add(startsOn);
+        startsOn.getDatePicker().addListener(Events.Select, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                formPanel.fireEvent(Events.OnClick);
+            }
+        });
+        startsOnLabel.setText("* " + JOB_MSGS.dialogAddScheduleStartsOnLabel());
+        startsOnLabel.setWidth(FORM_LABEL_WIDTH);
+        startsOnLabel.setStyleAttribute("padding", "0px 101px 0px 0px");
+        startsOnPanel.add(startsOnLabel);
+        startsOnPanel.add(startsOn);
 
         startsOnTime.setAllowBlank(false);
         startsOnTime.setFormat(DateTimeFormat.getFormat("HH:mm"));
         startsOnTime.setEditable(false);
-        startsOnTime.setWidth(85);
+        startsOnTime.setWidth(100);
+        startsOnTime.setStyleAttribute("padding", "0px 0px 0px 17px");
         startsOnTime.setEmptyText(JOB_MSGS.dialogAddScheduleTimePlaceholder());
         startsOnTime.setToolTip(JOB_MSGS.dialogAddScheduleStartsOnTimeTooltip());
-        multiFieldStartsOn.add(startsOnTime);
-        mainPanel.add(multiFieldStartsOn);
+        startsOnPanel.add(startsOnTime);
+        mainPanel.add(startsOnPanel);
 
         endsOn.setFormatValue(true);
-        endsOn.setWidth(90);
+        endsOn.setWidth(95);
         endsOn.setEmptyText(JOB_MSGS.dialogAddScheduleDatePlaceholder());
         endsOn.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         endsOn.setToolTip(JOB_MSGS.dialogAddScheduleEndsOnTooltip());
-        multiFieldEndsOn.add(endsOn);
+        endsOnLabel.setText("* " + JOB_MSGS.dialogAddScheduleEndsOnLabel());
+        endsOnLabel.setWidth(FORM_LABEL_WIDTH);
+        endsOnLabel.setStyleAttribute("padding", "0px 106px 0px 0px");
+        endsOn.getDatePicker().addListener(Events.Select, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                formPanel.fireEvent(Events.OnClick);
+            }
+        });
+        endsOnPanel.add(endsOnLabel);
+        endsOnPanel.add(endsOn);
 
         endsOnTime.setFormat(DateTimeFormat.getFormat("HH:mm"));
         endsOnTime.setEditable(false);
-        endsOnTime.setWidth(85);
+        endsOnTime.setWidth(100);
         endsOnTime.setEmptyText(JOB_MSGS.dialogAddScheduleTimePlaceholder());
         endsOnTime.setToolTip(JOB_MSGS.dialogAddScheduleEndsOnTimeTooltip());
-        multiFieldEndsOn.add(endsOnTime);
-        mainPanel.add(multiFieldEndsOn);
+        endsOnTime.setStyleAttribute("padding", "0px 0px 0px 17px");
+        endsOnPanel.add(endsOnTime);
+        mainPanel.add(endsOnPanel);
 
         retryInterval.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleRetryIntervalLabel());
         retryInterval.setAllowDecimals(false);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -98,6 +98,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel jobStepFormPanel = new FormPanel(FORM_LABEL_WIDTH);
 
         jobStepName.setFieldLabel("* " + JOB_MSGS.dialogAddStepJobNameLabel());

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
@@ -89,6 +89,7 @@ public class JobStepEditDialog extends JobStepAddDialog {
                     field.setValue(propertiesMap.get(field.getData(PROPERTY_NAME)));
                 }
 
+                formPanel.clearDirtyFields();
                 unmaskDialog();
             }
         });

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
@@ -44,6 +44,7 @@ public class TagAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel tagFormPanel = new FormPanel(FORM_LABEL_WIDTH);
         tagNameField = new KapuaTextField<String>();
         tagNameField.setAllowBlank(false);

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -12,6 +12,9 @@
 package org.eclipse.kapua.app.console.module.user.client.dialog;
 
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.widget.form.FieldSet;
 import com.extjs.gxt.ui.client.widget.form.LabelField;
 import com.extjs.gxt.ui.client.widget.form.NumberField;
@@ -77,6 +80,7 @@ public class UserAddDialog extends EntityAddEditDialog {
     @Override
     public void createBody() {
 
+        submitButton.disable();
         FormPanel userFormPanel = new FormPanel(FORM_LABEL_WIDTH);
         userFormPanel.setFrame(false);
         userFormPanel.setBorders(false);
@@ -206,6 +210,13 @@ public class UserAddDialog extends EntityAddEditDialog {
         expirationDate.setEmptyText(USER_MSGS.dialogAddNoExpiration());
         expirationDate.setValue(null);
         expirationDate.setMaxLength(10);
+        expirationDate.getDatePicker().addListener(Events.Select, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                formPanel.fireEvent(Events.OnClick);
+            }
+        });
         statusFieldSet.add(expirationDate, subFieldsetFormData);
 
         userFormPanel.add(infoFieldSet, subFormData);

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -143,5 +143,6 @@ public class UserEditDialog extends UserAddDialog {
         userStatus.setSimpleValue(gwtUser.getStatusEnum());
         expirationDate.setValue(gwtUser.getExpirationDate());
         expirationDate.setMaxLength(10);
+        formPanel.clearDirtyFields();
     }
 }


### PR DESCRIPTION
Brief description of the PR.
Disabled Submit button if there are no changes on the dialog

**Related Issue**
This PR fixes/closes #1795 

**Description of the solution adopted**
Added listener in `ActionDialog` class for `OnMouseUp`, `OnClick`, `OnKeyUp` and `keybord navigation` events. This listener calls `setSubmitButtonState()` function, that disables/enables the submit button depending on the _dirty state_ of the `formPanel`. Additional listener that fires formPanels _OnClick_ event was added for the DateFields _datePickers_ as their selection didn't trigger any of the before mentioned events. There were also some changes on the dialog themselves, like disabling of the submit button on the creation of the dialog body, and setting original values of the fields using `formPanel.clearDirtyFields()` funtion on the _Edit_ dialogs which were populated by previously entered data.  

**Screenshots**
_None_

**Any side note on the changes made**
Formatted _KapuaDateField_ class, something I overlooked when creating it in one of my previous PR.
Modified the _JobScheduleDialog_ to use the _HorizontalPanel_ instead of the _MultiField_ for field grouping. This way the above mentioned Listeners were enabled on those grouped fields as well, unlike the MultiField solution were any of the relevant events could not be registered. 

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>