### PR TITLE
Fix Exception Message with no Resource Bundle

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/KapuaException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaException.java
@@ -194,7 +194,7 @@ public class KapuaException extends Exception {
         }
     }
 
-    protected String getMessagePattern(Locale locale, KapuaErrorCode code) {
+    private String getMessagePattern(Locale locale, KapuaErrorCode code) {
         //
         // Load the message pattern from the bundle
         String messagePattern = null;
@@ -205,6 +205,7 @@ public class KapuaException extends Exception {
         } catch (MissingResourceException mre) {
             // log the failure to load a message bundle
             logger.warn("Could not load Exception Messages Bundle for Locale {}", locale);
+            return null;
         }
 
         return messagePattern;

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaRuntimeException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaRuntimeException.java
@@ -189,7 +189,7 @@ public class KapuaRuntimeException extends RuntimeException {
         }
     }
 
-    protected String getMessagePattern(Locale locale, KapuaErrorCode code) {
+    private String getMessagePattern(Locale locale, KapuaErrorCode code) {
         //
         // Load the message pattern from the bundle
         String messagePattern = null;
@@ -200,6 +200,7 @@ public class KapuaRuntimeException extends RuntimeException {
         } catch (MissingResourceException mre) {
             // log the failure to load a message bundle
             logger.warn("Could not load Exception Messages Bundle for Locale {}", locale);
+            return null;
         }
 
         return messagePattern;

--- a/service/api/src/main/java/org/eclipse/kapua/MissingKapuaErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/MissingKapuaErrorCodes.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua;
+
+public enum MissingKapuaErrorCodes implements KapuaErrorCode {
+
+    NOT_EXISTING
+
+}

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
@@ -42,4 +42,16 @@ public class KapuaExceptionTest {
         }, "abc", 1);
         Assert.assertEquals("Error: abc,1", ke.getMessage());
     }
+
+    @Test
+    public void missingBundleTest() {
+        KapuaExceptionWithoutBundle exceptionWithoutBundle = new KapuaExceptionWithoutBundle(KapuaErrorCodes.ILLEGAL_STATE, "param1", "param2");
+        Assert.assertEquals("Error: param1,param2", exceptionWithoutBundle.getMessage());
+    }
+
+    @Test
+    public void missingErrorCodeTest() {
+        KapuaException exceptionWithoutCode = new KapuaException(MissingKapuaErrorCodes.NOT_EXISTING, "param1", "param2");
+        Assert.assertEquals("Error: param1,param2", exceptionWithoutCode.getMessage());
+    }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionWithoutBundle.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionWithoutBundle.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua;
+
+public class KapuaExceptionWithoutBundle extends KapuaException {
+    public KapuaExceptionWithoutBundle(KapuaErrorCode code) {
+        super(code);
+    }
+
+    public KapuaExceptionWithoutBundle(KapuaErrorCode code, Object... arguments) {
+        super(code, arguments);
+    }
+
+    public KapuaExceptionWithoutBundle(KapuaErrorCode code, Throwable cause, Object... arguments) {
+        super(code, cause, arguments);
+    }
+
+    @Override
+    protected String getKapuaErrorMessagesBundle() {
+        return "non-existing-file.properties";
+    }
+}


### PR DESCRIPTION
This PR fixes the swallowed stack trace when an exception is thrown and no Resource Bundle is available to get the proper message format

**Related Issue**
This PR fixes #1338 

**Description of the solution adopted**
When the resource bundle cannot be found, `null` is returned anyway instead of just showing the warning message. This makes the `getLocalizedMessage()` to properly handle the missing value and continue instead of exiting due to the exception.

**Screenshots**
N/A

**Any side note on the changes made**
N/A