### PR TITLE
Fix API KEY undefiened credential in creation

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
@@ -149,6 +149,7 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
 
             // Convert
             gwtCredential = KapuaGwtAuthenticationModelConverter.convertCredential(credential, user);
+            gwtCredential.setCredentialKey(credential.getCredentialKey());
 
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);


### PR DESCRIPTION
After merging #2024, creating a new API KEY in the Console returned `undefined` instead of the actual API KEY created. This is a fix for such issue.

**Related Issue**
This PR fixes #2048 

**Description of the solution adopted**
The `credentialKey` field id now manually set when creating a new credential in `GwtCredentialServiceImpl`

**Screenshots**
N/A

**Any side note on the changes made**
N/A