### PR TITLE
set proper time format in Credentials add dialog

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
@@ -17,6 +17,7 @@ import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.widget.Label;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.util.DateUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.validator.ConfirmPasswordUpdateFieldValidator;
 import org.eclipse.kapua.app.console.module.api.client.util.validator.PasswordUpdateFieldValidator;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
@@ -114,7 +115,7 @@ public class CredentialEditDialog extends CredentialAddDialog {
         confirmPassword.setFieldLabel(MSGS.dialogEditFieldConfirmNewPassword());
         confirmPassword.setAllowBlank(true);
         if (selectedCredential.getLockoutReset() != null && selectedCredential.getLockoutReset().after(new Date())) {
-            lockedUntil.setText(MSGS.dialogEditLockedUntil(selectedCredential.getLockoutResetFormatted()));
+            lockedUntil.setText(MSGS.dialogEditLockedUntil(DateUtils.formatDateTime(selectedCredential.getLockoutReset())));
             credentialFormPanel.add(lockedUntil);
         }
     }


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added proper  Time format in Credentials Edit dialog.

**Related Issue**
This PR fixes issue #935 

**Description of the solution adopted**
Added Time format converter into Credentials Edit Dialog.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
