### PR TITLE
Changed java version back to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
         - bash <(curl -s https://codecov.io/bash)
     - stage: test
       script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.setadsftings.hotswap=true -Dgroups='org.eclipse.kapua.test.junit.JUnitTests' verify
+        - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dgroups='org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
 
 # The following upgrades Java during the build in
@@ -96,4 +96,4 @@ jobs:
 addons:
   apt:
     packages:
-      - oracle-java9-installer
+      - oracle-java8-installer


### PR DESCRIPTION
**Brief description of the PR.**
I have reverted the java version back to 8 since there was a problem with jdk9 (missing dependencies). It looks like that there was a glitch in Travis yesterday so everything should be fine now.
Also I have fixed syntax errors in the same file.

**Related Issues:**
/

**Screenshot (passing Travis build):**
![screen shot 2018-10-18 at 13 04 16](https://user-images.githubusercontent.com/15121999/47150208-33482300-d2d6-11e8-8e54-068ea6d262e1.png)

**Any side note on the changes made**
/

Signed-off-by: Leonardo Gaube <leonardo.gaube@comtrade.com>