### PR TITLE
Fix Data View by asset with same asset in multiple devices

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -54,7 +54,7 @@ public class AssetTabItem extends TabItem {
     private AssetTable assetTable;
     private MetricsTable metricsTable;
 
-    public AssetTabItem(GwtSession currentSession) {
+    AssetTabItem(GwtSession currentSession) {
         super(MSGS.assetTabItemTitle(), null);
         this.currentSession = currentSession;
         this.setBorders(false);
@@ -133,9 +133,10 @@ public class AssetTabItem extends TabItem {
 
             @Override
             public void componentSelected(ButtonEvent ce) {
+                GwtDatastoreDevice gwtDevice = deviceTable.getSelectedDevice();
                 GwtDatastoreAsset gwtAsset = assetTable.getSelectedAsset();
                 List<GwtHeader> metricsInfo = metricsTable.getSelectedMetrics();
-                resultsTable.refresh(gwtAsset, metricsInfo);
+                resultsTable.refresh(gwtDevice, gwtAsset, metricsInfo);
             }
         });
         queryButton.disable();
@@ -167,7 +168,7 @@ public class AssetTabItem extends TabItem {
         add(resultsTabPanel, resultsLayout);
     }
 
-    public void refreshTables() {
+    void refreshTables() {
         if (deviceTable != null) {
             deviceTable.refresh();
         }

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DataView.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DataView.java
@@ -22,16 +22,13 @@ import org.eclipse.kapua.app.console.module.device.shared.model.permission.Devic
 
 public class DataView extends AbstractView {
 
-    private GwtSession currentSession;
-    private TabPanel tabsPanel;
-
     private TopicsTabItem channelTabItem;
     private DeviceTabItem deviceTabItem;
     private AssetTabItem assetTabItem;
 
     private static final ConsoleDataMessages MSGS = GWT.create(ConsoleDataMessages.class);
 
-    public DataView(GwtSession currentGwtSession) {
+    DataView(GwtSession currentGwtSession) {
         currentSession = currentGwtSession;
     }
 
@@ -46,7 +43,7 @@ public class DataView extends AbstractView {
         setLayout(new FitLayout());
         setBorders(false);
 
-        tabsPanel = new TabPanel();
+        TabPanel tabsPanel = new TabPanel();
         tabsPanel.setPlain(false);
         tabsPanel.setBorders(false);
         tabsPanel.setBodyBorder(true);

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
@@ -40,6 +40,7 @@ import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
@@ -51,7 +52,6 @@ import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMessages;
 import org.eclipse.kapua.app.console.module.data.client.util.GwtMessage;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreAsset;
-import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreChannel;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtDatastoreDevice;
 import org.eclipse.kapua.app.console.module.data.shared.model.GwtHeader;
 import org.eclipse.kapua.app.console.module.data.shared.service.GwtDataService;
@@ -82,7 +82,7 @@ public class ResultsTable extends LayoutContainer {
     private GwtTopic selectedTopic;
     private GwtDatastoreDevice selectedDevice;
     private GwtDatastoreAsset selectedAsset;
-    private List<GwtDatastoreChannel> selectedChannels;
+    private List<GwtHeader> selectedChannels;
     private List<GwtHeader> selectedMetrics;
     private Date startDate;
     private Date endDate;
@@ -138,12 +138,9 @@ public class ResultsTable extends LayoutContainer {
                         dataService.findMessagesByTopic((PagingLoadConfig) loadConfig, currentSession.getSelectedAccountId(), selectedTopic, selectedMetrics, startDate, endDate, callback);
                     } else if (selectedDevice != null) {
                         dataService.findMessagesByDevice((PagingLoadConfig) loadConfig, currentSession.getSelectedAccountId(), selectedDevice, selectedMetrics, startDate, endDate, callback);
-                    } else if (selectedAsset != null) {
-                        dataService.findMessagesByAssets((PagingLoadConfig) loadConfig, currentSession.getSelectedAccountId(), selectedAsset, selectedMetrics, startDate, endDate, callback);
                     }
-
                 } else if (selectedDevice != null && selectedAsset != null && selectedChannels != null && !selectedChannels.isEmpty()) {
-                    // TODO fetch data.
+                    dataService.findMessagesByAssets((PagingLoadConfig) loadConfig, currentSession.getSelectedAccountId(), selectedDevice, selectedAsset, selectedChannels, startDate, endDate, callback);
                 } else {
                     callback.onSuccess(new BasePagingLoadResult<GwtMessage>(new ArrayList<GwtMessage>()));
                 }
@@ -176,7 +173,7 @@ public class ResultsTable extends LayoutContainer {
                     queryButton.disable();
                 }
             }
-        } );
+        });
         loader.addListener(Loader.Load, new Listener<BaseEvent>() {
 
             @Override
@@ -185,7 +182,7 @@ public class ResultsTable extends LayoutContainer {
                     queryButton.enable();
                 }
             }
-        } );
+        });
         loader.addListener(Loader.LoadException, new Listener<BaseEvent>() {
 
             @Override
@@ -194,7 +191,7 @@ public class ResultsTable extends LayoutContainer {
                     queryButton.enable();
                 }
             }
-        } );
+        });
 
         loader.setSortField("timestampFormatted");
         loader.setSortDir(SortDir.DESC);
@@ -288,20 +285,10 @@ public class ResultsTable extends LayoutContainer {
         refresh(headers);
     }
 
-    public void refresh(GwtDatastoreAsset asset, List<GwtHeader> headers) {
+    public void refresh(GwtDatastoreDevice device, GwtDatastoreAsset asset, List<GwtHeader> channels) {
         this.selectedAsset = asset;
-        refresh(headers);
-    }
-
-    public void refresh(GwtDatastoreDevice device, GwtDatastoreAsset asset, List<GwtDatastoreChannel> channels) {
-        if (channelColumn == null) {
-            channelColumn = new ColumnConfig("channel", MSGS.resultsTableChannelHeader(), 100);
-            columnConfigs.add(channelColumn);
-        }
         this.selectedDevice = device;
-        this.selectedAsset = asset;
-        this.selectedChannels = channels;
-        loader.load();
+        refresh(channels);
     }
 
     private void export(String format) {
@@ -324,8 +311,8 @@ public class ResultsTable extends LayoutContainer {
         }
 
         if (selectedChannels != null && !selectedChannels.isEmpty()) {
-            for (GwtDatastoreChannel channel : selectedChannels) {
-                sbUrl.append("&channels=").append(channel.getChannel());
+            for (GwtHeader channel : selectedChannels) {
+                sbUrl.append("&channels=").append(channel.getName());
             }
         }
 

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
@@ -395,10 +395,14 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
     }
 
     @Override
-    public PagingLoadResult<GwtMessage> findMessagesByAssets(PagingLoadConfig loadConfig, String scopeId, GwtDatastoreAsset asset, List<GwtHeader> headers, Date startDate, Date endDate)
+    public PagingLoadResult<GwtMessage> findMessagesByAssets(PagingLoadConfig loadConfig, String scopeId, GwtDatastoreDevice device, GwtDatastoreAsset asset, List<GwtHeader> headers, Date startDate, Date endDate)
             throws GwtKapuaException {
-        ChannelMatchPredicate predicate = STORABLE_PREDICATE_FACTORY.newChannelMatchPredicate(asset.getTopick());
-        return findMessages(loadConfig, scopeId, headers, startDate, endDate, predicate);
+        ChannelMatchPredicate assetPredicate = STORABLE_PREDICATE_FACTORY.newChannelMatchPredicate(asset.getTopick());
+        TermPredicate devicePredicate = STORABLE_PREDICATE_FACTORY.newTermPredicate(MessageField.CLIENT_ID, device.getDevice());
+        AndPredicate andPredicate = STORABLE_PREDICATE_FACTORY.newAndPredicate();
+        andPredicate.getPredicates().add(assetPredicate);
+        andPredicate.getPredicates().add(devicePredicate);
+        return findMessages(loadConfig, scopeId, headers, startDate, endDate, andPredicate);
     }
 
     private ListLoadResult<GwtHeader> findHeaders(String scopeId, StorablePredicate predicate) throws GwtKapuaException {

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/service/GwtDataService.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/service/GwtDataService.java
@@ -107,7 +107,7 @@ public interface GwtDataService extends RemoteService {
     PagingLoadResult<GwtMessage> findMessagesByDevice(PagingLoadConfig loadConfig, String scopeId, GwtDatastoreDevice device, List<GwtHeader> headers, Date startDate, Date endDate)
             throws GwtKapuaException;
 
-    PagingLoadResult<GwtMessage> findMessagesByAssets(PagingLoadConfig loadConfig, String scopeId, GwtDatastoreAsset asset, List<GwtHeader> headers, Date startDate, Date endDate) throws GwtKapuaException;
+    PagingLoadResult<GwtMessage> findMessagesByAssets(PagingLoadConfig loadConfig, String scopeId, GwtDatastoreDevice device, GwtDatastoreAsset asset, List<GwtHeader> headers, Date startDate, Date endDate) throws GwtKapuaException;
 
     ListLoadResult<GwtHeader> findHeaders(LoadConfig config, String scopeId, GwtDatastoreAsset gwtDatastoreAsset) throws GwtKapuaException;
 


### PR DESCRIPTION
Adds a device filter when browsing Data - By Asset

**Related Issue**
This PR fixes #2085 

**Description of the solution adopted**
Previously, the Data - By Asset view showed values from all the registered devices that had an asset with the same name. Now only data from the selected devices are shown

**Screenshots**
N/A

**Any side note on the changes made**
N/A