### PR TITLE
Restore readonly fields in Settings page

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
@@ -332,6 +332,12 @@ public class AccountConfigPanel extends LayoutContainer {
             } else {
                 field = paintMultiFieldConfigParameter(param);
             }
+            String allowSelfEditValue = param.getOtherAttributes() != null ? param.getOtherAttributes().get("allowSelfEdit") : null;
+            boolean allowSelfEdit = allowSelfEditValue != null && allowSelfEditValue.equals("true");
+            boolean isEditingSelf = selectedAccountId == null || selectedAccountId.equals(currentSession.getSelectedAccountId());
+            if (isEditingSelf && !allowSelfEdit) {
+                field.disable();
+            }
             actionFieldSet.add(field, formData);
         }
 


### PR DESCRIPTION
After merging #2029 any user could edit their own setting. This PR fixes this issue

**Related Issue**
This PR fixes #2069 

**Description of the solution adopted**
Restored code deleted by accident in #2029, restoring the checks when editing settings for the same account

**Screenshots**
N/A

**Any side note on the changes made**
N/A