### PR TITLE
SSL in Jetty and Broker containers

### DIFF
--- a/assembly/broker/docker/Dockerfile
+++ b/assembly/broker/docker/Dockerfile
@@ -41,6 +41,6 @@ ENV ACTIVEMQ_OPTS "-Dcommons.db.schema.update=true \
 
 EXPOSE 1883 8883 61614 61615 8161
 
-VOLUME /var/opt/activemq/data
+VOLUME /opt/activemq/data
 
 ENTRYPOINT /var/opt/activemq/run-broker

--- a/assembly/broker/entrypoint/run-broker
+++ b/assembly/broker/entrypoint/run-broker
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ################################################################################
 #    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 #
@@ -11,10 +11,48 @@
 #        Eurotech
 ################################################################################
 
+ACTIVEMQ_BASE="/var/opt/activemq"
+
 # Generate X509 certificate and private key
-openssl req -x509 -newkey rsa:4096 -keyout /var/opt/activemq/key.pem -out /var/opt/activemq/cert.pem -days 365 -nodes -subj '/O=Eclipse Kapua/C=XX'
-openssl pkcs8 -topk8 -in /var/opt/activemq/key.pem -out /var/opt/activemq/key.pk8 -nocrypt
-rm /var/opt/activemq/key.pem
+openssl req -x509 -newkey rsa:4096 -keyout ${ACTIVEMQ_BASE}/key.pem -out ${ACTIVEMQ_BASE}/cert.pem -days 365 -nodes -subj '/O=Eclipse Kapua/C=XX'
+openssl pkcs8 -topk8 -in ${ACTIVEMQ_BASE}/key.pem -out ${ACTIVEMQ_BASE}/key.pk8 -nocrypt
+rm ${ACTIVEMQ_BASE}/key.pem
+
+## Certificate Options
+
+: ${KAPUA_DISABLE_SSL:="true"}
+
+if [ "${KAPUA_DISABLE_SSL}" == "false" ]; then
+
+    # Certificates directory configuration
+    CERTIFICATES_PATH="tls"
+
+    if [ ! -d "${ACTIVEMQ_BASE}/${CERTIFICATES_PATH}" ]; then
+        mkdir -p "${ACTIVEMQ_BASE}/${CERTIFICATES_PATH}"
+    fi
+
+    # Keystore configuration
+    : ${KEYSTORE_NAME:="kapua.jks"}
+    : ${KAPUA_KEYSTORE_PASSWORD:="changeit"}
+
+    if [ ! -f "${ACTIVEMQ_BASE}/${CERTIFICATES_PATH}/${KEYSTORE_NAME}" ]; then
+      if [ -z "${KAPUA_KEYSTORE}" ]; then
+          if [ ! -z "${KAPUA_KEY_PASSWORD}" ]; then
+              PASSWORD_PARAM="-passin pass:${KAPUA_KEY_PASSWORD}";
+          fi
+          openssl pkcs12 -export -in <(echo "${KAPUA_CRT}"; echo "${KAPUA_CA}") -inkey <(echo "${KAPUA_KEY}") ${PASSWORD_PARAM} -name kapua -password pass:"${KAPUA_KEYSTORE_PASSWORD}" -out "${ACTIVEMQ_BASE}/${CERTIFICATES_PATH}/${KEYSTORE_NAME}"
+      else
+          echo "${KAPUA_KEYSTORE}" | base64 --decode > "${ACTIVEMQ_BASE}/${CERTIFICATES_PATH}/${KEYSTORE_NAME}"
+      fi
+    fi
+
+    ACTIVEMQ_SSL_OPTS="${ACTIVEMQ_SSL_OPTS} -Djavax.net.ssl.keyStore=${ACTIVEMQ_BASE}/${CERTIFICATES_PATH}/${KEYSTORE_NAME}"
+    ACTIVEMQ_SSL_OPTS="${ACTIVEMQ_SSL_OPTS} -Djavax.net.ssl.keyStorePassword=${KAPUA_KEYSTORE_PASSWORD}"
+    ACTIVEMQ_SSL_OPTS="${ACTIVEMQ_SSL_OPTS} -Djavax.net.ssl.trustStore=${ACTIVEMQ_BASE}/${CERTIFICATES_PATH}/${KEYSTORE_NAME}"
+    ACTIVEMQ_SSL_OPTS="${ACTIVEMQ_SSL_OPTS} -Djavax.net.ssl.trustStorePassword=${KAPUA_KEYSTORE_PASSWORD}"
+
+    export ACTIVEMQ_SSL_OPTS
+fi
 
 # Run broker
 /opt/activemq/bin/activemq console

--- a/assembly/jetty-base/docker/Dockerfile
+++ b/assembly/jetty-base/docker/Dockerfile
@@ -18,7 +18,7 @@ COPY maven /
 USER 0
 
 RUN useradd -u 1000 -g 0 -d '/var/opt/jetty' -s '/sbin/nologin' jetty && \
-    mkdir -p /opt/jetty /var/opt/jetty/lib/ext /var/opt/jetty/start.d && \
+    mkdir -p /opt/jetty /var/opt/jetty/lib/ext /var/opt/jetty/start.d /var/opt/jetty/tls && \
     curl -Ls @jetty.url@ -o /tmp/jetty.tar.gz && \
     tar --strip=1 -xzf /tmp/jetty.tar.gz -C /opt/jetty && \
     rm -f /tmp/jetty.tar.gz && \

--- a/assembly/jetty-base/entrypoint/run-jetty
+++ b/assembly/jetty-base/entrypoint/run-jetty
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ################################################################################
 #    Copyright (c) 2017 Red Hat Inc
@@ -12,16 +12,54 @@
 #        Red Hat Inc - initial API and implementation
 ################################################################################
 
-# Generate X509 certificate and private key
-openssl req -x509 -newkey rsa:4096 -keyout /var/opt/jetty/key.pem -out /var/opt/jetty/cert.pem -days 365 -nodes -subj '/O=Eclipse Kapua/C=XX'
-openssl pkcs8 -topk8 -in /var/opt/jetty/key.pem -out /var/opt/jetty/key.pk8 -nocrypt
-rm /var/opt/jetty/key.pem
+JETTY_HOME="/opt/jetty"
+JETTY_BASE="/var/opt/jetty"
 
-START_ARGS="$START_ARGS -Djetty.home=/opt/jetty"
-START_ARGS="$START_ARGS -Djetty.base=/var/opt/jetty"
+# Generate X509 certificate and private key
+openssl req -x509 -newkey rsa:4096 -keyout ${JETTY_BASE}/key.pem -out ${JETTY_BASE}/cert.pem -days 365 -nodes -subj '/O=Eclipse Kapua/C=XX'
+openssl pkcs8 -topk8 -in ${JETTY_BASE}/key.pem -out ${JETTY_BASE}/key.pk8 -nocrypt
+rm ${JETTY_BASE}/key.pem
+
+START_ARGS="$START_ARGS -Djetty.home=${JETTY_HOME}"
+START_ARGS="$START_ARGS -Djetty.base=${JETTY_BASE}"
 
 # START_ARGS : Arguments to the starter JVM
 # JAVA_OPTS : Arguments to the server JVMs
+
+# Certificate Options
+
+: ${KAPUA_DISABLE_SSL:="true"}
+
+if [ "${KAPUA_DISABLE_SSL}" == "false" ]; then
+    # Keystore configuration
+    CERTIFICATES_PATH="tls"
+    if [ ! -d "${JETTY_BASE}/${CERTIFICATES_PATH}" ]; then
+        mkdir -p "${JETTY_BASE}/${CERTIFICATES_PATH}"
+    fi
+    : ${KEYSTORE_NAME:="kapua.pkcs12"}
+    : ${KAPUA_KEYSTORE_PASSWORD:="changeit"}
+    if [ ! -f "${JETTY_BASE}/${CERTIFICATES_PATH}/${KEYSTORE_NAME}" ]; then
+        if [ -z "${KAPUA_KEYSTORE}" ]; then
+            if [ ! -z "${KAPUA_KEY_PASSWORD}" ]; then
+                PASSWORD_PARAM="-passin pass:${KAPUA_KEY_PASSWORD}";
+            fi
+            openssl pkcs12 -export -in <(echo "${KAPUA_CRT}"; echo "${KAPUA_CA}") -inkey <(echo "${KAPUA_KEY}") ${PASSWORD_PARAM} -name kapua -password pass:"${KAPUA_KEYSTORE_PASSWORD}" -out "${JETTY_BASE}/${CERTIFICATES_PATH}/${KEYSTORE_NAME}"
+        else
+            echo "${KAPUA_KEYSTORE}" | base64 --decode > "${JETTY_BASE}/${CERTIFICATES_PATH}/${KEYSTORE_NAME}"
+        fi
+    fi
+
+    echo "jetty.sslContext.keyStorePath=${CERTIFICATES_PATH}/${KEYSTORE_NAME}" >> ${JETTY_BASE}/start.d/ssl.ini
+    echo "jetty.sslContext.keyStorePassword=${KAPUA_KEYSTORE_PASSWORD}" >> ${JETTY_BASE}/start.d/ssl.ini
+    echo "jetty.sslContext.trustStorePath=${CERTIFICATES_PATH}/${KEYSTORE_NAME}" >> ${JETTY_BASE}/start.d/ssl.ini
+    echo "jetty.sslContext.trustStorePassword=${KAPUA_KEYSTORE_PASSWORD}" >> ${JETTY_BASE}/start.d/ssl.ini
+    echo "jetty.sslContext.keyManagerPassword=${KAPUA_KEYSTORE_PASSWORD}" >> ${JETTY_BASE}/start.d/ssl.ini
+
+else
+    rm -f ${JETTY_BASE}/start.d/https.ini
+fi
+
+# Start Jetty
 
 eval echo "START_ARGS = $START_ARGS"
 eval echo "JAVA_OPTS = $JAVA_OPTS"

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -69,3 +69,45 @@ mvn clean install -Pconsole,docker
 ```
 
 After the build has completed follow the steps from the [Running](#Running) section.
+
+#### Enabling SSL
+
+To enable SSL in the Jetty (Console and REST API) and Broker containers, set the `KAPUA_DISABLE_SSL` environment variable to `false`, and other variables according to the desired behavior, **before** running the `docker-deploy.sh` script:
+
+```bash
+export KAPUA_DISABLE_SSL=false
+```
+
+Additionally, the SSL can be configured in two ways: providing a certificate, a private key and an optional CA chain, or providing a keystore.
+
+##### Providing certificates and private key
+
+To use an existing certificate, a private key and a CA you can set the following environment variables:
+
+- **KAPUA_CRT**: The certificate to use
+- **KAPUA_CA**: *Optional* - The CA chain that validates the certificate
+- **KAPUA_KEY** The private key for the certificate
+- **KAPUA_KEY_PASSWORD** *Optional* - The password for the private key
+
+All the values should be exported as inline values. e.g.:
+
+```bash
+export KAPUA_CA=$(cat /path/to/myCA.pem)
+export KAPUA_CRT=$(cat /path/to/certificate.crt)
+export KAPUA_KEY=$(cat /path/to/private.key)
+export KAPUA_KEY_PASSWORD=private_key_password
+``` 
+
+##### Providing a Keystore
+
+Otherwise, two environment variables can be used to provide an already existing keystore and its password:
+
+- **KAPUA_KEYSTORE**: The base64 encoded keystore
+- **KAPUA_KEYSTORE_PASSWORD**: The password for the keystore
+
+Again, All the values should be exported as inline values. e.g.:
+
+```bash
+export KAPUA_KEYSTORE=$(base64 /path/to/keystore.pkcs)
+export KAPUA_KEYSTORE_PASSWORD=keystore_password
+```

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   db:
     image: kapua/kapua-sql:${IMAGE_VERSION}
     ports:
-    - 8181:8181
-    - 3306:3306
+      - 8181:8181
+      - 3306:3306
   es:
     image: elasticsearch:5.4.0
     ports:
@@ -20,12 +20,12 @@ services:
   events-broker:
     image: kapua/kapua-events-broker:${IMAGE_VERSION}
     ports:
-    - 5672:5672
+      - 5672:5672
   broker:
     image: kapua/kapua-broker:${IMAGE_VERSION}
     ports:
-    - 1883:1883
-    - 61614:61614
+      - 1883:1883
+      - 61614:61614
     depends_on:
       - db
       - es
@@ -33,18 +33,36 @@ services:
   kapua-console:
     image: kapua/kapua-console:${IMAGE_VERSION}
     ports:
-    - 8080:8080
+      - 8080:8080
+      - 8443:8443
     depends_on:
       - broker
       - db
       - es
       - events-broker
+    environment:
+      - KAPUA_DISABLE_SSL
+      - KAPUA_CA
+      - KAPUA_CRT
+      - KAPUA_KEY
+      - KAPUA_KEY_PASSWORD
+      - KAPUA_KEYSTORE
+      - KAPUA_KEYSTORE_PASSWORD
   kapua-api:
     image: kapua/kapua-api:${IMAGE_VERSION}
     ports:
-    - 8081:8080
+      - 8081:8080
+      - 8444:8443
     depends_on:
       - broker
       - db
       - es
       - events-broker
+    environment:
+      - KAPUA_DISABLE_SSL
+      - KAPUA_CA
+      - KAPUA_CRT
+      - KAPUA_KEY
+      - KAPUA_KEY_PASSWORD
+      - KAPUA_KEYSTORE
+      - KAPUA_KEYSTORE_PASSWORD

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -25,11 +25,20 @@ services:
     image: kapua/kapua-broker:${IMAGE_VERSION}
     ports:
       - 1883:1883
+      - 8883:8883
       - 61614:61614
     depends_on:
       - db
       - es
       - events-broker
+    environment:
+      - KAPUA_DISABLE_SSL
+      - KAPUA_CRT
+      - KAPUA_CA
+      - KAPUA_KEY
+      - KAPUA_KEY_PASSWORD
+      - KAPUA_KEYSTORE
+      - KAPUA_KEYSTORE_PASSWORD
   kapua-console:
     image: kapua/kapua-console:${IMAGE_VERSION}
     ports:


### PR DESCRIPTION
This PR aims at implementing support for enabling SSL in both Jetty (HTTPS) and ActiveMQ (MQTTS) Docker containers. Certificates/Key or a valid Keystore can be passed via environment variables when running `docker-deploy.sh`.

**Related Issue**
This PR resolves #2003

**Description of the solution adopted**
SSL is enabled by changing Docker deployment configuration files and scripts so that a Certificates/Key couple or a Keystore can be passed to the container. All the certificates must be passed inline.

**Screenshots**
N/A

**Any side note on the changes made**
N/A