### PR TITLE
Location of API war file is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ jobs:
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Djetty.war.file=/home/travis/.m2/repository/org/eclipse/kapua/kapua-rest-api-web/1.1.0-SNAPSHOT/kapua-rest-api-web-1.1.0-SNAPSHOT.war -Dcucumber.options="--tags @rest" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @rest" verify
         - bash <(curl -s https://codecov.io/bash)
 
 # The following upgrades Java during the build in

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
                         <cucumber.options>${cucumber.options}</cucumber.options>
                         <commons.db.schema>kapuadb</commons.db.schema>
                         <commons.settings.hotswap>true</commons.settings.hotswap>
-                        <jetty.war.file>../rest-api/web/target/api.war</jetty.war.file>
+                        <jetty.war.file>target/war/api.war</jetty.war.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -900,6 +900,12 @@
                 <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-rest-api-resources</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-rest-api-web</artifactId>
+                <version>${project.version}</version>
+                <type>war</type>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -173,6 +173,11 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-stream-internal</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-rest-api-web</artifactId>
+            <type>war</type>
+        </dependency>
 
         <!-- External dependencies -->
         <dependency>
@@ -302,4 +307,35 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kapua</groupId>
+                                    <artifactId>kapua-rest-api-web</artifactId>
+                                    <type>war</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/war</outputDirectory>
+                                    <destFileName>api.war</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Correct api.war usage for rest tests

Brief description of the PR.
API war file is copied from build or repository to test and run from there.
This way version of build is not necessary in travis or local build.

**Related Issue**
This PR helps fixing issue _2088_

**Description of the solution adopted**
API war file is copied from build or repository to test and run from there.
This way version of build is not necessary in travis or local build.

**Screenshots**
Not applicable.

**Any side note on the changes made**
Only used for rest api tests.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>
