### PR TITLE
Disabled operationRebootDelayField on creation

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
@@ -162,6 +162,7 @@ public class PackageInstallDialog extends TabbedDialog {
             operationRebootDelayField.setEmptyText("0");
             operationRebootDelayField.setAllowDecimals(false);
             operationRebootDelayField.setAllowNegative(false);
+            operationRebootDelayField.disable();
             operationOptionsForm.add(operationRebootDelayField, formData);
         }
 


### PR DESCRIPTION
Brief description of the PR.
Disabled operationRebootDelayField on creation. 

**Related Issue**
This PR fixes/closes #2112 

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>