### PR TITLE
ErrorMessage fix after Paste event on JobScheduleAddDialog

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
@@ -28,6 +28,8 @@ import com.extjs.gxt.ui.client.widget.toolbar.FillToolItem;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
@@ -84,6 +86,23 @@ public abstract class ActionDialog extends KapuaDialog {
             }
         };
 
+        final Listener<BaseEvent> pasteEventListener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                if (be.getType() == Events.OnPaste) {
+                    final Timer timer = new Timer() {
+
+                        @Override
+                        public void run() {
+                            setSubmitButtonState();
+                        }
+                    };
+                    timer.schedule(100);
+                };
+            }
+        };
+
         KeyNav<ComponentEvent> keyNav = new KeyNav<ComponentEvent>(formPanel) {
             public void onKeyPress(ComponentEvent ce) {
                 if (ce.getKeyCode() == KeyCodes.KEY_TAB || ce.getKeyCode() == KeyCodes.KEY_ENTER ) {
@@ -95,6 +114,8 @@ public abstract class ActionDialog extends KapuaDialog {
         formPanel.addListener(Events.OnMouseUp, listener);
         formPanel.addListener(Events.OnClick, listener);
         formPanel.addListener(Events.OnKeyUp, listener);
+        formPanel.addListener(Events.OnPaste, pasteEventListener);
+        sinkEvents(Event.ONPASTE);
 
         //
         // Buttons setup

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -169,6 +169,8 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
 
     @Override
     protected void preSubmit() {
+        cronExpression.clearInvalid();
+
         if (triggerName.getValue() == null) {
             triggerName.markInvalid(VAL_MSGS.nameRequiredMsg());
             return;
@@ -214,7 +216,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
             }
         }
 
-        if (cronExpression.getValue() == null && retryInterval.getValue() == null) {
+        if (cronExpression.getValue() == null && cronExpression.isValid() && retryInterval.getValue() == null && retryInterval.isValid()) {
             cronExpression.markInvalid(VAL_MSGS.retryIntervalOrCronRequired());
             retryInterval.markInvalid(VAL_MSGS.retryIntervalOrCronRequired());
             return;
@@ -238,8 +240,6 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
                     }
                 }
             });
-        } else {
-            cronExpression.markInvalid(VAL_MSGS.cronExpressionRequired());
         }
     }
 


### PR DESCRIPTION
Brief description of the PR.
ErrorMessage fix after Paste event on JobScheduleAddDialog

**Related Issue**
This PR fixes/closes #2009 

**Description of the solution adopted**
Updated error handling for invalid/null values in retryInterval and cronExpression fields on JobScheduleAddDialog.

**Screenshots**
None

**Any side note on the changes made**
Adden new pasteEventListener in ActionDialog for enabling/disabling Submit button for handling Pasted values.

Signed-off-by: ct-ajovanovic aleksandra.jovanovic@comtrade.com
