### PR TITLE
Fixing Jenkins Rest API tests of Kapua

### DIFF
--- a/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/DBHelper.java
+++ b/qa-steps/src/main/java/org/eclipse/kapua/qa/steps/DBHelper.java
@@ -75,7 +75,7 @@ public class DBHelper {
                         server = Server.createTcpServer("-tcpAllowOthers", "-tcpPort", "9092").start();
                         logger.info("H2 TCP and Web server started.");
                     } catch (SQLException e) {
-                        logger.warn("Error setting up H2 web server.");
+                        logger.warn("Error setting up H2 web server.", e);
                     }
                 }
             }

--- a/qa/src/test/java/org/eclipse/kapua/rest/RunRestUserTest.java
+++ b/qa/src/test/java/org/eclipse/kapua/rest/RunRestUserTest.java
@@ -35,5 +35,6 @@ import org.junit.runner.RunWith;
 @CucumberProperty(key="commons.db.connection.port", value="9092")
 @CucumberProperty(key="commons.db.name", value="mem:kapua")
 @CucumberProperty(key="test.h2.server", value="true")
+@CucumberProperty(key="h2.bindAddress", value="127.0.0.1")
 public class RunRestUserTest {
 }

--- a/qa/src/test/resources/features/rest/user/RestUser.feature
+++ b/qa/src/test/resources/features/rest/user/RestUser.feature
@@ -19,14 +19,14 @@ Feature: REST API tests for User
 
   Scenario: Start Jetty server for all scenarios
 
-    Given Start Jetty Server on host "127.0.0.1" at port "8080"
+    Given Start Jetty Server on host "127.0.0.1" at port "8085"
 
 
   Scenario: Simple Jetty with rest-api war
     Jetty with api.war is already started, now just login with sys user and
     call GET on users to retrieve list of all users.
 
-    Given Server with host "127.0.0.1" on port "8080"
+    Given Server with host "127.0.0.1" on port "8085"
     When REST POST call at "/v1/authentication/user" with JSON "{"password": "kapua-password", "username": "kapua-sys"}"
     Then REST response containing AccessToken
     When REST GET call at "/v1/_/users?offset=0&limit=50"
@@ -50,7 +50,7 @@ Feature: REST API tests for User
     Fetch user in that account and keep his ID.
     Login into account B and search for user from previous step with its ID.
 
-    Given Server with host "127.0.0.1" on port "8080"
+    Given Server with host "127.0.0.1" on port "8085"
 # ------ Service steps ------
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure account service


### PR DESCRIPTION
Minor changes for making Jenkins test run successfully for Rest API.

**Related Issue**
This PR in not related to any issue.

**Description of the solution adopted**
Embedded H2 database is run locally for rest api tests and exposes TCP connection on local host.
For that it had to be configured in a way to specify localhost as a connection endpoint and not host itself, which is default.

**Screenshots**
Not applicable.

**Any side note on the changes made**
This is just a code part that needs changes, build process on Jenkins has to be changed to. Changes provide similar approach to tests as is used on Travis CI.
