### PR TITLE
Set minValue for retryInterval on JobScheduleAddDialog

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -154,7 +154,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
 
         retryInterval.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleRetryIntervalLabel());
         retryInterval.setAllowDecimals(false);
-        retryInterval.setAllowNegative(false);
+        retryInterval.setMinValue(1);
         retryInterval.setMaxLength(9);
         retryInterval.setToolTip(JOB_MSGS.dialogAddScheduleRetryIntervalTooltip());
         mainPanel.add(retryInterval);


### PR DESCRIPTION
Brief description of the PR.
Set minValue for retryInterval on JobScheduleAddDialog

**Related Issue**
This PR fixes/closes #2008 

**Description of the solution adopted**
Set minValue property for retryInterval field to 1.

**Screenshots**
_None_

**Any side note on the changes made**
Removed _setAllowtNegative(false)_ function as no longer needed after _1_ is set as min value.

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>