### PR TITLE
Use the PID as the name for component factory instances

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -296,14 +296,13 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
                     if (ocd != null) {
                         GwtConfigComponent gwtConfig = new GwtConfigComponent();
                         gwtConfig.setId(config.getId());
-                        if(config.getId().indexOf('.') == -1){
-                            gwtConfig.setName(config.getId());
-                        } else {
-                            gwtConfig.setName(ocd.getName());
-                        }
                         if(config.getProperties() != null && config.getProperties().get("service.factoryPid") != null) {
                             String componentName = config.getId().substring(config.getId().lastIndexOf('.') + 1);
                             gwtConfig.setName(componentName);
+                        } else if(config.getId().indexOf('.') == -1) {
+                            gwtConfig.setName(config.getId());
+                        } else {
+                            gwtConfig.setName(ocd.getName());
                         }
                         gwtConfig.setDescription(ocd.getDescription());
                         if (ocd.getIcon() != null && !ocd.getIcon().isEmpty()) {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -301,6 +301,10 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
                         } else {
                             gwtConfig.setName(ocd.getName());
                         }
+                        if(config.getProperties() != null && config.getProperties().get("service.factoryPid") != null) {
+                            String componentName = config.getId().substring(config.getId().lastIndexOf('.') + 1);
+                            gwtConfig.setName(componentName);
+                        }
                         gwtConfig.setDescription(ocd.getDescription());
                         if (ocd.getIcon() != null && !ocd.getIcon().isEmpty()) {
                             KapuaTicon icon = ocd.getIcon().get(0);


### PR DESCRIPTION
Update the name of the services shown in the device configuration tab to use the PID for component factory instances.

**Related Issue**
N/A

**Description of the solution adopted**
Now that Kura uses component factories, it is possible to have multiple instances of a service (for example, the Cloud Service), which can result in multiple services labeled with the same name, making them indistinguishable (e.g. multiple "CloudService" instances).

This updates the name shown for services that were created with a component factory to use the last portion of the PID.  In the screenshot below, the duplicated services now have a unique name (CloudService-test, DataService-test, and MqttDataTransport-test).  This matches the behavior in Kura so that it now labels the services the same way as in the Kura UI.

**Screenshots**
![screen shot 2018-09-06 at 11 32 03 am](https://user-images.githubusercontent.com/1576903/45177726-95d2dd00-b1c8-11e8-8ca2-1f26a7b09901.png)

**Any side note on the changes made**
N/A