### PR TITLE
disable sorting of id columns

### DIFF
--- a/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/client/about/AboutView.java
+++ b/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/client/about/AboutView.java
@@ -121,7 +121,9 @@ public class AboutView extends AbstractView implements View {
 
         final List<ColumnConfig> columns = new LinkedList<ColumnConfig>();
         columns.add(rowExpander);
-        columns.add(new ColumnConfig("id", MSGS.columnNameId(), 200));
+        ColumnConfig column = new ColumnConfig("id", MSGS.columnNameId(), 200);
+        column.setSortable(false);
+        columns.add(column);
         columns.add(new ColumnConfig("name", MSGS.columnNameName(), 300));
         columns.add(new ColumnConfig("version", MSGS.columnNameVersion(), 200));
         columns.add(new ColumnConfig("license", MSGS.columnNameLicense(), 300));

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
@@ -123,6 +123,7 @@ public class AccountChildUserGrid extends EntityGrid<GwtUser> {
 
         columnConfig = new ColumnConfig("id", MSGS.gridUserColumnHeaderId(), 100);
         columnConfig.setHidden(true);
+        columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("username", MSGS.gridUserColumnHeaderUsername(), 400);

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
@@ -152,6 +152,7 @@ public class CredentialGrid extends EntityGrid<GwtCredential> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("id", CREDENTIAL_MSGS.gridCredentialColumnHeaderId(), 100);
+        columnConfig.setSortable(false);
         columnConfig.setHidden(true);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
@@ -76,6 +76,7 @@ public class GroupGrid extends EntityGrid<GwtGroup> {
 
         ColumnConfig columnConfig = new ColumnConfig("id", MSGS.gridGroupColumnHeaderId(), 100);
         columnConfig.setHidden(true);
+        columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("groupName", MSGS.gridGroupColumnHeaderGroupName(), 200);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
@@ -83,6 +83,7 @@ public class RolePermissionGrid extends EntityGrid<GwtRolePermission> {
         List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
 
         ColumnConfig columnConfig = new ColumnConfig("id", ROLE_MSGS.gridRolePermissionColumnHeaderId(), 100);
+        columnConfig.setSortable(false);
         columnConfig.setHidden(true);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
@@ -83,6 +83,7 @@ public class UserTabPermissionGrid extends EntityGrid<GwtAccessPermission> {
         List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
 
         ColumnConfig columnConfig = new ColumnConfig("id", PERMISSION_MSGS.gridAccessRoleColumnHeaderId(), 100);
+        columnConfig.setSortable(false);
         columnConfig.setHidden(true);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
@@ -81,6 +81,7 @@ public class UserTabAccessRoleGrid extends EntityGrid<GwtAccessRole> {
         List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
 
         ColumnConfig columnConfig = new ColumnConfig("roleId", MSGS.gridRoleColumnHeaderId(), 100);
+        columnConfig.setSortable(false);
         columnConfig.setHidden(true);
         columnConfigs.add(columnConfig);
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGrid.java
@@ -126,7 +126,6 @@ public class DeviceGrid extends EntityGrid<GwtDevice> {
         columnConfigs.add(column);
 
         column = new ColumnConfig("clientId", DEVICE_MSGS.deviceTableClientID(), 175);
-        column.setSortable(true);
         columnConfigs.add(column);
 
         column = new ColumnConfig("displayName", DEVICE_MSGS.deviceTableDisplayName(), 150);

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointGrid.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointGrid.java
@@ -68,6 +68,7 @@ public class EndpointGrid extends EntityGrid<GwtEndpoint> {
 
         ColumnConfig columnConfig = new ColumnConfig("id", MSGS.gridEndpointColumnHeaderId(), 100);
         columnConfig.setHidden(true);
+        columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("schema", MSGS.gridEndpointColumnHeaderEndpointSchema(), 200);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
@@ -79,6 +79,7 @@ public class JobGrid extends EntityGrid<GwtJob> {
 
         ColumnConfig columnConfig = new ColumnConfig("id", MSGS.gridJobColumnHeaderId(), 100);
         columnConfig.setHidden(true);
+        columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("jobName", MSGS.gridJobColumnHeaderName(), 400);

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
@@ -85,6 +85,7 @@ public class TagGrid extends EntityGrid<GwtTag> {
 
         ColumnConfig columnConfig = new ColumnConfig("id", MSGS.gridTagColumnHeaderId(), 100);
         columnConfig.setHidden(true);
+        columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("tagName", MSGS.gridTagColumnHeaderTagName(), 200);

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGrid.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGrid.java
@@ -127,6 +127,7 @@ public class UserGrid extends EntityGrid<GwtUser> {
 
         columnConfig = new ColumnConfig("id", USER_MSGS.gridUserColumnHeaderId(), 100);
         columnConfig.setHidden(true);
+        columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("username", USER_MSGS.gridUserColumnHeaderUsername(), 400);


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Id columns sorting is disabled in every grid where they exist.

**Related Issue**
This PR fixes #1969 

**Description of the solution adopted**
Just added sotSortable(false) methods in grids which have Id columns.

**Screenshots**
/

**Any side note on the changes made**
/
