### PR TITLE
Workaround for Travis fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 jdk:
   - oraclejdk8
 
-sudo: false
+sudo: true
 dist: trusty
 
 # The cache is stored per-branch

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 before_script:
   - export M2_HOME=$PWD/maven
   - export PATH=${M2_HOME}/bin:${PATH}
-  - export MAVEN_OPTS=-Xmx256m
+  - export MAVEN_OPTS=-Xmx4096m
   - hash -r
 
 jobs:


### PR DESCRIPTION
This PR contributes to the fix Travis unstable build. 

**Related Issue**
This PR closes #1949. 
This is the last fix put into the effort of resolving Travis CI build being unstable

**Description of the solution adopted**
https://github.com/travis-ci/travis-ci/issues/10055 as a reference issue.

It seems that Travis is currently affected by some problem fetching artifacts and dependencies. 
`sudo` mode set to `required` seems to work as a workaround.

**Screenshots**
_None_

**Any side note on the changes made**
_None_