### PR TITLE
Removed GwtAccountService.findRootAccount()

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
@@ -48,6 +48,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountService;
 import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountServiceAsync;
@@ -180,7 +181,7 @@ public class AccountConfigPanel extends LayoutContainer {
                         }
                     }
                     if (param != null) {
-                        param.setValues(multiFieldValues.toArray(new String[] {}));
+                        param.setValues(multiFieldValues.toArray(new String[]{ }));
                     }
                 }
             }
@@ -198,73 +199,73 @@ public class AccountConfigPanel extends LayoutContainer {
             return oMap.get(value);
         } else {
             switch (param.getType()) {
-            case LONG:
-                NumberField longField = (NumberField) field;
-                Number longNumber = longField.getValue();
-                if (longNumber != null) {
-                    return String.valueOf(longNumber.longValue());
-                } else {
-                    return null;
-                }
+                case LONG:
+                    NumberField longField = (NumberField) field;
+                    Number longNumber = longField.getValue();
+                    if (longNumber != null) {
+                        return String.valueOf(longNumber.longValue());
+                    } else {
+                        return null;
+                    }
 
-            case DOUBLE:
-                NumberField doubleField = (NumberField) field;
-                Number doubleNumber = doubleField.getValue();
-                if (doubleNumber != null) {
-                    return String.valueOf(doubleNumber.doubleValue());
-                } else {
-                    return null;
-                }
+                case DOUBLE:
+                    NumberField doubleField = (NumberField) field;
+                    Number doubleNumber = doubleField.getValue();
+                    if (doubleNumber != null) {
+                        return String.valueOf(doubleNumber.doubleValue());
+                    } else {
+                        return null;
+                    }
 
-            case FLOAT:
-                NumberField floatField = (NumberField) field;
-                Number floatNumber = floatField.getValue();
-                if (floatNumber != null) {
-                    return String.valueOf(floatNumber.floatValue());
-                } else {
-                    return null;
-                }
+                case FLOAT:
+                    NumberField floatField = (NumberField) field;
+                    Number floatNumber = floatField.getValue();
+                    if (floatNumber != null) {
+                        return String.valueOf(floatNumber.floatValue());
+                    } else {
+                        return null;
+                    }
 
-            case INTEGER:
-                NumberField integerField = (NumberField) field;
-                Number integerNumber = integerField.getValue();
-                if (integerNumber != null) {
-                    return String.valueOf(integerNumber.intValue());
-                } else {
-                    return null;
-                }
+                case INTEGER:
+                    NumberField integerField = (NumberField) field;
+                    Number integerNumber = integerField.getValue();
+                    if (integerNumber != null) {
+                        return String.valueOf(integerNumber.intValue());
+                    } else {
+                        return null;
+                    }
 
-            case SHORT:
-                NumberField shortField = (NumberField) field;
-                Number shortNumber = shortField.getValue();
-                if (shortNumber != null) {
-                    return String.valueOf(shortNumber.shortValue());
-                } else {
-                    return null;
-                }
+                case SHORT:
+                    NumberField shortField = (NumberField) field;
+                    Number shortNumber = shortField.getValue();
+                    if (shortNumber != null) {
+                        return String.valueOf(shortNumber.shortValue());
+                    } else {
+                        return null;
+                    }
 
-            case BYTE:
-                NumberField byteField = (NumberField) field;
-                Number byteNumber = byteField.getValue();
-                if (byteNumber != null) {
-                    return String.valueOf(byteNumber.byteValue());
-                } else {
-                    return null;
-                }
+                case BYTE:
+                    NumberField byteField = (NumberField) field;
+                    Number byteNumber = byteField.getValue();
+                    if (byteNumber != null) {
+                        return String.valueOf(byteNumber.byteValue());
+                    } else {
+                        return null;
+                    }
 
-            case BOOLEAN:
-                RadioGroup radioGroup = (RadioGroup) field;
-                Radio radio = radioGroup.getValue();
-                String booleanValue = radio.getItemId();
-                return booleanValue;
+                case BOOLEAN:
+                    RadioGroup radioGroup = (RadioGroup) field;
+                    Radio radio = radioGroup.getValue();
+                    String booleanValue = radio.getItemId();
+                    return booleanValue;
 
-            case PASSWORD:
-            case CHAR:
-            case STRING:
-                return (String) field.getValue();
+                case PASSWORD:
+                case CHAR:
+                case STRING:
+                    return (String) field.getValue();
 
-            default:
-                break;
+                default:
+                    break;
             }
         }
         return null;
@@ -332,21 +333,11 @@ public class AccountConfigPanel extends LayoutContainer {
             } else {
                 field = paintMultiFieldConfigParameter(param);
             }
-            ACCOUNT_SERVICE.findRootAccount(new AsyncCallback<GwtAccount>() {
+            String hideFor = param.getOtherAttributes().get("hideFor");
 
-                @Override
-                public void onFailure(Throwable caught) {
-                    FailureHandler.handle(caught);
-                }
-
-                @Override
-                public void onSuccess(GwtAccount gwtRootAccount) {
-                    String hideFor = param.getOtherAttributes().get("hideFor");
-                    if (hideFor != null && hideFor.equals("NON_ROOT") && !selectedAccountId.equals(gwtRootAccount.getId())) {
-                        field.hide();
-                    }
-                }
-            });
+            if (hideFor != null && hideFor.equals("NON_ROOT") && !selectedAccountId.equals(currentSession.getRootAccountId())) {
+                field.hide();
+            }
             String allowSelfEditValue = param.getOtherAttributes() != null ? param.getOtherAttributes().get("allowSelfEdit") : null;
             boolean allowSelfEdit = allowSelfEditValue != null && allowSelfEditValue.equals("true");
             boolean isEditingSelf = selectedAccountId == null || selectedAccountId.equals(currentSession.getSelectedAccountId());
@@ -365,36 +356,35 @@ public class AccountConfigPanel extends LayoutContainer {
 
                     @Override
                     public void onSuccess(final GwtAccount targetAccount) {
-                        ACCOUNT_SERVICE.findRootAccount(new AsyncCallback<GwtAccount>() {
 
-                            @Override
-                            public void onFailure(Throwable caught) {
-                                FailureHandler.handle(caught);
+                        if (showOnlyForActorValue != null) {
+                            boolean onlyShownForRootActor = showOnlyForActorValue.equals("ROOT");
+                            if (onlyShownForRootActor && !currentSession.getRootAccountId().equals(currentSession.getSelectedAccountId())) {
+                                field.hide();
                             }
+                        }
 
-                            @Override
-                            public void onSuccess(GwtAccount rootAccount) {
-                                if (showOnlyForActorValue != null) {
-                                    boolean onlyShownForRootActor = showOnlyForActorValue.equals("ROOT");
-                                    if (onlyShownForRootActor && !rootAccount.getId().equals(currentSession.getSelectedAccountId())) {
-                                        field.hide();
-                                    }
-                                }
-
-                                if (showOnlyForTargetValue != null) {
-                                    boolean onlyShownForRootChildrenTarget = showOnlyForTargetValue.equals("ROOT_AND_CHILDREN");
-                                    boolean onlyShownForRootTarget = showOnlyForTargetValue.equals("ROOT");
-                                    if (onlyShownForRootChildrenTarget && (!rootAccount.getId().equals(targetAccount.getId()) &&
-                                            !rootAccount.getId().equals(targetAccount.getParentAccountId()))) {
-                                        field.hide();
-                                    } else if (onlyShownForRootTarget && !rootAccount.getId().equals(targetAccount.getId())) {
-                                        field.hide();
-                                    }
-                                }
+                        if (showOnlyForTargetValue != null) {
+                            boolean onlyShownForRootChildrenTarget = showOnlyForTargetValue.equals("ROOT_AND_CHILDREN");
+                            boolean onlyShownForRootTarget = showOnlyForTargetValue.equals("ROOT");
+                            if (
+                                    (
+                                        onlyShownForRootChildrenTarget &&
+                                        (
+                                                !currentSession.getRootAccountId().equals(targetAccount.getId()) &&
+                                                !currentSession.getRootAccountId().equals(targetAccount.getParentAccountId())
+                                        )
+                                    ) || (
+                                        onlyShownForRootTarget &&
+                                        !currentSession.getRootAccountId().equals(targetAccount.getId())
+                                    )
+                            ) {
+                                field.hide();
                             }
-                        });
+                        }
                     }
                 });
+
             }
             actionFieldSet.add(field, formData);
         }
@@ -457,46 +447,46 @@ public class AccountConfigPanel extends LayoutContainer {
             String minValue = param.getMin();
             String maxValue = param.getMax();
             switch (param.getType()) {
-            case LONG:
-                field = paintNumberConfigParameter(param, new LongValidator(minValue, maxValue));
-                break;
+                case LONG:
+                    field = paintNumberConfigParameter(param, new LongValidator(minValue, maxValue));
+                    break;
 
-            case DOUBLE:
-                field = paintNumberConfigParameter(param, new DoubleValidator(minValue, maxValue));
-                break;
+                case DOUBLE:
+                    field = paintNumberConfigParameter(param, new DoubleValidator(minValue, maxValue));
+                    break;
 
-            case FLOAT:
-                field = paintNumberConfigParameter(param, new FloatValidator(minValue, maxValue));
-                break;
+                case FLOAT:
+                    field = paintNumberConfigParameter(param, new FloatValidator(minValue, maxValue));
+                    break;
 
-            case INTEGER:
-                field = paintNumberConfigParameter(param, new IntegerValidator(minValue, maxValue));
-                break;
+                case INTEGER:
+                    field = paintNumberConfigParameter(param, new IntegerValidator(minValue, maxValue));
+                    break;
 
-            case SHORT:
-                field = paintNumberConfigParameter(param, new ShortValidator(minValue, maxValue));
-                break;
+                case SHORT:
+                    field = paintNumberConfigParameter(param, new ShortValidator(minValue, maxValue));
+                    break;
 
-            case BYTE:
-                field = paintNumberConfigParameter(param, new ByteValidator(minValue, maxValue));
-                break;
+                case BYTE:
+                    field = paintNumberConfigParameter(param, new ByteValidator(minValue, maxValue));
+                    break;
 
-            case BOOLEAN:
-                field = paintBooleanConfigParameter(param);
-                break;
+                case BOOLEAN:
+                    field = paintBooleanConfigParameter(param);
+                    break;
 
-            case PASSWORD:
-                field = paintPasswordConfigParameter(param);
-                break;
+                case PASSWORD:
+                    field = paintPasswordConfigParameter(param);
+                    break;
 
-            case CHAR:
-                field = paintTextConfigParameter(param, new CharValidator(minValue, maxValue));
-                break;
+                case CHAR:
+                    field = paintTextConfigParameter(param, new CharValidator(minValue, maxValue));
+                    break;
 
-            default:
-            case STRING:
-                field = paintTextConfigParameter(param, new StringValidator(minValue, maxValue));
-                break;
+                default:
+                case STRING:
+                    field = paintTextConfigParameter(param, new StringValidator(minValue, maxValue));
+                    break;
             }
         }
 
@@ -590,49 +580,49 @@ public class AccountConfigPanel extends LayoutContainer {
         }
 
         switch (param.getType()) {
-        case LONG:
-            field.setPropertyEditorType(Long.class);
-            if (param.getValue() != null) {
-                field.setValue(Long.parseLong(param.getValue()));
-                field.setOriginalValue(Long.parseLong(param.getValue()));
-            }
-            break;
-        case DOUBLE:
-            field.setPropertyEditorType(Double.class);
-            if (param.getValue() != null) {
-                field.setValue(Double.parseDouble(param.getValue()));
-                field.setOriginalValue(Double.parseDouble(param.getValue()));
-            }
-            break;
-        case FLOAT:
-            field.setPropertyEditorType(Float.class);
-            if (param.getValue() != null) {
-                field.setValue(Float.parseFloat(param.getValue()));
-                field.setOriginalValue(Float.parseFloat(param.getValue()));
-            }
-            break;
-        case SHORT:
-            field.setPropertyEditorType(Short.class);
-            if (param.getValue() != null) {
-                field.setValue(Short.parseShort(param.getValue()));
-                field.setOriginalValue(Short.parseShort(param.getValue()));
-            }
-            break;
-        case BYTE:
-            field.setPropertyEditor(new BytePropertyEditor());
-            if (param.getValue() != null) {
-                field.setValue(Byte.parseByte(param.getValue()));
-                field.setOriginalValue(Byte.parseByte(param.getValue()));
-            }
-            break;
-        default:
-        case INTEGER:
-            field.setPropertyEditorType(Integer.class);
-            if (param.getValue() != null) {
-                field.setValue(Integer.parseInt(param.getValue()));
-                field.setOriginalValue(Integer.parseInt(param.getValue()));
-            }
-            break;
+            case LONG:
+                field.setPropertyEditorType(Long.class);
+                if (param.getValue() != null) {
+                    field.setValue(Long.parseLong(param.getValue()));
+                    field.setOriginalValue(Long.parseLong(param.getValue()));
+                }
+                break;
+            case DOUBLE:
+                field.setPropertyEditorType(Double.class);
+                if (param.getValue() != null) {
+                    field.setValue(Double.parseDouble(param.getValue()));
+                    field.setOriginalValue(Double.parseDouble(param.getValue()));
+                }
+                break;
+            case FLOAT:
+                field.setPropertyEditorType(Float.class);
+                if (param.getValue() != null) {
+                    field.setValue(Float.parseFloat(param.getValue()));
+                    field.setOriginalValue(Float.parseFloat(param.getValue()));
+                }
+                break;
+            case SHORT:
+                field.setPropertyEditorType(Short.class);
+                if (param.getValue() != null) {
+                    field.setValue(Short.parseShort(param.getValue()));
+                    field.setOriginalValue(Short.parseShort(param.getValue()));
+                }
+                break;
+            case BYTE:
+                field.setPropertyEditor(new BytePropertyEditor());
+                if (param.getValue() != null) {
+                    field.setValue(Byte.parseByte(param.getValue()));
+                    field.setOriginalValue(Byte.parseByte(param.getValue()));
+                }
+                break;
+            default:
+            case INTEGER:
+                field.setPropertyEditorType(Integer.class);
+                if (param.getValue() != null) {
+                    field.setValue(Integer.parseInt(param.getValue()));
+                    field.setOriginalValue(Integer.parseInt(param.getValue()));
+                }
+                break;
         }
         return field;
     }
@@ -766,12 +756,12 @@ public class AccountConfigPanel extends LayoutContainer {
         String description = param.getDescription();
         int idx = description.lastIndexOf('|');
         if (idx < 0) {
-            return new String[] { description };
+            return new String[]{ description };
         }
         if (idx < 1) {
-            return new String[] { "", description.substring(idx + 1) };
+            return new String[]{ "", description.substring(idx + 1) };
         }
-        return new String[] { description.substring(0, idx), description.substring(idx + 1) };
+        return new String[]{ description.substring(0, idx), description.substring(idx + 1) };
     }
 
     /**

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
@@ -47,7 +47,6 @@ import com.extjs.gxt.ui.client.widget.layout.FormLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountService;
@@ -332,59 +331,6 @@ public class AccountConfigPanel extends LayoutContainer {
                 field = paintConfigParameter(param);
             } else {
                 field = paintMultiFieldConfigParameter(param);
-            }
-            String hideFor = param.getOtherAttributes().get("hideFor");
-
-            if (hideFor != null && hideFor.equals("NON_ROOT") && !selectedAccountId.equals(currentSession.getRootAccountId())) {
-                field.hide();
-            }
-            String allowSelfEditValue = param.getOtherAttributes() != null ? param.getOtherAttributes().get("allowSelfEdit") : null;
-            boolean allowSelfEdit = allowSelfEditValue != null && allowSelfEditValue.equals("true");
-            boolean isEditingSelf = selectedAccountId == null || selectedAccountId.equals(currentSession.getSelectedAccountId());
-            if (isEditingSelf && !allowSelfEdit) {
-                field.disable();
-            }
-            final String showOnlyForActorValue = param.getOtherAttributes() != null ? param.getOtherAttributes().get("showOnlyForActor") : null;
-            final String showOnlyForTargetValue = param.getOtherAttributes() != null ? param.getOtherAttributes().get("showOnlyForTarget") : null;
-            if (showOnlyForActorValue != null || showOnlyForTargetValue != null) {
-                ACCOUNT_SERVICE.find(selectedAccountId, new AsyncCallback<GwtAccount>() {
-
-                    @Override
-                    public void onFailure(Throwable caught) {
-                        FailureHandler.handle(caught);
-                    }
-
-                    @Override
-                    public void onSuccess(final GwtAccount targetAccount) {
-
-                        if (showOnlyForActorValue != null) {
-                            boolean onlyShownForRootActor = showOnlyForActorValue.equals("ROOT");
-                            if (onlyShownForRootActor && !currentSession.getRootAccountId().equals(currentSession.getSelectedAccountId())) {
-                                field.hide();
-                            }
-                        }
-
-                        if (showOnlyForTargetValue != null) {
-                            boolean onlyShownForRootChildrenTarget = showOnlyForTargetValue.equals("ROOT_AND_CHILDREN");
-                            boolean onlyShownForRootTarget = showOnlyForTargetValue.equals("ROOT");
-                            if (
-                                    (
-                                        onlyShownForRootChildrenTarget &&
-                                        (
-                                                !currentSession.getRootAccountId().equals(targetAccount.getId()) &&
-                                                !currentSession.getRootAccountId().equals(targetAccount.getParentAccountId())
-                                        )
-                                    ) || (
-                                        onlyShownForRootTarget &&
-                                        !currentSession.getRootAccountId().equals(targetAccount.getId())
-                                    )
-                            ) {
-                                field.hide();
-                            }
-                        }
-                    }
-                });
-
             }
             actionFieldSet.add(field, formData);
         }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -40,8 +40,6 @@ import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModel
 import org.eclipse.kapua.broker.BrokerDomains;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
-import org.eclipse.kapua.commons.setting.system.SystemSetting;
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.ThrowingRunnable;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
@@ -226,11 +224,12 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
                 }
             });
 
-            accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "expirationDate", account.getExpirationDate() != null ? account.getExpirationDate() : "Never"));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountCreatedOn", account.getCreatedOn()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountCreatedBy", userCreatedBy != null ? userCreatedBy.getName() : null));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountModifiedOn", account.getModifiedOn()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("entityInfo", "accountModifiedBy", userModifiedBy != null ? userModifiedBy.getName() : null));
+            final String entityInfo = "entityInfo";
+            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "expirationDate", account.getExpirationDate() != null ? account.getExpirationDate() : "Never"));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountCreatedOn", account.getCreatedOn()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountCreatedBy", userCreatedBy != null ? userCreatedBy.getName() : null));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountModifiedOn", account.getModifiedOn()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountModifiedBy", userModifiedBy != null ? userModifiedBy.getName() : null));
 
             if (account.getScopeId() != null) {
                 Account parentAccount = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
@@ -255,17 +254,17 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
             for (EndpointInfo ei : endpointInfos.getItems()) {
                 accountPropertiesPairs.add(new GwtGroupedNVPair("deploymentInfo", ei.getSecure() ? "deploymentNodeUriSecure" : "deploymentNodeUri", ei.toStringURI()));
             }
-
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationName", account.getOrganization().getName()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationContactName", account.getOrganization().getPersonName()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationEmail", account.getOrganization().getEmail()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationPhoneNumber", account.getOrganization().getPhoneNumber()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationAddress1", account.getOrganization().getAddressLine1()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationAddress2", account.getOrganization().getAddressLine2()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationZip", account.getOrganization().getZipPostCode()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationCity", account.getOrganization().getCity()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationState", account.getOrganization().getStateProvinceCounty()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair("organizationInfo", "organizationCountry", account.getOrganization().getCountry()));
+            final String organizationInfo = "organizationInfo";
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationName", account.getOrganization().getName()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationContactName", account.getOrganization().getPersonName()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationEmail", account.getOrganization().getEmail()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationPhoneNumber", account.getOrganization().getPhoneNumber()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationAddress1", account.getOrganization().getAddressLine1()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationAddress2", account.getOrganization().getAddressLine2()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationZip", account.getOrganization().getZipPostCode()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationCity", account.getOrganization().getCity()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationState", account.getOrganization().getStateProvinceCounty()));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(organizationInfo, "organizationCountry", account.getOrganization().getCountry()));
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
         }
@@ -705,23 +704,6 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
         }
 
         return new BasePagingLoadResult<GwtAccount>(gwtAccounts, loadConfig.getOffset(), totalLength);
-    }
-
-    @Override
-    public GwtAccount findRootAccount() throws GwtKapuaException {
-        GwtAccount gwtAccount = null;
-        try {
-            gwtAccount = KapuaSecurityUtils.doPrivileged(new Callable<GwtAccount>() {
-
-                @Override
-                public GwtAccount call() throws Exception {
-                    return findByAccountName(SystemSetting.getInstance().getString(SystemSettingKey.SYS_ADMIN_ACCOUNT));
-                }
-            });
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
-        }
-        return gwtAccount;
     }
 
 }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/service/GwtAccountService.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/service/GwtAccountService.java
@@ -147,12 +147,4 @@ public interface GwtAccountService extends RemoteService {
     PagingLoadResult<GwtAccount> query(PagingLoadConfig loadConfig, GwtAccountQuery gwtAccountQuery)
             throws GwtKapuaException;
 
-    /**
-     * Returns the root account
-     *
-     * @return A {@link GwtAccount} pointing to the root account
-     * @throws GwtKapuaException
-     */
-    public GwtAccount findRootAccount()
-            throws GwtKapuaException;
 }


### PR DESCRIPTION
This PR aims to remove the `GwtAccountService.findRootAccount()` method, so that root account details are not exposed in GWT network traffic

**Related Issue**
This PR fixes #2022 

**Description of the solution adopted**
Since the method is not needed anymore, it has just been replaced with idempotent code

**Screenshots**
N/A

**Any side note on the changes made**
N/A