### PR TITLE
Trying to fix eclipse jenkins build with rest-api tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,11 +77,11 @@ jobs:
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true-Dcucumber.options="--tags @jobs" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @jobs" verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Djetty.war.file=/home/travis/.m2/repository/org/eclipse/kapua/kapua-rest-api-web/1.0.0-SNAPSHOT/kapua-rest-api-web-1.0.0-SNAPSHOT.war -Dcucumber.options="--tags @rest" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Djetty.war.file=/home/travis/.m2/repository/org/eclipse/kapua/kapua-rest-api-web/1.1.0-SNAPSHOT/kapua-rest-api-web-1.1.0-SNAPSHOT.war -Dcucumber.options="--tags @rest" verify
         - bash <(curl -s https://codecov.io/bash)
 
 # The following upgrades Java during the build in

--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,7 @@
                         <cucumber.options>${cucumber.options}</cucumber.options>
                         <commons.db.schema>kapuadb</commons.db.schema>
                         <commons.settings.hotswap>true</commons.settings.hotswap>
+                        <jetty.war.file>../rest-api/web/target/api.war</jetty.war.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fix to jenkins build by specifying correct reat api war file

**Related Issue**
No issue, just build on eclipse jenkins is failing.

**Description of the solution adopted**
As version has been lifted to 1.0.0, war file name has changed and had to be changed in deployment to test jetty container.

**Screenshots**
Not applicable.

**Any side note on the changes made**
This might not be a solution, but i need to try on eclipse jenkins instance.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>