### PR TITLE
Splitting tests to unit and integration cucumber tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,47 +41,51 @@ jobs:
         - $M2_HOME/bin/mvn -B javadoc:jar
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @default" -Pdev verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @default" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @brokerAcl" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @brokerAcl" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @tag" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @tag" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @broker" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @broker" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @device" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @device" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @connection" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @connection" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @datastore" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @datastore" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @user" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @user" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @security" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @security" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @jobs" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @jobs" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @rest" verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @rest" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
+        - bash <(curl -s https://codecov.io/bash)
+    - stage: test
+      script:
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.setadsftings.hotswap=true -Dgroups='org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
 
 # The following upgrades Java during the build in

--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -225,6 +225,11 @@
             <artifactId>log4j2-mock</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/broker-core/src/test/java/org/eclipse/kapua/broker/core/plugin/CamelRoutesLoaderTest.java
+++ b/broker-core/src/test/java/org/eclipse/kapua/broker/core/plugin/CamelRoutesLoaderTest.java
@@ -14,10 +14,13 @@ package org.eclipse.kapua.broker.core.plugin;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.KapuaBrokerJAXBContextLoader;
 import org.eclipse.kapua.broker.core.router.CamelKapuaDefaultRouter;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class CamelRoutesLoaderTest {
 
     private KapuaBrokerJAXBContextLoader kapuaBrokerJAXBContextLoader;

--- a/broker-core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
+++ b/broker-core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
@@ -18,14 +18,17 @@ import org.eclipse.kapua.broker.core.KapuaBrokerJAXBContextLoader;
 import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor.MessageType;
 import org.eclipse.kapua.broker.core.setting.BrokerSetting;
 import org.eclipse.kapua.broker.core.setting.BrokerSettingKey;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@Category(JUnitTests.class)
 public class ConnectorDescriptorTest {
 
     private static final String BROKER_IP_RESOLVER_CLASS_NAME;

--- a/client/gateway/api/pom.xml
+++ b/client/gateway/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2018 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -43,6 +43,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/CredentialsTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/CredentialsTest.java
@@ -12,9 +12,12 @@
 package org.eclipse.kapua.client.gateway;
 
 import org.eclipse.kapua.client.gateway.Credentials.UserAndPassword;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class CredentialsTest {
 
     @Test

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/PayloadTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/PayloadTest.java
@@ -14,9 +14,12 @@ package org.eclipse.kapua.client.gateway;
 import java.time.Instant;
 import java.util.Collections;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class PayloadTest {
 
     @Test(expected = NullPointerException.class)

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/TopicTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/TopicTest.java
@@ -19,9 +19,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class TopicTest {
 
     @Test

--- a/client/gateway/profile/kura/pom.xml
+++ b/client/gateway/profile/kura/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2018 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -78,6 +78,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/NamespaceTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/NamespaceTest.java
@@ -13,9 +13,12 @@ package org.eclipse.kapua.client.gateway.kura;
 
 import org.eclipse.kapua.client.gateway.Topic;
 import org.eclipse.kapua.client.gateway.kura.KuraNamespace.Builder;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class NamespaceTest {
 
     @Test(expected = IllegalArgumentException.class)

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/PayloadCodecTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/PayloadCodecTest.java
@@ -15,10 +15,13 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 
 import org.eclipse.kapua.client.gateway.Payload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class PayloadCodecTest {
 
     private KuraBinaryPayloadCodec codec;

--- a/client/gateway/spi/pom.xml
+++ b/client/gateway/spi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2018 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -47,6 +47,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/BuffersTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/BuffersTest.java
@@ -13,9 +13,12 @@ package org.eclipse.kapua.client.gateway.spi.util;
 
 import java.nio.ByteBuffer;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class BuffersTest {
 
     @Test

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/StringsTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/StringsTest.java
@@ -11,8 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.client.gateway.spi.util;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class StringsTest {
 
     @Test(expected = IllegalArgumentException.class)

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsyncTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsyncTest.java
@@ -20,9 +20,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.kapua.client.gateway.Transport;
 import org.eclipse.kapua.client.gateway.Transport.ListenerHandle;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class TransportAsyncTest {
 
     @Test

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxyTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxyTest.java
@@ -17,11 +17,14 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.kapua.client.gateway.Transport.ListenerHandle;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class TransportProxyTest {
 
     private static final class TestListener {

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -115,6 +115,11 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-account-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/commons/src/test/java/org/eclipse/kapua/commons/about/AboutTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/about/AboutTest.java
@@ -11,9 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.about;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class AboutTest {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/StringUtilTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/StringUtilTest.java
@@ -14,8 +14,11 @@ package org.eclipse.kapua.commons.configuration;
 import org.eclipse.kapua.commons.configuration.metatype.Password;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class StringUtilTest {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImplTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImplTest.java
@@ -11,9 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration.metatype;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaMetatypeFactoryImplTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImplTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImplTest.java
@@ -11,9 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration.metatype;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class ObjectFactoryImplTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/PasswordTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/PasswordTest.java
@@ -11,9 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration.metatype;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class PasswordTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/metric/MetricServiceFactoryTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/metric/MetricServiceFactoryTest.java
@@ -13,12 +13,15 @@ package org.eclipse.kapua.commons.metric;
 
 import java.lang.reflect.Constructor;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * {@link MetricsService} factory.
  */
+@Category(JUnitTests.class)
 public class MetricServiceFactoryTest extends Assert {
 
     public static MetricsService instance2;

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaEidTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaEidTest.java
@@ -19,12 +19,15 @@ import java.util.Random;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+@Category(JUnitTests.class)
 @RunWith(value = Parameterized.class)
 public class KapuaEidTest {
 

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
@@ -22,9 +22,11 @@ import org.eclipse.kapua.commons.model.misc.CollisionServiceImpl;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Test the random identifier generator retry mechanism.
@@ -32,6 +34,7 @@ import org.junit.Test;
  * @since 1.0
  *
  */
+@Category(JUnitTests.class)
 public class KapuaIdGeneratorTest extends AbstractCommonServiceTest {
 
     public static final String DEFAULT_TEST_FILTER = "test_*.sql";

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/id/KapuaEidTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/id/KapuaEidTest.java
@@ -13,9 +13,12 @@ package org.eclipse.kapua.commons.model.id;
 
 import java.math.BigInteger;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaEidTest {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
@@ -11,8 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.security;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +31,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @since 1.0
  */
+@Category(JUnitTests.class)
 public class KapuaDoPrivilegeTest {
 
     private static Logger logger = LoggerFactory.getLogger(KapuaDoPrivilegeTest.class);

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/AbstractKapuaSettingTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/AbstractKapuaSettingTest.java
@@ -13,8 +13,11 @@
 package org.eclipse.kapua.commons.setting;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class AbstractKapuaSettingTest {
 
     private static class TestSettingKey implements SettingKey {

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/SimpleSettingKeyTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/SimpleSettingKeyTest.java
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.setting;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class SimpleSettingKeyTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
@@ -13,14 +13,17 @@ package org.eclipse.kapua.commons.util;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.KapuaIllegalNullArgumentException;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Random;
 
+@Category(JUnitTests.class)
 public class ArgumentValidatorTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/CryptoUtilTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/CryptoUtilTest.java
@@ -15,9 +15,12 @@ package org.eclipse.kapua.commons.util;
 import java.lang.reflect.Constructor;
 import java.util.Random;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class CryptoUtilTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/KapuaDateUtilsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/KapuaDateUtilsTest.java
@@ -15,9 +15,12 @@ package org.eclipse.kapua.commons.util;
 import java.lang.reflect.Constructor;
 import java.util.Date;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaDateUtilsTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/KapuaExceptionUtilsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/KapuaExceptionUtilsTest.java
@@ -18,9 +18,12 @@ import javax.persistence.PersistenceException;
 import javax.persistence.RollbackException;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaExceptionUtilsTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/PayloadsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/PayloadsTest.java
@@ -17,9 +17,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class PayloadsTest {
 
     private static final String PAYLOAD_DISPLAY_STR = "Boolean=true~~Double=42.42~~Float=42.42~~Integer=42~~Long=43~~String=Big brown fox~~byte=626F647900~~unknown=";

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ResourceUtilsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ResourceUtilsTest.java
@@ -16,11 +16,14 @@ import java.io.Reader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.io.CharStreams;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class ResourceUtilsTest {
 
     /**

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlNamespaceFilterTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlNamespaceFilterTest.java
@@ -11,11 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.util.xml;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
+import org.junit.experimental.categories.Category;
 import org.xml.sax.Attributes;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+@Category(JUnitTests.class)
 public class XmlNamespaceFilterTest extends Assert {
 
     @Test

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlUtilTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlUtilTest.java
@@ -11,12 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.util.xml;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import javax.xml.bind.JAXBException;
 import java.lang.reflect.Constructor;
 
+@Category(JUnitTests.class)
 public class XmlUtilTest extends Assert {
 
     @Test

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -60,6 +60,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
@@ -25,10 +25,13 @@ import org.eclipse.kapua.locator.internal.guice.ServiceA;
 import org.eclipse.kapua.locator.internal.guice.ServiceB;
 import org.eclipse.kapua.locator.internal.guice.ServiceC;
 import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class GuiceLocatorImplTest {
 
     private KapuaLocator locator = GuiceLocatorImpl.getInstance();

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/ResolverTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/ResolverTest.java
@@ -20,8 +20,11 @@ import org.eclipse.kapua.locator.internal.guice.ServiceA;
 import org.eclipse.kapua.locator.internal.guice.ServiceAImpl;
 import org.eclipse.kapua.locator.internal.guice.ServiceC;
 import org.eclipse.kapua.locator.internal.guice.ServiceCImpl;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class ResolverTest {
 
     @Test(expected = KapuaLocatorException.class)

--- a/marker-api/pom.xml
+++ b/marker-api/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+        Red Hat Inc
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>marker-api</artifactId>
+
+    <properties>
+        <maven.test.skip>true</maven.test.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/marker-api/src/main/java/org/eclipse/kapua/test/junit/JUnitTests.java
+++ b/marker-api/src/main/java/org/eclipse/kapua/test/junit/JUnitTests.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.test.junit;
+
+public interface JUnitTests {
+
+}

--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -72,6 +72,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.message.internal;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -23,5 +25,6 @@ import org.junit.runners.Suite;
         KapuaPositionTest.class,
         KapuaPayloadTest.class
 })
+@Category(JUnitTests.class)
 public class BasicMessageTestSuite {
 }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
@@ -14,6 +14,8 @@ package org.eclipse.kapua.message.internal;
 import org.eclipse.kapua.message.internal.device.data.KapuaDeviceDataTest;
 import org.eclipse.kapua.message.internal.device.lifecycle.LifecycleTestSuite;
 import org.eclipse.kapua.message.internal.xml.MetricTestSuite;
+import org.eclipse.kapua.test.junit.JUnitTests;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -25,5 +27,6 @@ import org.junit.runners.Suite;
         LifecycleTestSuite.class
 
 })
+@Category(JUnitTests.class)
 public class FullMessageTestSuite {
 }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
@@ -13,13 +13,16 @@ package org.eclipse.kapua.message.internal;
 
 import org.eclipse.kapua.message.device.data.KapuaDataChannel;
 import org.eclipse.kapua.message.internal.device.data.KapuaDataChannelImpl;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Category(JUnitTests.class)
 public class KapuaChannelTest extends Assert {
 
     KapuaDataChannel kapuaDataChannel;

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
@@ -18,10 +18,13 @@ import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.message.device.data.KapuaDataChannel;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaMessageFactoryTest extends Assert {
 
     private KapuaMessageFactory kapuaMessageFactory;

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
@@ -25,11 +25,14 @@ import org.eclipse.kapua.message.KapuaChannel;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaMessageTest extends Assert {
 
     private static final String KAPUA_MESSAGE_XML_STR = "missing";

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
@@ -16,11 +16,14 @@ import java.util.Map;
 
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaPayloadTest extends Assert {
 
     private static final String PAYLOAD_DISPLAY_STR = "Boolean=true~~Double=42.42~~Float=42.42~~Integer=42~~Long=43~~String=Big brown fox~~byte=626F647900~~unknown=";

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
@@ -18,10 +18,13 @@ import java.time.ZonedDateTime;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.model.xml.DateXmlAdapter;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaPositionTest extends Assert {
 
     private static final String NEWLINE = System.lineSeparator();

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
@@ -12,9 +12,12 @@
 package org.eclipse.kapua.message.internal;
 
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class MessageExceptionTest extends Assert {
 
     @Test

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
@@ -16,9 +16,12 @@ import java.util.List;
 
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.message.device.data.KapuaDataPayload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaDeviceDataTest extends Assert {
 
     @Test

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
@@ -13,9 +13,12 @@ package org.eclipse.kapua.message.internal.device.lifecycle;
 
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsPayload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaAppsMessageTest extends Assert {
 
     private static final String PAYLOAD_DISPLAY_STR = "[ getUptime()=12" +

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
@@ -14,9 +14,12 @@ package org.eclipse.kapua.message.internal.device.lifecycle;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthPayload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaBirthMessageTest extends Assert {
 
     private static final String PAYLOAD_DISPLAY_STR = "[ getUptime()=12" +

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
@@ -14,9 +14,12 @@ package org.eclipse.kapua.message.internal.device.lifecycle;
 import org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectPayload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaDisconnectMessageTest extends Assert {
 
     private static final String PAYLOAD_DISPLAY_STR = "[ getUptime()=12" +

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
@@ -14,9 +14,12 @@ package org.eclipse.kapua.message.internal.device.lifecycle;
 import org.eclipse.kapua.message.device.lifecycle.KapuaMissingChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaMissingPayload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaMissingMessageTest extends Assert {
 
     @Test

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaNotifyMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaNotifyMessageTest.java
@@ -16,9 +16,12 @@ import java.util.List;
 
 import org.eclipse.kapua.message.device.lifecycle.KapuaNotifyChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaNotifyPayload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaNotifyMessageTest extends Assert {
 
     private static final String NOTIFY_MSG_STR = "Client id 'clientId-1' - semantic topic 'part1/part2/part3'";

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaUnmatchedMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaUnmatchedMessageTest.java
@@ -16,9 +16,12 @@ import java.util.List;
 
 import org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaUnmatchedPayload;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaUnmatchedMessageTest extends Assert {
 
     private static final String UNMATCHED_MSG_STR = "Client id 'clientId-1' - semantic topic 'part1/part2/part3'";

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.message.internal.device.lifecycle;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -23,5 +25,6 @@ import org.junit.runners.Suite;
         KapuaNotifyMessageTest.class,
         KapuaUnmatchedMessageTest.class
 })
+@Category(JUnitTests.class)
 public class LifecycleTestSuite {
 }

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
@@ -16,10 +16,13 @@ import java.math.BigDecimal;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.message.internal.MessageJAXBContextProvider;
 import org.eclipse.kapua.message.xml.XmlAdaptedMetric;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaMetricTest extends Assert {
 
     private static final String NEWLINE = System.lineSeparator();

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
@@ -19,10 +19,13 @@ import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.internal.KapuaPayloadImpl;
 import org.eclipse.kapua.message.internal.MessageJAXBContextProvider;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaMetricsMapAdapterTest extends Assert {
 
     private static final String NEWLINE = System.lineSeparator();

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.message.internal.xml;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -19,5 +21,6 @@ import org.junit.runners.Suite;
         KapuaMetricTest.class,
         KapuaMetricsMapAdapterTest.class
 })
+@Category(JUnitTests.class)
 public class MetricTestSuite {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -917,6 +917,12 @@
                 <artifactId>kapua-security-certificate-internal</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>marker-api</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
@@ -1331,6 +1337,9 @@
 
         <module>dev-tools</module>
         <module>deployment</module>
+
+        <!-- JUnit marker interfaces -->
+        <module>marker-api</module>
     </modules>
 
     <profiles>

--- a/qa-openshift/pom.xml
+++ b/qa-openshift/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -50,6 +50,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/qa-openshift/src/test/java/org/eclipse/kapua/qa/openshift/OpenShiftTest.java
+++ b/qa-openshift/src/test/java/org/eclipse/kapua/qa/openshift/OpenShiftTest.java
@@ -15,13 +15,16 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.kapua.kura.simulator.main.SimulatorRunner;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Category(JUnitTests.class)
 public class OpenShiftTest {
 
     String oc = "/tmp/openshift/openshift-origin-server-v1.4.1+3f9807a-linux-64bit/oc";

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/BasicSteps.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/BasicSteps.java
@@ -91,6 +91,10 @@ public class BasicSteps extends Assert {
 
     @Given("^System property \"(.*)\" with value \"(.*)\"$")
     public void setSystemProperty(String key, String value) {
-        System.setProperty(key, value);
+        if ("null".equalsIgnoreCase(value)) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
     }
 }

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedBroker.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedBroker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2018 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,8 @@
 package org.eclipse.kapua.qa.steps;
 
 import java.time.Duration;
+
+import cucumber.api.java.en.Given;
 import org.eclipse.kapua.qa.utils.Ports;
 import org.eclipse.kapua.qa.utils.Suppressed;
 
@@ -26,8 +28,6 @@ import org.elasticsearch.common.UUIDs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
 import cucumber.runtime.java.guice.ScenarioScoped;
 
 @ScenarioScoped
@@ -53,10 +53,10 @@ public class EmbeddedBroker {
     public EmbeddedBroker() {
     }
 
-    @Before(value = "@StartBroker")
+    @Given("^Start Broker$")
     public void start() {
 
-        logger.info("Starting new instance");
+        logger.info("Starting new Broker instance");
 
         try {
             // test if port is already open
@@ -88,9 +88,9 @@ public class EmbeddedBroker {
         }
     }
 
-    @After(value = "@StopBroker")
+    @Given("^Stop Broker$")
     public void stop() {
-        logger.info("Stopping instance ...");
+        logger.info("Stopping Broker instance ...");
 
         try (final Suppressed<RuntimeException> s = Suppressed.withRuntimeException()) {
 
@@ -107,12 +107,20 @@ public class EmbeddedBroker {
             }
 
         } catch (Exception e) {
-            throw new RuntimeException("Failed to stop broker", e);
+            logger.error("Failed to stop Broker!");
+            e.printStackTrace();
         }
 
         DatastoreMediator.getInstance().clearCache();
 
-        logger.info("Stopping instance ... done!");
+        if (EXTRA_STARTUP_DELAY > 0) {
+            try {
+                Thread.sleep(Duration.ofSeconds(EXTRA_STARTUP_DELAY).toMillis());
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        logger.info("Stopping Broker instance ... done!");
     }
 
 }

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedDatastore.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedDatastore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,8 +15,7 @@ package org.eclipse.kapua.qa.steps;
 import java.io.IOException;
 import java.time.Duration;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
 import org.eclipse.kapua.service.datastore.client.embedded.EsEmbeddedEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +34,8 @@ public class EmbeddedDatastore {
 
     private static EsEmbeddedEngine esEmbeddedEngine;
 
-    @Before(order = HookPriorities.DATASTORE, value = "@StartDatastore")
+
+    @Given("^Start Datastore$")
     public void setup() {
         logger.info("starting embedded datastore");
         esEmbeddedEngine = new EsEmbeddedEngine();
@@ -49,7 +49,7 @@ public class EmbeddedDatastore {
         logger.info("starting embedded datastore DONE");
     }
 
-    @After(order = HookPriorities.DATASTORE, value = "@StopDatastore")
+    @Given("^Stop Datastore$")
     public void closeNode() throws IOException {
         logger.info("closing embedded datastore");
         if (EXTRA_STARTUP_DELAY > 0) {

--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedJetty.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/EmbeddedJetty.java
@@ -11,8 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.qa.steps;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AllowSymLinkAliasChecker;
@@ -31,10 +30,10 @@ public class EmbeddedJetty {
 
     private static Server jetty;
 
-    @Before(value = "@StartJetty")
-    public void start() throws Exception {
+    @Given("^Start Jetty Server on host \"(.*)\" at port \"(.+)\"$")
+    public void start(String host, int port) throws Exception {
 
-        InetSocketAddress address = new InetSocketAddress("127.0.0.1", 8080);
+        InetSocketAddress address = new InetSocketAddress(host, port);
         jetty = new Server(address);
         logger.info("Starting Jetty " + jetty);
 
@@ -68,7 +67,7 @@ public class EmbeddedJetty {
         //jetty.join();
     }
 
-    @After(value = "@StopJetty")
+    @Given("^Stop Jetty Server$")
     public void stop() throws Exception {
         logger.info("Stopping Jetty " + jetty);
 

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -224,6 +224,11 @@
             <artifactId>cucumber-guice</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- activemq -->
         <dependency>
@@ -331,7 +336,7 @@
                                 </artifactItem>
                             </artifactItems>
                             <overWriteReleases>true</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <overWriteSnapshots>false</overWriteSnapshots>
                         </configuration>
                     </execution>
                 </executions>

--- a/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -15,14 +15,21 @@ Feature: Device Broker Integration
   Each Scenario starts with BIRTH of device and then the communication over MQTT
   between device and Kapua.
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "broker.ip" with value "localhost"
+
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
+  Scenario: Start event broker for all scenarios
+
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
 
-  @StartBroker
-  Scenario: Start event broker for all scenarios
+    Given Start Broker
 
   Scenario: Send BIRTH message and then DC message
     Effectively this is connect and disconnect of Kura device.
@@ -43,12 +50,14 @@ Feature: Device Broker Integration
     And I logout
     And Device death message is sent
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
-  Scenario: Stop event broker after all scenarios
+    Given Stop Broker
 
-  @StopDatastore
+  Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
 
+    Given Stop Datastore

--- a/qa/src/test/resources/features/broker/DeviceBrokerIpConfigFileI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerIpConfigFileI9n.feature
@@ -13,11 +13,23 @@
 Feature: Device Broker connection ip with config file
   Device Service integration scenarios with running broker service.
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "commons.settings.hotswap" with value "true"
+      And System property "broker.ip" with value "null"
+      And System property "kapua.config.url" with value "broker.setting/kapua-broker-setting-1.properties"
+
   Scenario: Start datastore for all scenarios
 
-  @StartBroker
+    Given Start Datastore
+
+  Scenario: Start event broker for all scenarios
+
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
   Scenario: Send BIRTH message and then DC message while broker ip is set by config file
     Effectively this is connect and disconnect of Kura device.
@@ -32,8 +44,14 @@ Feature: Device Broker connection ip with config file
     And I logout
     And Device death message is sent
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopDatastore
+    Given Stop Broker
+
+  Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/broker/DeviceBrokerIpSysEnvI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerIpSysEnvI9n.feature
@@ -13,11 +13,23 @@
 Feature: Device Broker connection ip with System environment variable
   Device Service integration scenarios with running broker service.
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "commons.settings.hotswap" with value "true"
+    And System property "broker.ip" with value "192.168.33.10"
+    And System property "kapua.config.url" with value "null"
+
   Scenario: Start datastore for all scenarios
 
-  @StartBroker
+    Given Start Datastore
+
+  Scenario: Start event broker for all scenarios
+
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
   Scenario: Send BIRTH message and then DC message while broker ip is set by System
   environment variable. Effectively this is connect and disconnect of Kura device.
@@ -32,8 +44,14 @@ Feature: Device Broker connection ip with System environment variable
     And I logout
     And Device death message is sent
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopDatastore
+    Given Stop Broker
+
+  Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/broker/DeviceBrokerIpUndefinedI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerIpUndefinedI9n.feature
@@ -13,11 +13,23 @@
 Feature: Device Broker connection ip not set
   Device Service integration scenarios with running broker service.
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "commons.settings.hotswap" with value "true"
+    And System property "broker.ip" with value "null"
+    And System property "kapua.config.url" with value "null"
+
   Scenario: Start datastore for all scenarios
 
-  @StartBroker
+    Given Start Datastore
+
+  Scenario: Start event broker for all scenarios
+
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
   Scenario: Send BIRTH message and then DC message while broker ip is NOT set
   Effectively this is connect and disconnect of Kura device.
@@ -31,11 +43,18 @@ Feature: Device Broker connection ip not set
 #    And I login as user with name "kapua-sys" and password "kapua-password"
 #    Then Device is connected with "192.168.33.10" server ip
 #    Then An exception was thrown
-    And I logout
+#    And I logout
     And Device death message is sent
+    And I wait 5 seconds for system to receive and process that message
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopDatastore
+    Given Stop Broker
+
+  Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/broker/DeviceBrokerStealingLinkI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerStealingLinkI9n.feature
@@ -17,14 +17,23 @@ Feature: Device Broker Cluster tests
     others in cluster and by this disconnecting client form other brokers.
     Tests also include connecting client with same id.
 
-    @StartDatastore
+    Scenario: Set environment variables
+
+        Given System property "commons.settings.hotswap" with value "true"
+        And System property "broker.ip" with value "localhost"
+        And System property "kapua.config.url" with value "null"
+
     Scenario: Start datastore for all scenarios
 
-    @StartEventBroker
+        Given Start Datastore
+
+    Scenario: Start event broker for all scenarios
+
+        Given Start Event Broker
+
     Scenario: Start broker for all scenarios
 
-    @StartBroker
-    Scenario: Start broker for all scenarios
+        Given Start Broker
 
     Scenario: Positive scenario without stealing link
         Connect first client and send BIRTH message. Then connect two more
@@ -95,11 +104,14 @@ Feature: Device Broker Cluster tests
     Then Disconnect client with name "client-1-1"
         And Disconnect client with name "client-1-2"
 
-    @StopBroker
     Scenario: Stop broker after all scenarios
 
-    @StopEventBroker
-    Scenario: Stop event broker after all scenarios
+        Given Stop Broker
 
-    @StopDatastore
-    Scenario: Stop datastore after all scenario
+    Scenario: Stop event broker for all scenarios
+
+        Given Stop Event Broker
+
+    Scenario: Stop datastore after all scenarios
+
+        Given Stop Datastore

--- a/qa/src/test/resources/features/broker/DeviceData.feature
+++ b/qa/src/test/resources/features/broker/DeviceData.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -12,14 +12,23 @@
 @device
 Feature: Device data scenarios
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "commons.settings.hotswap" with value "true"
+    And System property "broker.ip" with value "localhost"
+    And System property "kapua.config.url" with value "null"
+
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
 Scenario: Connect to the system and publish some data
 
@@ -65,11 +74,14 @@ Scenario: Connect to the system and publish some data
   When I stop the simulator
   Then Device sim-1 for account kapua-sys is not registered after 5 seconds
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
 
-  @StopDatastore
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/broker/DeviceLifecycle.feature
+++ b/qa/src/test/resources/features/broker/DeviceLifecycle.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -12,14 +12,23 @@
 @device
 Feature: Device lifecycle scenarios
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "commons.settings.hotswap" with value "true"
+    And System property "broker.ip" with value "localhost"
+    And System property "kapua.config.url" with value "null"
+
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
 Scenario: Starting and stopping the simulator should create a device entry and properly set its status
   This starts and stops a simulator instance and checks if the connection state
@@ -71,11 +80,14 @@ Scenario: Installing a package
   When I fetch the package states
   Then Package "foo.bar" with version 1.2.3 is installed and has 10 mock bundles
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
 
-  @StopDatastore
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -41,14 +41,17 @@ Feature: Broker ACL tests
   ACL_DATA_ACC_CLI = {0}.{1}.>
   ACL_CTRL_ACC_NOTIFY = $EDC.{0}.*.*.NOTIFY.{1}.>
 
-  @StartDatastore
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
 #
 # Data manage
@@ -207,11 +210,14 @@ Feature: Broker ACL tests
     And clients are disconnected
     And Mqtt Device is stoped
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
 
-  @StopDatastore
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -40,14 +40,17 @@ Feature: Broker ACL tests
   ACL_DATA_ACC_CLI = {0}.{1}.>
   ACL_CTRL_ACC_NOTIFY = $EDC.{0}.*.*.NOTIFY.{1}.>
 
-  @StartDatastore
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
 #
 #  Admin
@@ -602,11 +605,14 @@ Feature: Broker ACL tests
       And clients are disconnected
       And Mqtt Device is stoped
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
 
-  @StopDatastore
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/connection/UserCouplingI9n.feature
+++ b/qa/src/test/resources/features/connection/UserCouplingI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -12,11 +12,13 @@
 @connection
 Feature: User Coupling
 
-  @StartEventBroker
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
   Scenario: Test LOOSE user coupling on single connection
 
@@ -1652,8 +1654,10 @@ Feature: User Coupling
     Then I stop the simulator
     And I wait for 2 seconds
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker

--- a/qa/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/src/test/resources/features/datastore/Datastore.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -13,15 +13,17 @@
 @datastore
 Feature: Datastore tests
 
-  @StartDatastore
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
 
+    Given Start Broker
   Scenario: Delete items by the datastore ID
     Delete a previously stored message and verify that it is not in the store any more. Also delete and check the
     message related channel, metric and client info entries.
@@ -654,11 +656,14 @@ Feature: Datastore tests
       |tba_2/1/1/3 |
     And All indices are deleted
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
 
-  @StopDatastore
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -13,14 +13,25 @@
 @datastore
 Feature: Datastore tests
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "commons.settings.hotswap" with value "true"
+    And System property "datastore.index.prefix" with value "null"
+    And System property "kapua.config.url" with value "null"
+    And System property "broker.ip" with value "192.168.33.10"
+    And System property "datastore.client.class" with value "org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient"
+
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
 
   Scenario: Simple positive scenario for creating default - weekly index
   Create elasticsearch index with default setting for index creation which is weekly
@@ -197,11 +208,14 @@ Feature: Datastore tests
     And REST response containing "-2018-01" with prefix account "LastAccount"
     And All indices are deleted
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
 
-  @StopDatastore
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
+++ b/qa/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
@@ -13,14 +13,26 @@
 @datastore
 Feature: Datastore tests
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "commons.settings.hotswap" with value "true"
+    And System property "datastore.index.prefix" with value "custom-prefix"
+    And System property "kapua.config.url" with value "null"
+    And System property "broker.ip" with value "192.168.33.10"
+    And System property "datastore.client.class" with value "org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient"
+
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
+
+    Given Start Broker
+
 
   Scenario: Create index with specific prefix
   Create elasticsearch index with specific prefix set by system property.
@@ -39,11 +51,14 @@ Feature: Datastore tests
     And REST response containing text "custom-prefix-1-2018-01"
     And All indices are deleted
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
 
-  @StopDatastore
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -14,15 +14,23 @@ Feature: Device Registry Integration
     Device Registy integration test scenarios. These scenarios test higher level device service functionality
     with all services live.
 
-  @StartDatastore
+  Scenario: Set environment variables
+
+    Given System property "commons.settings.hotswap" with value "true"
+    And System property "broker.ip" with value "localhost"
+    And System property "kapua.config.url" with value "null"
+
   Scenario: Start datastore for all scenarios
 
-  @StartEventBroker
+    Given Start Datastore
+
   Scenario: Start event broker for all scenarios
 
-  @StartBroker
+    Given Start Event Broker
+
   Scenario: Start broker for all scenarios
 
+    Given Start Broker
 Scenario: Birth message handling from a new device
     A birth message is received. The referenced device does not yet exist and is created on-the-fly. After the
     message is processed a new device must be created and a BIRTH event inserted in the database.
@@ -306,11 +314,14 @@ Scenario: Creating new device, tagging it with specific Tag and then deleting th
     And I verify that tag "KuraDevice2" is deleted
     And I logout
 
-  @StopBroker
   Scenario: Stop broker after all scenarios
 
-  @StopEventBroker
+    Given Stop Broker
+
   Scenario: Stop event broker for all scenarios
 
-  @StopDatastore
+    Given Stop Event Broker
+
   Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore

--- a/qa/src/test/resources/features/rest/user/RestUser.feature
+++ b/qa/src/test/resources/features/rest/user/RestUser.feature
@@ -13,11 +13,13 @@
 Feature: REST API tests for User
   REST API test of Kapua User API.
 
-  @StartEventBroker
   Scenario: Start event broker for all scenarios
 
-  @StartJetty
+    Given Start Event Broker
+
   Scenario: Start Jetty server for all scenarios
+
+    Given Start Jetty Server on host "127.0.0.1" at port "8080"
 
 
   Scenario: Simple Jetty with rest-api war
@@ -30,8 +32,10 @@ Feature: REST API tests for User
     When REST GET call at "/v1/_/users?offset=0&limit=50"
     Then REST response containing Users
 
-  @StopJetty
   Scenario: Stop Jetty server for all scenarios
 
-  @StopEventBroker
+    Given Stop Jetty Server
+
   Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker

--- a/qa/src/test/resources/features/user/TenantSEI9n.feature
+++ b/qa/src/test/resources/features/user/TenantSEI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -14,8 +14,9 @@ Feature: Tenant service with Service Events
   Basic workflow of Account and User creation and deletion, where Service Events are
   being trigered on create, update and delete action on Account and User service.
 
-  @StartEventBroker
   Scenario: Start event broker for all scenarios
+
+    Given Start Event Broker
 
   Scenario: To be defined
     Given this step says to skip
@@ -57,5 +58,6 @@ Feature: Tenant service with Service Events
     And I don't find user "kapua-g"
     And I logout
 
-  @StopEventBroker
   Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker

--- a/qa/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/src/test/resources/features/user/UserServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -13,8 +13,9 @@
 Feature: User Service Integration
   User Service integration scenarios
 
-  @StartEventBroker
   Scenario: Start event broker for all scenarios
+
+    Given Start Event Broker
 
   Scenario: Deleting user in account that is lower in hierarchy
   Using user A in in different scope than user B, try to delete user B. Scope of user A is one
@@ -170,5 +171,6 @@ Feature: User Service Integration
     Then An exception was thrown
     And I logout
 
-  @StopEventBroker
   Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -189,6 +189,12 @@
             <artifactId>joda-time</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- use logback only for testing -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -82,6 +82,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/api/pom.xml
+++ b/service/api/pom.xml
@@ -38,5 +38,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
@@ -11,9 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaExceptionTest {
 
     @Test

--- a/service/datastore/client-transport/pom.xml
+++ b/service/datastore/client-transport/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -64,6 +64,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- jna is required to run a elasticsearch instance in embedded mode -->

--- a/service/datastore/client-transport/src/test/java/org/eclipse/kapua/service/datastore/client/transport/EsClientTest.java
+++ b/service/datastore/client-transport/src/test/java/org/eclipse/kapua/service/datastore/client/transport/EsClientTest.java
@@ -16,11 +16,14 @@ import java.net.UnknownHostException;
 import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.elasticsearch.client.transport.TransportClient;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 @Ignore
+@Category(JUnitTests.class)
 public class EsClientTest {
 
     @Test

--- a/service/datastore/client-transport/src/test/java/org/eclipse/kapua/service/datastore/client/transport/EsTransportClientProviderTest.java
+++ b/service/datastore/client-transport/src/test/java/org/eclipse/kapua/service/datastore/client/transport/EsTransportClientProviderTest.java
@@ -15,9 +15,11 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.eclipse.kapua.commons.setting.AbstractBaseKapuaSetting;
 import org.eclipse.kapua.service.datastore.client.ClientUnavailableException;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.elasticsearch.client.Client;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -28,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Category(JUnitTests.class)
 public class EsTransportClientProviderTest {
 
     /**

--- a/service/datastore/internal/pom.xml
+++ b/service/datastore/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -119,6 +119,11 @@
         <dependency>
             <groupId>de.dentrassi.elasticsearch</groupId>
             <artifactId>log4j2-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/AbstractMessageStoreServiceTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/AbstractMessageStoreServiceTest.java
@@ -14,9 +14,12 @@ package org.eclipse.kapua.service.datastore.internal;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public abstract class AbstractMessageStoreServiceTest extends KapuaTest {
 
 

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/IndexCalculatorTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/IndexCalculatorTest.java
@@ -21,7 +21,9 @@ import org.eclipse.kapua.service.datastore.client.ClientException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +35,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
+@Category(JUnitTests.class)
 public class IndexCalculatorTest extends AbstractMessageStoreServiceTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(IndexCalculatorTest.class);

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceSslTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceSslTest.java
@@ -56,11 +56,14 @@ import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceCreator;
 import org.eclipse.kapua.service.device.registry.DeviceFactory;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(JUnitTests.class)
 public class MessageStoreServiceSslTest extends AbstractMessageStoreServiceTest {
 
     private static final Logger logger = LoggerFactory.getLogger(MessageStoreServiceSslTest.class);

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceTest.java
@@ -90,10 +90,12 @@ import org.eclipse.kapua.service.device.registry.DeviceCreator;
 import org.eclipse.kapua.service.device.registry.DeviceFactory;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,6 +122,7 @@ import java.util.TimeZone;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Category(JUnitTests.class)
 public class MessageStoreServiceTest extends AbstractMessageStoreServiceTest {
 
     private static final Logger logger = LoggerFactory.getLogger(MessageStoreServiceTest.class);

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsConvertDateTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsConvertDateTest.java
@@ -19,8 +19,11 @@ import org.assertj.core.api.Assertions;
 
 import org.eclipse.kapua.service.datastore.internal.AbstractMessageStoreServiceTest;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class ClientUtilsConvertDateTest extends AbstractMessageStoreServiceTest {
 
     @Test(expected = java.lang.IllegalArgumentException.class)

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsIndexNameTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/ClientUtilsIndexNameTest.java
@@ -24,9 +24,12 @@ import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.internal.AbstractMessageStoreServiceTest;
 import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class ClientUtilsIndexNameTest extends AbstractMessageStoreServiceTest {
 
     private static final KapuaId ONE = new KapuaEid(BigInteger.ONE);

--- a/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/MessageStoreConfigurationTest.java
+++ b/service/datastore/internal/src/test/java/org/eclipse/kapua/service/datastore/internal/client/MessageStoreConfigurationTest.java
@@ -20,9 +20,12 @@ import java.util.Map;
 
 import org.eclipse.kapua.service.datastore.internal.AbstractMessageStoreServiceTest;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfiguration;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class MessageStoreConfigurationTest extends AbstractMessageStoreServiceTest {
 
     @Test

--- a/service/device/call/kura/pom.xml
+++ b/service/device/call/kura/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -77,6 +77,11 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-registry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/service/device/registry/internal/pom.xml
+++ b/service/device/registry/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -111,6 +111,11 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-guice</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>kapua-scheduler-quartz</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/service/liquibase/pom.xml
+++ b/service/liquibase/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016 Red Hat and/or its affiliates and others
+    Copyright (c) 2016, 2018 Red Hat and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -63,6 +63,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/service/liquibase/src/test/java/org/eclipse/kapua/service/liquibase/KapuaLiquibaseClientTest.java
+++ b/service/liquibase/src/test/java/org/eclipse/kapua/service/liquibase/KapuaLiquibaseClientTest.java
@@ -21,10 +21,13 @@ import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaLiquibaseClientTest {
 
     private Connection connection;

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -136,6 +136,11 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-guice</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/TemporaryLockedAccountExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/TemporaryLockedAccountExceptionTest.java
@@ -14,9 +14,12 @@ package org.eclipse.kapua.service.authentication.shiro.exceptions;
 import java.util.Date;
 
 import org.eclipse.kapua.service.authentication.shiro.exceptions.TemporaryLockedAccountException;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class TemporaryLockedAccountExceptionTest {
 
     @Test

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AbstractAuthorizationServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AbstractAuthorizationServiceTest.java
@@ -28,10 +28,13 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.shiro.AuthenticationEntityManagerFactory;
 import org.eclipse.kapua.service.liquibase.KapuaLiquibaseClient;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Category(JUnitTests.class)
 public abstract class AbstractAuthorizationServiceTest extends Assert {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractAuthorizationServiceTest.class);

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/AccessInfoServiceTest.java
@@ -38,13 +38,16 @@ import org.eclipse.kapua.service.user.UserFactory;
 import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.test.KapuaTest;
 import org.eclipse.kapua.test.ResourceLimitsConfig;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.Set;
 
+@Category(JUnitTests.class)
 public class AccessInfoServiceTest extends KapuaTest {
 
     private static final TestDomain TEST_DOMAIN = new TestDomain();

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainRegistryServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/DomainRegistryServiceTest.java
@@ -25,11 +25,14 @@ import org.eclipse.kapua.service.authorization.domain.DomainQuery;
 import org.eclipse.kapua.service.authorization.domain.DomainRegistryService;
 import org.eclipse.kapua.service.authorization.domain.shiro.DomainAttributes;
 import org.eclipse.kapua.test.KapuaTest;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.HashSet;
 import java.util.Set;
 
+@Category(JUnitTests.class)
 public class DomainRegistryServiceTest extends KapuaTest {
 
     KapuaEid scope = new KapuaEid(IdGenerator.generate());

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/GroupServiceTest.java
@@ -30,11 +30,14 @@ import org.eclipse.kapua.service.authorization.group.GroupAttributes;
 import org.eclipse.kapua.service.authorization.group.shiro.GroupQueryImpl;
 import org.eclipse.kapua.test.KapuaTest;
 import org.eclipse.kapua.test.ResourceLimitsConfig;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class GroupServiceTest extends KapuaTest {
 
     public static final String DROP_FILTER = "athz_*_drop.sql";

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/RoleServiceTest.java
@@ -34,16 +34,19 @@ import org.eclipse.kapua.service.authorization.role.RoleAttributes;
 import org.eclipse.kapua.service.authorization.role.shiro.RoleQueryImpl;
 import org.eclipse.kapua.test.KapuaTest;
 import org.eclipse.kapua.test.ResourceLimitsConfig;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+@Category(JUnitTests.class)
 public class RoleServiceTest extends KapuaTest {
 
     public static final String DROP_FILTER = "athz_*_drop.sql";

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -83,6 +83,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSettingTest.java
+++ b/service/user/internal/src/test/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSettingTest.java
@@ -11,9 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.internal.setting;
 
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class KapuaUserSettingTest {
 
     @Test

--- a/simulator-kura/pom.xml
+++ b/simulator-kura/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2018 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -103,6 +103,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/AppTest.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/AppTest.java
@@ -25,9 +25,12 @@ import org.eclipse.kapua.kura.simulator.simulation.Configuration.MetricsMapping;
 import org.eclipse.kapua.kura.simulator.simulation.Configuration.Topic;
 import org.eclipse.kapua.kura.simulator.simulation.Configurations;
 import org.eclipse.kapua.kura.simulator.simulation.Simulation;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.eclipse.kura.core.message.protobuf.KuraPayloadProto.KuraPayload.Builder;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class AppTest {
 
     @Test

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/ConfigurationTest.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/ConfigurationTest.java
@@ -16,8 +16,11 @@ import org.assertj.core.api.Assertions;
 import org.eclipse.kapua.kura.simulator.simulation.Configuration;
 import org.eclipse.kapua.kura.simulator.simulation.Configuration.Application;
 import org.eclipse.kapua.kura.simulator.simulation.Configuration.Topic;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class ConfigurationTest {
 
     @Test

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/JsonTest.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/JsonTest.java
@@ -22,9 +22,12 @@ import org.eclipse.kapua.kura.simulator.simulation.Configuration.Topic;
 import org.eclipse.kapua.kura.simulator.simulation.JsonReader;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class JsonTest {
 
     @Test

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/ValidationTest.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/ValidationTest.java
@@ -18,8 +18,11 @@ import org.eclipse.kapua.kura.simulator.simulation.Configuration;
 import org.eclipse.kapua.kura.simulator.simulation.Configuration.Application;
 import org.eclipse.kapua.kura.simulator.simulation.Configuration.MetricsMapping;
 import org.eclipse.kapua.kura.simulator.simulation.Configuration.Topic;
+import org.eclipse.kapua.test.junit.JUnitTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(JUnitTests.class)
 public class ValidationTest {
 
     @Test

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -209,6 +209,11 @@
             <artifactId>cucumber-junit</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/translator/kapua/kura/pom.xml
+++ b/translator/kapua/kura/pom.xml
@@ -94,5 +94,10 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/translator/kura/jms/pom.xml
+++ b/translator/kura/jms/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -43,6 +43,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/translator/kura/mqtt/pom.xml
+++ b/translator/kura/mqtt/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -46,6 +46,11 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+          <groupId>org.eclipse.kapua</groupId>
+          <artifactId>marker-api</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
 </project>

--- a/transport/jms/pom.xml
+++ b/transport/jms/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/transport/mqtt/pom.xml
+++ b/transport/mqtt/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -50,6 +50,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
All unit tests were grouped with annotation on test itself.
When tests are run it is specified by this grouping which tests to run.
One set of tests is unit and those are marked with org.eclipse.kapua.test.junit.JUnitTests

**Description of the solution adopted**

In case of cucumber integration tests, those are not marked and that means
that when running those tests -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests'
is specified in command line. In addition to that --tags for cucumber are
also specified to specify group of tests on cucumber level.

This solves issue with unit tests running every time with each integration
tests group. This will speed up tests at least 5 min times number of
integration tests groups. It might also resolve timeouts on travis side.

Embedded servers are started and stopped by step and not with before and
after steps. This required some refactoring of many feature files (cucumber
scenarios).

Added start of event broker to broker scenarios.

Added environment variable settings into feature files, because custom
junit runner CucumberWithProperties didn't work.

Also added was timeout at some of embedded servers. Embedded servers
member variables were changed to static.

**Related Issue**
This PR helps resolving  _2088_

**Screenshots**
Not applicable.

**Any side note on the changes made**
This change required quite a lot of cucumber test refactoring. CucumberWithProperites runner was
replaced by setting properties in scenarios. Embedded brokers and datastore are also started and
stopped with steps and not with before / after annotations.

This is basis for further stabilization of integration tests on travis and jenkins.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>
