### PR TITLE
Update Device by passing the updated entity to DAO

### DIFF
--- a/qa-steps/src/main/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/service/device/steps/DeviceServiceSteps.java
@@ -397,9 +397,10 @@ public class DeviceServiceSteps extends BaseQATests /*KapuaTest*/ {
             stepData.put("ExceptionCaught", false);
             tags.add(tag.getId());
             device.setTagIds(tags);
-            deviceRegistryService.update(device);
+            Device updatedDevice = deviceRegistryService.update(device);
             stepData.put("tag", tag);
             stepData.put("tags", tags);
+            stepData.put("Device", updatedDevice);
         } catch (KapuaException ex) {
             stepData.put("ExceptionCaught", true);
         }
@@ -441,7 +442,8 @@ public class DeviceServiceSteps extends BaseQATests /*KapuaTest*/ {
         stepData.remove("tags");
         Set<KapuaId> tags = new HashSet<>();
         device.setTagIds(tags);
-        deviceRegistryService.update(device);
+        Device updatedDevice = deviceRegistryService.update(device);
+        stepData.put("Device", updatedDevice);
         Assert.assertEquals(device.getTagIds().isEmpty(), true);
     }
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -89,35 +89,8 @@ public class DeviceRegistryServiceImpl extends AbstractKapuaConfigurableResource
             if (currentDevice == null) {
                 throw new KapuaEntityNotFoundException(Device.TYPE, device.getId());
             }
-
-            currentDevice.setStatus(device.getStatus());
-            currentDevice.setDisplayName(device.getDisplayName());
-            currentDevice.setGroupId(device.getGroupId());
-            currentDevice.setSerialNumber(device.getSerialNumber());
-            currentDevice.setModelId(device.getModelId());
-            currentDevice.setImei(device.getImei());
-            currentDevice.setImsi(device.getImsi());
-            currentDevice.setIccid(device.getIccid());
-            currentDevice.setBiosVersion(device.getBiosVersion());
-            currentDevice.setFirmwareVersion(device.getFirmwareVersion());
-            currentDevice.setOsVersion(device.getOsVersion());
-            currentDevice.setJvmVersion(device.getJvmVersion());
-            currentDevice.setOsgiFrameworkVersion(device.getOsgiFrameworkVersion());
-            currentDevice.setApplicationFrameworkVersion(device.getApplicationFrameworkVersion());
-            currentDevice.setApplicationIdentifiers(device.getApplicationIdentifiers());
-            currentDevice.setAcceptEncoding(device.getAcceptEncoding());
-            currentDevice.setCustomAttribute1(device.getCustomAttribute1());
-            currentDevice.setCustomAttribute2(device.getCustomAttribute2());
-            currentDevice.setCustomAttribute3(device.getCustomAttribute3());
-            currentDevice.setCustomAttribute4(device.getCustomAttribute4());
-            currentDevice.setCustomAttribute5(device.getCustomAttribute5());
-
-            currentDevice.setConnectionId(device.getConnectionId());
-            currentDevice.setLastEventId(device.getLastEventId());
-
-            currentDevice.setTagIds(device.getTagIds());
             // Update
-            return DeviceDAO.update(entityManager, currentDevice);
+            return DeviceDAO.update(entityManager, device);
         });
     }
 


### PR DESCRIPTION
Conform the `DeviceServiceImpl` entity `update()` method to other services `update()` by passing the updated entity to the DAO instead of updating individual properties on original entity

**Related Issue**
This PR fixes #2084 

**Description of the solution adopted**
N/A

**Screenshots**
N/A

**Any side note on the changes made**
N/A