### PR TITLE
set no_user option when connection does not have reserved user

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -238,6 +238,8 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
                 }
             } else if (gwtUser.getId().equals(selectedDeviceConnection.getReservedUserId())) {
                 reservedUserCombo.setValue(gwtUser);
+            } else {
+                reservedUserCombo.setValue(NO_USER);
             }
         }
         formPanel.clearDirtyFields();


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added else statement when selected connection does not have reserved user.

**Related Issue**
This PR fixes issue #2068 

**Description of the solution adopted**
A more detailed description of the changes made to solve/close one or more issues.
If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
