### PR TITLE
Hide Credential Key in GWT service traffic

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/KapuaGwtAuthenticationModelConverter.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/KapuaGwtAuthenticationModelConverter.java
@@ -34,7 +34,8 @@ public class KapuaGwtAuthenticationModelConverter {
         KapuaGwtCommonsModelConverter.convertUpdatableEntity(credential, gwtCredential);
         gwtCredential.setUserId(credential.getUserId().toCompactId());
         gwtCredential.setCredentialType(credential.getCredentialType().toString());
-        gwtCredential.setCredentialKey(credential.getCredentialKey());
+        // DO NOT SET CredentialKey, otherwise it will show up when inspecting network traffic!
+        // See https://github.com/eclipse/kapua/issues/2024
         gwtCredential.setCredentialStatus(credential.getStatus().toString());
         gwtCredential.setExpirationDate(credential.getExpirationDate());
         gwtCredential.setLoginFailures(credential.getLoginFailures());


### PR DESCRIPTION
Credentials Key field will not be returned anymore when querying credentials, so it's not exposed in GWT network traffic anymore

**Related Issue**
This PR fixes #2024 

**Description of the solution adopted**
The field was exposed by GWT in response of a call to `GwtCredentialService.query()`, when it was copied from the related `Credential` entity. Since it's not needed, we just don't carry it over anymore.

**Screenshots**
N/A

**Any side note on the changes made**
N/A