### PR TITLE
change date fields validators

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelector.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelector.java
@@ -13,6 +13,8 @@ package org.eclipse.kapua.app.console.module.api.client.ui.widget;
 
 import java.util.Date;
 
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+
 import com.extjs.gxt.ui.client.Style.HorizontalAlignment;
 import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
@@ -36,7 +38,6 @@ import com.extjs.gxt.ui.client.widget.menu.SeparatorMenuItem;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.user.client.Element;
-import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 
 public class DateRangeSelector extends LayoutContainer {
 
@@ -245,7 +246,6 @@ public class DateRangeSelector extends LayoutContainer {
         startDateField.setFieldLabel(MSGS.dataDateRangeStartDate());
         startDateField.setAllowBlank(false);
         startDateField.setValue(start);
-        startDateField.setEditable(false);
         startDateField.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         startDateField.setFormatValue(true);
         form.add(startDateField, formData);
@@ -263,7 +263,6 @@ public class DateRangeSelector extends LayoutContainer {
         endDateField.setFieldLabel(MSGS.dataDateRangeStopDate());
         endDateField.setAllowBlank(false);
         endDateField.setValue(end);
-        endDateField.setEditable(false);
         endDateField.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         endDateField.setFormatValue(true);
         form.add(endDateField, formData);
@@ -276,27 +275,38 @@ public class DateRangeSelector extends LayoutContainer {
         endTimeField.setDateValue(end);
         endTimeField.setEditable(false);
         form.add(endTimeField, formData);
+        startDateField.addListener(Events.OnBlur, new Listener<BaseEvent>() {
 
-        startDateField.setValidator(new Validator() {
+                @Override
+                public void handleEvent(BaseEvent be) {
+                   startDateField.setValidator(new Validator() {
+                    @Override
+                    public String validate(Field<?> field, String value) {
+                        if (startDateField.getValue().after(endDateField.getValue())) {
+                        return MSGS.dataDateRangeInvalidStartDate();
+                        }
+                        return null;
+                    }
+                 });
 
-            @Override
-            public String validate(Field<?> field, String value) {
-                if (startDateField.getValue().after(endDateField.getValue())) {
-                    return MSGS.dataDateRangeInvalidStartDate();
-                }
-                return null;
             }
         });
-        endDateField.setValidator(new Validator() {
+        endDateField.addListener(Events.OnBlur, new Listener<BaseEvent>() {
 
-            @Override
-            public String validate(Field<?> field, String value) {
-                if (endDateField.getValue().before(startDateField.getValue())) {
-                    return MSGS.dataDateRangeInvalidStopDate();
-                }
-                return null;
+                @Override
+                public void handleEvent(BaseEvent be) {
+                    endDateField.setValidator(new Validator() {
+                        @Override
+                        public String validate(Field<?> field, String value) {
+                            if (endDateField.getValue().before(startDateField.getValue())) {
+                                return MSGS.dataDateRangeInvalidStopDate();
+                            }
+                            return null;
+                        }
+                    });
             }
         });
+
         startTimeField.setValidator(new Validator() {
 
             @Override


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added new listener for checking values of date fields. Until now we had validators on that places which were doing validation of start and end date, but now we have that validators and validators for wrong date format and wrong input type.

**Related Issue**
This PR fixes issue #2090 
**Description of the solution adopted**
A more detailed description of the changes made to solve/close one or more issues.
If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
