### PR TITLE
Marked cronExpression field invalid after validation failure on submit

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -195,7 +195,8 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
 
                 @Override
                 public void onFailure(Throwable caught) {
-                    ConsoleInfo.display(MSGS.popupError(), JOB_MSGS.unableToValidateCronExpression(caught.getMessage()));
+                    ConsoleInfo.display(MSGS.popupError(), JOB_MSGS.unableToValidateCronExpression());
+                    cronExpression.markInvalid(VAL_MSGS.invalidCronExpression());
                 }
 
                 @Override

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -159,7 +159,7 @@ dialogAddScheduleConfirmation=Schedule successfully created.
 dialogAddScheduleError=Error while creating schedule: {0}
 dialogAddScheduleDatePlaceholder=Select Date
 dialogAddScheduleTimePlaceholder=Select Time
-unableToValidateCronExpression=Unable to validate cron expression: {0}
+unableToValidateCronExpression=Unable to validate CRON expression. Please check the CRON format and try again.
 
 #
 # Edit schedule dialog


### PR DESCRIPTION
Brief description of the PR.
Marked cronExpression field invalid after validation failure on submit

**Related Issue**
This PR fixes/closes #1799 

**Description of the solution adopted**
CronExpression field is marked as invalid after validation failure. Error message for this field is updated as well. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>