### PR TITLE
REST API tests in combination with service steps

### DIFF
--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedDatabase.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedDatabase.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.qa.steps;
+
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtilsWithResources;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+
+public class EmbeddedDatabase {
+
+    private static final Logger logger = LoggerFactory.getLogger(EmbeddedDatabase.class);
+
+    /**
+     * Path to root of full DB scripts.
+     */
+    public static final String FULL_SCHEMA_PATH = "database";
+
+    /**
+     * Filter for deleting all new DB data except base data.
+     */
+    public static final String DELETE_SCRIPT = "all_delete.sql";
+
+    public EmbeddedDatabase() {
+    }
+
+    private DBHelper dbHelper;
+
+    @Before(value = "@StartDB")
+    public void start() throws SQLException {
+
+        logger.info("Starting embedded in memory H2 database.");
+
+        dbHelper = new DBHelper();
+        dbHelper.setup();
+    }
+
+    @After(value = "@StopDB")
+    public void close() throws SQLException {
+    }
+
+    public void deleteAll() throws SQLException {
+
+        KapuaConfigurableServiceSchemaUtilsWithResources.scriptSession(FULL_SCHEMA_PATH, DELETE_SCRIPT);
+    }
+
+}

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedJetty.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedJetty.java
@@ -17,6 +17,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AllowSymLinkAliasChecker;
 import org.eclipse.jetty.webapp.Configuration;
 import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,10 @@ public class EmbeddedJetty {
 
     @Given("^Start Jetty Server on host \"(.*)\" at port \"(.+)\"$")
     public void start(String host, int port) throws Exception {
+
+        // Switch back to default DB connection resolver
+        // as Jetty has its own class loader and has to access in memory DB over TCP
+        System.setProperty(SystemSettingKey.DB_JDBC_CONNECTION_URL_RESOLVER.key(), "DEFAULT");
 
         InetSocketAddress address = new InetSocketAddress(host, port);
         jetty = new Server(address);
@@ -72,6 +77,7 @@ public class EmbeddedJetty {
         logger.info("Stopping Jetty " + jetty);
 
         jetty.stop();
+        System.setProperty(SystemSettingKey.DB_JDBC_CONNECTION_URL_RESOLVER.key(), "H2");
     }
 
 }

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/RestClientSteps.java
@@ -17,11 +17,14 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.RestJAXBContextProvider;
 import org.eclipse.kapua.service.StepData;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserListResult;
+import org.eclipse.kapua.service.user.steps.ComparableUser;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +36,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.List;
 
 @ScenarioScoped
 public class RestClientSteps extends Assert {
@@ -66,6 +70,7 @@ public class RestClientSteps extends Assert {
         String host = (String) stepData.get("host");
         String port = (String) stepData.get("port");
         String tokenId = (String) stepData.get("tokenId");
+        resource = insertStepData(resource);
         URL url = new URL("http://" + host + ":" + port + resource);
 
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -76,15 +81,18 @@ public class RestClientSteps extends Assert {
             if (tokenId != null) {
                 conn.setRequestProperty("Authorization", "Bearer " + tokenId);
             }
-            assertFalse("Wrong response.", conn.getResponseCode() != 200);
-            StringBuilder sb = new StringBuilder();
-            try (BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())))) {
-                String output;
-                while ((output = br.readLine()) != null) {
-                    sb.append(output);
+            int httpRespCode = conn.getResponseCode();
+            if (httpRespCode == 200) {
+                StringBuilder sb = new StringBuilder();
+                try (BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())))) {
+                    String output;
+                    while ((output = br.readLine()) != null) {
+                        sb.append(output);
+                    }
                 }
+                stepData.put("restResponse", sb.toString());
             }
-            stepData.put("restResponse", sb.toString());
+            stepData.put("restResponseCode", httpRespCode);
         } catch ( IOException ioe) {
             logger.error("Exception on REST GET call execution: " + resource);
             throw ioe;
@@ -96,6 +104,9 @@ public class RestClientSteps extends Assert {
 
         String host = (String) stepData.get("host");
         String port = (String) stepData.get("port");
+        String tokenId = (String) stepData.get("tokenId");
+        resource = insertStepData(resource);
+        json = insertStepData(json);
         URL url = new URL("http://" + host + ":" + port + resource);
 
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -103,20 +114,27 @@ public class RestClientSteps extends Assert {
             conn.setRequestProperty("Accept-Language", "UTF-8");
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+            conn.setRequestProperty("Accept", "application/json");
+            if (tokenId != null) {
+                conn.setRequestProperty("Authorization", "Bearer " + tokenId);
+            }
             conn.setDoOutput(true);
             try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(conn.getOutputStream())) {
                 outputStreamWriter.write(json);
                 outputStreamWriter.flush();
             }
-            assertFalse("Wrong response.", conn.getResponseCode() != 200);
-            StringBuilder sb = new StringBuilder();
-            try (BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())))) {
-                String output;
-                while ((output = br.readLine()) != null) {
-                    sb.append(output);
+            int httpRespCode = conn.getResponseCode();
+            if (httpRespCode == 200) {
+                StringBuilder sb = new StringBuilder();
+                try (BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())))) {
+                    String output;
+                    while ((output = br.readLine()) != null) {
+                        sb.append(output);
+                    }
                 }
+                stepData.put("restResponse", sb.toString());
             }
-            stepData.put("restResponse", sb.toString());
+            stepData.put("restResponseCode", httpRespCode);
         } catch (IOException ioe) {
             logger.error("Exception on REST POST call execution: " + resource);
             throw ioe;
@@ -131,7 +149,18 @@ public class RestClientSteps extends Assert {
                 restResponse.contains(checkStr));
     }
 
-    @Then("^REST response containing \"(.*)\" with prefix account \"(.*)\"")
+    @Then("^REST response containing Account$")
+    public void restResponseContainingAccount() throws Exception {
+
+        String restResponse = (String) stepData.get("restResponse");
+        Account account = XmlUtil.unmarshalJson(restResponse, Account.class, null);
+        KapuaId accId = account.getId();
+        System.out.println("Account Id = " + accId);
+        stepData.put("lastAccountId", accId.toStringId());
+        stepData.put("lastAccountCompactId", accId.toCompactId());
+    }
+
+    @Then("^REST response containing \"(.*)\" with prefix account \"(.*)\"$")
     public void restResponseContainingPrefixVar(String checkStr, String var) {
 
         String restResponse = (String) stepData.get("restResponse");
@@ -144,17 +173,91 @@ public class RestClientSteps extends Assert {
     public void restResponseContainingAccessToken() throws Exception {
 
         String restResponse = (String) stepData.get("restResponse");
+        XmlUtil.setContextProvider(new RestJAXBContextProvider());
         AccessToken token = XmlUtil.unmarshalJson(restResponse, AccessToken.class, null);
         assertTrue("Token is null.", token.getTokenId() != null);
         stepData.put("tokenId", token.getTokenId());
     }
 
-    @Then("^REST response containing Users")
-    public void restResponseContainingUsers() throws Exception {
+    @Then("^REST response containing User")
+    public void restResponseContainingUser() throws Exception {
 
         String restResponse = (String) stepData.get("restResponse");
-        UserListResult users = XmlUtil.unmarshalJson(restResponse, UserListResult.class, null);
-        assertFalse("Users list is empty.", users.isEmpty());
+        User user = XmlUtil.unmarshalJson(restResponse, User.class, null);
+        stepData.put("lastUserCompactId", user.getId().toCompactId());
     }
 
+    @Then("^REST response contains list of Users")
+    public void restResponseContainsUsers() throws Exception {
+
+        String restResponse = (String) stepData.get("restResponse");
+        UserListResult userList = XmlUtil.unmarshalJson(restResponse, UserListResult.class, null);
+        Assert.assertFalse("Retrieved user list should NOT be empty.", userList.isEmpty());
+    }
+
+    @Then("^REST response doesn't contain User")
+    public void restResponseDoesntContainUser() throws Exception {
+
+        String restResponse = (String) stepData.get("restResponse");
+        User user = XmlUtil.unmarshalJson(restResponse, User.class, null);
+        Assert.assertTrue("There should be NO User retrieved.", user == null);
+    }
+
+    @Then("^REST response code is (\\d+)$")
+    public void restResponseDoesntContainUser(int expeted) throws Exception {
+
+        int restResponseCode = (Integer) stepData.get("restResponseCode");
+        Assert.assertEquals("Wrong response code.", expeted, restResponseCode);
+    }
+
+    /**
+     * Take input parameter and replace its $var$ with value of var that is stored
+     * in step data.
+     *
+     * @param template string that gets parameters replaced with value
+     * @return string with inserted parameter values
+     */
+    private String insertStepData(String template) {
+        List<String> keys = stepData.getKeys();
+        for (String key: keys) {
+            Object oValue = stepData.get(key);
+            if (oValue instanceof String) {
+                String value = (String) oValue;
+                template = template.replace("$" + key + "$", value);
+            }
+        }
+
+        return template;
+    }
+
+    // TODO move this step in common steps
+    @Given("^Move step data \"(.*)\" to \"(.*)\"$")
+    public void moveStepData(String keyFrom, String keyTo) {
+
+        Object valueFrom = stepData.get(keyFrom);
+        stepData.put(keyTo, valueFrom);
+    }
+
+    // TODO move this step in common steps
+    @Given("^Move Account compact id from step data \"(.*)\" to \"(.*)\"$")
+    public void moveAccountCompactIdStepData(String keyFrom, String keyTo) {
+
+        Account account = (Account) stepData.get(keyFrom);
+        stepData.put(keyTo, account.getId().toCompactId());
+    }
+
+    // TODO move this step in common steps
+    @Given("^Move User compact id from step data \"(.*)\" to \"(.*)\"$")
+    public void moveUserCompactIdStepData(String keyFrom, String keyTo) {
+
+        ComparableUser comparableUser = (ComparableUser) stepData.get(keyFrom);
+        stepData.put(keyTo, comparableUser.getUser().getId().toCompactId());
+    }
+
+    // TODO move this step in common steps
+    @Given("^Clear step data with key \"(.*)\"$")
+    public void clearStepData(String key) {
+
+        stepData.remove(key);
+    }
 }

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/RestJAXBContextProvider.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/RestJAXBContextProvider.java
@@ -13,6 +13,9 @@ package org.eclipse.kapua.service;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountCreator;
+import org.eclipse.kapua.service.account.AccountListResult;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserCreator;
@@ -50,7 +53,11 @@ public class RestJAXBContextProvider implements JAXBContextProvider {
                         UserCreator.class,
                         UserListResult.class,
                         UserQuery.class,
-                        UserXmlRegistry.class
+                        UserXmlRegistry.class,
+                        // Account
+                        Account.class,
+                        AccountCreator.class,
+                        AccountListResult.class
                 }, properties);
             }
             return context;

--- a/qa-steps/src/main/java/org/eclipse/kapua/service/StepData.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/StepData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,8 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Singleton;
 
@@ -53,5 +57,17 @@ public class StepData {
 
     public void remove(String key) {
         stepDataMap.remove(key);
+    }
+
+    public List<String> getKeys() {
+        List<String> keys = new ArrayList<>();
+
+        Set<String> setOfKeys = stepDataMap.keySet();
+        Iterator<String> keyIterator = setOfKeys.iterator();
+        while (keyIterator.hasNext()) {
+            keys.add(keyIterator.next());
+        }
+
+        return keys;
     }
 }

--- a/qa/src/test/java/org/eclipse/kapua/rest/RunRestUserTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/rest/RunRestUserTest.java
@@ -19,7 +19,8 @@ import org.junit.runner.RunWith;
 @RunWith(CucumberWithProperties.class)
 @CucumberOptions(
         features = "classpath:features/rest/user/RestUser.feature",
-        glue = {"org.eclipse.kapua.qa.steps"
+        glue = {"org.eclipse.kapua.qa.steps",
+                "org.eclipse.kapua.service.user.steps"
         },
         plugin = { "pretty",
                 "html:target/cucumber/RestUser",
@@ -28,7 +29,11 @@ import org.junit.runner.RunWith;
         monochrome = true)
 @CucumberProperty(key="certificate.jwt.private.key", value= "cert/key.pk8")
 @CucumberProperty(key="certificate.jwt.certificate", value= "cert/certificate.pem")
-@CucumberProperty(key="commons.db.schema", value="TEST")
+@CucumberProperty(key="commons.db.schema", value="kapuadb")
 @CucumberProperty(key="commons.db.schema.update", value="true")
+@CucumberProperty(key="commons.db.connection.host", value="localhost")
+@CucumberProperty(key="commons.db.connection.port", value="9092")
+@CucumberProperty(key="commons.db.name", value="mem:kapua")
+@CucumberProperty(key="test.h2.server", value="true")
 public class RunRestUserTest {
 }

--- a/qa/src/test/resources/features/rest/user/RestUser.feature
+++ b/qa/src/test/resources/features/rest/user/RestUser.feature
@@ -30,7 +30,107 @@ Feature: REST API tests for User
     When REST POST call at "/v1/authentication/user" with JSON "{"password": "kapua-password", "username": "kapua-sys"}"
     Then REST response containing AccessToken
     When REST GET call at "/v1/_/users?offset=0&limit=50"
-    Then REST response containing Users
+    Then REST response contains list of Users
+
+#  Commented out as it is not possible to set configuration of user account
+#
+#  Scenario: Create account and user in that account
+#
+#    Given Server with host "127.0.0.1" on port "8080"
+#    And REST POST call at "/v1/authentication/user" with JSON "{"password": "kapua-password", "username": "kapua-sys"}"
+#    And REST response containing AccessToken
+#    And REST POST call at "/v1/AQ/accounts" with JSON "{"expirationDate": "2030-02-21T12:05:00.000Z", "organizationName": "Org A", "organizationPersonName": "Person Name", "organizationEmail": "person@org-a.com", "organizationPhoneNumber": "555-123-456", "organizationAddressLine1": "Address A", "organizationAddressLine2": "NA",  "organizationCity": "Ljubljana", "organizationZipPostCode": "1000", "organizationStateProvinceCounty": "Province", "organizationCountry": "Slovenia", "name": "Person Name","entityAttributes": {}, "scopeId": "1"}"
+#    Then REST response containing Account
+#    And REST POST call at "/v1/$lastAccountCompactId$/users" with JSON "{"displayName": "User A", "email": "user.a@comp-a.com", "phoneNumber": "555-123-456", "userType": "INTERNAL", "externalId": "", "expirationDate": "2030-02-21T12:05:00.000Z", "userStatus": "ENABLED", "name": "usera", "entityAttributes": {}, "scopeId": "$lastAccountId$"}"
+#
+
+  Scenario: Bug when user can retrieve user in another account if it has other account's user id
+    Prepare two different accounts with each having single user.
+    Login into account A.
+    Fetch user in that account and keep his ID.
+    Login into account B and search for user from previous step with its ID.
+
+    Given Server with host "127.0.0.1" on port "8080"
+# ------ Service steps ------
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And Move step data "LastAccount" to "AccountA"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Move step data "LastUser" to "UserA"
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And Permissions
+      | domain | action |
+      | user   | read   |
+      | user   | write  |
+      | user   | delete |
+    And Account
+      | name      | scopeId |
+      | account-b | 1       |
+    And Move step data "LastAccount" to "AccountB"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And User B
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-b | Kapua User B | kapua_b@kapua.com | +386 31 323 555 | ENABLED | INTERNAL |
+    And Credentials
+      | name    | password          | enabled |
+      | kapua-b | ToManySecrets123# | true    |
+    And Permissions
+      | domain | action |
+      | user   | read   |
+      | user   | write  |
+      | user   | delete |
+    And I logout
+# ------ Service steps ------
+    Then REST POST call at "/v1/authentication/user" with JSON "{"password": "ToManySecrets123#", "username": "kapua-a"}"
+    And REST response containing AccessToken
+    And Move Account compact id from step data "AccountA" to "accountACompactId"
+    And Move User compact id from step data "UserA" to "userACompactId"
+    And REST GET call at "/v1/$accountACompactId$/users/$userACompactId$"
+    Then REST response containing User
+    Then REST POST call at "/v1/authentication/logout" with JSON ""
+    And Clear step data with key "tokenId"
+    And REST POST call at "/v1/authentication/user" with JSON "{"password": "ToManySecrets123#", "username": "kapua-b"}"
+    And REST response containing AccessToken
+    And Move Account compact id from step data "AccountB" to "accountBCompactId"
+    And REST GET call at "/v1/$accountBCompactId$/users/$lastUserCompactId$"
+    Then REST response code is 404
 
   Scenario: Stop Jetty server for all scenarios
 


### PR DESCRIPTION
REST API steps and service steps are combined in Gherkin scenarios.

**Related Issue**
This PR contains tests for issue _2011_ resolved in PR _2040_

**Description of the solution adopted**
This principle is used for test of issue 2011 where there are two
users in two different accounts, and user from one account can see
user in another account, using REST interface.

Mixing service steps and embedded jetty with rest steps is now working
and this is template for this kind of tests.

**Screenshots**
Not applicable.

**Any side note on the changes made**
Merger of test steps from services and REST api testing steps.

This principle is used for test of issue 2011 where there are two
users in two different accounts, and user from one account can see
user in another account, using REST interface.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>