### PR TITLE
Fix for Query button not working consistently

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -118,10 +118,13 @@ public class AssetTabItem extends TabItem {
 
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtHeader> se) {
+                resultsTable.setMetrics(metricsTable.getSelectedMetrics());
                 if (!se.getSelection().isEmpty()) {
                     queryButton.enable();
+                    resultsTable.getDateRangeSelector().enable();
                 } else {
                     queryButton.disable();
+                    resultsTable.getDateRangeSelector().disable();
                 }
             }
         });

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
@@ -98,10 +98,13 @@ public class DeviceTabItem extends TabItem {
 
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtHeader> se) {
+                resultsTable.setMetrics(metricsTable.getSelectedMetrics());
                 if (!se.getSelection().isEmpty()) {
                     queryButton.enable();
+                    resultsTable.getDateRangeSelector().enable();
                 } else {
                     queryButton.disable();
+                    resultsTable.getDateRangeSelector().disable();
                 }
             }
         });

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
@@ -89,6 +89,7 @@ public class ResultsTable extends LayoutContainer {
     private Button exportButton;
     private DateRangeSelector dateRangeSelector;
     private Button queryButton;
+    private List<GwtHeader> metrics;
 
     public ResultsTable(GwtSession currentSession, Button queryButton) {
         this.currentSession = currentSession;
@@ -106,6 +107,8 @@ public class ResultsTable extends LayoutContainer {
         add(tableContainer);
 
         loader.load();
+        queryButton.disable();
+        dateRangeSelector.disable();
     }
 
     private void initResultsTable() {
@@ -178,7 +181,7 @@ public class ResultsTable extends LayoutContainer {
 
             @Override
             public void handleEvent(BaseEvent baseEvent) {
-                if (queryButton != null) {
+                if (queryButton != null && !metrics.isEmpty()) {
                     queryButton.enable();
                 }
             }
@@ -345,5 +348,17 @@ public class ResultsTable extends LayoutContainer {
 
     public void clearTable() {
         resultsGrid.getStore().removeAll();
+    }
+
+    public List<GwtHeader> getMetrics() {
+        return metrics;
+    }
+
+    public void setMetrics(List<GwtHeader> metrics) {
+        this.metrics = metrics;
+    }
+
+    public DateRangeSelector getDateRangeSelector() {
+        return dateRangeSelector;
     }
 }

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
@@ -97,10 +97,13 @@ public class TopicsTabItem extends TabItem {
 
             @Override
             public void selectionChanged(SelectionChangedEvent<GwtHeader> se) {
+                resultsTable.setMetrics(metricsTable.getSelectedMetrics());
                 if (!se.getSelection().isEmpty()) {
                     queryButton.enable();
+                    resultsTable.getDateRangeSelector().enable();
                 } else {
                     queryButton.disable();
+                    resultsTable.getDateRangeSelector().disable();
                 }
             }
         });


### PR DESCRIPTION
Brief description of the PR.
Fix for Query button not working consistently

**Related Issue**
This PR fixes/closes #2096 

**Description of the solution adopted**
Added additional check for selected metrics when setting the state of _queryButton_ after loading the _ResultsTable_ and set the _queryButton_ state on initial render . 
Also, set the state of _dateRangeSelector_ on the _ResultsTable_  to depend of the selected metrics - if there aren't any it will be disabled. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>