### PR TITLE
Feature transport amqp proton

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -137,7 +137,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-mqtt</artifactId>
+            <artifactId>kapua-transport-amqp-proton</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/assembly/broker/configurations/activemq.xml
+++ b/assembly/broker/configurations/activemq.xml
@@ -181,8 +181,10 @@
             <!-- don't enable the nio since with the nio (amqp+nio) during the qa tests a lot of
             org.apache.activemq.broker.TransportConnection.Transport - Transport Connection to: null failed: java.io.IOException: Frame size of 1 GB larger than max allowed 1 MB
             are shown-->
+            <!-- option: transport.transformer=jms
+            for details see http://activemq.apache.org/amqp.html#AMQP-MappingtoJMS -->
             <transportConnector name="amqp"
-                                uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=1048576" />
+                                uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=1048576&amp;transport.transformer=jms" />
         </transportConnectors>
         <!-- NOTE:
         The following template shows how to configure a network of brokers (i.e. a broker cluster).

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -136,7 +136,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-mqtt</artifactId>
+            <artifactId>kapua-transport-amqp-proton</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/broker/client/amqp-proton/pom.xml
+++ b/broker/client/amqp-proton/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kapua-broker-client</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kapua-broker-client-amqp-proton</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.qpid</groupId>
+            <artifactId>proton-j</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/broker/client/amqp-proton/src/main/java/org/eclipse/kapua/broker/client/amqp/proton/AmqpClient.java
+++ b/broker/client/amqp-proton/src/main/java/org/eclipse/kapua/broker/client/amqp/proton/AmqpClient.java
@@ -1,0 +1,378 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.client.amqp.proton;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.messaging.Target;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.engine.BaseHandler;
+import org.apache.qpid.proton.engine.Connection;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.Event;
+import org.apache.qpid.proton.engine.Receiver;
+import org.apache.qpid.proton.engine.Sender;
+import org.apache.qpid.proton.engine.Session;
+import org.apache.qpid.proton.message.Message;
+import org.apache.qpid.proton.message.impl.MessageImpl;
+import org.apache.qpid.proton.reactor.FlowController;
+import org.apache.qpid.proton.reactor.Handshaker;
+import org.apache.qpid.proton.reactor.Reactor;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.client.amqp.proton.ClientOptions.AmqpClientOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AmqpClient extends BaseHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(AmqpClient.class);
+
+    private final static String ID_PATTERN = "%s_%s";
+
+    private DestinationTranslator destinationTranslator;
+
+    private Thread threadClient;
+    protected boolean connected;
+    protected AtomicInteger reconnectionFaultCount = new AtomicInteger();
+    protected Long reconnectTaskId;
+    private ClientOptions options;
+    private String clientId;
+    private Reactor r;
+    private Connection conn;
+    private Session ssn;
+    private Sender snd;
+    private Receiver rec;
+    private ConsumerHandler consumerHandler;
+
+    //internal fields used by the publisher
+    private int nextTag;
+    protected ByteArrayOutputStream current = new ByteArrayOutputStream();
+    byte[] buffer = new byte[1024];
+
+    public AmqpClient(ClientOptions options) throws IOException {
+        this.options = options;
+        clientId = options.getString(AmqpClientOptions.CLIENT_ID);
+        Object tmp = options.get(AmqpClientOptions.DESTINATION_TRANSLATOR);
+        if (tmp == null) {
+            logger.debug("No destiantion translator defined.");
+        }
+        else if (tmp instanceof DestinationTranslator) {
+            destinationTranslator = (DestinationTranslator) tmp;
+        }
+        else {
+            KapuaException.internalError(String.format("The destination translator must be null or an instance of DestinationTranslator! found {}", tmp));
+        }
+        logger.info("Creating client: {}", clientId);
+        add(new Handshaker());
+        add(new FlowController());
+        r = Proton.reactor(this);
+    }
+
+    @Override
+    public void onReactorInit(Event event) {
+        conn = event.getReactor().connectionToHost(options.getString(AmqpClientOptions.BROKER_HOST), options.getInt(AmqpClientOptions.BROKER_PORT, 5672), this);
+    }
+
+    @Override
+    public void onConnectionInit(Event event) {
+        conn = event.getConnection();
+        conn.setContainer(clientId);
+        conn.open();
+
+        ssn = conn.session();
+        ssn.open();
+    }
+
+    public void subscribe(String destination, ConsumerHandler consumerHandler) {
+        logger.info("Subscribe to {}", destination);
+        this.consumerHandler = consumerHandler;
+        rec = ssn.receiver(getReceiverId());
+        Source source = new Source();
+        source.setAddress(getAddress(destination));
+        rec.setSource(source);
+        Target t = new Target();
+        t.setAddress(getAddress(destination));
+        rec.setTarget(t);
+        rec.flow(10);
+        rec.open();
+    }
+
+    @Override
+    public void onTransportError(Event event) {
+        ErrorCondition condition = event.getTransport().getCondition();
+        if (condition != null) {
+            logger.error("Error: " + condition.getDescription());
+        } else {
+            logger.error("Error (no description returned).");
+        }
+    }
+
+    @Override
+    public void onDelivery(Event event) {
+        Receiver receiver = (Receiver)event.getLink();
+        logger.info("Received delivery - Receiver: {} - from link: {} - equals: {} - consumer handler {}", rec, receiver, rec==receiver, consumerHandler);
+        Delivery delivery = receiver.current();
+        if (delivery != null) {
+            int count;
+            while ((count = receiver.recv(buffer, 0, buffer.length)) > 0) {
+                current.write(buffer, 0, count);
+            }
+            if (delivery.isPartial()) {
+                return;
+            }
+            byte[] data = current.toByteArray();
+            current.reset();
+            Message msg = Proton.message();
+            msg.decode(data, 0, data.length);
+            receiver.advance();
+            logger.debug("Received message from {}", msg.getAddress());
+
+            try {
+                if (consumerHandler != null) {
+                    consumerHandler.consumeMessage(delivery, msg);
+                }
+                else {
+                    logger.warn("Message received for a null consumer handler!");
+                }
+            } catch (Exception e) {
+                logger.error("Message processing error: {}", e.getMessage(), e);
+            }
+            finally {
+                delivery.settle();
+            }
+            //close the receiver since the pattern used by the "device command" sends one message as request and wait for only one message as reply
+            receiver.close();
+            //no needing to call free() for both receiver and sender since it's called implicitly by the close method!
+            //receiver.free();
+        }
+    }
+
+    public void send(Message message, String destination) throws KapuaException {
+        snd = ssn.sender(getSenderId());
+        logger.debug("Send message to {} - snd {}", destination, snd);
+        Target target = new Target();
+        target.setAddress(getAddress(destination));
+        snd.setTarget(target);
+        Source source = new Source();
+        source.setAddress(getAddress(destination));
+        snd.setSource(source);
+        message.setAddress(message.getAddress());
+        snd.open();
+
+        int bufferSize = 1024;
+        byte[] encodedMessage = new byte[bufferSize];
+        MessageImpl msg = (MessageImpl) message;
+        int len = msg.encode2(encodedMessage, 0, bufferSize);
+
+        // looks like the message is bigger than our initial buffer, lets resize and try again.
+        if (len > encodedMessage.length) {
+          encodedMessage = new byte[len];
+          msg.encode(encodedMessage, 0, len);
+        }
+        byte[] tag = String.valueOf(nextTag++).getBytes();
+        Delivery dlv = snd.delivery(tag);
+        snd.send(encodedMessage, 0, len);
+        dlv.settle();
+        snd.advance();
+        snd.close();
+        //no needing to call free() for both receiver and sender since it's called implicitly by the close method!
+        //snd.free();
+        snd = null;
+        logger.info("Send message to {} - snd {} DONE", destination, snd);
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    @Override
+    public void onLinkLocalOpen(Event e) {
+        super.onLinkLocalOpen(e);
+        logger.debug("onLinkLocalOpen! {}", e);
+    }
+
+    @Override
+    public void onLinkLocalClose(Event e) {
+        super.onLinkLocalClose(e);
+        if (e.getContext() instanceof Receiver) {
+            //if the closing object is the Receiver then set to null also the consumer handler
+            logger.info("Cleaning consumer handler...");
+            consumerHandler = null;
+        }
+        logger.debug("onLinkLocalClose! {}", e);
+    }
+
+    @Override
+    public void onLinkLocalDetach(Event e) {
+        super.onLinkLocalDetach(e);
+        logger.debug("onLinkLocalDetach! {}", e);
+    }
+
+    @Override
+    public void onLinkRemoteOpen(Event e) {
+        super.onLinkRemoteOpen(e);
+        logger.debug("onLinkRemoteOpen! {}", e);
+    }
+
+    @Override
+    public void onLinkRemoteDetach(Event e) {
+        super.onLinkRemoteDetach(e);
+        logger.debug("onLinkRemoteDetach! {}", e);
+    }
+
+    @Override
+    public void onLinkRemoteClose(Event e) {
+        super.onLinkRemoteClose(e);
+        logger.debug("onLinkRemoteClose! {}", e);
+    }
+
+    @Override
+    public void onConnectionLocalClose(Event e) {
+        super.onConnectionLocalClose(e);
+        logger.debug("onConnectionLocalClose! {}", e);
+    }
+
+    @Override
+    public void onConnectionRemoteClose(Event e) {
+        super.onConnectionRemoteClose(e);
+        logger.debug("onConnectionRemoteClose! {}", e);
+    }
+
+    @Override
+    public void onConnectionLocalOpen(Event e) {
+        super.onConnectionLocalOpen(e);
+        logger.debug("onConnectionLocalOpen! {}", e);
+    }
+
+    @Override
+    public void onConnectionRemoteOpen(Event e) {
+        super.onConnectionRemoteOpen(e);
+        setConnected(true);
+        logger.debug("onConnectionRemoteOpen! {}", e);
+    }
+
+    @Override
+    public void onConnectionUnbound(Event e) {
+        super.onConnectionUnbound(e);
+        logger.debug("onConnectionUnbound! {}", e);
+        notifyConnectionLost();
+    }
+
+    @Override
+    public void onConnectionBound(Event e) {
+        super.onConnectionBound(e);
+        logger.debug("onConnectionBound! {}", e);
+    }
+
+    @Override
+    public void onConnectionFinal(Event e) {
+        super.onConnectionFinal(e);
+        logger.debug("onConnectionFinal! {}", e);
+    }
+
+    public boolean isConnected() {
+        return connected;
+    }
+
+    protected void setConnected(boolean connected) {
+        synchronized (this) {
+            this.connected = connected;
+            this.notify();
+        }
+    }
+
+    public void clean() {
+        logger.info("Clean client {} - snd {} - rec {}", clientId, snd, rec);
+        if (snd!=null) {
+            snd.close();
+            //no needing to call free() for both receiver and sender since it's called implicitly by the close method!
+            //snd.free();
+            snd = null;
+        }
+        if (rec!=null) {
+            //no needing to call free() for both receiver and sender since it's called implicitly by the close method!
+            //rec.free();
+            rec.close();
+            rec = null;
+        }
+    }
+
+    public void disconnect() {
+        logger.info("Disconnecting client '{}'...", clientId);
+        clean();
+        if (ssn!=null) {
+            logger.info("Freeing and closing session for client id '{}'...", clientId);
+            ssn.free();
+            ssn.close();
+        }
+        if (conn!=null) {
+            logger.info("Freeing and closing connection for client id '{}'...", clientId);
+            conn.free();
+            conn.close();
+        }
+        if (r != null) {
+            r.stop();
+        }
+        synchronized (this) {
+            threadClient = null;
+        }
+        logger.info("Disconnecting client '{}'... DONE", clientId);
+        connected = false;
+    }
+
+    public void connect() {
+        synchronized (this) {
+            if (threadClient!=null) {
+                KapuaException.internalError("Cannot start the client since another instance is still running!");
+            }
+            else {
+                threadClient = new Thread(() -> {
+                    logger.info("Starting client: {}", clientId);
+                    r.run();
+                    logger.info("Closing client: {}", clientId);
+                });
+                threadClient.start();
+            }
+        }
+    }
+
+    protected void notifyConnectionLost() {
+        disconnect();
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        disconnect();
+    }
+
+    private String getAddress(String destination) {
+        if (destinationTranslator!=null) {
+            return destinationTranslator.translate(destination);
+        }
+        else {
+            return destination;
+        }
+    }
+
+    private String getReceiverId() {
+        return String.format(ID_PATTERN, clientId, "rec");
+    }
+
+    private String getSenderId() {
+        return String.format(ID_PATTERN, clientId, "snd");
+    }
+}

--- a/broker/client/amqp-proton/src/main/java/org/eclipse/kapua/broker/client/amqp/proton/ClientOptions.java
+++ b/broker/client/amqp-proton/src/main/java/org/eclipse/kapua/broker/client/amqp/proton/ClientOptions.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.client.amqp.proton;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ClientOptions {
+
+    public enum AmqpClientOptions {
+        BROKER_HOST,
+        BROKER_PORT,
+        USERNAME,
+        PASSWORD,
+        CLIENT_ID,
+        DESTINATION,
+        MAXIMUM_RECONNECTION_ATTEMPTS,
+        WAIT_BETWEEN_RECONNECT,
+        CONNECT_TIMEOUT,
+        IDLE_TIMEOUT,
+        AUTO_ACCEPT,
+        QOS,
+        PREFETCH_MESSAGES,
+        EXIT_CODE,
+        /**
+         * object responsible to translate address coming from a received message (i.e. using ActiveMQ with the VirtualTopic enabled the message coming from an MQTT connector will have the prefix "VirtualTopic")
+         */
+        DESTINATION_TRANSLATOR
+    }
+
+    private Map<String, Object> options;
+
+    public ClientOptions() {
+        options = new HashMap<>();
+        //fill default values
+        put(AmqpClientOptions.MAXIMUM_RECONNECTION_ATTEMPTS, 10);
+        put(AmqpClientOptions.EXIT_CODE, -1);
+    }
+
+    public ClientOptions(String host, int port, String username, String password, DestinationTranslator destinationTranslator) {
+        this();
+        options = new HashMap<>();
+        //fill default values
+        put(AmqpClientOptions.BROKER_HOST, host);
+        put(AmqpClientOptions.BROKER_PORT, port);
+        put(AmqpClientOptions.USERNAME, username);
+        put(AmqpClientOptions.PASSWORD, password);
+        put(AmqpClientOptions.DESTINATION_TRANSLATOR, destinationTranslator);
+    }
+
+    public void put(String key, Object value) {
+        options.put(key, value);
+    }
+
+    public Object get(String key) {
+        return options.get(key);
+    }
+
+    public Integer getInt(AmqpClientOptions key, Integer defaultValue) {
+        Integer tmp = (Integer)options.get(key.name());
+        return (tmp!=null ? tmp : defaultValue);
+    }
+
+    public Long getLong(AmqpClientOptions key, Long defaultValue) {
+        Long tmp = (Long)options.get(key.name());
+        return (tmp!=null ? tmp : defaultValue);
+    }
+
+    public String getString(AmqpClientOptions key) {
+        return (String)options.get(key.name());
+    }
+
+    public void put(AmqpClientOptions key, Object value) {
+        options.put(key.name(), value);
+    }
+
+    public Object get(AmqpClientOptions key) {
+        return options.get(key.name());
+    }
+
+    public void clear() {
+        options.clear();
+    }
+
+}

--- a/broker/client/amqp-proton/src/main/java/org/eclipse/kapua/broker/client/amqp/proton/ConsumerHandler.java
+++ b/broker/client/amqp-proton/src/main/java/org/eclipse/kapua/broker/client/amqp/proton/ConsumerHandler.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.client.amqp.proton;
+
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.message.Message;
+
+public interface ConsumerHandler {
+
+    void consumeMessage(Delivery delivery, Message message) throws Exception;
+
+}

--- a/broker/client/amqp-proton/src/main/java/org/eclipse/kapua/broker/client/amqp/proton/DestinationTranslator.java
+++ b/broker/client/amqp-proton/src/main/java/org/eclipse/kapua/broker/client/amqp/proton/DestinationTranslator.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.client.amqp.proton;
+
+/**
+ * Destination translator
+ *
+ */
+public interface DestinationTranslator {
+
+    /**
+     * Translate destination if needed by the architecture/use case
+     * 
+     * @param destination
+     * @return
+     */
+    String translate(String destination);
+
+}

--- a/broker/client/pom.xml
+++ b/broker/client/pom.xml
@@ -25,6 +25,7 @@
 
     <modules>
         <module>amqp</module>
+        <module>amqp-proton</module>
         <module>hono</module>
     </modules>
 </project>

--- a/broker/plugin/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker/plugin/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -23,6 +23,7 @@ import org.apache.activemq.broker.ProducerBrokerExchange;
 import org.apache.activemq.broker.TransportConnector;
 import org.apache.activemq.broker.region.Subscription;
 import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.apache.activemq.command.ConnectionInfo;
 import org.apache.activemq.command.ConsumerInfo;
@@ -574,6 +575,11 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
         if (destination instanceof ActiveMQTopic) {
             ActiveMQTopic destinationTopic = (ActiveMQTopic) destination;
             messageSend.setProperty(Properties.PROPERTY_ORIGINAL_TOPIC, destinationTopic.getTopicName().substring(VT_TOPIC_PREFIX.length()));
+        }
+        else {
+            ActiveMQQueue destinationQueue = (ActiveMQQueue) destination;
+            logger.info(destinationQueue.toString());
+            messageSend.setProperty(Properties.PROPERTY_ORIGINAL_TOPIC, destinationQueue.getQueueName().substring(VT_TOPIC_PREFIX.length()));
         }
         publishMetric.getAllowedMessages().inc();
         super.send(producerExchange, messageSend);

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -51,9 +51,14 @@ commons.db.character.wildcard.single=_
 #
 # Broker settings
 #
-broker.scheme=tcp
+#using MQTT device command connector
+#broker.scheme=tcp
+#broker.host=localhost
+#broker.port=1883
+#using AMQP device command connector
+broker.scheme=amqp
 broker.host=localhost
-broker.port=1883
+broker.port=5672
 
 character.encoding=UTF-8
 

--- a/connector/api/src/main/java/org/eclipse/kapua/connector/AbstractAmqpSource.java
+++ b/connector/api/src/main/java/org/eclipse/kapua/connector/AbstractAmqpSource.java
@@ -88,14 +88,14 @@ public abstract class AbstractAmqpSource<M> implements MessageSource<M> {
         logger.debug("Received message with body: {}", body);
         if (body instanceof Data) {
             Binary data = ((Data) body).getValue();
-            logger.debug("Received DATA message");
-            return data.getArray();
+            logger.debug("Received data message: {}", body);
+            return data != null ? data.getArray() : new byte[0];
         } else if (body instanceof AmqpValue) {
             String content = (String) ((AmqpValue) body).getValue();
             logger.debug("Received message with content: {}", content);
-            return content.getBytes();
+            return content != null ? content.getBytes() : new byte[0];
         } else {
-            logger.warn("Recevide message with unknown message type! ({})", body != null ? body.getClass() : "NULL");
+            logger.warn("Received message with unknown message type! ({})", body != null ? body.getClass() : "null");
             throw new KapuaConverterException(KapuaErrorCodes.INTERNAL_ERROR);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -866,6 +866,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-translator-kura-amqp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-translator-kura-jms</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -887,6 +892,11 @@
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-transport-mqtt</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-transport-amqp-proton</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -933,6 +943,11 @@
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-broker-client-amqp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-broker-client-amqp-proton</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/qa-steps/pom.xml
+++ b/qa-steps/pom.xml
@@ -100,6 +100,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-transport-amqp-proton</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-datastore-client-embedded</artifactId>
         </dependency>
         <dependency>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -141,7 +141,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-translator-kura-mqtt</artifactId>
+            <artifactId>kapua-translator-kura-amqp</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
@@ -155,11 +155,7 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-mqtt</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-jms</artifactId>
+            <artifactId>kapua-transport-amqp-proton</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/qa/src/test/resources/activemq.xml
+++ b/qa/src/test/resources/activemq.xml
@@ -185,8 +185,10 @@
             <!-- don't enable the nio since with the nio (amqp+nio) during the qa tests a lot of
             org.apache.activemq.broker.TransportConnection.Transport - Transport Connection to: null failed: java.io.IOException: Frame size of 1 GB larger than max allowed 1 MB
             are shown-->
+            <!-- option: transport.transformer=jms
+            for details see http://activemq.apache.org/amqp.html#AMQP-MappingtoJMS -->
             <transportConnector name="amqp"
-                                uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=1048576" />
+                                uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=1048576&amp;transport.transformer=jms" />
         </transportConnectors>
         <!-- NOTE:
         The following template shows how to configure a network of brokers (i.e. a broker cluster).

--- a/qa/src/test/resources/kapua-environment-setting.properties
+++ b/qa/src/test/resources/kapua-environment-setting.properties
@@ -48,9 +48,14 @@ commons.db.pool.borrow.timeout=15000
 #
 # Broker settings
 #
-broker.scheme=tcp
+#using MQTT device command connector
+#broker.scheme=tcp
+#broker.host=localhost
+#broker.port=1883
+#using AMQP device command connector
+broker.scheme=amqp
 broker.host=localhost
-broker.port=1883
+broker.port=5672
 
 character.encoding=UTF-8
 

--- a/rest-api/resources/pom.xml
+++ b/rest-api/resources/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-mqtt</artifactId>
+            <artifactId>kapua-transport-amqp-proton</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -143,7 +143,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-transport-mqtt</artifactId>
+            <artifactId>kapua-transport-amqp-proton</artifactId>
         </dependency>
 
         <dependency>

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/MqttAsyncTransport.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/MqttAsyncTransport.java
@@ -63,6 +63,7 @@ public class MqttAsyncTransport extends AbstractMqttTransport implements AutoClo
 
             @Override
             public void connectionLost(final Throwable cause) {
+                logger.warn("Client Disconnected: {}", cause.getMessage(), cause);
                 handleDisconnected();
             }
         });
@@ -127,7 +128,7 @@ public class MqttAsyncTransport extends AbstractMqttTransport implements AutoClo
 
                 @Override
                 public void messageArrived(final String topic, final MqttMessage mqttMessage) throws Exception {
-                    logger.debug("Received MQTT message from {}", topic);
+                    logger.info("Received MQTT message from {}", topic);
                     consumer.accept(new Message(Topic.fromString(topic), mqttMessage.getPayload(),
                             MqttAsyncTransport.this.topicContext));
                 }

--- a/translator/kura/amqp/about.html
+++ b/translator/kura/amqp/about.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 5, 2006</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in ("Content").  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 ("EPL").  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, "Program" will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party ("Redistributor") and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+
+</body></html>

--- a/translator/kura/amqp/pom.xml
+++ b/translator/kura/amqp/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+        Red Hat Inc
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>org.eclipse.kapua</groupId>
+    <artifactId>kapua-translator-kura</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>kapua-translator-kura-amqp</artifactId>
+  <name>${project.artifactId}</name>
+  
+  <dependencies>
+        <!-- Implemented service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-api</artifactId>
+        </dependency>
+        
+         <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-call-kura</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-transport-amqp-proton</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+  </dependencies>
+
+</project>

--- a/translator/kura/amqp/src/main/java/org/eclipse/kapua/translator/amqp/kura/TranslatorDataAmqpKura.java
+++ b/translator/kura/amqp/src/main/java/org/eclipse/kapua/translator/amqp/kura/TranslatorDataAmqpKura.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.amqp.kura;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataChannel;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataPayload;
+import org.eclipse.kapua.translator.Translator;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpMessage;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpPayload;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpTopic;
+
+/**
+ * Messages translator implementation from {@link AmqpMessage} to {@link org.eclipse.kapua.service.device.call.message.kura.KuraMessage}
+ */
+public class TranslatorDataAmqpKura extends Translator<AmqpMessage, KuraDataMessage> {
+
+    @Override
+    public KuraDataMessage translate(AmqpMessage aqmpMessage)
+            throws KapuaException {
+        // Kura topic
+        KuraDataChannel kuraChannel = translate(aqmpMessage.getRequestTopic());
+
+        // Kura payload
+        KuraDataPayload kuraPayload = translate(aqmpMessage.getPayload());
+
+        // Return Kura message
+        return new KuraDataMessage(kuraChannel,
+                aqmpMessage.getTimestamp(),
+                kuraPayload);
+    }
+
+    private KuraDataChannel translate(AmqpTopic aqmpTopic)
+            throws KapuaException {
+        String[] aqmpTopicTokens = aqmpTopic.getSplittedTopic();
+        return new KuraDataChannel(aqmpTopicTokens[0],
+                aqmpTopicTokens[1]);
+    }
+
+    private KuraDataPayload translate(AmqpPayload aqmpPayload)
+            throws KapuaException {
+        byte[] jmsBody = aqmpPayload.getBody();
+
+        KuraDataPayload kuraPayload = new KuraDataPayload();
+        kuraPayload.readFromByteArray(jmsBody);
+        return kuraPayload;
+    }
+
+    @Override
+    public Class<AmqpMessage> getClassFrom() {
+        return AmqpMessage.class;
+    }
+
+    @Override
+    public Class<KuraDataMessage> getClassTo() {
+        return KuraDataMessage.class;
+    }
+
+}

--- a/translator/kura/amqp/src/main/java/org/eclipse/kapua/translator/amqp/kura/TranslatorResponseAmqpKura.java
+++ b/translator/kura/amqp/src/main/java/org/eclipse/kapua/translator/amqp/kura/TranslatorResponseAmqpKura.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.amqp.kura;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseChannel;
+import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseMessage;
+import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponsePayload;
+import org.eclipse.kapua.translator.Translator;
+import org.eclipse.kapua.translator.exception.TranslatorErrorCodes;
+import org.eclipse.kapua.translator.exception.TranslatorException;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpMessage;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpPayload;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpTopic;
+
+/**
+ * Messages translator implementation from {@link AmqpMessage} to {@link KuraResponseMessage}
+ * 
+ * @since 1.0
+ *
+ */
+public class TranslatorResponseAmqpKura extends Translator<AmqpMessage, KuraResponseMessage> {
+
+    private static final String CONTROL_MESSAGE_CLASSIFIER = SystemSetting.getInstance().getMessageClassifier();
+
+    @Override
+    public KuraResponseMessage translate(AmqpMessage aqmpMessage)
+            throws KapuaException {
+        // Kura topic
+        KuraResponseChannel kuraChannel = translate(aqmpMessage.getRequestTopic());
+
+        // Kura payload
+        KuraResponsePayload kuraPayload = translate(aqmpMessage.getPayload());
+
+        // Kura message
+        return new KuraResponseMessage(kuraChannel,
+                aqmpMessage.getTimestamp(),
+                kuraPayload);
+    }
+
+    private KuraResponseChannel translate(AmqpTopic aqmpTopic)
+            throws KapuaException {
+        String[] aqmpTopicTokens = aqmpTopic.getSplittedTopic();
+
+        if (!CONTROL_MESSAGE_CLASSIFIER.equals(aqmpTopicTokens[0])) {
+            throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_CLASSIFIER,
+                    null,
+                    aqmpTopicTokens[0]);
+        }
+
+        KuraResponseChannel kuraResponseChannel = new KuraResponseChannel(aqmpTopicTokens[0],
+                aqmpTopicTokens[1],
+                aqmpTopicTokens[2]);
+
+        kuraResponseChannel.setAppId(aqmpTopicTokens[3]);
+        kuraResponseChannel.setReplyPart(aqmpTopicTokens[4]);
+        kuraResponseChannel.setRequestId(aqmpTopicTokens[5]);
+        return kuraResponseChannel;
+    }
+
+    private KuraResponsePayload translate(AmqpPayload aqmpPayload)
+            throws KapuaException {
+        byte[] aqmpBody = aqmpPayload.getBody();
+
+        KuraResponsePayload kuraResponsePayload = new KuraResponsePayload();
+        kuraResponsePayload.readFromByteArray(aqmpBody);
+        return kuraResponsePayload;
+    }
+
+    @Override
+    public Class<AmqpMessage> getClassFrom() {
+        return AmqpMessage.class;
+    }
+
+    @Override
+    public Class<KuraResponseMessage> getClassTo() {
+        return KuraResponseMessage.class;
+    }
+}

--- a/translator/kura/amqp/src/main/java/org/eclipse/kapua/translator/kura/amqp/TranslatorDataKuraAmqp.java
+++ b/translator/kura/amqp/src/main/java/org/eclipse/kapua/translator/kura/amqp/TranslatorDataKuraAmqp.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kura.amqp;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataChannel;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
+import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataPayload;
+import org.eclipse.kapua.translator.Translator;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpMessage;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpPayload;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpTopic;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Messages translator implementation from {@link org.eclipse.kapua.service.device.call.message.kura.KuraMessage} to {@link AmqpMessage}
+ */
+public class TranslatorDataKuraAmqp extends Translator<KuraDataMessage, AmqpMessage> {
+
+    @Override
+    public AmqpMessage translate(KuraDataMessage kuraMessage)
+            throws KapuaException {
+        // Amqp request topic
+        AmqpTopic aqmpRequestTopic = translate(kuraMessage.getChannel());
+
+        // Amqp payload
+        AmqpPayload aqmpPayload = translate(kuraMessage.getPayload());
+
+        // Return Amqp message
+        return new AmqpMessage(aqmpRequestTopic,
+                new Date(),
+                aqmpPayload);
+    }
+
+    private AmqpTopic translate(KuraDataChannel kuraChannel)
+            throws KapuaException {
+        List<String> topicTokens = new ArrayList<>();
+
+        topicTokens.add(kuraChannel.getScope());
+        topicTokens.add(kuraChannel.getClientId());
+
+        if (kuraChannel.getSemanticChannelParts() != null &&
+                !kuraChannel.getSemanticChannelParts().isEmpty()) {
+            topicTokens.addAll(kuraChannel.getSemanticChannelParts());
+        }
+
+        return new AmqpTopic(topicTokens.toArray(new String[0]));
+    }
+
+    private AmqpPayload translate(KuraDataPayload kuraPayload)
+            throws KapuaException {
+        return new AmqpPayload(kuraPayload.toByteArray());
+    }
+
+    @Override
+    public Class<KuraDataMessage> getClassFrom() {
+        return KuraDataMessage.class;
+    }
+
+    @Override
+    public Class<AmqpMessage> getClassTo() {
+        return AmqpMessage.class;
+    }
+
+}

--- a/translator/kura/amqp/src/main/java/org/eclipse/kapua/translator/kura/amqp/TranslatorRequestKuraAmqp.java
+++ b/translator/kura/amqp/src/main/java/org/eclipse/kapua/translator/kura/amqp/TranslatorRequestKuraAmqp.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.translator.kura.amqp;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.service.device.call.message.kura.KuraPayload;
+import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestChannel;
+import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestMessage;
+import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSetting;
+import org.eclipse.kapua.service.device.call.message.kura.setting.DeviceCallSettingKeys;
+import org.eclipse.kapua.translator.Translator;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpMessage;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpPayload;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpTopic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Messages translator implementation from {@link KuraRequestMessage} to {@link AmqpMessage}
+ *
+ * @since 1.0
+ */
+public class TranslatorRequestKuraAmqp extends Translator<KuraRequestMessage, AmqpMessage> {
+
+    @Override
+    public AmqpMessage translate(KuraRequestMessage kuraMessage)
+            throws KapuaException {
+        // Amqp request topic
+        AmqpTopic aqmpRequestTopic = translate(kuraMessage.getChannel());
+
+        // Amqp response topic
+        AmqpTopic aqmpResponseTopic = generateResponseTopic(kuraMessage.getChannel());
+
+        // Amqp payload
+        AmqpPayload aqmpPayload = translate(kuraMessage.getPayload());
+        return new AmqpMessage(aqmpRequestTopic,
+                aqmpResponseTopic,
+                aqmpPayload);
+    }
+
+    public AmqpTopic translate(KuraRequestChannel kuraChannel)
+            throws KapuaException {
+        List<String> topicTokens = new ArrayList<>();
+
+        if (kuraChannel.getMessageClassification() != null) {
+            topicTokens.add(kuraChannel.getMessageClassification());
+        }
+
+        topicTokens.add(kuraChannel.getScope());
+        topicTokens.add(kuraChannel.getClientId());
+        topicTokens.add(kuraChannel.getAppId());
+        topicTokens.add(kuraChannel.getMethod().name());
+
+        for (String s : kuraChannel.getResources()) {
+            topicTokens.add(s);
+        }
+        return new AmqpTopic(topicTokens.toArray(new String[0]));
+    }
+
+    private AmqpTopic generateResponseTopic(KuraRequestChannel kuraChannel) {
+        String replyPart = DeviceCallSetting.getInstance().getString(DeviceCallSettingKeys.DESTINATION_REPLY_PART);
+
+        List<String> topicTokens = new ArrayList<>();
+
+        if (kuraChannel.getMessageClassification() != null) {
+            topicTokens.add(kuraChannel.getMessageClassification());
+        }
+
+        topicTokens.add(kuraChannel.getScope());
+        topicTokens.add(kuraChannel.getRequesterClientId());
+        topicTokens.add(kuraChannel.getAppId());
+        topicTokens.add(replyPart);
+        topicTokens.add(kuraChannel.getRequestId());
+
+        return new AmqpTopic(topicTokens.toArray(new String[0]));
+    }
+
+    private AmqpPayload translate(KuraPayload kuraPayload)
+            throws KapuaException {
+        return new AmqpPayload(kuraPayload.toByteArray());
+    }
+
+    @Override
+    public Class<KuraRequestMessage> getClassFrom() {
+        return KuraRequestMessage.class;
+    }
+
+    @Override
+    public Class<AmqpMessage> getClassTo() {
+        return AmqpMessage.class;
+    }
+}

--- a/translator/kura/amqp/src/main/resources/META-INF/services/org.eclipse.kapua.translator.Translator
+++ b/translator/kura/amqp/src/main/resources/META-INF/services/org.eclipse.kapua.translator.Translator
@@ -1,0 +1,4 @@
+org.eclipse.kapua.translator.kura.amqp.TranslatorDataKuraAmqp
+org.eclipse.kapua.translator.kura.amqp.TranslatorRequestKuraAmqp
+org.eclipse.kapua.translator.amqp.kura.TranslatorDataAmqpKura
+org.eclipse.kapua.translator.amqp.kura.TranslatorResponseAmqpKura

--- a/translator/kura/amqp/src/test/resources/logback.xml
+++ b/translator/kura/amqp/src/test/resources/logback.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Red Hat Inc and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Red Hat - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="liquibase" level="WARN" />
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/translator/kura/pom.xml
+++ b/translator/kura/pom.xml
@@ -25,6 +25,7 @@
     <name>${project.artifactId}</name>
 
     <modules>
+        <module>amqp</module>
         <module>jms</module>
         <module>mqtt</module>
     </modules>

--- a/transport/amqp-proton/README.md
+++ b/transport/amqp-proton/README.md
@@ -1,0 +1,4 @@
+# Kapua
+## Transport MQTT Implementation
+
+Implements the Transport API for the MQTT protocol.

--- a/transport/amqp-proton/about.html
+++ b/transport/amqp-proton/about.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 5, 2006</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in ("Content").  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 ("EPL").  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, "Program" will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party ("Redistributor") and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+
+</body></html>

--- a/transport/amqp-proton/pom.xml
+++ b/transport/amqp-proton/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+        Red Hat Inc
+ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua-transport</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-transport-amqp-proton</artifactId>
+
+
+    <dependencies>
+        <!-- Implemented service interfaces -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-transport-api</artifactId>
+        </dependency>
+
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-translator-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-broker-client-amqp-proton</artifactId>
+        </dependency>
+
+        <!-- External dependencies -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClient.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClient.java
@@ -1,0 +1,273 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton;
+
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.client.amqp.proton.ClientOptions;
+import org.eclipse.kapua.broker.client.amqp.proton.DestinationTranslator;
+import org.eclipse.kapua.broker.client.amqp.proton.ClientOptions.AmqpClientOptions;
+import org.eclipse.kapua.transport.TransportClientConnectOptions;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpMessage;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpPayload;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpTopic;
+import org.eclipse.kapua.transport.amqpproton.setting.AmqpClientSetting;
+import org.eclipse.kapua.transport.amqpproton.setting.AmqpClientSettingKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Class that wrap a {@link org.eclipse.kapua.broker.client.amqp.proton.AmqpClient} and
+ * adds some utility methods to manage the operations at the transport level
+ * in Kapua.
+ *
+ * @since 1.0.0
+ */
+public class AmqpClient {
+
+    private final static String VT_PREFIX_PATTERN = "topic://VirtualTopic.%s";
+    /**
+     * The wrapped proton-j client.
+     */
+    private org.eclipse.kapua.broker.client.amqp.proton.AmqpClient amqpClient;
+    private ClientOptions clientOptions;
+    private static final Logger logger = LoggerFactory.getLogger(AmqpClient.class);
+
+    public AmqpClient() {
+        clientOptions = new ClientOptions();
+        clientOptions.put(AmqpClientOptions.AUTO_ACCEPT, false);
+        clientOptions.put(AmqpClientOptions.QOS, 1);
+        clientOptions.put(AmqpClientOptions.CONNECT_TIMEOUT, AmqpClientSetting.getInstance().getInt(AmqpClientSettingKeys.TRANSPORT_CONNECT_TIMEOUT));
+        clientOptions.put(AmqpClientOptions.EXIT_CODE, AmqpClientSetting.getInstance().getInt(AmqpClientSettingKeys.EXIT_CODE));
+        clientOptions.put(AmqpClientOptions.IDLE_TIMEOUT, AmqpClientSetting.getInstance().getInt(AmqpClientSettingKeys.TRANSPORT_IDLE_TIMEOUT));
+        clientOptions.put(AmqpClientOptions.MAXIMUM_RECONNECTION_ATTEMPTS, AmqpClientSetting.getInstance().getInt(AmqpClientSettingKeys.TRANSPORT_IDLE_TIMEOUT));
+        clientOptions.put(AmqpClientOptions.PREFETCH_MESSAGES, AmqpClientSetting.getInstance().getInt(AmqpClientSettingKeys.TRANSPORT_PREFETCH_MESSAGES));
+        clientOptions.put(AmqpClientOptions.WAIT_BETWEEN_RECONNECT, AmqpClientSetting.getInstance().getInt(AmqpClientSettingKeys.TRANSPORT_WAIT_BETWEEN_RECONNECT));
+        if (AmqpClientSetting.getInstance().getBoolean(AmqpClientSettingKeys.TRANSPORT_MQTT_VT_ENABLED)) {
+            //enable it if the device is connected through ActiveMQ MQTT connector with VirtualTopic enabled
+            clientOptions.put(AmqpClientOptions.DESTINATION_TRANSLATOR, new DestinationTranslator() {
+
+                @Override
+                public String translate(String destination) {
+                    return String.format(VT_PREFIX_PATTERN, destination.replaceAll("/", "."));
+                }
+            });
+        }
+    }
+
+    private ClientOptions wrapOptions(TransportClientConnectOptions options) {
+        clientOptions.put(AmqpClientOptions.BROKER_HOST, options.getEndpointURI().getHost());
+        //the connection port is a deployment parameter so read it from configuration
+        clientOptions.put(AmqpClientOptions.BROKER_PORT, AmqpClientSetting.getInstance().getInt(AmqpClientSettingKeys.TRANSPORT_CONNECTION_PORT));
+        clientOptions.put(AmqpClientOptions.PASSWORD, options.getPassword());
+        clientOptions.put(AmqpClientOptions.USERNAME, options.getUsername());
+        clientOptions.put(AmqpClientOptions.CLIENT_ID, options.getClientId());
+        return clientOptions;
+    }
+
+    /**
+     * Connects the {@link AmqpClient#amqpClient} according to the given {@link TransportClientConnectOptions}.
+     *
+     * @param options The connection options to use
+     * @throws AmqpClientException When connect fails.
+     * @since 1.0.0
+     */
+    public void connectClient(TransportClientConnectOptions options)
+            throws KapuaException {
+        try {
+            if (amqpClient != null) {
+                throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_ALREADY_CONNECTED,
+                        null,
+                        (Object[]) null);
+
+            }
+
+            amqpClient = new org.eclipse.kapua.broker.client.amqp.proton.AmqpClient(wrapOptions(options));
+            amqpClient.connect();
+            //since the AMQP client connect is asynchronous and Apache commons pool will test the borrowed client soon as it will be returned from this method we need to wait for the connection to be completed
+            //otherwise the result will be an error since the borrowed client will be invalid (see org.eclipse.kapua.broker.client.amqp.AmqpClient for detail)
+            long currentTime = System.currentTimeMillis();
+            synchronized (amqpClient) {
+                try {
+                    amqpClient.wait(AmqpClientSetting.getInstance().getInt(AmqpClientSettingKeys.TRANSPORT_CONNECT_TIMEOUT));
+                } catch (InterruptedException e) {
+                    logger.error("Interrupted: {}", e.getMessage(), e);
+                }
+                logger.info("Acquired connected client after {}ms", (System.currentTimeMillis() - currentTime));
+            }
+        } catch (IOException e) {
+            throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_CONNECT_ERROR,
+                    e,
+                    options.getEndpointURI().toString(),
+                    options.getClientId(),
+                    options.getUsername());
+        }
+    }
+
+    /**
+     * Disconnects the {@link AmqpClient#amqpClient}.
+     * <p>
+     * Before disconnecting cleaning of subscriptions is attempted.
+     * </p>
+     *
+     * @throws KapuaException When disconnect fails.
+     * @since 1.0.0
+     */
+    public void disconnectClient()
+            throws KapuaException {
+        try {
+            getAmqpClient().disconnect();
+        } catch (AmqpClientException e) {
+            throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_DISCONNECT_ERROR, e, (Object) null);
+        }
+    }
+
+    /**
+     * Disconnects the {@link AmqpClient#amqpClient}.
+     * <p>
+     * Before termination {@link AmqpClient#disconnectClient()} is invoked to clean up appended subscriptions and close connection.
+     * </p>
+     *
+     * @throws KapuaException Whne close fails.
+     * @since 1.0.0
+     */
+    public void terminateClient()
+            throws KapuaException {
+        try {
+            if (getAmqpClient().isConnected()) {
+                disconnectClient();
+            }
+            amqpClient = null;
+        } catch (AmqpClientException e) {
+            throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_TERMINATE_ERROR, e, (Object) null);
+        }
+    }
+
+    /**
+     * Checks if this {@link AmqpClient} is connected.
+     *
+     * @return {@code true} if connected, {@code false} otherwise.
+     * @since 1.0.0
+     */
+    public boolean isConnected() {
+        try {
+            return getAmqpClient().isConnected();
+        } catch (KapuaException e) {
+            // FIXME: add log
+            return false;
+        }
+    }
+
+    //
+    // Message management
+    //
+
+    /**
+     * Publish a {@link AmqpMessage}.
+     * <p>
+     * QoS of publishing is set to 0.
+     * </p>
+     *
+     * @param amqpMessage The {@link AmqpMessage} to publish.
+     * @throws KapuaException When publish fails.
+     * @since 1.0.0
+     */
+    public void publish(AmqpMessage amqpMessage)
+            throws KapuaException {
+        AmqpTopic amqpTopic = amqpMessage.getRequestTopic();
+        AmqpPayload amqpPayload = amqpMessage.getPayload();
+        try {
+            getAmqpClient().send(createMesage(amqpPayload.getBody(), amqpTopic.getTopic()), amqpTopic.getTopic());
+        } catch (KapuaException e) {
+            throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_SUBSCRIBE_ERROR, e, amqpTopic.toString());
+        }
+    }
+
+    /**
+     * Subscribes this client to the given {@link AmqpTopic}.
+     *
+     * @param amqpTopic The {@link AmqpTopic} to subscribe to.
+     * @param amqpClientConsumerHandler
+     * @throws KapuaException When subscribe fails.
+     * @since 1.0.0
+     */
+    public void subscribe(AmqpTopic amqpTopic, AmqpClientConsumerHandler amqpClientConsumerHandler)
+            throws KapuaException {
+        try {
+            getAmqpClient().subscribe(amqpTopic.getTopic(), amqpClientConsumerHandler);
+        } catch (KapuaException e) {
+            throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_SUBSCRIBE_ERROR, e, amqpTopic.getTopic());
+        }
+    }
+
+    /**
+     * Cleans this client from any callback set and unsubscribes from all {@link AmqpTopic} subscribed.
+     *
+     * @throws KapuaException When any of the clean operations fails.
+     */
+    public void clean()
+            throws KapuaException {
+        try {
+            getAmqpClient().clean();
+        } catch (KapuaException e) {
+            terminateClient();
+            throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_CLEAN_ERROR, e, (Object) null);
+        }
+
+    }
+
+    //
+    // Utilty
+    //
+
+    /**
+     * Gets the clientId of the wrapped {@link AmqpClient#amqpClient}.
+     *
+     * @return The clientId of the wrapped {@link AmqpClient#amqpClient}.
+     */
+    public String getClientId() {
+        try {
+            return getAmqpClient().getClientId();
+        } catch (KapuaException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the reference to the wrapped {@link AmqpClient#amqpClient} ready to be used.
+     *
+     * @return The wrapped {@link AmqpClient#amqpClient}.
+     * @throws KapuaException If client has never been connected using {@link AmqpClient#connectClient(TransportClientConnectOptions)}.
+     */
+    private synchronized org.eclipse.kapua.broker.client.amqp.proton.AmqpClient getAmqpClient() throws KapuaException {
+        if (amqpClient == null) {
+            throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_NOT_CONNECTED, null, (Object) null);
+        }
+
+        return amqpClient;
+    }
+
+    private Message createMesage(byte[] payload, String destination) {
+      Message msg = Proton.message();
+      Section s = new Data(new Binary(payload));
+      msg.setBody(s);
+      msg.setAddress(destination);
+      return msg;
+    }
+
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientConnectionOptions.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientConnectionOptions.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton;
+
+import java.net.URI;
+
+import org.eclipse.kapua.transport.TransportClientConnectOptions;
+
+/**
+ * Implementation of {@link TransportClientConnectOptions} API for Amqp transport facade.
+ * 
+ * @since 1.0.0
+ */
+public class AmqpClientConnectionOptions implements TransportClientConnectOptions {
+
+    /**
+     * The AMQP client id to use.
+     * 
+     * @since 1.0.0
+     */
+    private String clientId;
+
+    /**
+     * The AMQP username id to use.
+     * 
+     * @since 1.0.0
+     */
+    private String username;
+
+    /**
+     * The AMQP password id to use.
+     * 
+     * @since 1.0.0
+     */
+    private char[] password;
+
+    /**
+     * The AMQP broker URI id to use.
+     * 
+     * @since 1.0.0
+     */
+    private URI endpointURI;
+
+    /**
+     * Gets the clientID to use for the AMQP client connection.
+     * 
+     * @since 1.0.0
+     */
+    @Override
+    public String getClientId() {
+        return clientId;
+    }
+
+    /**
+     * Sets the client ID to use for the AMQP client connection.
+     * 
+     * @since 1.0.0
+     */
+    @Override
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    /**
+     * Gets the username to use for the AMQP client connection.
+     * 
+     * @since 1.0.0
+     */
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Sets the username to use for the AMQP client connection.
+     * 
+     * @since 1.0.0
+     */
+    @Override
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * Gets the password to use for the AMQP client connection.
+     * 
+     * @since 1.0.0
+     */
+    @Override
+    public char[] getPassword() {
+        return password;
+    }
+
+    /**
+     * Sets the password to use for the AMQP client connection.
+     * 
+     * @since 1.0.0
+     */
+    @Override
+    public void setPassword(char[] password) {
+        this.password = password;
+    }
+
+    /**
+     * Gets the {@link URI} to use for the AMQP client connection.
+     */
+    @Override
+    public URI getEndpointURI() {
+        return endpointURI;
+    }
+
+    /**
+     * Sets the {@link URI} to use for the AQMP client connection.
+     */
+    @Override
+    public void setEndpointURI(URI endpointURI) {
+        this.endpointURI = endpointURI;
+    }
+
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientConsumerHandler.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientConsumerHandler.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.message.Message;
+import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.client.amqp.proton.ConsumerHandler;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpMessage;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpPayload;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpTopic;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generic implementation of {@link ConsumerHandler} interface.
+ * <p>
+ * This generic implementation is meant to be used in the transport layer of Kapua
+ * to receive responses from the device when a request is sent to the device.
+ * It offers the capability of receive one or more responses.
+ * </p>
+ * 
+ * @since 1.0.0
+ */
+public class AmqpClientConsumerHandler implements ConsumerHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(AmqpClientConsumerHandler.class);
+
+    /**
+     * List of received messages.
+     * 
+     * @since 1.0.0
+     */
+    private List<AmqpMessage> responses;
+
+    /**
+     * Number of response messages expected
+     * 
+     * @since 1.0.0
+     */
+    private int expectedResponses;
+
+    /**
+     * Construct a callback with the given response container and 1 as expected response messages
+     * 
+     * @param responses
+     *            The container in which put the received messages
+     * @since 1.0.0
+     */
+    public AmqpClientConsumerHandler(List<AmqpMessage> responses) {
+        this(responses, 1);
+    }
+
+    /**
+     * Construct a callback with the given response container and the given number of expected responses
+     * 
+     * @param responses
+     *            The container in which put the received messages
+     * @param expectedResponses
+     *            The number of the expected responses to wait before notify observers.
+     * @since 1.0.0
+     */
+    public AmqpClientConsumerHandler(List<AmqpMessage> responses, int expectedResponses) {
+        this.responses = responses;
+        this.expectedResponses = expectedResponses;
+    }
+
+    @Override
+    public void consumeMessage(Delivery delivery, Message message) throws Exception {
+        AmqpTopic amqpTopic = new AmqpTopic(message.getAddress());
+        Section body = message.getBody();
+        byte[] payload = null;
+        if (body instanceof Data) {
+            Binary data = ((Data) body).getValue();
+            logger.info("Received DATA message");
+            payload = data.getArray();
+        } else if (body instanceof AmqpValue) {
+            String content = (String) ((AmqpValue) body).getValue();
+            logger.info("Received message with content: {}", content);
+            payload = content.getBytes();
+        } else {
+            logger.warn("Received message with unknown message type! ({})", body != null ? body.getClass() : "NULL");
+            throw new KapuaException(KapuaErrorCodes.INTERNAL_ERROR);
+        }
+        AmqpMessage amqpMessage = new AmqpMessage(amqpTopic,
+                new Date(),
+                new AmqpPayload(payload));
+
+        //
+        // Add to the received responses
+        if (responses == null) {
+            responses = new ArrayList<AmqpMessage>();
+        }
+
+        //
+        // Convert MqttMessage to the given device-levelMessage
+        responses.add(amqpMessage);
+
+        //
+        // notify if all expected responses arrived
+        if (expectedResponses == responses.size()) {
+            synchronized (this) {
+                notifyAll();
+            }
+        }
+    }
+
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientErrorCodes.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientErrorCodes.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton;
+
+import org.eclipse.kapua.KapuaErrorCode;
+
+/**
+ * Enum with all possible values for exceptions for the {@link org.eclipse.kapua.transport.amqpproton} implementation.
+ * Each value must be matched with a value in the error messages resource file.
+ *
+ * @since 1.0.0
+ */
+public enum AmqpClientErrorCodes implements KapuaErrorCode {
+
+    /**
+     * Error while publishing a message.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_PUBLISH_ERROR,
+
+    /**
+     * Error while subscribing to a topic.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_SUBSCRIBE_ERROR,
+
+    /**
+     * Error while unsubscribing from a topic.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_UNSUBSCRIBE_ERROR,
+
+    /**
+     * Error while adding callback to the client or while awaiting for notify observer.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_CALLBACK_ERROR,
+
+    /**
+     * Timeout expired while waiting for device answer.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_TIMEOUT_EXCEPTION,
+
+    /**
+     * Error while connecting client.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_CONNECT_ERROR,
+
+    /**
+     * Error while cleaning client.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_CLEAN_ERROR,
+
+    /**
+     * Error while disconnecting client.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_DISCONNECT_ERROR,
+
+    /**
+     * Client has lost connection.
+     */
+    CLIENT_CONNECTION_LOST,
+
+    /**
+     * Error while terminating client.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_TERMINATE_ERROR,
+
+    /**
+     * Client is not connected while doing operation that requires client connected.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_NOT_CONNECTED,
+
+    /**
+     * Client is connected while doing operation that requires client not connected.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_ALREADY_CONNECTED,
+
+    /**
+     * Generic exception while sending a request to a device.
+     * 
+     * @since 1.0.0
+     */
+    SEND_ERROR
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientException.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientException.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton;
+
+import org.eclipse.kapua.KapuaException;
+
+/**
+ * Class that extends {@link KapuaException} with a specialized set of exceptions
+ * for the {@link org.eclipse.kapua.transport.amqpproton} implementation.
+ *
+ * @since 1.0.0
+ */
+public class AmqpClientException extends KapuaException {
+
+    private static final long serialVersionUID = -6207605695086240243L;
+
+    /**
+     * The name of the resource file from which to source the error messages.
+     */
+    private static final String KAPUA_ERROR_MESSAGES = "amqp-client-error-messages";
+
+    /**
+     * Builds a {@link AmqpClientException} with the given {@link AmqpClientErrorCodes} and {@code null} cause and {@code null} arguments
+     * 
+     * @param code
+     *            The {@link AmqpClientErrorCodes} of this exception
+     * @since 1.0.0
+     */
+    public AmqpClientException(AmqpClientErrorCodes code) {
+        super(code);
+    }
+
+    /**
+     * Builds a {@link AmqpClientException} with the given {@link AmqpClientErrorCodes} and given arguments and {@code null} cause.
+     * 
+     * @param code
+     *            The {@link AmqpClientErrorCodes} of this exception
+     * @param arguments
+     *            Additional optional arguments to describe the exception.
+     * @since 1.0.0
+     */
+    public AmqpClientException(AmqpClientErrorCodes code, Object... arguments) {
+        super(code, arguments);
+    }
+
+    /**
+     * Builds a {@link AmqpClientException} with the given {@link AmqpClientErrorCodes} and given cause and given arguments
+     * 
+     * @param code
+     *            The {@link AmqpClientErrorCodes} of this exception
+     * @param cause
+     *            The root cause of the current exception chain.
+     * @param arguments
+     *            Additional optional arguments to describe the exception.
+     * @since 1.0.0
+     */
+    public AmqpClientException(AmqpClientErrorCodes code, Throwable cause, Object... arguments) {
+        super(code, cause, arguments);
+    }
+
+    /**
+     * Return the resource file name from which to source the error messages for {@link AmqpClientException} exceptions.
+     * 
+     * @since 1.0.0
+     */
+    protected String getKapuaErrorMessagesBundle() {
+        return KAPUA_ERROR_MESSAGES;
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientFactoryImpl.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpClientFactoryImpl.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.transport.TransportClientFactory;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpMessage;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpPayload;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpTopic;
+
+import java.util.Map;
+
+/**
+ * Implementation of {@link TransportClientFactory} API for AQMP transport facade
+ * 
+ * @since 1.0.0
+ *
+ */
+@KapuaProvider
+public class AmqpClientFactoryImpl implements TransportClientFactory<AmqpTopic, AmqpPayload, AmqpMessage, AmqpMessage, AmqpFacade, AmqpClientConnectionOptions> {
+
+    @Override
+    public AmqpFacade getFacade(Map<String, Object> configParameters)
+            throws KapuaException {
+        return new AmqpFacade(formatNodeUri(configParameters.get("serverAddress").toString()));
+    }
+
+    @Override
+    public AmqpClientConnectionOptions newConnectOptions() {
+        return new AmqpClientConnectionOptions();
+    }
+
+    private String formatNodeUri(String nodeAddress) {
+        return SystemSetting.getInstance().getString(SystemSettingKey.BROKER_SCHEME) + "://" + nodeAddress + ":" + SystemSetting.getInstance().getString(SystemSettingKey.BROKER_PORT);
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpFacade.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/AmqpFacade.java
@@ -1,0 +1,211 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton;
+
+import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.transport.TransportFacade;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpMessage;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpPayload;
+import org.eclipse.kapua.transport.amqpproton.message.AmqpTopic;
+import org.eclipse.kapua.transport.amqpproton.pooling.AmqpClientPool;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Implementation of {@link TransportFacade} API for AMQP transport facade.
+ *
+ * @since 1.0.0
+ */
+public class AmqpFacade implements TransportFacade<AmqpTopic, AmqpPayload, AmqpMessage, AmqpMessage> {
+
+    private final static String VT_TOPIC_PREFIX = "topic://VirtualTopic.";
+
+    /**
+     * The client to use to make requests.
+     *
+     * @since 1.0.0
+     */
+    private AmqpClient borrowedClient;
+
+    /**
+     * The client callback for this set of requests.
+     *
+     * @since 1.0.0
+     */
+    private AmqpClientConsumerHandler amqpClientCallback;
+
+    private final String nodeUri;
+
+    /**
+     * Initialize a transport facade to be used to send requests to devices.
+     * 
+     * @param nodeUri
+     * @throws KapuaException When AMQP client is not available.
+     */
+    public AmqpFacade(String nodeUri) throws KapuaException {
+        this.nodeUri = nodeUri;
+
+        //
+        // Get the client form the pool
+        try {
+            borrowedClient = AmqpClientPool.getInstance(nodeUri).borrowObject();
+        } catch (Exception e) {
+            // FIXME use appropriate exception for this
+            throw new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, e, (Object[]) null);
+        }
+    }
+
+    //
+    // Message management
+    //
+
+    /**
+     *
+     */
+    @Override
+    public void sendAsync(AmqpMessage amqpMessage)
+            throws KapuaException {
+        sendSync(amqpMessage, null);
+    }
+
+    @Override
+    public AmqpMessage sendSync(AmqpMessage amqpMessage, Long timeout)
+            throws KapuaException {
+        List<AmqpMessage> responses = new ArrayList<>();
+
+        sendInternal(amqpMessage, responses, timeout);
+
+        if (timeout != null) {
+            if (responses.isEmpty()) {
+                throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_TIMEOUT_EXCEPTION, null, amqpMessage.getRequestTopic());
+            }
+            AmqpMessage response = responses.get(0);
+            //TODO FIXME why the message interchanges between AMQP-MQTT connectors (with MQTT virtual topic on) on AtiveMQ doesn't clean the topic://VirtualTopic prefix?
+            if (response.getChannel().getTopic().toString().startsWith(VT_TOPIC_PREFIX)) {
+                response.setChannel(new AmqpTopic(response.getChannel().getTopic().toString().substring(VT_TOPIC_PREFIX.length()).replaceAll("\\.", "/")));
+            }
+            return response;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Actual implementation of the send operations.
+     * <p>
+     * According to the parameters given, it will make a sync or async request.
+     * </p>
+     *
+     * @param amqpMessage The request to send.
+     * @param responses   The container in which load responses received from the device
+     * @param timeout     The timeout of waiting the response from the device.
+     *                    If {@code null} request will be fired without waiting for the response.
+     *                    If amqpMessage has no response message set, timeout will be ignore even if set.
+     * @throws KapuaException
+     * @see AmqpMessage#getResponseTopic()
+     * @since 1.0.0.
+     */
+    private void sendInternal(AmqpMessage amqpMessage, List<AmqpMessage> responses, Long timeout)
+            throws KapuaException {
+        try {
+            //
+            // Subscribe if necessary
+            if (amqpMessage.getResponseTopic() != null) {
+                try {
+                    amqpClientCallback = new AmqpClientConsumerHandler(responses);
+                    borrowedClient.subscribe(amqpMessage.getResponseTopic(), amqpClientCallback);
+                } catch (KapuaException e) {
+                    throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_SUBSCRIBE_ERROR, e, amqpMessage.getResponseTopic().getTopic());
+                }
+            }
+
+            //
+            // Publish message
+            try {
+                borrowedClient.publish(amqpMessage);
+            } catch (KapuaException e) {
+                throw new AmqpClientException(
+                        AmqpClientErrorCodes.CLIENT_PUBLISH_ERROR,
+                        e,
+                        amqpMessage.getRequestTopic().getTopic(),
+                        amqpMessage.getPayload().getBody());
+            }
+
+            //
+            // Wait if required
+            if (amqpMessage.getResponseTopic() != null &&
+                    timeout != null) {
+                String timerName = new StringBuilder().append(AmqpFacade.class.getSimpleName())
+                        .append("-TimeoutTimer-")
+                        .append(borrowedClient.getClientId())
+                        .toString();
+
+                Timer timeoutTimer = new Timer(timerName, true);
+
+                timeoutTimer.schedule(new TimerTask() {
+
+                    @Override
+                    public void run() {
+                        if (amqpMessage.getResponseTopic() != null) {
+                            synchronized (amqpClientCallback) {
+                                amqpClientCallback.notifyAll();
+                            }
+                        }
+                    }
+                }, timeout);
+
+                try {
+                    synchronized (amqpClientCallback) {
+                        amqpClientCallback.wait();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                    throw new AmqpClientException(AmqpClientErrorCodes.CLIENT_CALLBACK_ERROR, e, (Object) null);
+                } finally {
+                    timeoutTimer.cancel();
+                }
+            }
+        } catch (Exception e) {
+            throw new AmqpClientException(AmqpClientErrorCodes.SEND_ERROR,
+                    e,
+                    amqpMessage.getRequestTopic().getTopic());
+        }
+    }
+
+    @Override
+    public String getClientId() {
+        return borrowedClient.getClientId();
+    }
+
+    @Override
+    public Class<AmqpMessage> getMessageClass() {
+        return AmqpMessage.class;
+    }
+
+    @Override
+    public void clean() {
+        //
+        // Return the client form the pool
+        try {
+            borrowedClient.clean();
+        } catch (KapuaException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        AmqpClientPool.getInstance(nodeUri).returnObject(borrowedClient);
+        borrowedClient = null;
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/message/AmqpMessage.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/message/AmqpMessage.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.message;
+
+import java.util.Date;
+
+import org.eclipse.kapua.transport.message.TransportMessage;
+import org.eclipse.kapua.transport.message.pubsub.PubSubTransportMessage;
+
+/**
+ * Implementation of {@link TransportMessage} API for MQTT transport facade.
+ */
+public class AmqpMessage implements PubSubTransportMessage<AmqpTopic, AmqpPayload> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The request topic of this {@link AmqpMessage}.
+     */
+    private AmqpTopic requestTopic;
+
+    /**
+     * The response topic of this {@link AmqpMessage}.
+     */
+    private AmqpTopic responseTopic;
+
+    /**
+     * The timestamp of this {@link AmqpMessage}.
+     */
+    private Date timestamp;
+
+    /**
+     * The payload of this {@link AmqpPayload}.
+     */
+    private AmqpPayload payload;
+
+    /**
+     * Construct a {@link AmqpMessage} with the given parameters.
+     * 
+     * @param requestTopic
+     *            The request {@link AmqpTopic} to set for this {@link AmqpMessage}.
+     * @param responseTopic
+     *            The response {@link AmqpTopic} to set for this {@link AmqpMessage}.
+     * @param requestPayload
+     *            The request {@link AmqpPayload} to set for this {@link AmqpMessage}.
+     */
+    public AmqpMessage(AmqpTopic requestTopic, AmqpTopic responseTopic, AmqpPayload requestPayload) {
+        this(requestTopic, (Date) null, requestPayload);
+        this.responseTopic = responseTopic;
+    }
+
+    /**
+     * Construct a {@link AmqpMessage} with the given parameters.
+     * 
+     * @param requestTopic
+     *            The request {@link AmqpTopic} to set for this {@link AmqpMessage}.
+     * @param receivedOn
+     *            The timestamp to set for this {@link AmqpMessage}.
+     * @param requestPayload
+     *            The request {@link AmqpPayload} to set for this {@link AmqpMessage}.
+     */
+    public AmqpMessage(AmqpTopic requestTopic, Date receivedOn, AmqpPayload requestPayload) {
+        this.requestTopic = requestTopic;
+        this.timestamp = receivedOn;
+        this.payload = requestPayload;
+    }
+
+    /**
+     * Gets the request {@link AmqpTopic} set for this {@link AmqpMessage}.
+     * 
+     * @return The request {@link AmqpTopic} set for this {@link AmqpMessage}.
+     */
+    public AmqpTopic getRequestTopic() {
+        return requestTopic;
+    }
+
+    /**
+     * Sets the request {@link AmqpTopic} set for this {@link AmqpMessage}.
+     * 
+     * @param requestTopic
+     *            The request {@link AmqpTopic} to set for this {@link AmqpMessage}.
+     */
+    public void setRequestTopic(AmqpTopic requestTopic) {
+        this.requestTopic = requestTopic;
+    }
+
+    /**
+     * Gets the response {@link AmqpTopic} set for this {@link AmqpMessage}.
+     * 
+     * @return The response {@link AmqpTopic} set for this {@link AmqpMessage}.
+     */
+    public AmqpTopic getResponseTopic() {
+        return responseTopic;
+    }
+
+    /**
+     * Sets the response {@link AmqpTopic} set for this {@link AmqpMessage}.
+     * 
+     * @param responseTopic
+     *            The response {@link AmqpTopic} to set for this {@link AmqpMessage}.
+     */
+    public void setResponseTopic(AmqpTopic responseTopic) {
+        this.responseTopic = responseTopic;
+    }
+
+    /**
+     * Gets the timestamp set for this {@link AmqpMessage}.
+     * 
+     * @return The timestamp set for this {@link AmqpMessage}.
+     */
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Sets the timestamp set for this {@link AmqpMessage}.
+     * 
+     * @param timestamp
+     *            The timestamp to set for this {@link AmqpMessage}.
+     */
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Gets the {@link AmqpPayload} set for this {@link AmqpMessage}.
+     * 
+     * @return The {@link AmqpPayload} set for this {@link AmqpMessage}.
+     */
+    public AmqpPayload getPayload() {
+        return payload;
+    }
+
+    /**
+     * Sets the {@link AmqpPayload} set for this {@link AmqpMessage}.
+     * 
+     * @param payload
+     *            The {@link AmqpPayload} to set for this {@link AmqpMessage}.
+     */
+    public void setPayload(AmqpPayload payload) {
+        this.payload = payload;
+    }
+
+    public AmqpTopic getChannel( ) {
+        return requestTopic;
+    }
+
+    public void setChannel(AmqpTopic topic) {
+        this.requestTopic = topic;
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/message/AmqpPayload.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/message/AmqpPayload.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.message;
+
+import org.eclipse.kapua.transport.message.TransportPayload;
+
+/**
+ * Implementation of {@link TransportPayload} API for MQTT transport facade.
+ * 
+ * @since 1.0.0
+ *
+ */
+public class AmqpPayload implements TransportPayload {
+
+    /**
+     * The raw body of this {@link AmqpPayload}.
+     */
+    private byte[] body;
+
+    /**
+     * Construct a {@link AmqpPayload} with the given parameter.
+     * 
+     * @param body
+     *            The raw body to set for this {@link AmqpPayload}.
+     * @since 1.0.0
+     */
+    public AmqpPayload(byte[] body) {
+        this.body = body;
+    }
+
+    /**
+     * Gets the raw body set for this {@link AmqpPayload}.
+     * 
+     * @return The raw body set for this {@link AmqpPayload}.
+     * @since 1.0.0
+     */
+    public byte[] getBody() {
+        return body;
+    }
+
+    /**
+     * Sets the raw body set for this {@link AmqpPayload}.
+     * 
+     * @param body
+     *            the raw body set for this {@link AmqpPayload}.
+     * @since 1.0.0
+     */
+    public void setBody(byte[] body) {
+        this.body = body;
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/message/AmqpTopic.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/message/AmqpTopic.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.message;
+
+import org.eclipse.kapua.transport.amqpproton.setting.AmqpClientSetting;
+import org.eclipse.kapua.transport.amqpproton.setting.AmqpClientSettingKeys;
+import org.eclipse.kapua.transport.message.TransportChannel;
+
+/**
+ * Implementation of {@link TransportChannel} API for MQTT transport facade
+ * 
+ * @since 1.0.0
+ */
+public class AmqpTopic implements TransportChannel {
+
+    /**
+     * The topic separator value for MQTT topics returned from {@link AmqpClientSetting}.{@link AmqpClientSettingKeys#TRANSPORT_TOPIC_SEPARATOR}
+     * 
+     * @since 1.0.0
+     */
+    private static String topicSeparator = AmqpClientSetting.getInstance().getString(AmqpClientSettingKeys.TRANSPORT_TOPIC_SEPARATOR);
+
+    /**
+     * The full topic.
+     * 
+     * @since 1.0.0
+     */
+    private String topic;
+
+    /**
+     * Construct a {@link AmqpTopic} with the given parameter
+     * 
+     * @param topic
+     *            The topic to set for this {@link AmqpTopic}
+     * @since 1.0.0
+     */
+    public AmqpTopic(String topic) {
+        this.topic = topic;
+    }
+
+    /**
+     * Construct a {@link AmqpTopic} with the given parameters.
+     * <p>
+     * Topic is built by concatenating all {@link String}[] token following the array order,
+     * separating each token with the topic separator configured in {@link AmqpClientSetting}.{@link AmqpClientSettingKeys#TRANSPORT_TOPIC_SEPARATOR}
+     * </p>
+     * 
+     * @param topicParts
+     *            The {@link String}[] from which build the full topic.
+     * @since 1.0.0
+     */
+    public AmqpTopic(String[] topicParts) {
+        //
+        // Concatenate topic parts
+        if (topicParts != null) {
+            StringBuilder sb = new StringBuilder();
+            for (String s : topicParts) {
+                sb.append(s)
+                        .append(topicSeparator);
+            }
+            sb.deleteCharAt(sb.length() - topicSeparator.length());
+            setTopic(sb.toString());
+        }
+    }
+
+    /**
+     * Gets the full topic set for this {@link AmqpTopic}
+     * 
+     * @return the full topic of this {@link AmqpTopic}
+     * @since 1.0.0
+     */
+    public String getTopic() {
+        return topic;
+    }
+
+    /**
+     * Sets the full topic for this {@link AmqpTopic}
+     * 
+     * @param topic
+     *            The full topic to set for this {@link AmqpTopic}
+     * @since 1.0.0
+     */
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    /**
+     * Gets the topic split-ed by the topic separator configured in {@link AmqpClientSetting}.{@link AmqpClientSettingKeys#TRANSPORT_TOPIC_SEPARATOR}
+     * 
+     * @return The topic tokens or {@code null} if full topic has been set to {@code null}
+     * @since 1.0.0
+     */
+    public String[] getSplittedTopic() {
+        if (topic == null) {
+            return null;
+        }
+        return topic.split("\\" + topicSeparator);
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/pooling/AmqpClientPool.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/pooling/AmqpClientPool.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.pooling;
+
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.transport.amqpproton.AmqpClient;
+import org.eclipse.kapua.transport.amqpproton.pooling.setting.AmqpClientPoolSetting;
+import org.eclipse.kapua.transport.amqpproton.pooling.setting.AmqpClientPoolSettingKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Client pool for {@link AmqpClient} objects.
+ * <p>
+ * This serves to optimize communication at the transport level of Kapua.
+ * Client borrowed from this pool are already connected and ready to publish and subscribe.
+ * </p>
+ * 
+ * @since 1.0.0
+ *
+ */
+public class AmqpClientPool extends GenericObjectPool<AmqpClient> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AmqpClientPool.class);
+    /**
+     * Singleton instance of {@link AmqpClientPool}
+     */
+    private static Map<String, AmqpClientPool> mqttClientPoolInstances = new HashMap<>();
+
+    /**
+     * Initialize a {@link AmqpClientPool} with the according configuration sourced from {@link AmqpClientPoolSetting}.
+     * 
+     * @since 1.0.0
+     */
+    private AmqpClientPool(PooledAmqpClientFactory factory) {
+        super(factory);
+
+        AmqpClientPoolSetting config = AmqpClientPoolSetting.getInstance();
+        GenericObjectPoolConfig clientPoolConfig = new GenericObjectPoolConfig();
+        clientPoolConfig.setMinIdle(config.getInt(AmqpClientPoolSettingKeys.CLIENT_POOL_SIZE_IDLE_MIN));
+        clientPoolConfig.setMaxIdle(config.getInt(AmqpClientPoolSettingKeys.CLIENT_POOL_SIZE_IDLE_MAX));
+        clientPoolConfig.setMaxTotal(config.getInt(AmqpClientPoolSettingKeys.CLIENT_POOL_SIZE_TOTAL_MAX));
+
+        clientPoolConfig.setMaxWaitMillis(config.getInt(AmqpClientPoolSettingKeys.CLIENT_POOL_BORROW_WAIT_MAX));
+
+        clientPoolConfig.setTestOnReturn(config.getBoolean(AmqpClientPoolSettingKeys.CLIENT_POOL_ON_RETURN_TEST));
+        clientPoolConfig.setTestOnBorrow(config.getBoolean(AmqpClientPoolSettingKeys.CLIENT_POOL_ON_BORROW_TEST));
+
+        clientPoolConfig.setTestWhileIdle(config.getBoolean(AmqpClientPoolSettingKeys.CLIENT_POOL_WHEN_IDLE_TEST));
+        clientPoolConfig.setBlockWhenExhausted(config.getBoolean(AmqpClientPoolSettingKeys.CLIENT_POOL_WHEN_EXAUSTED_BLOCK));
+
+        clientPoolConfig.setTimeBetweenEvictionRunsMillis(config.getLong(AmqpClientPoolSettingKeys.CLIENT_POOL_EVICTION_INTERVAL));
+
+        setConfig(clientPoolConfig);
+    }
+
+    /**
+     * Gets the singleton instance of {@link AmqpClientPool}.
+     * 
+     * @param nodeUri
+     * @return The singleton instance of {@link AmqpClientPool}.
+     * @since 1.0.0
+     */
+    public static AmqpClientPool getInstance(String nodeUri) {
+        AmqpClientPool mqttClientPool = mqttClientPoolInstances.get(nodeUri);
+        if (mqttClientPool == null) {
+            mqttClientPool = new AmqpClientPool(new PooledAmqpClientFactory(nodeUri));
+            mqttClientPoolInstances.put(nodeUri, mqttClientPool);
+        }
+
+        return mqttClientPool;
+    }
+
+    /**
+     * Returns a borrowed object to the pool.
+     * <p>
+     * Before calling super implementation {@link GenericObjectPool#returnObject(Object)} the {@link AmqpClient} is cleaned by invoking the {@link AmqpClient#clean()}.
+     * </p>
+     * 
+     * @since 1.0.0
+     */
+    @Override
+    public void returnObject(AmqpClient kapuaClient) {
+        //
+        // Clean up callback
+        try {
+            kapuaClient.clean();
+
+            //
+            // Return object to pool
+            super.returnObject(kapuaClient);
+        } catch (KapuaException e) {
+            try {
+                kapuaClient.terminateClient();
+            } catch (KapuaException e1) {
+                // FIXME: Manage exception
+            }
+            logger.error("Exception while returning object to the pool: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/pooling/PooledAmqpClientFactory.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/pooling/PooledAmqpClientFactory.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.pooling;
+
+import java.net.URI;
+
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.transport.amqpproton.AmqpClient;
+import org.eclipse.kapua.transport.amqpproton.AmqpClientConnectionOptions;
+import org.eclipse.kapua.transport.amqpproton.pooling.setting.AmqpClientPoolSetting;
+import org.eclipse.kapua.transport.amqpproton.pooling.setting.AmqpClientPoolSettingKeys;
+import org.eclipse.kapua.transport.amqpproton.setting.AmqpClientSetting;
+import org.eclipse.kapua.transport.amqpproton.setting.AmqpClientSettingKeys;
+import org.eclipse.kapua.transport.utils.ClientIdGenerator;
+
+/**
+ * Pooled object factory for {@link AmqpClientPool}.
+ * 
+ * @since 1.0.0
+ *
+ */
+public class PooledAmqpClientFactory extends BasePooledObjectFactory<AmqpClient> {
+
+    private final String nodeUri;
+
+    public PooledAmqpClientFactory(String nodeUri) {
+        this.nodeUri = nodeUri;
+    }
+
+    /**
+     * Creates the {@link AmqpClient} for the {@link AmqpClientPool}.
+     * 
+     * <p>
+     * The client is initialized and connected. In case of any failure on connect operation, an exception is thrown and the the created client is destroyed.
+     * </p>
+     * 
+     * @throws Exception
+     *             FIXME [javadoc] document exception.
+     * @since 1.0.0
+     */
+    @Override
+    public AmqpClient create()
+            throws Exception {
+        //
+        // User pwd generation
+        AmqpClientSetting amqpClientSettings = AmqpClientSetting.getInstance();
+        AmqpClientPoolSetting amqpClientPoolSettings = AmqpClientPoolSetting.getInstance();
+
+        String username = amqpClientSettings.getString(AmqpClientSettingKeys.TRANSPORT_CREDENTIAL_USERNAME);
+        char[] password = amqpClientSettings.getString(AmqpClientSettingKeys.TRANSPORT_CREDENTIAL_PASSWORD).toCharArray();
+        String clientId = ClientIdGenerator.getInstance().next(amqpClientPoolSettings.getString(AmqpClientPoolSettingKeys.CLIENT_POOL_CLIENT_ID_PREFIX));
+
+        //
+        // Get new client and connection options
+        AmqpClientConnectionOptions connectionOptions = new AmqpClientConnectionOptions();
+        connectionOptions.setClientId(clientId);
+        connectionOptions.setUsername(username);
+        connectionOptions.setPassword(password);
+        connectionOptions.setEndpointURI(URI.create(nodeUri));
+
+        //
+        // Connect client
+        AmqpClient kapuaClient = new AmqpClient();
+        try {
+            kapuaClient.connectClient(connectionOptions);
+        } catch (KapuaException ke) {
+            kapuaClient.terminateClient();
+            throw ke;
+        }
+
+        return kapuaClient;
+    }
+
+    /**
+     * Wraps the given {@link AmqpClient} into a {@link DefaultPooledObject}.
+     * 
+     * @param amqpClient
+     *            The object to wrap for {@link BasePooledObjectFactory}.
+     * @since 1.0.0
+     */
+    @Override
+    public PooledObject<AmqpClient> wrap(AmqpClient amqpClient) {
+        return new DefaultPooledObject<>(amqpClient);
+    }
+
+    /**
+     * Validates status of the given {@link AmqpClient} pooled object.
+     * 
+     * <p>
+     * Check performed for the client to be marked as valid are:
+     * </p>
+     * <ul>
+     * <li>{@link AmqpClient} {@code != null}</li>
+     * <li>{@link AmqpClient#isConnected()} {@code == true}</li>
+     * </ul>
+     * 
+     * @param pooledAmqpClient
+     *            The object to validate.
+     * 
+     * @since 1.0.0
+     */
+    @Override
+    public boolean validateObject(PooledObject<AmqpClient> pooledAmqpClient) {
+        AmqpClient amqpClient = pooledAmqpClient.getObject();
+        return (amqpClient != null && amqpClient.isConnected());
+    }
+
+    /**
+     * Destroys the given {@link AmqpClient} pooled object.
+     * <p>
+     * Before calling super implementation {@link BasePooledObjectFactory#destroyObject(PooledObject)} it tries to clean up the {@link AmqpClient}.
+     * </p>
+     * 
+     * @param pooledAmqpClient
+     *            The pooled object to destroy.
+     * 
+     * @since 1.0.0.
+     */
+    @Override
+    public void destroyObject(PooledObject<AmqpClient> pooledAmqpClient)
+            throws Exception {
+        AmqpClient amqpClient = pooledAmqpClient.getObject();
+        if (amqpClient != null) {
+            if (amqpClient.isConnected()) {
+                amqpClient.disconnectClient();
+            }
+            amqpClient.terminateClient();
+        }
+        super.destroyObject(pooledAmqpClient);
+    }
+
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/pooling/setting/AmqpClientPoolSetting.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/pooling/setting/AmqpClientPoolSetting.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.pooling.setting;
+
+import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+
+/**
+ * Class that offers access to all setting of {@link org.eclipse.kapua.transport.amqpproton.pooling}
+ *
+ * @since 1.0.0
+ */
+public class AmqpClientPoolSetting extends AbstractKapuaSetting<AmqpClientPoolSettingKeys> {
+
+    /**
+     * Resource file from which source properties.
+     * 
+     * @since 1.0.0
+     */
+    private static final String AMQP_CLIENT_POOL_CONFIG_RESOURCE = "amqp-client-pool-setting.properties";
+
+    /**
+     * Singleton instance of this {@link Class}.
+     * 
+     * @since 1.0.0
+     */
+    private static final AmqpClientPoolSetting INSTANCE = new AmqpClientPoolSetting();
+
+    /**
+     * Initialize the {@link AbstractKapuaSetting} with the {@link AmqpClientPoolSetting#AMQP_CLIENT_POOL_CONFIG_RESOURCE} value.
+     * 
+     * @since 1.0.0
+     */
+    private AmqpClientPoolSetting() {
+        super(AMQP_CLIENT_POOL_CONFIG_RESOURCE);
+    }
+
+    /**
+     * Gets a singleton instance of {@link AmqpClientPoolSetting}.
+     * 
+     * @return A singleton instance of AmqpClientPoolSetting.
+     * @since 1.0.0
+     */
+    public static AmqpClientPoolSetting getInstance() {
+        return INSTANCE;
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/pooling/setting/AmqpClientPoolSettingKeys.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/pooling/setting/AmqpClientPoolSettingKeys.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.pooling.setting;
+
+import org.eclipse.kapua.commons.setting.SettingKey;
+
+/**
+ * Available settings key for MQTT client pool for MQTT transport level
+ *
+ * @since 1.0.0
+ */
+public enum AmqpClientPoolSettingKeys implements SettingKey {
+
+    /**
+     * The prefix for the id set to the AMQP Client
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_CLIENT_ID_PREFIX("client.pool.client.id.prefix"),
+
+    /**
+     * The minimum size for the client pool.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_SIZE_IDLE_MIN("client.pool.size.idle.min"),
+
+    /**
+     * The maximum size for the client pool.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_SIZE_IDLE_MAX("client.pool.size.idle.max"),
+
+    /**
+     * FIXME [javadoc] document property
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_SIZE_TOTAL_MAX("client.pool.size.total.max"),
+
+    /**
+     * The max time to wait an available AMQP Client
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_BORROW_WAIT_MAX("client.pool.borrow.wait.max"),
+
+    /**
+     * The time interval between each eviction on the client pool
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_EVICTION_INTERVAL("client.pool.eviction.interval"),
+
+    /**
+     * FIXME [javadoc] document property
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_WHEN_EXAUSTED_BLOCK("client.pool.when.exhausted.block"),
+
+    /**
+     * FIXME [javadoc] document property
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_WHEN_IDLE_TEST("client.pool.when.idle.test"),
+
+    /**
+     * Checks client status when borrowing client from the pool.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_ON_BORROW_TEST("client.pool.on.borrow.test"),
+
+    /**
+     * Checks client status when returning client to the pool.
+     * 
+     * @since 1.0.0
+     */
+    CLIENT_POOL_ON_RETURN_TEST("client.pool.on.return.test"),
+    ;
+
+    /**
+     * The key value in the configuration resources.
+     * 
+     * @since 1.0.0
+     */
+    private String key;
+
+    /**
+     * Set up the {@code enum} with the key value provided
+     * 
+     * @param key
+     *            The value mapped by this {@link Enum} value
+     * @since 1.0.0
+     */
+    private AmqpClientPoolSettingKeys(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Gets the key for this {@link AmqpClientPoolSettingKeys}
+     * 
+     * @since 1.0.0
+     */
+    public String key() {
+        return key;
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/setting/AmqpClientSetting.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/setting/AmqpClientSetting.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.setting;
+
+import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+
+/**
+ * Class that offers access to all setting of {@link org.eclipse.kapua.transport.amqpproton}
+ *
+ * @since 1.0.0
+ */
+public class AmqpClientSetting extends AbstractKapuaSetting<AmqpClientSettingKeys> {
+
+    /**
+     * Resource file from which source properties.
+     * 
+     * @since 1.0.0
+     */
+    private static final String AMQP_CLIENT_CONFIG_RESOURCE = "amqp-client-setting.properties";
+
+    /**
+     * Singleton instance of this {@link Class}.
+     * 
+     * @since 1.0.0
+     */
+    private static final AmqpClientSetting INSTANCE = new AmqpClientSetting();
+
+    /**
+     * Initialize the {@link AbstractKapuaSetting} with the {@link AmqpClientSetting#AMQP_CLIENT_CONFIG_RESOURCE} value.
+     * 
+     * @since 1.0.0
+     */
+    private AmqpClientSetting() {
+        super(AMQP_CLIENT_CONFIG_RESOURCE);
+    }
+
+    /**
+     * Gets a singleton instance of {@link AmqpClientSetting}.
+     * 
+     * @return A singleton instance of JmsClientSetting.
+     * @since 1.0.0
+     */
+    public static AmqpClientSetting getInstance() {
+        return INSTANCE;
+    }
+}

--- a/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/setting/AmqpClientSettingKeys.java
+++ b/transport/amqp-proton/src/main/java/org/eclipse/kapua/transport/amqpproton/setting/AmqpClientSettingKeys.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.amqpproton.setting;
+
+import org.eclipse.kapua.commons.setting.SettingKey;
+
+/**
+ * Available settings key for AMQP transport level
+ *
+ * @since 1.0.0
+ */
+public enum AmqpClientSettingKeys implements SettingKey {
+
+    /**
+     * The username to use for AMQP connection
+     * 
+     * @since 1.0.0
+     */
+    TRANSPORT_CREDENTIAL_USERNAME("transport.credential.username"),
+
+    /**
+     * The password to use for AMQP connection
+     * 
+     * @since 1.0.0
+     */
+    TRANSPORT_CREDENTIAL_PASSWORD("transport.credential.password"),
+
+    /**
+     * The character separator for topic levels.
+     * 
+     * @since 1.0.0
+     */
+    TRANSPORT_TOPIC_SEPARATOR("transport.topic.separator"),
+
+    /**
+     * Timeout for send sync operations.
+     * 
+     * @since 1.0.0
+     */
+    SEND_TIMEOUT_MAX("send.timeout.max"),
+
+    /**
+     * Connection port
+     */
+    TRANSPORT_CONNECTION_PORT("transport.amqp.connection.port"),
+
+    /**
+     * Prefetch messages
+     */
+    TRANSPORT_PREFETCH_MESSAGES("transport.amqp.connection.prefetch_messages"),
+
+    /**
+     * Wait between reconnection (in milliseconds)
+     */
+    TRANSPORT_WAIT_BETWEEN_RECONNECT("transport.amqp.connection.wait_between_reconnect"),
+
+    /**
+     * Connect timeout (in milliseconds)
+     */
+    TRANSPORT_CONNECT_TIMEOUT("transport.amqp.connection.connect_timeout"),
+
+    /**
+     * Connection idle timeout (in seconds)
+     */
+    TRANSPORT_IDLE_TIMEOUT("transport.amqp.connection.idle_timeout"),
+
+    /**
+     * Maximum reconnection attempts
+     */
+    TRANSPORT_MAXIMUM_RECONNECTION_ATTEMPTS("transport.amqp.connection.maximum_reconnection_attempt"),
+
+    /**
+     * Set to true if the devices are connected through ActiveMQ with VirtualTopic enabled
+     */
+    TRANSPORT_MQTT_VT_ENABLED("transport.mqtt.enabled_virtual_topic"),
+
+    /**
+     * Exit code
+     */
+    EXIT_CODE("transport.amqp.exit_code");
+
+    /**
+     * The key value in the configuration resources.
+     * 
+     * @since 1.0.0
+     */
+    private String key;
+
+    /**
+     * Set up the {@code enum} with the key value provided
+     * 
+     * @param key
+     *            The value mapped by this {@link Enum} value
+     * @since 1.0.0
+     */
+    private AmqpClientSettingKeys(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Gets the key for this {@link AmqpClientSettingKeys}
+     * 
+     * @since 1.0.0
+     */
+    public String key() {
+        return key;
+    }
+}

--- a/transport/amqp-proton/src/main/resources/amqp-client-pool-setting.properties
+++ b/transport/amqp-proton/src/main/resources/amqp-client-pool-setting.properties
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+client.pool.client.id.prefix=KapuaPool
+
+client.pool.size.idle.min=5
+client.pool.size.idle.max=50
+client.pool.size.total.max=50
+
+client.pool.borrow.wait.max=15000
+
+client.pool.eviction.interval=300000
+
+client.pool.when.exhausted.block=true
+client.pool.when.idle.test=true
+
+client.pool.on.borrow.test=true
+client.pool.on.return.test=true

--- a/transport/amqp-proton/src/main/resources/amqp-client-setting.properties
+++ b/transport/amqp-proton/src/main/resources/amqp-client-setting.properties
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+transport.credential.username=kapua-sys
+transport.credential.password=kapua-password
+
+transport.topic.separator=/
+
+send.timeout.max=1800000
+
+transport.mqtt.enabled_virtual_topic=true
+transport.amqp.connection.port=5672
+transport.amqp.connection.prefetch_messages=10
+#milliseconds
+transport.amqp.connection.wait_between_reconnect=1000
+#milliseconds
+transport.amqp.connection.connect_timeout=5000
+#seconds
+transport.amqp.connection.idle_timeout=300
+transport.amqp.connection.maximum_reconnection_attempt=10
+transport.amqp.exit_code=-1

--- a/transport/amqp-proton/src/test/resources/logback.xml
+++ b/transport/amqp-proton/src/test/resources/logback.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Red Hat Inc and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Red Hat - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="liquibase" level="WARN" />
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -27,6 +27,7 @@
     <modules>
         <module>api</module>
 
+        <module>amqp-proton</module>
         <module>jms</module>
         <module>mqtt</module>
     </modules>


### PR DESCRIPTION
Move the server side device commands implementation from MQTT to AMQP (proton-j)

Implementing a new client wrapper over proton-j AMQP library.
Create a new Apache commons pool factory to use this client.
Update the device command configuration to use the new Apache commons pool.