### PR TITLE
Unable To Save New Settings fix

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -303,6 +303,7 @@ public class AccountAddDialog extends EntityAddEditDialog {
         gwtAccountCreator.setOrganizationZipPostCode(organizationZipPostCode.getValue());
         gwtAccountCreator.setOrganizationStateProvinceCounty(organizationStateProvinceCounty.getValue());
         gwtAccountCreator.setOrganizationCountry(organizationCountry.getValue());
+        gwtAccountCreator.setScopeId(currentSession.getSelectedAccountId());
 
         GWT_ACCOUNT_SERVICE.create(xsrfToken,
                 gwtAccountCreator,

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
@@ -47,6 +47,23 @@ public class AccountEditDialog extends AccountAddDialog {
         accountNameLabel.setValue(selectedAccount.getName());
         accountNameField.setValue(selectedAccount.getName());
 
+        if (selectedAccount.getParentAccountId() != null) {
+            GWT_ACCOUNT_SERVICE.find(selectedAccount.getParentAccountId(), new AsyncCallback<GwtAccount>() {
+
+                @Override
+                public void onSuccess(GwtAccount result) {
+                    if (parentAccountNameLabel != null) {
+                        parentAccountNameLabel.setValue(result.getName());
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable caught) {
+                    caught.printStackTrace();
+                }
+            });
+        }      
+
         expirationDateField.setValue(selectedAccount.getExpirationDate());
         expirationDateField.setOriginalValue(selectedAccount.getExpirationDate());
 

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
@@ -59,7 +59,7 @@ public class AccountEditDialog extends AccountAddDialog {
 
                 @Override
                 public void onFailure(Throwable caught) {
-                    caught.printStackTrace();
+                    FailureHandler.handle(caught);
                 }
             });
         }      

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -151,7 +151,6 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         ArgumentValidator.notEmptyOrNull(account.getName(), "account.name");
         ArgumentValidator.notNull(account.getOrganization(), "account.organization");
         ArgumentValidator.match(account.getOrganization().getEmail(), CommonsValidationRegex.EMAIL_REGEXP, "account.organization.email");
-        Account parentAccount = null;
 
         //
         // Check Access
@@ -171,6 +170,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         }
 
         // check that expiration date is no later than parent expiration date
+        Account parentAccount = null;
         if (oldAccount.getScopeId() != null) {
             parentAccount = KapuaSecurityUtils.doPrivileged(() -> find(oldAccount.getScopeId()));
         }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -151,6 +151,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         ArgumentValidator.notEmptyOrNull(account.getName(), "account.name");
         ArgumentValidator.notNull(account.getOrganization(), "account.organization");
         ArgumentValidator.match(account.getOrganization().getEmail(), CommonsValidationRegex.EMAIL_REGEXP, "account.organization.email");
+        Account parentAccount = null;
 
         //
         // Check Access
@@ -170,7 +171,9 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         }
 
         // check that expiration date is no later than parent expiration date
-        Account parentAccount = KapuaSecurityUtils.doPrivileged(() -> find(oldAccount.getScopeId()));
+        if (oldAccount.getScopeId() != null) {
+            parentAccount = KapuaSecurityUtils.doPrivileged(() -> find(oldAccount.getScopeId()));
+        }
         if (parentAccount != null && parentAccount.getExpirationDate() != null) {
             // if parent account never expires no check is needed
             if (account.getExpirationDate() == null || parentAccount.getExpirationDate().before(account.getExpirationDate())) {


### PR DESCRIPTION
Brief description of the PR.
Unable To Save New Settings fix

**Related Issue**
This PR fixes/closes #1961 

**Description of the solution adopted**
Added a null check for _oldAccount.getScopeId()_ when creating a parentAccount in update() function of the AccountServiceImpl class. Set ScopeId when adding a new account to _currentSession.getSelectedAccountId()_ .  Also set the correct value to be displayed for parent account name on the AccountEditDialog.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>