### PR TITLE
Bump Jetty version to 9.4.12.v20180830

### DIFF
--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -24,6 +24,10 @@
     <packaging>pom</packaging>
     <artifactId>kapua-assembly-jetty-base</artifactId>
 
+    <properties>
+        <jetty.version>9.4.12.v20180830</jetty.version>
+    </properties>
+
     <profiles>
         <profile>
             <id>release</id>
@@ -47,7 +51,7 @@
                                         <runCmds>
                                             <runCmd><![CDATA[
                                     cd /home/kapua && \
-                                    curl -s https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/9.4.6.v20170531/jetty-distribution-9.4.6.v20170531.tar.gz -o jetty-distribution.tar.gz && \
+                                    curl -s https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/jetty-distribution-${jetty.version}.tar.gz -o jetty-distribution.tar.gz && \
                                     mkdir -p jetty && cd jetty && \
                                     tar --strip=1 -xzf ../jetty-distribution.tar.gz && \
                                     rm ../jetty-distribution.tar.gz && \

--- a/console/README.md
+++ b/console/README.md
@@ -8,7 +8,6 @@ please see the branch `impl-consoleV2`.
 It is possible to run the web console locally by starting the docker containers `kapua-sql`, `kapua-broker` and `kapua-elasticsearch` according to "[Running docker containers](../assembly/README.md#run)" first and then by running:
 
 
-    mvn org.eclipse.jetty:jetty-maven-plugin:9.4.6.v20170531:run-exploded -nsu -Pdev -DuseTestScope=true -Djetty.daemon=false -Dcommons.db.connection.host=localhost
+    mvn org.eclipse.jetty:jetty-maven-plugin:9.4.12.v20180830:run-exploded -nsu -Pdev -DuseTestScope=true -Djetty.daemon=false -Dcommons.db.connection.host=localhost
 
 **Note:** Be sure that the port 8080 is open before starting the web console.
- 

--- a/dev-tools/vagrant/Vagrantfile
+++ b/dev-tools/vagrant/Vagrantfile
@@ -19,7 +19,7 @@ env_vars = {
   'H2DB_VERSION'          => '1.4.192',
   'ACTIVEMQ_VERSION'      => '5.14.5',
   'ARTEMIS_VERSION'       => '2.2.0',
-  'JETTY_VERSION'         => '9.4.6.v20170531',
+  'JETTY_VERSION'         => '9.4.12.v20180830',
   'KAPUA_VERSION'         => '1.1.0-SNAPSHOT'
 }
 

--- a/dev-tools/vagrant/baseBox/Vagrantfile
+++ b/dev-tools/vagrant/baseBox/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(2) do |config|
     export H2DB_VERSION="1.4.192"
     export ACTIVE_MQ_VERSION="5.14.5"
     export ARTEMIS_VERSION="2.2.0"
-    export JETTY_VERSION="9.4.6.v20170531"
+    export JETTY_VERSION="9.4.12.v20180830"
 
     export BINDING_IP="192.168.33.10"
 


### PR DESCRIPTION
This PR bumps the Jetty version to 9.4.12.v20180830

**Related Issue**
This PR fixes #1982

**Description of the solution adopted**
Updated version in Docker and Vagrant scripts

**Screenshots**
N/A

**Any side note on the changes made**
N/A