### PR TITLE
Changed Java version in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,4 +96,4 @@ jobs:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java9-installer


### PR DESCRIPTION
**Brief description of the PR:**
I have changed Oracle Java version from "java8" to "java9" because of failures in current Travis build.

**Related Issue**
There is no releated issue, but if you look at curent Kapua Travis ([develop branch](https://travis-ci.org/eclipse/kapua/builds/442141522)) build, there are some errors regarding this matter.
As stated above, I have changed java version from 8 to 9 and my Travis build is now OK. 

**Description of the solution adopted**
I have changed java version from 8 to 9. 

**Screenshot No. 1 (My Travis build):**
![screen shot 2018-10-17 at 12 52 04](https://user-images.githubusercontent.com/15121999/47081630-81442480-d20b-11e8-994c-53408853a49c.png)

**Screenshot No. 2 (Local "clean install"):**
<img width="692" alt="screen shot 2018-10-17 at 13 06 26" src="https://user-images.githubusercontent.com/15121999/47082281-58bd2a00-d20d-11e8-8bdc-e09ce48dcbe2.png">

**Any side note on the changes made**
/

Signed-off-by: Leonardo Gaube <leonardo.gaube@comtrade.com>