### PR TITLE
credential type instead of credentials id in Credentials Unlock dialog

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialUnlockDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialUnlockDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -34,7 +34,7 @@ public class CredentialUnlockDialog extends EntityDeleteDialog {
     @Override
     public String getHeaderMessage() {
         // TODO will be credential name
-        return MSGS.dialogUnlockHeader(selectedCredential.getId());
+        return MSGS.dialogUnlockHeader(selectedCredential.getCredentialType());
     }
 
     @Override

--- a/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
+++ b/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
@@ -82,7 +82,7 @@ dialogDeleteErrorAPI=API Key delete failed: {0}
 #
 # Unlock dialog
 unlockButton=Unlock
-dialogUnlockHeader=Unlock credentials: {0}
+dialogUnlockHeader=Unlock credential: {0}
 dialogUnlockInfo=Unlock selected credentials?
 dialogUnlockConfirmation=Credentials successfully unlocked.
 dialogUnlockError=Credentials unlock failed: {0}


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

drop s from credential info message

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Replaced credential id with credential type in Header of UnlockDialog in Credentials.

**Related Issue**
This PR fixes issue #1998 

**Description of the solution adopted**
Just replaced text in Header of UnlockDialog in Credentials.
**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
