### PR TITLE
fix the api doc can not perform try invocation under HTTPS scheme.

### DIFF
--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
@@ -90,7 +90,6 @@ public class RestApisApplication extends ResourceConfig {
         beanConfig.setVersion(apiVersion);
         beanConfig.setBasePath(basePath);
         beanConfig.setTitle(apiTitle);
-        beanConfig.setSchemes(new String[] { "http" });
         beanConfig.setResourcePackage(apiResourcePackage);
         beanConfig.setScan(true);
     }


### PR DESCRIPTION
Signed-off-by: alva.huang <alva@izhiju.cn>

**Brief description of the PR.**
This PR modifies Swagger UI  can only use HTTP access mode.

**Description of the solution adopted**
 remove the fix HTTP scheme code
`
beanConfig.setSchemes(new String[] { "http" });
`

