### PR TITLE
set max length in package install and uninstall dialog

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
@@ -13,10 +13,13 @@ package org.eclipse.kapua.app.console.module.device.client.device.packages;
 
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.TabbedDialog;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaNumberField;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.device.management.packages.GwtPackageInstallRequest;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementServiceAsync;
 
 import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.Events;
@@ -25,13 +28,10 @@ import com.extjs.gxt.ui.client.widget.TabItem;
 import com.extjs.gxt.ui.client.widget.Text;
 import com.extjs.gxt.ui.client.widget.form.CheckBox;
 import com.extjs.gxt.ui.client.widget.form.FormPanel;
-import com.extjs.gxt.ui.client.widget.form.NumberField;
 import com.extjs.gxt.ui.client.widget.layout.FormData;
 import com.extjs.gxt.ui.client.widget.layout.FormLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
-import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementServiceAsync;
 
 public class PackageInstallDialog extends TabbedDialog {
 
@@ -53,7 +53,7 @@ public class PackageInstallDialog extends TabbedDialog {
     private FormPanel operationOptionsForm;
     private Text operationInfoText;
     private CheckBox operationRebootField;
-    private NumberField operationRebootDelayField;
+    private KapuaNumberField operationRebootDelayField;
 
     public PackageInstallDialog(String scopeId, String deviceId) {
         super();
@@ -155,7 +155,7 @@ public class PackageInstallDialog extends TabbedDialog {
 
             operationOptionsForm.add(operationRebootField, formData);
 
-            operationRebootDelayField = new NumberField();
+            operationRebootDelayField = new KapuaNumberField();
             operationRebootDelayField.setName("installRebootDelay");
             operationRebootDelayField.setFieldLabel(DEVICE_MSGS.packageInstallOperationTabRebootDelay());
             operationRebootDelayField.setToolTip(DEVICE_MSGS.devicePackageRebootDelayTooltip());
@@ -163,6 +163,9 @@ public class PackageInstallDialog extends TabbedDialog {
             operationRebootDelayField.setAllowDecimals(false);
             operationRebootDelayField.setAllowNegative(false);
             operationRebootDelayField.disable();
+            operationRebootDelayField.setMaxLength(5);
+            operationRebootDelayField.setMaxValue(65535);
+            operationRebootDelayField.setPropertyEditorType(Integer.class);
             operationOptionsForm.add(operationRebootDelayField, formData);
         }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageUninstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageUninstallDialog.java
@@ -14,23 +14,23 @@ package org.eclipse.kapua.app.console.module.device.client.device.packages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.SimpleDialog;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaNumberField;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeploymentPackage;
 import org.eclipse.kapua.app.console.module.device.shared.model.device.management.packages.GwtPackageUninstallRequest;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementServiceAsync;
 
 import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.widget.form.CheckBox;
 import com.extjs.gxt.ui.client.widget.form.FormPanel;
-import com.extjs.gxt.ui.client.widget.form.NumberField;
 import com.extjs.gxt.ui.client.widget.layout.FormData;
 import com.extjs.gxt.ui.client.widget.layout.FormLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
-import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementServiceAsync;
 
 public class PackageUninstallDialog extends SimpleDialog {
 
@@ -44,7 +44,7 @@ public class PackageUninstallDialog extends SimpleDialog {
 
     private FormPanel operationOptionsForm;
     private CheckBox operationReboot;
-    private NumberField operationRebootDelay;
+    private KapuaNumberField operationRebootDelay;
 
     public PackageUninstallDialog(String scopeId, String deviceId, GwtDeploymentPackage selectedDeploymentPackage) {
 
@@ -93,13 +93,16 @@ public class PackageUninstallDialog extends SimpleDialog {
             }
         });
 
-        operationRebootDelay = new NumberField();
+        operationRebootDelay = new KapuaNumberField();
         operationRebootDelay.setName("operationRebootDelay");
         operationRebootDelay.setFieldLabel(DEVICE_MSGS.deviceUnistallAsyncUninstallRebootDelay());
         operationRebootDelay.setEmptyText("0");
         operationRebootDelay.setAllowDecimals(false);
         operationRebootDelay.setAllowNegative(false);
         operationRebootDelay.disable();
+        operationRebootDelay.setMaxLength(5);
+        operationRebootDelay.setMaxValue(65535);
+        operationRebootDelay.setPropertyEditorType(Integer.class);
         operationOptionsForm.add(operationRebootDelay, formData);
 
         bodyPanel.add(operationOptionsForm);


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

set max values in reboot delay fields in Packages Install and Uninstall dialogs

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

max length reduced to 9

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

add property editor type for integer

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

change max length and max value for boot delay in Packages dialogs

Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
[e.g. Added max value and max length in Package Install and Uninstall dialogs

**Related Issue**
This PR fixes issues #2110 and #2116 

**Description of the solution adopted**
A more detailed description of the changes made to solve/close one or more issues.
If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
