### PR TITLE
Rest tests jetty port configuration

### DIFF
--- a/qa/src/test/resources/features/rest/user/RestUser.feature
+++ b/qa/src/test/resources/features/rest/user/RestUser.feature
@@ -19,14 +19,14 @@ Feature: REST API tests for User
 
   Scenario: Start Jetty server for all scenarios
 
-    Given Start Jetty Server on host "127.0.0.1" at port "8080"
+    Given Start Jetty Server on host "127.0.0.1" at port "8085"
 
 
   Scenario: Simple Jetty with rest-api war
     Jetty with api.war is already started, now just login with sys user and
     call GET on users to retrieve list of all users.
 
-    Given Server with host "127.0.0.1" on port "8080"
+    Given Server with host "127.0.0.1" on port "8085"
     When REST POST call at "/v1/authentication/user" with JSON "{"password": "kapua-password", "username": "kapua-sys"}"
     Then REST response containing AccessToken
     When REST GET call at "/v1/_/users?offset=0&limit=50"
@@ -50,7 +50,7 @@ Feature: REST API tests for User
     Fetch user in that account and keep his ID.
     Login into account B and search for user from previous step with its ID.
 
-    Given Server with host "127.0.0.1" on port "8080"
+    Given Server with host "127.0.0.1" on port "8085"
 # ------ Service steps ------
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure account service


### PR DESCRIPTION
Changed port of embedded Jetty server because it interfered with jenkins CI server port on
local jenkins builds.

**Related Issue**
This is not directly connected to any specific issue.

**Description of the solution adopted**
It is already provided in rest test scenarios to define port of embedded jetty server that is used to test Kapua rest api. It is only changed in scenarios, so that regular 8080 port is not used, but 8085 instead.

**Screenshots**
Not applicable.

**Any side note on the changes made**
It might interfere with some other configuration, but it will alway be problem to define free port. I didn't want to resolve to automatic free port search, because of transparency of tests.