### PR TITLE
Use property id instead of name when updatding device configuration

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -407,7 +407,7 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
                 String[] strValues = gwtConfigParam.getValues();
                 objValue = getObjectValue(gwtConfigParam, strValues);
             }
-            compProps.put(gwtConfigParam.getName(), objValue);
+            compProps.put(gwtConfigParam.getId(), objValue);
         }
         compConfig.setProperties(compProps);
 


### PR DESCRIPTION
Previously, the Metadata Property Name was used when sending a configuration to a Device, instead of the Id. Now the Id is correctly used.

**Related Issue**
This PR fixes #2093

**Screenshots**
N/A

**Any side note on the changes made**
N/A