### PR TITLE
Remove HTTP2 modules from Jetty startup

### DIFF
--- a/assembly/jetty-base/docker/Dockerfile
+++ b/assembly/jetty-base/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN useradd -u 1000 -g 0 -d '/var/opt/jetty' -s '/sbin/nologin' jetty && \
     tar --strip=1 -xzf /tmp/jetty.tar.gz -C /opt/jetty && \
     rm -f /tmp/jetty.tar.gz && \
     cd /var/opt/jetty && \
-    java -jar /opt/jetty/start.jar --approve-all-licenses --create-startd --add-to-start=http,http2,https,jsp,jstl,websocket,deploy,logging-logback,jmx,ssl,stats && \
+    java -jar /opt/jetty/start.jar --approve-all-licenses --create-startd --add-to-start=http,https,jsp,jstl,websocket,deploy,logging-logback,jmx,ssl,stats && \
     chown -R 1000:0 /opt/jetty /var/opt/jetty && \
     chmod -R g=u /opt/jetty /var/opt/jetty
 

--- a/assembly/jetty-base/entrypoint/run-jetty
+++ b/assembly/jetty-base/entrypoint/run-jetty
@@ -57,6 +57,7 @@ if [ "${KAPUA_DISABLE_SSL}" == "false" ]; then
 
 else
     rm -f ${JETTY_BASE}/start.d/https.ini
+    rm -f ${JETTY_BASE}/start.d/ssl.ini
 fi
 
 # Start Jetty


### PR DESCRIPTION
The current version of Jetty, 9.4.12.v20180830, is not compatible with OpenJDK 1.8.0_191, which is automatically installed in java-base docker container since it's the latest OpenJDK version published. The incompatibility lies specifically in the ALPN module, which is required from HTTP2 module. Since we're no actually make any specific use of such module, this PR disables it until a proper solution is found; an hint coming from the Jetty project maintainer suggests that we should move to OpenJDK 9+ where ALPN is bundled with the JDK (https://github.com/eclipse/jetty.project/issues/3028#issuecomment-432604515).

**Related Issue**
This PR fixes #2139 
Also related to eclipse/jetty.project#3028

**Description of the solution adopted**
The `http2` module has been removed from Jetty startup

**Screenshots**
N/A

**Any side note on the changes made**
This is only a short-term solution. When we will want to bring back HTTP2 in Jetty we may want to consider moving to OpenJDK 9+.