### PR TITLE
Use SystemToken to authenticate Pooled MQTT Clients

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -52,6 +52,7 @@ import org.eclipse.kapua.broker.core.setting.BrokerSettingKey;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.ClassUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.account.Account;
@@ -403,7 +404,17 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
         try {
             logger.info("User name {} - client id: {}, connection id: {}", kcc.getUserName(), kcc.getClientId(), kcc.getConnectionId());
             Context loginShiroLoginTimeContext = loginMetric.getShiroLoginTime().time();
-            LoginCredentials credentials = credentialsFactory.newUsernamePasswordCredentials(kcc.getUserName(), info.getPassword());
+
+            SystemSetting systemSettings = SystemSetting.getInstance();
+            String username = systemSettings.getString(SystemSettingKey.SYSTOKEN_AUTH_USERNAME);
+
+            LoginCredentials credentials;
+            if (kcc.getUserName().equals(username)) {
+                credentials = credentialsFactory.newSysTokenCredentials(kcc.getUserName(), info.getPassword());
+            } else {
+                credentials = credentialsFactory.newUsernamePasswordCredentials(kcc.getUserName(), info.getPassword());
+
+            }
             AccessToken accessToken = authenticationService.login(credentials);
 
             final Account account;

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -257,7 +257,11 @@ public enum SystemSettingKey implements SettingKey {
     /**
      * Allow System Settings to be updatable at runtime via System.setProperty()
      */
-    SETTINGS_HOTSWAP("commons.settings.hotswap");
+    SETTINGS_HOTSWAP("commons.settings.hotswap"),
+    /**
+     * Username of the user to use when connecting the pooled MQTT Client to the broker
+     */
+    SYSTOKEN_AUTH_USERNAME("systoken.auth.username");
 
     private String key;
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/RandomUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/RandomUtil.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.util;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RandomUtil {
+
+    private static SecureRandom random;
+    private static final Logger LOGGER = LoggerFactory.getLogger(RandomUtil.class);
+
+    static {
+        try {
+            random = SecureRandom.getInstance("SHA1PRNG");
+        } catch (NoSuchAlgorithmException e) {
+            LOGGER.error("Unable to initialize RNG", e);
+        }
+    }
+
+    private RandomUtil() { }
+
+    public static String getRandomString(int length) {
+
+        byte[] bPre = new byte[length];
+        random.nextBytes(bPre);
+        return Base64.getEncoder().encodeToString(bPre).substring(0, length);
+
+    }
+}

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -91,3 +91,5 @@ commons.eventbus.messageSerializer=org.eclipse.kapua.commons.event.XmlServiceEve
 commons.eventbus.transport.useEpoll=true
 
 commons.settings.hotswap=false
+
+systoken.auth.username=kapua-sys

--- a/console/web/src/main/resources/shiro.ini
+++ b/console/web/src/main/resources/shiro.ini
@@ -14,8 +14,9 @@ securityManager.authenticator = $authenticator
 #realms
 kapuaAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
-jwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
-securityManager.realms = $kapuaAuthorizingRealm, $kapuaAuthenticatingRealm, $jwtAuthenticatingRealm
+kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+kapuaSysTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.SysTokenAuthenticatingRealm
+securityManager.realms = $kapuaAuthorizingRealm, $kapuaAuthenticatingRealm, $kapuaJwtAuthenticatingRealm, $kapuaSysTokenAuthenticatingRealm
 
 [users]
 # The 'users' section is for simple deployments

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -89,3 +89,5 @@ commons.eventbus.producerPool.evictionInterval=600000
 commons.eventbus.consumerPool.size=10
 commons.eventbus.messageSerializer=org.eclipse.kapua.commons.event.XmlServiceEventMarshaler
 commons.eventbus.transport.useEpoll=true
+
+systoken.auth.username=kapua-sys

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -22,6 +22,7 @@ kapuaAuthcAccessToken = org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthentica
 kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
 kapuaApiKeyAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.ApiKeyAuthenticatingRealm
 kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+kapuaSysTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.SysTokenAuthenticatingRealm
 
 # Session
 kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
@@ -29,7 +30,7 @@ kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.s
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
 
-securityManager.realms = $kapuaAuthorizingRealm, $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
+securityManager.realms = $kapuaAuthorizingRealm, $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm, $kapuaSysTokenAuthenticatingRealm
 
 # 90*24*60*60 seconds = 90 days = 7776000 seconds
 securityManager.rememberMeManager.cookie.name = kapua-rememberme

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
@@ -69,4 +69,6 @@ public interface CredentialsFactory extends KapuaObjectFactory {
      */
     RefreshTokenCredentials newRefreshTokenCredentials(String tokenId, String refreshToken);
 
+    SysTokenCredentials newSysTokenCredentials(String username, String password);
+
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/SysTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/SysTokenCredentials.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * Username and password {@link LoginCredentials} definition.
+ *
+ * @since 1.0
+ */
+@XmlRootElement(name = "sysTokenCredentials")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(propOrder = { "username", "password" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newSysTokenCredentials")
+public interface SysTokenCredentials extends LoginCredentials {
+
+    /**
+     * return the username
+     *
+     * @return
+     */
+    String getUsername();
+
+    /**
+     * Set the username
+     *
+     * @param username
+     */
+    void setUsername(String username);
+
+    /**
+     * return the password
+     *
+     * @return
+     */
+    String getPassword();
+
+    /**
+     * Set the password
+     *
+     * @param password
+     */
+    void setPassword(String password);
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialAttributes.java
@@ -24,5 +24,6 @@ public class CredentialAttributes extends KapuaUpdatableEntityAttributes {
     public static final String CREDENTIAL_TYPE = "credentialType";
     public static final String CREDENTIAL_KEY = "credentialKey";
     public static final String EXPIRATION_DATE = "expirationDate";
+    public static final String STATUS = "status";
 
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialType.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialType.java
@@ -30,5 +30,10 @@ public enum CredentialType {
     /**
      * Json Web Token
      */
-    JWT;
+    JWT,
+
+    /**
+     * System Token
+     */
+    SYS_TOKEN;
 }

--- a/service/security/authentication/api/src/main/resources/shiro.ini
+++ b/service/security/authentication/api/src/main/resources/shiro.ini
@@ -23,6 +23,7 @@ securityManager.authenticator = $authenticator
 kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
 kapuaApiKeyAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.ApiKeyAuthenticatingRealm
 kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+kapuaSysTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.SysTokenAuthenticatingRealm
 
 # Session
 kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
@@ -30,7 +31,7 @@ kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.s
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
 
-securityManager.realms = $kapuaAuthorizingRealm, $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
+securityManager.realms = $kapuaAuthorizingRealm, $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm, $kapuaSysTokenAuthenticatingRealm
 
 
 #edcCacheManager = com.eurotech.cloud.commons.service.security.KapuaCacheManager
@@ -58,4 +59,3 @@ securityManager.subjectDAO.sessionStorageEvaluator.sessionStorageEnabled = false
 # The 'urls' section is used for url-based security
 # in web applications.  We'll discuss this section in the
 # Web documentation
- 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -45,6 +45,7 @@ import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticatio
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,8 +112,8 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
             switch (credentialCreator.getCredentialType()) {
                 case API_KEY: // Generate new api key
                     KapuaAuthenticationSetting setting = KapuaAuthenticationSetting.getInstance();
-                int preLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH);
-                int keyLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_KEY_LENGTH);
+                    int preLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH);
+                    int keyLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_KEY_LENGTH);
 
                     String pre = RandomUtil.getRandomString(preLength);
                     String key = RandomUtil.getRandomString(keyLength);
@@ -144,6 +145,9 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
             switch (credentialCreator.getCredentialType()) {
                 case API_KEY:
                     credential.setCredentialKey(fullKey);
+                    break;
+                case SYS_TOKEN:
+                    credential.setCredentialKey(credentialCreator.getCredentialPlainKey());
                     break;
                 case PASSWORD:
                 default:

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential.shiro;
 
-import org.apache.shiro.codec.Base64;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
@@ -20,6 +19,7 @@ import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.CommonsValidationRegex;
 import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
+import org.eclipse.kapua.commons.util.RandomUtil;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
@@ -47,8 +47,6 @@ import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.security.SecureRandom;
 
 /**
  * {@link CredentialService} implementation.
@@ -112,19 +110,12 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
             String fullKey = null;
             switch (credentialCreator.getCredentialType()) {
                 case API_KEY: // Generate new api key
-                    SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
-
                     KapuaAuthenticationSetting setting = KapuaAuthenticationSetting.getInstance();
-                    int preLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH);
-                    int keyLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_KEY_LENGTH);
+                int preLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH);
+                int keyLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_KEY_LENGTH);
 
-                    byte[] bPre = new byte[preLength];
-                    random.nextBytes(bPre);
-                    String pre = Base64.encodeToString(bPre).substring(0, preLength);
-
-                    byte[] bKey = new byte[keyLength];
-                    random.nextBytes(bKey);
-                    String key = Base64.encodeToString(bKey);
+                    String pre = RandomUtil.getRandomString(preLength);
+                    String key = RandomUtil.getRandomString(keyLength);
 
                     fullKey = pre + key;
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -42,6 +42,7 @@ import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
 import org.eclipse.kapua.service.authentication.credential.CredentialService;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
+import org.eclipse.kapua.service.authentication.SysTokenCredentials;
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSetting;
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
@@ -89,6 +90,7 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         try {
             realms.add(new org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm());
             realms.add(new org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm());
+            realms.add(new org.eclipse.kapua.service.authentication.shiro.realm.SysTokenAuthenticatingRealm());
         } catch (KapuaException e) {
             LOG.error("Unable to build realms", e);
             throw new ExceptionInInitializerError(e);
@@ -129,6 +131,9 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             shiroAuthenticationToken = new ApiKeyCredentialsImpl(((ApiKeyCredentialsImpl) loginCredentials).getApiKey());
         } else if (loginCredentials instanceof JwtCredentialsImpl) {
             shiroAuthenticationToken = new JwtCredentialsImpl(((JwtCredentialsImpl) loginCredentials).getJwt());
+        } else if (loginCredentials instanceof SysTokenCredentials) {
+            SysTokenCredentialsImpl sysTokenCredentials = (SysTokenCredentialsImpl) loginCredentials;
+            shiroAuthenticationToken = new SysTokenCredentialsImpl(sysTokenCredentials.getUsername(), sysTokenCredentials.getPassword());
         } else {
             throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_CREDENTIALS_TYPE_PROVIDED);
         }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
@@ -17,6 +17,7 @@ import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
 import org.eclipse.kapua.service.authentication.CredentialsFactory;
 import org.eclipse.kapua.service.authentication.JwtCredentials;
 import org.eclipse.kapua.service.authentication.RefreshTokenCredentials;
+import org.eclipse.kapua.service.authentication.SysTokenCredentials;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 
 /**
@@ -53,4 +54,8 @@ public class CredentialsFactoryImpl implements CredentialsFactory {
         return new RefreshTokenCredentialsImpl(tokenId, refreshToken);
     }
 
+    @Override
+    public SysTokenCredentials newSysTokenCredentials(String username, String password) {
+        return new SysTokenCredentialsImpl(username, password);
+    }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/SysTokenCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/SysTokenCredentialsImpl.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro;
+
+import org.eclipse.kapua.service.authentication.AuthenticationCredentials;
+import org.eclipse.kapua.service.authentication.SysTokenCredentials;
+
+import org.apache.shiro.authc.AuthenticationToken;
+
+/**
+ * Username and password {@link AuthenticationCredentials} implementation.
+ * 
+ * @since 1.0
+ * 
+ */
+public class SysTokenCredentialsImpl implements SysTokenCredentials, AuthenticationToken {
+
+    private String username;
+    private String password;
+
+    /**
+     * Constructor
+     *  @param username
+     * @param password
+     */
+    public SysTokenCredentialsImpl(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return getUsername();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return getPassword();
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
@@ -60,11 +60,11 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
 
     @Override
     public Object getPrincipal() {
-        return username;
+        return getUsername();
     }
 
     @Override
     public Object getCredentials() {
-        return password;
+        return getPassword();
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
@@ -11,39 +11,29 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
-import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.ShiroException;
-import org.apache.shiro.authc.AuthenticationException;
-import org.apache.shiro.authc.AuthenticationInfo;
-import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.DisabledAccountException;
-import org.apache.shiro.authc.ExpiredCredentialsException;
-import org.apache.shiro.authc.UnknownAccountException;
-import org.apache.shiro.realm.AuthenticatingRealm;
-import org.apache.shiro.subject.Subject;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
-import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
 import org.eclipse.kapua.service.authentication.shiro.AccessTokenCredentialsImpl;
-import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.authentication.token.AccessTokenService;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
-import org.eclipse.kapua.service.user.UserStatus;
 
-import java.util.Date;
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.realm.AuthenticatingRealm;
 
 /**
  * {@link AccessTokenCredentials} based {@link AuthenticatingRealm} implementation.
  * <p>
  * since 1.0
  */
-public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
+public class AccessTokenAuthenticatingRealm extends KapuaAuthenticatingRealm {
 
     /**
      * Realm name
@@ -69,8 +59,7 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
     }
 
     @Override
-    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken)
-            throws AuthenticationException {
+    protected SessionAuthenticationInfo buildAuthenticationInfo(AuthenticationToken authenticationToken) {
         //
         // Extract credentials
         AccessTokenCredentialsImpl token = (AccessTokenCredentialsImpl) authenticationToken;
@@ -87,17 +76,6 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
             throw new ShiroException("Error while find access token!", e);
         }
 
-        // Check existence
-        if (accessToken == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check validity
-        if ((accessToken.getExpiresOn() != null && accessToken.getExpiresOn().before(new Date())) ||
-                (accessToken.getInvalidatedOn() != null && accessToken.getInvalidatedOn().before(new Date()))) {
-            throw new ExpiredCredentialsException();
-        }
-
         //
         // Get the associated user by name
         final User user;
@@ -107,21 +85,6 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
             throw ae;
         } catch (Exception e) {
             throw new ShiroException("Error while find user!", e);
-        }
-
-        // Check existence
-        if (user == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check disabled
-        if (UserStatus.DISABLED.equals(user.getStatus())) {
-            throw new DisabledAccountException();
-        }
-
-        // Check if expired
-        if (user.getExpirationDate() != null && !user.getExpirationDate().after(new Date())) {
-            throw new ExpiredCredentialsException();
         }
 
         //
@@ -135,43 +98,12 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
             throw new ShiroException("Error while find account!", e);
         }
 
-        // Check existence
-        if (account == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check account expired
-        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
-            throw new ExpiredAccountException(account.getExpirationDate());
-        }
-
         //
         // BuildAuthenticationInfo
         return new SessionAuthenticationInfo(getName(),
                 account,
                 user,
                 accessToken);
-    }
-
-    @Override
-    protected void assertCredentialsMatch(AuthenticationToken authcToken, AuthenticationInfo info)
-            throws AuthenticationException {
-        SessionAuthenticationInfo kapuaInfo = (SessionAuthenticationInfo) info;
-
-        //
-        // Credential match
-        super.assertCredentialsMatch(authcToken, info);
-
-        //
-        // Set kapua session
-        AccessToken accessToken = kapuaInfo.getAccessToken();
-        KapuaSession kapuaSession = new KapuaSession(accessToken, accessToken.getScopeId(), accessToken.getUserId());
-        KapuaSecurityUtils.setSession(kapuaSession);
-
-        //
-        // Set shiro session
-        Subject currentSubject = SecurityUtils.getSubject();
-        currentSubject.getSession().setAttribute(KapuaSession.KAPUA_SESSION_KEY, kapuaSession);
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
@@ -11,20 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
-import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.ShiroException;
-import org.apache.shiro.authc.AuthenticationException;
-import org.apache.shiro.authc.AuthenticationInfo;
-import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.DisabledAccountException;
-import org.apache.shiro.authc.ExpiredCredentialsException;
-import org.apache.shiro.authc.UnknownAccountException;
-import org.apache.shiro.authc.credential.CredentialsMatcher;
-import org.apache.shiro.realm.AuthenticatingRealm;
-import org.apache.shiro.session.Session;
-import org.apache.shiro.subject.Subject;
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.account.Account;
@@ -32,16 +18,15 @@ import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
 import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialService;
-import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.shiro.ApiKeyCredentialsImpl;
-import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
-import org.eclipse.kapua.service.authentication.shiro.exceptions.TemporaryLockedAccountException;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
-import org.eclipse.kapua.service.user.UserStatus;
 
-import java.util.Date;
-import java.util.Map;
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.credential.CredentialsMatcher;
+import org.apache.shiro.realm.AuthenticatingRealm;
 
 /**
  * {@link ApiKeyCredentials} based {@link AuthenticatingRealm} implementation.
@@ -49,21 +34,22 @@ import java.util.Map;
  * since 1.0
  * 
  */
-public class ApiKeyAuthenticatingRealm extends AuthenticatingRealm {
+public class ApiKeyAuthenticatingRealm extends LockoutPolicyAuthenticatingRealm {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AccountService ACCOUNT_SERVICE = LOCATOR.getService(AccountService.class);
+    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
+    private static final CredentialService CREDENTIAL_SERVICE = LOCATOR.getService(CredentialService.class);
 
     /**
      * Realm name
      */
-    public static final String REALM_NAME = "apiKeyAuthenticatingRealm";
+    private static final String REALM_NAME = "apiKeyAuthenticatingRealm";
 
     /**
      * Constructor
-     * 
-     * @throws KapuaException
      */
-    public ApiKeyAuthenticatingRealm() throws KapuaException {
+    public ApiKeyAuthenticatingRealm() {
         setName(REALM_NAME);
 
         CredentialsMatcher credentialsMather = new ApiKeyCredentialsMatcher();
@@ -71,192 +57,43 @@ public class ApiKeyAuthenticatingRealm extends AuthenticatingRealm {
     }
 
     @Override
-    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken)
-            throws AuthenticationException {
-        //
-        // Extract credentials
-        ApiKeyCredentialsImpl token = (ApiKeyCredentialsImpl) authenticationToken;
-        String tokenApiKey = token.getApiKey();
-
-        //
-        // Get Services
-        UserService userService;
-        AccountService accountService;
-        CredentialService credentialService;
-
-        try {
-            userService = LOCATOR.getService(UserService.class);
-            accountService = LOCATOR.getService(AccountService.class);
-            credentialService = LOCATOR.getService(CredentialService.class);
-        } catch (KapuaRuntimeException kre) {
-            throw new ShiroException("Error while getting services!", kre);
-        }
+    protected LoginAuthenticationInfo buildAuthenticationInfo(AuthenticationToken authenticationToken) {
 
         //
         // Find credentials
         // FIXME: manage multiple credentials and multiple credentials type
         final Credential credential;
         try {
-            credential = KapuaSecurityUtils.doPrivileged(() -> credentialService.findByApiKey(tokenApiKey));
+            credential = KapuaSecurityUtils.doPrivileged(() -> CREDENTIAL_SERVICE.findByApiKey(authenticationToken.getPrincipal().toString()));
         } catch (AuthenticationException ae) {
             throw ae;
         } catch (Exception e) {
             throw new ShiroException("Error while find credentials!", e);
         }
 
-        // Check existence
-        if (credential == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check credential disabled
-        if (CredentialStatus.DISABLED.equals(credential.getStatus())) {
-            throw new DisabledAccountException();
-        }
-
-        // Check if credential expired
-        if (credential.getExpirationDate() != null && !credential.getExpirationDate().after(new Date())) {
-            throw new ExpiredCredentialsException();
-        }
-
         //
         // Get the associated user by name
         final User user;
         try {
-            user = KapuaSecurityUtils.doPrivileged(() -> userService.find(credential.getScopeId(), credential.getUserId()));
+            user = KapuaSecurityUtils.doPrivileged(() -> USER_SERVICE.find(credential.getScopeId(), credential.getUserId()));
         } catch (AuthenticationException ae) {
             throw ae;
         } catch (Exception e) {
             throw new ShiroException("Error while find user!", e);
         }
 
-        // Check existence
-        if (user == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check disabled
-        if (UserStatus.DISABLED.equals(user.getStatus())) {
-            throw new DisabledAccountException();
-        }
-
-        // Check if expired
-        if (user.getExpirationDate() != null && !user.getExpirationDate().after(new Date())) {
-            throw new ExpiredCredentialsException();
-        }
-
         //
         // Find account
         final Account account;
         try {
-            account = KapuaSecurityUtils.doPrivileged(() -> accountService.find(user.getScopeId()));
+            account = KapuaSecurityUtils.doPrivileged(() -> ACCOUNT_SERVICE.find(user.getScopeId()));
         } catch (AuthenticationException ae) {
             throw ae;
         } catch (Exception e) {
             throw new ShiroException("Error while find account!", e);
         }
 
-        // Check existence
-        if (account == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check account expired
-        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
-            throw new ExpiredAccountException(account.getExpirationDate());
-        }
-
-        // Check credential disabled
-        if (CredentialStatus.DISABLED.equals(credential.getStatus())) {
-            throw new DisabledAccountException();
-        }
-
-        // Check if credential expired
-        if (credential.getExpirationDate() != null && !credential.getExpirationDate().after(new Date())) {
-            throw new ExpiredCredentialsException();
-        }
-
-        // Check if lockout policy is blocking credential
-        Map<String, Object> credentialServiceConfig;
-        try {
-            credentialServiceConfig = KapuaSecurityUtils.doPrivileged(() -> credentialService.getConfigValues(account.getId()));
-            boolean lockoutPolicyEnabled = (boolean) credentialServiceConfig.get("lockoutPolicy.enabled");
-            if (lockoutPolicyEnabled) {
-                Date now = new Date();
-                if (credential.getLockoutReset() != null && now.before(credential.getLockoutReset())) {
-                    throw new TemporaryLockedAccountException(credential.getLockoutReset());
-                }
-            }
-        } catch (KapuaException kex) {
-            throw new ShiroException("Error while checking lockout policy", kex);
-        }
-
-        //
-        // BuildAuthenticationInfo
-        return new LoginAuthenticationInfo(getName(),
-                account,
-                user,
-                credential,
-                credentialServiceConfig);
-    }
-
-    @Override
-    protected void assertCredentialsMatch(AuthenticationToken authcToken, AuthenticationInfo info)
-            throws AuthenticationException {
-        LoginAuthenticationInfo kapuaInfo = (LoginAuthenticationInfo) info;
-        CredentialService credentialService = LOCATOR.getService(CredentialService.class);
-        try {
-            super.assertCredentialsMatch(authcToken, info);
-        } catch (AuthenticationException authenticationEx) {
-            try {
-                Credential failedCredential = (Credential) kapuaInfo.getCredentials();
-                KapuaSecurityUtils.doPrivileged(() -> {
-                    Map<String, Object> credentialServiceConfig = kapuaInfo.getCredentialServiceConfig();
-                    boolean lockoutPolicyEnabled = (boolean) credentialServiceConfig.get("lockoutPolicy.enabled");
-                    if (lockoutPolicyEnabled) {
-                        Date now = new Date();
-                        int resetAfterSeconds = (int)credentialServiceConfig.get("lockoutPolicy.resetAfter");
-                        Date firstLoginFailure;
-                        boolean resetAttempts = failedCredential.getFirstLoginFailure() == null || now.after(failedCredential.getLoginFailuresReset());
-                        if (resetAttempts) {
-                            firstLoginFailure = now;
-                            failedCredential.setLoginFailures(1);
-                        } else {
-                            firstLoginFailure = failedCredential.getFirstLoginFailure();
-                            failedCredential.setLoginFailures(failedCredential.getLoginFailures() + 1);
-                        }
-                        Date loginFailureWindowExpiration = new Date(firstLoginFailure.getTime() + (resetAfterSeconds * 1000));
-                        failedCredential.setFirstLoginFailure(firstLoginFailure);
-                        failedCredential.setLoginFailuresReset(loginFailureWindowExpiration);
-                        int maxLoginFailures = (int)credentialServiceConfig.get("lockoutPolicy.maxFailures");
-                        if (failedCredential.getLoginFailures() >= maxLoginFailures) {
-                            long lockoutDuration = (int)credentialServiceConfig.get("lockoutPolicy.lockDuration");
-                            Date resetDate = new Date(now.getTime() + (lockoutDuration * 1000));
-                            failedCredential.setLockoutReset(resetDate);
-                        }
-                    }
-
-                    credentialService.update(failedCredential);
-                });
-            } catch (KapuaException kex) {
-                throw new ShiroException("Error while updating lockout policy", kex);
-            }
-            throw authenticationEx;
-        }
-        Credential credential = (Credential) kapuaInfo.getCredentials();
-        credential.setFirstLoginFailure(null);
-        credential.setLoginFailuresReset(null);
-        credential.setLockoutReset(null);
-        credential.setLoginFailures(0);
-        try {
-            KapuaSecurityUtils.doPrivileged(() -> credentialService.update(credential));
-        } catch (KapuaException kex) {
-            throw new ShiroException("Error while updating lockout policy", kex);
-        }
-        Subject currentSubject = SecurityUtils.getSubject();
-        Session session = currentSubject.getSession();
-        session.setAttribute("scopeId", kapuaInfo.getUser().getScopeId());
-        session.setAttribute("userId", kapuaInfo.getUser().getId());
+        return new LoginAuthenticationInfo(getName(), account, user, credential);
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -12,53 +12,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
-import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.ShiroException;
-import org.apache.shiro.authc.AuthenticationException;
-import org.apache.shiro.authc.AuthenticationInfo;
-import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.DisabledAccountException;
-import org.apache.shiro.authc.ExpiredCredentialsException;
-import org.apache.shiro.authc.UnknownAccountException;
-import org.apache.shiro.realm.AuthenticatingRealm;
-import org.apache.shiro.session.Session;
-import org.apache.shiro.subject.Subject;
-import org.apache.shiro.util.Destroyable;
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
 import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
 import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
-import org.eclipse.kapua.service.authentication.credential.shiro.CredentialImpl;
 import org.eclipse.kapua.service.authentication.shiro.JwtCredentialsImpl;
-import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
 import org.eclipse.kapua.service.authentication.shiro.utils.JwtProcessors;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
-import org.eclipse.kapua.service.user.UserStatus;
 import org.eclipse.kapua.sso.jwt.JwtProcessor;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.realm.AuthenticatingRealm;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.util.Destroyable;
 import org.jose4j.jwt.consumer.JwtContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
-
 /**
  * {@link ApiKeyCredentials} based {@link AuthenticatingRealm} implementation.
  */
-public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destroyable {
+public class JwtAuthenticatingRealm extends KapuaAuthenticatingRealm implements Destroyable {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticatingRealm.class);
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AccountService ACCOUNT_SERVICE = LOCATOR.getService(AccountService.class);
+    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
+    private static final CredentialFactory CREDENTIAL_FACTORY = LOCATOR.getFactory(CredentialFactory.class);
 
     /**
      * Realm name
      */
-    public static final String REALM_NAME = "jwtAuthenticatingRealm";
+    private static final String REALM_NAME = "jwtAuthenticatingRealm";
 
     /**
      * JWT Processor
@@ -67,10 +63,8 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
 
     /**
      * Constructor
-     *
-     * @throws KapuaException
      */
-    public JwtAuthenticatingRealm() throws KapuaException {
+    public JwtAuthenticatingRealm() {
         setName(REALM_NAME);
     }
 
@@ -91,89 +85,48 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
     }
 
     @Override
-    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken) throws AuthenticationException {
+    protected LoginAuthenticationInfo buildAuthenticationInfo(AuthenticationToken authenticationToken) {
         //
         // Extract credentials
         JwtCredentialsImpl token = (JwtCredentialsImpl) authenticationToken;
         String jwt = token.getJwt();
 
-        //
-        // Get Services
-        final KapuaLocator locator;
-        final UserService userService;
-        final AccountService accountService;
-        try {
-            locator = KapuaLocator.getInstance();
-            userService = locator.getService(UserService.class);
-            accountService = locator.getService(AccountService.class);
-        } catch (KapuaRuntimeException kre) {
-            throw new ShiroException("Error while getting services!", kre);
-        }
-
         final String id = extractExternalId(jwt);
         logger.debug("JWT contains external id: {}", id);
 
+        //
         // Get the associated user by external id
-
         final User user;
         try {
-            user = KapuaSecurityUtils.doPrivileged(() -> userService.findByExternalId(id));
+            user = KapuaSecurityUtils.doPrivileged(() -> USER_SERVICE.findByExternalId(id));
         } catch (AuthenticationException ae) {
             throw ae;
         } catch (Exception e) {
             throw new ShiroException("Error looking up the user", e);
         }
 
-        // Check user existence
-
-        if (user == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check disabled
-
-        if (UserStatus.DISABLED.equals(user.getStatus())) {
-            throw new DisabledAccountException();
-        }
-
-        // Check if expired
-        if (user.getExpirationDate() != null && !user.getExpirationDate().after(new Date())) {
-            throw new ExpiredCredentialsException();
-        }
-
+        //
         // Find account
-
         final Account account;
         try {
-            account = KapuaSecurityUtils.doPrivileged(() -> accountService.find(user.getScopeId()));
+            account = KapuaSecurityUtils.doPrivileged(() -> ACCOUNT_SERVICE.find(user.getScopeId()));
         } catch (AuthenticationException e) {
             throw e;
         } catch (Exception e) {
             throw new ShiroException("Error while find account!", e);
         }
 
-        // Check account expired
-        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
-            throw new ExpiredAccountException(account.getExpirationDate());
-        }
-
-        // Check account existence
-
-        if (account == null) {
-            throw new UnknownAccountException();
-        }
-
+        //
         // Create credential
+        final Credential credential = CREDENTIAL_FACTORY.newCredential(user.getScopeId(), user.getId(), CredentialType.JWT, jwt, CredentialStatus.ENABLED, null);
 
-        final Credential credential = new CredentialImpl(user.getScopeId(), user.getId(), CredentialType.JWT, jwt, CredentialStatus.ENABLED, null);
-
+        //
         // Build AuthenticationInfo
-
         return new LoginAuthenticationInfo(getName(),
                 account,
                 user,
                 credential,
-               null);
+                null);
     }
 
     /**
@@ -202,11 +155,10 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
     }
 
     @Override
-    protected void assertCredentialsMatch(AuthenticationToken authcToken, AuthenticationInfo info)
-            throws AuthenticationException {
+    protected void assertCredentialsMatch(AuthenticationToken authenticationToken, AuthenticationInfo info) {
         final LoginAuthenticationInfo kapuaInfo = (LoginAuthenticationInfo) info;
 
-        super.assertCredentialsMatch(authcToken, info);
+        super.assertCredentialsMatch(authenticationToken, info);
 
         final Subject currentSubject = SecurityUtils.getSubject();
         Session session = currentSubject.getSession();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/KapuaAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/KapuaAuthenticatingRealm.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import java.util.Date;
+
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
+import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserStatus;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.DisabledAccountException;
+import org.apache.shiro.authc.ExpiredCredentialsException;
+import org.apache.shiro.authc.UnknownAccountException;
+import org.apache.shiro.realm.AuthenticatingRealm;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.Subject;
+
+public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
+
+    @Override
+    protected KapuaAuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken) {
+
+        final KapuaAuthenticationInfo authenticationInfo = buildAuthenticationInfo(authenticationToken);
+
+        User user = authenticationInfo.getUser();
+        Account account = authenticationInfo.getAccount();
+        Credential credential = null;
+
+        // USER //
+        //
+        // Check user existence
+        if (user == null) {
+            throw new UnknownAccountException();
+        }
+
+        // Check user disabled
+        if (UserStatus.DISABLED.equals(user.getStatus())) {
+            throw new DisabledAccountException();
+        }
+
+        // Check user expired
+        if (user.getExpirationDate() != null && !user.getExpirationDate().after(new Date())) {
+            throw new ExpiredCredentialsException();
+        }
+
+        // ACCOUNT //
+        //
+        // Check account existence
+        if (account == null) {
+            throw new UnknownAccountException();
+        }
+
+        // Check account expired
+        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
+            throw new ExpiredAccountException(account.getExpirationDate());
+        }
+
+        if (authenticationInfo instanceof LoginAuthenticationInfo) {
+            LoginAuthenticationInfo loginAuthenticationInfo = (LoginAuthenticationInfo)authenticationInfo;
+            credential = loginAuthenticationInfo.getCredential();
+            // CREDENTIAL //
+            //
+            // Check credential existence
+            if (credential == null) {
+                throw new UnknownAccountException();
+            }
+
+            // Check credential disabled
+            if (CredentialStatus.DISABLED.equals(credential.getStatus())) {
+                throw new DisabledAccountException();
+            }
+
+            // Check if credential expired
+            if (credential.getExpirationDate() != null && !credential.getExpirationDate().after(new Date())) {
+                throw new ExpiredCredentialsException();
+            }
+
+        } else if (authenticationInfo instanceof SessionAuthenticationInfo) {
+            SessionAuthenticationInfo sessionAuthenticationInfo = (SessionAuthenticationInfo)authenticationInfo;
+            AccessToken accessToken = sessionAuthenticationInfo.getAccessToken();
+            // ACCESS TOKEN //
+            //
+            // Check existence
+            if (accessToken == null) {
+                throw new UnknownAccountException();
+            }
+
+            // Check validity
+            if ((accessToken.getExpiresOn() != null && accessToken.getExpiresOn().before(new Date())) ||
+                    (accessToken.getInvalidatedOn() != null && accessToken.getInvalidatedOn().before(new Date()))) {
+                throw new ExpiredCredentialsException();
+            }
+        }
+
+        return authenticationInfo;
+    }
+
+    @Override
+    protected void assertCredentialsMatch(AuthenticationToken token, AuthenticationInfo info) {
+        super.assertCredentialsMatch(token, info);
+        KapuaAuthenticationInfo kapuaAuthenticationInfo = (KapuaAuthenticationInfo) info;
+        Subject currentSubject = SecurityUtils.getSubject();
+
+        //
+        // Set shiro session
+        Session session = currentSubject.getSession();
+        session.setAttribute("scopeId", kapuaAuthenticationInfo.getUser().getScopeId());
+        session.setAttribute("userId", kapuaAuthenticationInfo.getUser().getId());
+
+        if (info instanceof SessionAuthenticationInfo) {
+            SessionAuthenticationInfo sessionAuthenticationInfo = (SessionAuthenticationInfo) info;
+
+            //
+            // Set kapua session
+            AccessToken accessToken = sessionAuthenticationInfo.getAccessToken();
+            KapuaSession kapuaSession = new KapuaSession(accessToken, accessToken.getScopeId(), accessToken.getUserId());
+            KapuaSecurityUtils.setSession(kapuaSession);
+            session.setAttribute(KapuaSession.KAPUA_SESSION_KEY, kapuaSession);
+        }
+    }
+
+    protected abstract KapuaAuthenticationInfo buildAuthenticationInfo(AuthenticationToken authenticationToken);
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/KapuaAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/KapuaAuthenticationInfo.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.user.User;
+
+import org.apache.shiro.authc.AuthenticationInfo;
+
+public abstract class KapuaAuthenticationInfo implements AuthenticationInfo {
+    private String realmName;
+    private Account account;
+    private User user;
+
+    public KapuaAuthenticationInfo(String realmName, Account account, User user) {
+        this.realmName = realmName;
+        this.account = account;
+        this.user = user;
+    }
+
+    /**
+     * Return the user
+     *
+     * @return
+     */
+    public User getUser() {
+        return user;
+    }
+
+    /**
+     * Return the account
+     *
+     * @return
+     */
+    public Account getAccount() {
+        return account;
+    }
+
+    String getRealmName() {
+        return realmName;
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LockoutPolicyAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LockoutPolicyAuthenticatingRealm.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import java.util.Date;
+import java.util.Map;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialService;
+import org.eclipse.kapua.service.authentication.shiro.exceptions.TemporaryLockedAccountException;
+import org.eclipse.kapua.service.user.User;
+
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+
+public abstract class LockoutPolicyAuthenticatingRealm extends KapuaAuthenticatingRealm {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final CredentialService CREDENTIAL_SERVICE = LOCATOR.getService(CredentialService.class);
+
+    /**
+     * Realm name
+     */
+    private static final String REALM_NAME = "lockoutPolicyAuthenticatingRealm";
+
+    LockoutPolicyAuthenticatingRealm() {
+        setName(REALM_NAME);
+    }
+
+    @Override
+    protected LoginAuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token) {
+        LoginAuthenticationInfo authenticationInfo = (LoginAuthenticationInfo)super.doGetAuthenticationInfo(token);
+
+        Account account = authenticationInfo.getAccount();
+        User user = authenticationInfo.getUser();
+        Credential credential = authenticationInfo.getCredential();
+
+        // Check if lockout policy is blocking credential
+        Map<String, Object> credentialServiceConfig;
+        try {
+            credentialServiceConfig = KapuaSecurityUtils.doPrivileged(() -> CREDENTIAL_SERVICE.getConfigValues(authenticationInfo.getAccount().getId()));
+            boolean lockoutPolicyEnabled = (boolean) credentialServiceConfig.get("lockoutPolicy.enabled");
+            if (lockoutPolicyEnabled) {
+                Date now = new Date();
+                if (credential.getLockoutReset() != null && now.before(credential.getLockoutReset())) {
+                    throw new TemporaryLockedAccountException(credential.getLockoutReset());
+                }
+            }
+        } catch (KapuaException kex) {
+            throw new ShiroException("Error while checking lockout policy", kex);
+        }
+
+        return new LoginAuthenticationInfo(getName(), account, user, credential, credentialServiceConfig);
+    }
+
+    @Override
+    protected void assertCredentialsMatch(AuthenticationToken authcToken, AuthenticationInfo info) {
+        LoginAuthenticationInfo kapuaInfo = (LoginAuthenticationInfo) info;
+        CredentialService credentialService = LOCATOR.getService(CredentialService.class);
+        try {
+            super.assertCredentialsMatch(authcToken, info);
+        } catch (AuthenticationException authenticationEx) {
+            try {
+                Credential failedCredential = (Credential) kapuaInfo.getCredentials();
+                KapuaSecurityUtils.doPrivileged(() -> {
+                    Map<String, Object> credentialServiceConfig = kapuaInfo.getCredentialServiceConfig();
+                    boolean lockoutPolicyEnabled = (boolean) credentialServiceConfig.get("lockoutPolicy.enabled");
+                    if (lockoutPolicyEnabled) {
+                        manageLockoutPolicy(credentialServiceConfig, failedCredential);
+                    }
+
+                    credentialService.update(failedCredential);
+                });
+            } catch (KapuaException kex) {
+                throw new ShiroException("Error while updating lockout policy", kex);
+            }
+            throw authenticationEx;
+        }
+        Credential credential = (Credential) kapuaInfo.getCredentials();
+        credential.setFirstLoginFailure(null);
+        credential.setLoginFailuresReset(null);
+        credential.setLockoutReset(null);
+        credential.setLoginFailures(0);
+        try {
+            KapuaSecurityUtils.doPrivileged(() -> credentialService.update(credential));
+        } catch (KapuaException kex) {
+            throw new ShiroException("Error while updating lockout policy", kex);
+        }
+    }
+
+    private void manageLockoutPolicy(Map<String, Object> credentialServiceConfig, Credential failedCredential) {
+        Date now = new Date();
+        int resetAfterSeconds = (int) credentialServiceConfig.get("lockoutPolicy.resetAfter");
+        Date firstLoginFailure;
+        boolean resetAttempts = failedCredential.getFirstLoginFailure() == null || now.after(failedCredential.getLoginFailuresReset());
+        if (resetAttempts) {
+            firstLoginFailure = now;
+            failedCredential.setLoginFailures(1);
+        } else {
+            firstLoginFailure = failedCredential.getFirstLoginFailure();
+            failedCredential.setLoginFailures(failedCredential.getLoginFailures() + 1);
+        }
+        Date loginFailureWindowExpiration = new Date(firstLoginFailure.getTime() + (resetAfterSeconds * 1000));
+        failedCredential.setFirstLoginFailure(firstLoginFailure);
+        failedCredential.setLoginFailuresReset(loginFailureWindowExpiration);
+        int maxLoginFailures = (int) credentialServiceConfig.get("lockoutPolicy.maxFailures");
+        if (failedCredential.getLoginFailures() >= maxLoginFailures) {
+            long lockoutDuration = (int) credentialServiceConfig.get("lockoutPolicy.lockDuration");
+            Date resetDate = new Date(now.getTime() + (lockoutDuration * 1000));
+            failedCredential.setLockoutReset(resetDate);
+        }
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfo.java
@@ -18,6 +18,7 @@ import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.user.User;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -26,15 +27,19 @@ import java.util.Map;
  * @since 1.0
  *
  */
-public class LoginAuthenticationInfo implements AuthenticationInfo {
+public class LoginAuthenticationInfo extends KapuaAuthenticationInfo {
 
     private static final long serialVersionUID = -8682457531010599453L;
 
-    private String realmName;
-    private Account account;
-    private User user;
+
     private Credential credentials;
     private Map<String, Object> credentialServiceConfig;
+
+    LoginAuthenticationInfo(String realmName, Account account, User user, Credential credentials) {
+        super(realmName,account, user);
+        this.credentials = credentials;
+        this.credentialServiceConfig = new HashMap<>();
+    }
 
     /**
      * Constructor
@@ -44,38 +49,14 @@ public class LoginAuthenticationInfo implements AuthenticationInfo {
      * @param user
      * @param credentials
      */
-    public LoginAuthenticationInfo(String realmName,
+    LoginAuthenticationInfo(String realmName,
             Account account,
             User user,
             Credential credentials,
             Map<String, Object> credentialServiceConfig) {
-        this.realmName = realmName;
-        this.account = account;
-        this.user = user;
+        super(realmName,account, user);
         this.credentials = credentials;
         this.credentialServiceConfig = credentialServiceConfig;
-    }
-
-    /**
-     * Return the user
-     * 
-     * @return
-     */
-    public User getUser() {
-        return user;
-    }
-
-    /**
-     * Return the account
-     * 
-     * @return
-     */
-    public Account getAccount() {
-        return account;
-    }
-
-    public String getRealmName() {
-        return realmName;
     }
 
     @Override
@@ -83,12 +64,16 @@ public class LoginAuthenticationInfo implements AuthenticationInfo {
         return new SimplePrincipalCollection(getUser(), getRealmName());
     }
 
-    @Override
-    public Object getCredentials() {
+    public Credential getCredential() {
         return credentials;
     }
 
-    public Map<String, Object> getCredentialServiceConfig() {
+    @Override
+    public Object getCredentials() {
+        return getCredential();
+    }
+
+    Map<String, Object> getCredentialServiceConfig() {
         return credentialServiceConfig;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
@@ -24,13 +24,10 @@ import org.eclipse.kapua.service.user.User;
  * @since 1.0
  *
  */
-public class SessionAuthenticationInfo implements AuthenticationInfo {
+public class SessionAuthenticationInfo extends KapuaAuthenticationInfo {
 
     private static final long serialVersionUID = -8682457531010599453L;
 
-    private String realmName;
-    private Account account;
-    private User user;
     private AccessToken accessToken;
 
     /**
@@ -45,32 +42,8 @@ public class SessionAuthenticationInfo implements AuthenticationInfo {
             Account account,
             User user,
             AccessToken accessToken) {
-        this.realmName = realmName;
-        this.account = account;
-        this.user = user;
+        super(realmName, account, user);
         this.accessToken = accessToken;
-    }
-
-    /**
-     * Return the user
-     * 
-     * @return
-     */
-    public User getUser() {
-        return user;
-    }
-
-    /**
-     * Return the account
-     * 
-     * @return
-     */
-    public Account getAccount() {
-        return account;
-    }
-
-    public String getRealmName() {
-        return realmName;
     }
 
     public AccessToken getAccessToken() {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SysTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SysTokenAuthenticatingRealm.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import java.util.Date;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialAttributes;
+import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
+import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
+import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
+import org.eclipse.kapua.service.authentication.credential.CredentialService;
+import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
+import org.eclipse.kapua.service.authentication.credential.CredentialType;
+import org.eclipse.kapua.service.authentication.shiro.SysTokenCredentialsImpl;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserService;
+
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.credential.CredentialsMatcher;
+import org.apache.shiro.realm.AuthenticatingRealm;
+
+/**
+ * {@link UsernamePasswordCredentials} based {@link AuthenticatingRealm} implementation.
+ * <p>
+ * since 1.0
+ */
+public class SysTokenAuthenticatingRealm extends LockoutPolicyAuthenticatingRealm {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AccountService ACCOUNT_SERVICE = LOCATOR.getService(AccountService.class);
+    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
+    private static final CredentialService CREDENTIAL_SERVICE = LOCATOR.getService(CredentialService.class);
+    private static final CredentialFactory CREDENTIAL_FACTORY = LOCATOR.getFactory(CredentialFactory.class);
+
+    /**
+     * Realm name
+     */
+    private static final String REALM_NAME = "userPassAuthenticatingRealm";
+
+    /**
+     * Constructor
+     */
+    public SysTokenAuthenticatingRealm() {
+        setName(REALM_NAME);
+
+        CredentialsMatcher credentialsMather = new SysTokenCredentialsMatcher();
+        setCredentialsMatcher(credentialsMather);
+    }
+
+    @Override
+    protected LoginAuthenticationInfo buildAuthenticationInfo(AuthenticationToken authenticationToken) {
+
+        //
+        // Get the associated user by name
+        final User user;
+        try {
+            user = KapuaSecurityUtils.doPrivileged(() -> USER_SERVICE.findByName(authenticationToken.getPrincipal().toString()));
+        } catch (AuthenticationException ae) {
+            throw ae;
+        } catch (Exception e) {
+            throw new ShiroException("Error while find user!", e);
+        }
+
+        final Credential enabledCredential;
+        // FIXME: manage multiple credentials and multiple credentials type
+        try {
+            enabledCredential = KapuaSecurityUtils.doPrivileged(() -> {
+                CredentialQuery query = CREDENTIAL_FACTORY.newQuery(user.getScopeId());
+                AndPredicate andPredicate = new AndPredicateImpl()
+                        .and(new AttributePredicateImpl<>(CredentialAttributes.USER_ID, user.getId()))
+                        .and(new AttributePredicateImpl<>(CredentialAttributes.CREDENTIAL_TYPE, CredentialType.SYS_TOKEN))
+                        .and(new AttributePredicateImpl<>(CredentialAttributes.STATUS, CredentialStatus.ENABLED));
+                query.setPredicate(andPredicate);
+                CredentialListResult credentialList = CREDENTIAL_SERVICE.query(query);
+                if (credentialList != null && !credentialList.isEmpty() && credentialList.getSize() == 1) {
+                    return credentialList.getFirstItem();
+                } else {
+                    return null;
+                }
+            });
+        } catch (AuthenticationException ae) {
+            throw ae;
+        } catch (Exception e) {
+            throw new ShiroException("Error while find credentials!", e);
+        }
+
+        //
+        // Find account
+        final Account account;
+        try {
+            account = KapuaSecurityUtils.doPrivileged(() -> ACCOUNT_SERVICE.find(user.getScopeId()));
+        } catch (AuthenticationException ae) {
+            throw ae;
+        } catch (Exception e) {
+            throw new ShiroException("Error while find account!", e);
+        }
+
+        return new LoginAuthenticationInfo(getName(), account, user, enabledCredential);
+    }
+
+    @Override
+    protected void assertCredentialsMatch(AuthenticationToken authcToken, AuthenticationInfo info) {
+        super.assertCredentialsMatch(authcToken, info);
+        Credential credential = (Credential) info.getCredentials();
+        credential.setStatus(CredentialStatus.DISABLED);
+        credential.setExpirationDate(new Date());
+        try {
+            KapuaSecurityUtils.doPrivileged(() -> CREDENTIAL_SERVICE.update(credential));
+        } catch (KapuaException kex) {
+            throw new ShiroException("Error while updating lockout policy", kex);
+        }
+    }
+
+    @Override
+    public boolean supports(AuthenticationToken authenticationToken) {
+        return authenticationToken instanceof SysTokenCredentialsImpl;
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SysTokenCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SysTokenCredentialsMatcher.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import org.eclipse.kapua.service.authentication.SysTokenCredentials;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialType;
+import org.eclipse.kapua.service.user.User;
+
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.credential.CredentialsMatcher;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
+/**
+ * {@link SysTokenCredentials} credential matcher implementation
+ * 
+ * @since 1.0
+ * 
+ */
+public class SysTokenCredentialsMatcher implements CredentialsMatcher {
+
+    @Override
+    public boolean doCredentialsMatch(AuthenticationToken authenticationToken, AuthenticationInfo authenticationInfo) {
+
+        //
+        // Token data
+        SysTokenCredentials token = (SysTokenCredentials) authenticationToken;
+        String tokenUsername = token.getUsername();
+        String tokenPassword = token.getPassword();
+
+        //
+        // Info data
+        LoginAuthenticationInfo info = (LoginAuthenticationInfo) authenticationInfo;
+        User infoUser = (User) info.getPrincipals().getPrimaryPrincipal();
+        Credential infoCredential = (Credential) info.getCredentials();
+
+        //
+        // Match token with info
+        boolean credentialMatch = false;
+        if (tokenUsername.equals(infoUser.getName()) && CredentialType.SYS_TOKEN.equals(infoCredential.getCredentialType()) && BCrypt.checkpw(tokenPassword, infoCredential.getCredentialKey())) {
+            credentialMatch = true;
+
+            // FIXME: if true cache token password for authentication performance improvement
+        }
+
+        return credentialMatch;
+    }
+
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
@@ -11,59 +11,53 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
-import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.ShiroException;
-import org.apache.shiro.authc.AuthenticationException;
-import org.apache.shiro.authc.AuthenticationInfo;
-import org.apache.shiro.authc.AuthenticationToken;
-import org.apache.shiro.authc.DisabledAccountException;
-import org.apache.shiro.authc.ExpiredCredentialsException;
-import org.apache.shiro.authc.UnknownAccountException;
-import org.apache.shiro.authc.credential.CredentialsMatcher;
-import org.apache.shiro.realm.AuthenticatingRealm;
-import org.apache.shiro.session.Session;
-import org.apache.shiro.subject.Subject;
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialAttributes;
+import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
 import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
+import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
 import org.eclipse.kapua.service.authentication.credential.CredentialService;
-import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
 import org.eclipse.kapua.service.authentication.shiro.UsernamePasswordCredentialsImpl;
-import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
-import org.eclipse.kapua.service.authentication.shiro.exceptions.TemporaryLockedAccountException;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
-import org.eclipse.kapua.service.user.UserStatus;
 
-import java.util.Date;
-import java.util.Map;
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.credential.CredentialsMatcher;
+import org.apache.shiro.realm.AuthenticatingRealm;
 
 /**
  * {@link UsernamePasswordCredentials} based {@link AuthenticatingRealm} implementation.
  * <p>
  * since 1.0
  */
-public class UserPassAuthenticatingRealm extends AuthenticatingRealm {
+public class UserPassAuthenticatingRealm extends LockoutPolicyAuthenticatingRealm {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final AccountService ACCOUNT_SERVICE = LOCATOR.getService(AccountService.class);
+    private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
+    private static final CredentialService CREDENTIAL_SERVICE = LOCATOR.getService(CredentialService.class);
+    private static final CredentialFactory CREDENTIAL_FACTORY = LOCATOR.getFactory(CredentialFactory.class);
+
     /**
      * Realm name
      */
-    public static final String REALM_NAME = "userPassAuthenticatingRealm";
+    private static final String REALM_NAME = "userPassAuthenticatingRealm";
 
     /**
      * Constructor
-     *
-     * @throws KapuaException
      */
-    public UserPassAuthenticatingRealm() throws KapuaException {
+    public UserPassAuthenticatingRealm() {
         setName(REALM_NAME);
 
         CredentialsMatcher credentialsMather = new UserPassCredentialsMatcher();
@@ -71,91 +65,31 @@ public class UserPassAuthenticatingRealm extends AuthenticatingRealm {
     }
 
     @Override
-    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken)
-            throws AuthenticationException {
-        //
-        // Extract credentials
-        UsernamePasswordCredentialsImpl token = (UsernamePasswordCredentialsImpl) authenticationToken;
-        String tokenUsername = token.getUsername();
-
-        //
-        // Get Services
-        UserService userService;
-        AccountService accountService;
-        CredentialService credentialService;
-
-        try {
-            userService = LOCATOR.getService(UserService.class);
-            accountService = LOCATOR.getService(AccountService.class);
-            credentialService = LOCATOR.getService(CredentialService.class);
-        } catch (KapuaRuntimeException kre) {
-            throw new ShiroException("Error while getting services!", kre);
-        }
+    protected LoginAuthenticationInfo buildAuthenticationInfo(AuthenticationToken authenticationToken) {
 
         //
         // Get the associated user by name
         final User user;
         try {
-            user = KapuaSecurityUtils.doPrivileged(() -> userService.findByName(tokenUsername));
+            user = KapuaSecurityUtils.doPrivileged(() -> USER_SERVICE.findByName(authenticationToken.getPrincipal().toString()));
         } catch (AuthenticationException ae) {
             throw ae;
         } catch (Exception e) {
             throw new ShiroException("Error while find user!", e);
         }
 
-        // Check existence
-        if (user == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check disabled
-        if (UserStatus.DISABLED.equals(user.getStatus())) {
-            throw new DisabledAccountException();
-        }
-
-        // Check if expired
-        if (user.getExpirationDate() != null && !user.getExpirationDate().after(new Date())) {
-            throw new ExpiredCredentialsException();
-        }
-
-        //
-        // Find account
-        final Account account;
-        try {
-            account = KapuaSecurityUtils.doPrivileged(() -> accountService.find(user.getScopeId()));
-        } catch (AuthenticationException ae) {
-            throw ae;
-        } catch (Exception e) {
-            throw new ShiroException("Error while find account!", e);
-        }
-
-        // Check existence
-        if (account == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check account expired
-        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
-            throw new ExpiredAccountException(account.getExpirationDate());
-        }
-
-        //
-        // Find credentials
+        final Credential credential;
         // FIXME: manage multiple credentials and multiple credentials type
-        Credential credential;
         try {
             credential = KapuaSecurityUtils.doPrivileged(() -> {
-                CredentialListResult credentialList = credentialService.findByUserId(user.getScopeId(), user.getId());
-
-                if (credentialList != null && !credentialList.isEmpty()) {
-                    Credential credentialMatched = null;
-                    for (Credential c : credentialList.getItems()) {
-                        if (CredentialType.PASSWORD.equals(c.getCredentialType())) {
-                            credentialMatched = c;
-                            break;
-                        }
-                    }
-                    return credentialMatched;
+                CredentialQuery query = CREDENTIAL_FACTORY.newQuery(user.getScopeId());
+                AndPredicate andPredicate = new AndPredicateImpl()
+                        .and(new AttributePredicateImpl<>(CredentialAttributes.USER_ID, user.getId()))
+                        .and(new AttributePredicateImpl<>(CredentialAttributes.CREDENTIAL_TYPE, CredentialType.PASSWORD));
+                query.setPredicate(andPredicate);
+                CredentialListResult credentialList = CREDENTIAL_SERVICE.query(query);
+                if (credentialList != null && !credentialList.isEmpty() && credentialList.getSize() == 1) {
+                    return credentialList.getFirstItem();
                 } else {
                     return null;
                 }
@@ -166,102 +100,18 @@ public class UserPassAuthenticatingRealm extends AuthenticatingRealm {
             throw new ShiroException("Error while find credentials!", e);
         }
 
-        // Check existence
-        if (credential == null) {
-            throw new UnknownAccountException();
-        }
-
-        // Check credential disabled
-        if (CredentialStatus.DISABLED.equals(credential.getStatus())) {
-            throw new DisabledAccountException();
-        }
-
-        // Check if credential expired
-        if (credential.getExpirationDate() != null && !credential.getExpirationDate().after(new Date())) {
-            throw new ExpiredCredentialsException();
-        }
-
-        // Check if lockout policy is blocking credential
-        Map<String, Object> credentialServiceConfig;
-        try {
-            credentialServiceConfig = KapuaSecurityUtils.doPrivileged(() -> credentialService.getConfigValues(account.getId()));
-            boolean lockoutPolicyEnabled = (boolean) credentialServiceConfig.get("lockoutPolicy.enabled");
-            if (lockoutPolicyEnabled) {
-                Date now = new Date();
-                if (credential.getLockoutReset() != null && now.before(credential.getLockoutReset())) {
-                    throw new TemporaryLockedAccountException(credential.getLockoutReset());
-                }
-            }
-        } catch (KapuaException kex) {
-            throw new ShiroException("Error while checking lockout policy", kex);
-        }
-
         //
-        // BuildAuthenticationInfo
-        return new LoginAuthenticationInfo(getName(),
-                account,
-                user,
-                credential,
-                credentialServiceConfig);
-    }
-
-    @Override
-    protected void assertCredentialsMatch(AuthenticationToken authcToken, AuthenticationInfo info)
-            throws AuthenticationException {
-        LoginAuthenticationInfo kapuaInfo = (LoginAuthenticationInfo) info;
-        CredentialService credentialService = LOCATOR.getService(CredentialService.class);
+        // Find account
+        final Account account;
         try {
-            super.assertCredentialsMatch(authcToken, info);
-        } catch (AuthenticationException authenticationEx) {
-            try {
-                Credential failedCredential = (Credential) kapuaInfo.getCredentials();
-                KapuaSecurityUtils.doPrivileged(() -> {
-                    Map<String, Object> credentialServiceConfig = kapuaInfo.getCredentialServiceConfig();
-                    boolean lockoutPolicyEnabled = (boolean) credentialServiceConfig.get("lockoutPolicy.enabled");
-                    if (lockoutPolicyEnabled) {
-                        Date now = new Date();
-                        int resetAfterSeconds = (int)credentialServiceConfig.get("lockoutPolicy.resetAfter");
-                        Date firstLoginFailure;
-                        boolean resetAttempts = failedCredential.getFirstLoginFailure() == null || now.after(failedCredential.getLoginFailuresReset());
-                        if (resetAttempts) {
-                            firstLoginFailure = now;
-                            failedCredential.setLoginFailures(1);
-                        } else {
-                            firstLoginFailure = failedCredential.getFirstLoginFailure();
-                            failedCredential.setLoginFailures(failedCredential.getLoginFailures() + 1);
-                        }
-                        Date loginFailureWindowExpiration = new Date(firstLoginFailure.getTime() + (resetAfterSeconds * 1000));
-                        failedCredential.setFirstLoginFailure(firstLoginFailure);
-                        failedCredential.setLoginFailuresReset(loginFailureWindowExpiration);
-                        int maxLoginFailures = (int)credentialServiceConfig.get("lockoutPolicy.maxFailures");
-                        if (failedCredential.getLoginFailures() >= maxLoginFailures) {
-                            long lockoutDuration = (int)credentialServiceConfig.get("lockoutPolicy.lockDuration");
-                            Date resetDate = new Date(now.getTime() + (lockoutDuration * 1000));
-                            failedCredential.setLockoutReset(resetDate);
-                        }
-                    }
+            account = KapuaSecurityUtils.doPrivileged(() -> ACCOUNT_SERVICE.find(user.getScopeId()));
+        } catch (AuthenticationException ae) {
+            throw ae;
+        } catch (Exception e) {
+            throw new ShiroException("Error while find account!", e);
+        }
 
-                    credentialService.update(failedCredential);
-                });
-            } catch (KapuaException kex) {
-                throw new ShiroException("Error while updating lockout policy", kex);
-            }
-            throw authenticationEx;
-        }
-        Credential credential = (Credential) kapuaInfo.getCredentials();
-        credential.setFirstLoginFailure(null);
-        credential.setLoginFailuresReset(null);
-        credential.setLockoutReset(null);
-        credential.setLoginFailures(0);
-        try {
-            KapuaSecurityUtils.doPrivileged(() -> credentialService.update(credential));
-        } catch (KapuaException kex) {
-            throw new ShiroException("Error while updating lockout policy", kex);
-        }
-        Subject currentSubject = SecurityUtils.getSubject();
-        Session session = currentSubject.getSession();
-        session.setAttribute("scopeId", kapuaInfo.getUser().getScopeId());
-        session.setAttribute("userId", kapuaInfo.getUser().getId());
+        return new LoginAuthenticationInfo(getName(), account, user, credential);
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
@@ -44,6 +44,7 @@ public enum KapuaAuthenticationSettingKeys implements SettingKey {
     AUTHENTICATION_CREDENTIAL_APIKEY_CACHE_ENABLE("authentication.credential.apiKey.cache.enabled"), //
     AUTHENTICATION_CREDENTIAL_APIKEY_CACHE_TTL("authentication.credential.apiKey.cache.ttl"), //
 
+    AUTHENTICATION_MQTT_CLIENT_USERNAME("authentication.mqtt.client.username"),
     //event queues
     AUTHENTICATION_EVENT_ADDRESS("authentication.eventAddress");
 

--- a/test/src/main/java/org/eclipse/kapua/test/authentication/SysTokenCredentialsMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/authentication/SysTokenCredentialsMock.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.test.authentication;
+
+import org.eclipse.kapua.service.authentication.SysTokenCredentials;
+
+public class SysTokenCredentialsMock implements SysTokenCredentials {
+
+    private String username;
+    private String password;
+
+    public SysTokenCredentialsMock(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.username;
+    }
+
+    @Override
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password;
+    }
+
+    @Override
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+}

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSettingKeys.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSettingKeys.java
@@ -21,20 +21,6 @@ import org.eclipse.kapua.commons.setting.SettingKey;
 public enum MqttClientSettingKeys implements SettingKey {
 
     /**
-     * The username to use for MQTT connection
-     * 
-     * @since 1.0.0
-     */
-    TRANSPORT_CREDENTIAL_USERNAME("transport.credential.username"),
-
-    /**
-     * The password to use for MQTT connection
-     * 
-     * @since 1.0.0
-     */
-    TRANSPORT_CREDENTIAL_PASSWORD("transport.credential.password"),
-
-    /**
      * The MQTT protocol version to use.
      * 
      * @since 1.0.0
@@ -54,6 +40,16 @@ public enum MqttClientSettingKeys implements SettingKey {
      * @since 1.0.0
      */
     SEND_TIMEOUT_MAX("send.timeout.max"),
+
+    /**
+     * MQTT Client SystemToken Length
+     */
+    SYSTEM_TOKEN_LENGTH("system.token.length"),
+
+    /**
+     * SystemToken TTL (in seconds)
+     */
+    SYSTEM_TOKEN_TTL("system.token.ttl"),
     ;
 
     /**

--- a/transport/mqtt/src/main/resources/mqtt-client-setting.properties
+++ b/transport/mqtt/src/main/resources/mqtt-client-setting.properties
@@ -11,8 +11,8 @@
 #
 ###############################################################################
 
-transport.credential.username=kapua-sys
-transport.credential.password=kapua-password
+system.token.length=16
+system.token.ttl=15
 
 transport.protocol.version=3.1.1
 transport.topic.separator=/


### PR DESCRIPTION
Currently every Kapua application (Console, REST API) that wants to connect to the broker has to provide a username and a password via system properties (`transport.credential.username` and `transport.credential.password`). This means that every change to this user's password must be reflected in such properties.

With this PR System Tokens are introduced, so that knowing and configuring the connecting user's password in advance is not needed anymore.

Additionally, Shiro Realms have been refactored to better reflect classes hierarchy.

**Related Issue**
This PR fixes #2031

**Description of the solution adopted**
`PooledMqttClientFactory` will automatically generate, when connecting a new client, a new credential of type `SYS_TOKEN` that will only last 15 seconds (configurable via the `system.token.ttl` system property) and will be disabled after one successful login. `KapuaSecurityBrokerFilter` will then be able to match the login attempt against this credential.

Please be aware that the `transport.credential.password` system properties has been removed, and that `transport.credential.username` is now called `systoken.auth.username` and moved from `kapua-transport-mqtt` module to `kapua-security-shiro` module.

**Screenshots**
N/A

**Any side note on the changes made**
N/A