### PR TITLE
Disabled formPanel events on PackageUninstallDialog

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageUninstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageUninstallDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -61,6 +61,7 @@ public class PackageUninstallDialog extends SimpleDialog {
 
         FormLayout formLayout = new FormLayout();
         formLayout.setLabelWidth(FORM_LABEL_WIDTH);
+        formPanel.disableEvents(true);
 
         operationOptionsForm = new FormPanel();
         operationOptionsForm.setFrame(false);


### PR DESCRIPTION
Brief description of the PR.
Disabled formPanel events on PackageUninstallDialog

**Related Issue**
This PR fixes/closes #2111 

**Description of the solution adopted**
Disabled formPanel events as they are not needed on _PackageUninstallDialog_. 
Listeners for disabling submit button were added to the formPanel in one of my previous PR, but they should not be triggered on this dialog. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>