### PR TITLE
Remove sender pool from map after closing

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
@@ -254,6 +254,7 @@ public class JMSServiceEventBus implements ServiceEventBus, ServiceEventBusDrive
                 senderPool.close();
                 senderPool.clear();
                 // borrowed object will be returned to the pool soon (since the connection is gone bad) and then destroyed by the pool (since the pool is stopped)
+                senderIterator.remove();
             }
         }
 


### PR DESCRIPTION
Remove sender pool from map after closing.  This fixes an issue where the closed pool can get reused if the JMSServiceEventBus is restarted, for example when running multiple QA tests.

**Related Issue**
N/A
