### PR TITLE
Fixing failing test TransportAsync

### DIFF
--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsyncTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsyncTest.java
@@ -42,7 +42,7 @@ public class TransportAsyncTest {
             Duration duration = Duration.between(start, Instant.now());
             System.out.println(duration);
 
-            Assert.assertTrue(duration.compareTo(Duration.ofMillis(100)) > 0);
+            Assert.assertTrue(duration.compareTo(Duration.ofMillis(100)) >= 0);
 
         } finally {
             executor.shutdown();


### PR DESCRIPTION
Wrong timeout duration comparison in test

Tests is failing because time duration that is checked is exactely 100
milli seconds. It should be more, but it is not. If execution is really
fast it could happen that it is exactly 100 milli seconds.

**Related Issue**
This is part of solution to _2088_

**Description of the solution adopted**
Time comparison was changed to also cover equal time duration.

**Screenshots**
Not applicable.

**Any side note on the changes made**
Solves failing travis, which was failing at this test on multiple occasions. Error was:
```
   [INFO] Running org.eclipse.kapua.client.gateway.spi.util.TransportAsyncTest
   PT0.1S
   [ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.239 s <<< FAILURE! - in 
   org.eclipse.kapua.client.gateway.spi.util.TransportAsyncTest
```

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>
