### PR TITLE
Fix Swagger home redirection with Jetty

### DIFF
--- a/rest-api/web/src/main/webapp/index.jsp
+++ b/rest-api/web/src/main/webapp/index.jsp
@@ -1,3 +1,3 @@
 <%
-    response.sendRedirect(request.getRequestURI() + "doc");
+    response.sendRedirect(request.getRequestURI().replace("index.jsp", "") + "doc");
 %>


### PR DESCRIPTION
After merging #1966 it looks like Jetty proposes a wrong redirect from the REST API home page to Swagger UI. This PR removes the "index.jsp" file from the proposed redirect.

**Related Issue**
N/A

**Description of the solution adopted**
Simply replace `index.jsp` with an empty string in the default redirection

**Screenshots**
N/A

**Any side note on the changes made**
N/A