### PR TITLE
Disabled submitButton when there are no changes on ChangePasswordDialog

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/ChangePasswordDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/ChangePasswordDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -42,6 +42,7 @@ public class ChangePasswordDialog extends SimpleDialog {
 
     @Override
     public void createBody() {
+        submitButton.disable();
         FormPanel credentialFormPanel = new FormPanel(ActionDialog.FORM_LABEL_WIDTH);
         DialogUtils.resizeDialog(this, 400, 200);
 


### PR DESCRIPTION
Brief description of the PR.
Disabled submitButton when there are no changes on ChangePasswordDialog

**Related Issue**
This PR fixes/closes #2045 

**Description of the solution adopted**
Disabled submitButton in createBody() function of ChangePasswordDialog. This button will be enabled when change is made in any of the inputs of the dialog.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>