### PR TITLE
Fix for Submit button not enabled on ComboBox value change

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
@@ -92,7 +92,7 @@ public class CredentialEditDialog extends CredentialAddDialog {
             credentialStatus.setToolTip(MSGS.dialogAddStatusApiKeyTooltip());
         } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
             passwordTooltip.show();
-            DialogUtils.resizeDialog(CredentialEditDialog.this, 400, 335);
+            DialogUtils.resizeDialog(CredentialEditDialog.this, 400, 355);
             expirationDate.setToolTip(MSGS.dialogAddFieldExpirationDatePasswordTooltip());
             credentialStatus.setToolTip(MSGS.dialogAddStatusPasswordTooltip());
         }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -146,8 +146,8 @@ public class AccessRoleAddDialog extends EntityAddEditDialog {
 
             @Override
             public void handleEvent(BaseEvent be) {
-                formPanel.fireEvent(Events.OnClick);
-                }
+                AccessRoleAddDialog.this.formPanel.fireEvent(Events.OnClick);
+            }
         });
 
         GWT_ROLE_SERVICE.findAll(currentSession.getAccountId(), new AsyncCallback<List<GwtRole>>() {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -12,6 +12,9 @@
 package org.eclipse.kapua.app.console.module.device.client.connection;
 
 import com.extjs.gxt.ui.client.data.ListLoadResult;
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.form.CheckBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
@@ -75,6 +78,14 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         FormLayout layoutSecurityOptions = new FormLayout();
         layoutSecurityOptions.setLabelWidth(Constants.LABEL_WIDTH_DEVICE_FORM);
 
+        Listener<BaseEvent> comboBoxListener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                formPanel.fireEvent(Events.OnClick);
+            }
+        };
+
         lastUserField = new LabelField();
         lastUserField.setName("connectionUserLastUserField");
         lastUserField.setLabelSeparator(":");
@@ -113,6 +124,7 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         reservedUserCombo.setDisplayField("username");
         reservedUserCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={username}>{username}</div></tpl>");
         reservedUserCombo.setValueField("id");
+        reservedUserCombo.addListener(Events.Select, comboBoxListener);
 
         if (currentSession.hasPermission(UserSessionPermission.read())) {
             // Device User
@@ -238,6 +250,7 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
                 }
             } else if (gwtUser.getId().equals(selectedDeviceConnection.getReservedUserId())) {
                 reservedUserCombo.setValue(gwtUser);
+                break;
             } else {
                 reservedUserCombo.setValue(NO_USER);
             }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -12,6 +12,9 @@
 package org.eclipse.kapua.app.console.module.device.client.device;
 
 import com.extjs.gxt.ui.client.Style.Scroll;
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
@@ -126,6 +129,14 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         // formPanel.setStyleAttribute("padding-bottom", "0px");
         // formPanel.setLayout(new FlowLayout());
 
+        Listener<BaseEvent> comboBoxListener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                DeviceAddDialog.this.formPanel.fireEvent(Events.OnClick);
+            }
+        };
+
         // Device general info fieldset
         FieldSet fieldSet = new FieldSet();
         FormLayout layout = new FormLayout();
@@ -190,6 +201,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
             groupCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={groupName}>{groupName}</div></tpl>");
             groupCombo.setValueField("id");
             groupCombo.setEmptyText(DEVICE_MSGS.deviceFilteringPanelGroupEmptyText());
+            groupCombo.addListener(Events.Select, comboBoxListener);
 
             gwtGroupService.findAll(currentSession.getSelectedAccountId(), new AsyncCallback<List<GwtGroup>>() {
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -132,7 +132,7 @@ public class DeviceEditDialog extends DeviceAddDialog {
 
                         @Override
                         public void onSuccess(GwtGroup result) {
-                            groupCombo.setValue(result);
+                            setAccessGroup();
                         }
                     });
                 } else {
@@ -149,6 +149,20 @@ public class DeviceEditDialog extends DeviceAddDialog {
 
             // Other data
             optlock.setValue(device.getOptlock());
+        }
+        formPanel.clearDirtyFields();
+    }
+
+    private void setAccessGroup() {
+        for (GwtGroup gwtGroup : groupCombo.getStore().getModels()) {
+            if (gwtGroup.getId() == null) {
+                if (selectedDevice.getGroupId() == null) {
+                    groupCombo.setValue(gwtGroup);
+                }
+            } else if (gwtGroup.getId().equals(selectedDevice.getGroupId())) {
+                groupCombo.setValue(gwtGroup);
+                break;
+            }
         }
         formPanel.clearDirtyFields();
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -11,6 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.client.device.tag;
 
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
@@ -101,6 +104,13 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
         submitButton.disable();
 
         FormPanel formPanel = new FormPanel(FORM_LABEL_WIDTH);
+        Listener<BaseEvent> comboBoxListener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                DeviceTagAddDialog.this.formPanel.fireEvent(Events.OnClick);
+            }
+        };
 
         //
         // Tags
@@ -116,6 +126,7 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
         tagsCombo.setTriggerAction(TriggerAction.ALL);
         tagsCombo.setDisplayField("tagName");
         tagsCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={tagName}>{tagName}</div></tpl>");
+        tagsCombo.addListener(Events.Select, comboBoxListener);
 
         GWT_TAG_SERVICE.findAll(selectedDevice.getScopeId(), new AsyncCallback<List<GwtTag>>() {
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -91,6 +91,14 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         HorizontalPanel endsOnPanel = new HorizontalPanel();
         endsOnPanel.setStyleAttribute("padding", "4px 0px 4px 0px");
 
+        Listener<BaseEvent> listener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                formPanel.fireEvent(Events.OnClick);
+            }
+        };
+
         triggerName.setAllowBlank(false);
         triggerName.setMaxLength(255);
         triggerName.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleScheduleNameLabel());
@@ -103,13 +111,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         startsOn.setEmptyText(JOB_MSGS.dialogAddScheduleDatePlaceholder());
         startsOn.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         startsOn.setToolTip(JOB_MSGS.dialogAddScheduleStartsOnTooltip());
-        startsOn.getDatePicker().addListener(Events.Select, new Listener<BaseEvent>() {
-
-            @Override
-            public void handleEvent(BaseEvent be) {
-                formPanel.fireEvent(Events.OnClick);
-            }
-        });
+        startsOn.getDatePicker().addListener(Events.Select, listener);
         startsOnLabel.setText("* " + JOB_MSGS.dialogAddScheduleStartsOnLabel());
         startsOnLabel.setWidth(FORM_LABEL_WIDTH);
         startsOnLabel.setStyleAttribute("padding", "0px 91px 0px 0px");
@@ -125,6 +127,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         startsOnTime.setEmptyText(JOB_MSGS.dialogAddScheduleTimePlaceholder());
         startsOnTime.setToolTip(JOB_MSGS.dialogAddScheduleStartsOnTimeTooltip());
         startsOnTime.setTriggerAction(TriggerAction.ALL);
+        startsOnTime.addListener(Events.Select, listener);
         startsOnPanel.add(startsOnTime);
         mainPanel.add(startsOnPanel);
 
@@ -136,13 +139,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         endsOnLabel.setText("* " + JOB_MSGS.dialogAddScheduleEndsOnLabel());
         endsOnLabel.setWidth(FORM_LABEL_WIDTH);
         endsOnLabel.setStyleAttribute("padding", "0px 96px 0px 0px");
-        endsOn.getDatePicker().addListener(Events.Select, new Listener<BaseEvent>() {
-
-            @Override
-            public void handleEvent(BaseEvent be) {
-                formPanel.fireEvent(Events.OnClick);
-            }
-        });
+        endsOn.getDatePicker().addListener(Events.Select, listener);
         endsOnPanel.add(endsOnLabel);
         endsOnPanel.add(endsOn);
 
@@ -154,6 +151,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         endsOnTime.setEmptyText(JOB_MSGS.dialogAddScheduleTimePlaceholder());
         endsOnTime.setToolTip(JOB_MSGS.dialogAddScheduleEndsOnTimeTooltip());
         endsOnTime.setTriggerAction(TriggerAction.ALL);
+        endsOnTime.addListener(Events.Select, listener);
         endsOnPanel.add(endsOnTime);
         mainPanel.add(endsOnPanel);
 


### PR DESCRIPTION
Brief description of the PR.
Fix for Submit button not enabled on ComboBox value change

**Related Issue**
This PR fixes/closes #2146 , #2018 , #1965  

**Description of the solution adopted**
If the clicked comboBox value was outside the `formPanel`, the `submitButton `was not enabled as the previously created listeners had no effect there. 
Added Select listeners on problematic ComboBoxes that trigger `onClick() `event of the `formPanel`.
Made changes on the _DeviceEditDialog_ when setting the `groupCombo` value, because the previous implementation didn't set the `value `and the `originalValue `of the field correctly so there were some problems with enabling/disabling the `submitButton`. 

**Screenshots**
_None_

**Any side note on the changes made**
None

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>