### PR TITLE
Merge Travis build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ jobs:
       script:
         - $M2_HOME/bin/mvn -v
         - $M2_HOME/bin/mvn -B -f external/pom.xml install
-    - stage: build
-      script:
-        - $M2_HOME/bin/mvn -v
         - $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -DskipTests install
     - stage: test
       script:


### PR DESCRIPTION
This PR merges the first two Travis build steps making them a single step with two subsequent Maven runs, to make sure that the dependencies built by the first step will be available during the actual build.

**Related Issue**
No related issue

**Description of the solution adopted**
By joining the two step into a single one, we are now safe to assume that the `swagger-ui` and `swagger-ui-lib` will be available in the same local Maven repository that will be used in the second step when running the whole build. 

**Screenshots**
N/A

**Any side note on the changes made**
N/A