### PR TITLE
Workaround to start Jetty on OpenJDK 1.8.0_191

### DIFF
--- a/assembly/jetty-base/docker/Dockerfile
+++ b/assembly/jetty-base/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN useradd -u 1000 -g 0 -d '/var/opt/jetty' -s '/sbin/nologin' jetty && \
     curl -Ls @jetty.url@ -o /tmp/jetty.tar.gz && \
     tar --strip=1 -xzf /tmp/jetty.tar.gz -C /opt/jetty && \
     rm -f /tmp/jetty.tar.gz && \
+    ln -s /opt/jetty/modules/alpn-impl/alpn-1.8.0_181.mod /opt/jetty/modules/alpn-impl/alpn-1.8.0_191.mod && \
     cd /var/opt/jetty && \
     java -jar /opt/jetty/start.jar --approve-all-licenses --create-startd --add-to-start=http,http2,https,jsp,jstl,websocket,deploy,logging-logback,jmx,ssl,stats && \
     chown -R 1000:0 /opt/jetty /var/opt/jetty && \


### PR DESCRIPTION
The current version of Jetty, 9.4.12.v20180830, is not compatible with OpenJDK 1.8.0_191, which is automatically installed in java-base docker container since it's the latest OpenJDK version published. This workaround fixes this, but we should remove it as soon as we update to the latest Jetty that will cover such issue.

**Related Issue**
This PR fixes #2139 
Also related to eclipse/jetty.project#3028

**Description of the solution adopted**
Just a symlink from an existing ALPN module to the one Jetty asks for

**Screenshots**
N/A

**Any side note on the changes made**
This is only a workaround, and should be removed as soon as we update Jetty to a version that supports 1.8.0_191.