### PR TITLE
Removed unneeded grid refresh that caused the pagingToolbar to be…

### DIFF
--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionDeleteDialog.java
@@ -47,7 +47,6 @@ public class RolePermissionDeleteDialog extends EntityDeleteDialog {
                 public void onSuccess(Void arg0) {
                     exitStatus = true;
                     exitMessage = MSGS.permissionDeleteDialogConfirmation();
-                    rolePermissionGrid.refresh();
                     hide();
                 }
 


### PR DESCRIPTION
…disabled

Brief description of the PR.
Removed unneeded grid refresh that caused the pagingToolbar to be disabled

**Related Issue**
This PR fixes/closes #2067 

**Description of the solution adopted**
Removed the unneeded `rolePermissionGrid.refresh()` call in the _RolePermissionDeleteDialog_ as this caused the `entityLoader.load()` method to be called twice which disabled the pagingToolbar. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>