### PR TITLE
Solving problem with javadoc:jar test steep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,7 @@ jobs:
       script:
         - $M2_HOME/bin/mvn -v
         - $M2_HOME/bin/mvn -B -f external/pom.xml install
-        - $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -DskipTests install
-    - stage: test
-      script:
-        - $M2_HOME/bin/mvn -B javadoc:jar
+        - $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -DskipTests clean install
     - stage: test
       script:
         - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @default" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' verify
@@ -87,6 +84,9 @@ jobs:
       script:
         - ./travis.sh $M2_HOME/bin/mvn -B -Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dgroups='org.eclipse.kapua.test.junit.JUnitTests' verify
         - bash <(curl -s https://codecov.io/bash)
+    - stage: test
+      script:
+        - $M2_HOME/bin/mvn -B -DskipTests install javadoc:jar
 
 # The following upgrades Java during the build in
 # order to work around an older Java 8 compiler issue


### PR DESCRIPTION
Trying to fix issue with failing test step where javadocs are generated, but sometimes fail because artifacts are downloaded from remote repository.
  
**Related Issue**
This helps fixing issue _2088_

**Description of the solution adopted**
Moved javadoc:jar to last task on test stage of Travis.
I also added install to this step, so that artifacts are not downloaded.
I am not sure why artifacts from cache are not used.

Added clean to build, as cache is used and it should be cleaned between builds.

**Screenshots**
Not applicable.

**Any side note on the changes made**
Change is effecting only travis.yml configuration file for Travis CI.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>