### PR TITLE
Fix for error shown when buttons clicked in particular way

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -66,6 +66,9 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     protected boolean keepSelectedItemsAfterLoad = true;
     protected boolean entityGridConfigured;
     private EntityGridLoadListener<M> entityGridLoadListener;
+    protected boolean selectedAgain;
+    protected M selectedItem;
+    private boolean deselectable;
 
     protected EntityGrid(AbstractEntityView<M> entityView, GwtSession currentSession) {
         super(new FitLayout());
@@ -115,13 +118,26 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
 
         //
         // Grid selection mode
-        GridSelectionModel<M> selectionModel = entityGrid.getSelectionModel();
+        final GridSelectionModel<M> selectionModel = entityGrid.getSelectionModel();
         selectionModel.setSelectionMode(selectionMode);
         selectionModel.addSelectionChangedListener(new SelectionChangedListener<M>() {
 
+            @SuppressWarnings("unchecked")
             @Override
             public void selectionChanged(SelectionChangedEvent<M> se) {
-                selectionChangedEvent(se.getSelectedItem());
+                if (selectionModel.getSelectedItem() != null && selectedAgain == false && !deselectable) {
+                    selectionChangedEvent(se.getSelectedItem());
+                    selectedItem = selectionModel.getSelectedItem();
+                } if (selectionModel.getSelectedItem() == null && !deselectable) {
+                    selectedAgain = true;
+                    selectionModel.select(true, selectedItem);
+                } if (selectedItem != selectionModel.getSelectedItem() && !deselectable) {
+                    selectedAgain = false;
+                    selectionChangedEvent(se.getSelectedItem());
+                    selectedItem = selectionModel.getSelectedItem();
+                } if (deselectable) {
+                    selectionChangedEvent(se.getSelectedItem());
+                }
             }
         });
 
@@ -243,4 +259,9 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     public void loaded() {
         entityCRUDToolbar.getRefreshEntityButton().setEnabled(true);
     }
+
+    public void setDeselectable() {
+        deselectable = true;
+    }
+
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -159,7 +159,6 @@ public class DeviceAssetsValues extends LayoutContainer {
                     dirty = true;
                     refresh();
                     refreshProcess = false;
-                    refreshButton.setEnabled(true);
                 }
             }
         });
@@ -195,13 +194,9 @@ public class DeviceAssetsValues extends LayoutContainer {
                 }
             }
         });
-        if (selectedDevice != null) {
-            refreshButton.setEnabled(true);
-        } else {
-            refreshButton.setEnabled(false);
-        }
         apply.setEnabled(false);
         reset.setEnabled(false);
+        refreshButton.setEnabled(false);
         toolBar.add(refreshButton);
         toolBar.add(new SeparatorToolItem());
         toolBar.add(apply);
@@ -503,11 +498,18 @@ public class DeviceAssetsValues extends LayoutContainer {
         }
 
         @Override
+        public void loaderBeforeLoad(LoadEvent le) {
+            super.loaderBeforeLoad(le);
+            refreshButton.disable();
+        }
+
+        @Override
         public void loaderLoad(LoadEvent le) {
             if (le.exception != null) {
                 FailureHandler.handle(le.exception);
             }
             tree.unmask();
+            refreshButton.enable();
         }
 
         @Override
@@ -525,6 +527,7 @@ public class DeviceAssetsValues extends LayoutContainer {
             treeStore.add(assets, false);
 
             tree.unmask();
+            refreshButton.enable();
         }
     }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -163,7 +163,6 @@ public class DeviceConfigComponents extends LayoutContainer {
                     dirty = true;
                     refresh();
                     refreshProcess = false;
-                    refreshButton.setEnabled(true);
                     gwtSession.setFormDirty(false);
                 }
             }
@@ -206,11 +205,6 @@ public class DeviceConfigComponents extends LayoutContainer {
         apply.setEnabled(false);
         reset.setEnabled(false);
         gwtSession.setFormDirty(false);
-        if (selectedDevice == null) {
-            refreshButton.setEnabled(false);
-        } else {
-            refreshButton.setEnabled(true);
-        }
         toolBar.add(refreshButton);
         toolBar.add(new SeparatorToolItem());
         toolBar.add(apply);
@@ -402,11 +396,6 @@ public class DeviceConfigComponents extends LayoutContainer {
 
     public void refresh() {
         if (dirty && initialized) {
-            if (selectedDevice != null) {
-                refreshButton.setEnabled(true);
-            } else {
-                refreshButton.setEnabled(false);
-            }
             // clear the tree and disable the toolbar
             apply.setEnabled(false);
             reset.setEnabled(false);
@@ -620,11 +609,18 @@ public class DeviceConfigComponents extends LayoutContainer {
         }
 
         @Override
+        public void loaderBeforeLoad(LoadEvent le) {
+            super.loaderBeforeLoad(le);
+            refreshButton.disable();
+        }
+
+        @Override
         public void loaderLoad(LoadEvent le) {
             if (le.exception != null) {
                 FailureHandler.handle(le.exception);
             }
             tree.unmask();
+            refreshButton.enable();
         }
 
         @Override
@@ -644,6 +640,7 @@ public class DeviceConfigComponents extends LayoutContainer {
             treeStore.add(comps, false);
 
             tree.unmask();
+            refreshButton.enable();
         }
     }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
@@ -163,7 +163,6 @@ public class DeviceConfigSnapshots extends LayoutContainer {
                     dirty = true;
                     reload();
 
-                    refreshButton.setEnabled(true);
                     refreshProcess = false;
                 }
             }
@@ -199,12 +198,11 @@ public class DeviceConfigSnapshots extends LayoutContainer {
 
                     uploadSnapshot();
 
-                    uploadButton.setEnabled(true);
                     uploadProcess = false;
                 }
             }
         });
-        uploadButton.setEnabled(true);
+        uploadButton.setEnabled(false);
 
         rollbackButton = new SnapshotRollbackButton(new SelectionListener<ButtonEvent>() {
 
@@ -377,7 +375,6 @@ public class DeviceConfigSnapshots extends LayoutContainer {
                 grid.getStore().removeAll();
             } else {
                 toolBar.enable();
-                refreshButton.enable();
                 downloadButton.disable();
                 rollbackButton.disable();
                 reload();
@@ -508,10 +505,19 @@ public class DeviceConfigSnapshots extends LayoutContainer {
         }
 
         @Override
+        public void loaderBeforeLoad(LoadEvent le) {
+            super.loaderBeforeLoad(le);
+            refreshButton.disable();
+            uploadButton.disable();
+        }
+
+        @Override
         public void loaderLoad(LoadEvent le) {
             if (le.exception != null) {
                 FailureHandler.handle(le.exception);
             }
+            refreshButton.enable();
+            uploadButton.enable();
         }
 
         @Override
@@ -523,6 +529,8 @@ public class DeviceConfigSnapshots extends LayoutContainer {
             store.removeAll();
             grid.unmask();
             toolBar.enable();
+            refreshButton.enable();
+            uploadButton.enable();
         }
     }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -333,6 +333,8 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
             if (selectedEntity != null && selectedEntity.isOnline()) {
                 toolBar.enable();
                 uninstallButton.disable();
+                installButton.disable();
+                refreshButton.disable();
             } else {
                 toolBar.disable();
             }
@@ -359,4 +361,11 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
         return uninstallButton;
     }
 
+    public Button getRefreshButton() {
+        return refreshButton;
+    }
+
+    public Button getInstallButton() {
+        return installButton;
+    }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
@@ -50,6 +50,7 @@ public class DeviceTabPackagesInstalled extends TabItem {
     private DeviceTabPackages rootTabPanel;
     private TreeGrid<ModelData> treeGrid;
     private TreeStore<ModelData> treeStore = new TreeStore<ModelData>();
+    private boolean refreshing;
 
     public DeviceTabPackagesInstalled(DeviceTabPackages rootTabPanel) {
         super(DEVICE_MSGS.deviceInstallTabInstalled(), null);
@@ -119,14 +120,20 @@ public class DeviceTabPackagesInstalled extends TabItem {
     }
 
     public void refresh() {
+        if (refreshing) {
+            return;
+        } else {
+            refreshing = true;
+        }
 
-        if (dirty && initialized) {
+        if (initialized) {
 
             GwtDevice selectedDevice = getSelectedDevice();
             if (selectedDevice == null || !selectedDevice.isOnline()) {
                 treeStore.removeAll();
                 treeGrid.unmask();
                 treeGrid.getView().setEmptyText(DEVICE_MSGS.deviceNoDeviceSelectedOrOffline());
+                refreshing = false;
             } else {
                 treeGrid.mask(MSGS.loading());
 
@@ -152,12 +159,16 @@ public class DeviceTabPackagesInstalled extends TabItem {
                         }
 
                         treeGrid.unmask();
+                        rootTabPanel.getRefreshButton().enable();
+                        rootTabPanel.getInstallButton().enable();
+                        refreshing = false;
                     }
 
                     @Override
                     public void onFailure(Throwable caught) {
                         ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
                         treeGrid.unmask();
+                        refreshing = false;
                     }
                 });
             }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
@@ -92,6 +92,7 @@ public class JobTargetAddDialog extends EntityAddEditDialog {
         targetRadioGroup.add(selectedRadio);
 
         targetGrid = new JobTargetAddGrid(currentSession, gwtSelectedJob);
+        targetGrid.setDeselectable();
         targetGrid.disable();
         targetGrid.setHeight(255);
 


### PR DESCRIPTION
Brief description of the PR.
Fix for error shown when buttons clicked in particular way

**Related Issue**
This PR fixes/closes #1780 

**Description of the solution adopted**
Disabled Refresh button while grid loading is in progress on Device Configuration(Components and Snapshots)/Assets/Packages. 
Modified the EntityGrids selectionChangedEvent() method, so that the user can no longer deselect the grid row using Ctrl+Click. If the user tries to do this, the same row will be automatically selected again and the selectionChangedEvent() will not be called.  Added possibility of still deselecting items on the grid, if that grids deselectable boolean property is set to true. 
This way the problematic error messages will no longer be shown.

**Screenshots**
None

**Any side note on the changes made**
None

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>