### PR TITLE
Uninstall button in Devices state fix

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -12,11 +12,13 @@
 package org.eclipse.kapua.app.console.module.device.client.device.packages;
 
 import com.extjs.gxt.ui.client.Style.Scroll;
+import com.extjs.gxt.ui.client.data.ModelData;
 import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
 import com.extjs.gxt.ui.client.event.ComponentEvent;
 import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.widget.ContentPanel;
 import com.extjs.gxt.ui.client.widget.TabPanel;
@@ -233,7 +235,11 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
 
                 Boolean exitStatus = packageInstallDialog.getExitStatus();
                 if (exitStatus == null) { // Operation Aborted
-                    uninstallButton.setEnabled(false);
+                    if (installedPackageTab.getTreeGrid() != null) {
+                        installedPackageTab.getTreeGrid().getSelectionModel().fireEvent(Events.SelectionChange, 
+                                new SelectionChangedEvent<ModelData>(installedPackageTab.getTreeGrid().getSelectionModel(), 
+                                        installedPackageTab.getTreeGrid().getSelectionModel().getSelectedItems()));
+                    } 
                     return;
                 } else {
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
@@ -176,4 +176,8 @@ public class DeviceTabPackagesInstalled extends TabItem {
             dirty = false;
         }
     }
+
+    public TreeGrid<ModelData> getTreeGrid() {
+        return treeGrid;
+    }
 }


### PR DESCRIPTION
Brief description of the PR.
Uninstall button in Devices state fix

**Related Issue**
This PR fixes/closes #2113 

**Description of the solution adopted**
After closing the _packageInstallDialog_ without any changes made, _SelectionChangedEvent_ is triggered and the state of the _uninstallButton_ set is correctly, depending on the selection of the packages. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>