### PR TITLE
Changed the field type for the Command Output

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -21,6 +21,7 @@ import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.MessageBoxEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.widget.ContentPanel;
+import com.extjs.gxt.ui.client.widget.Label;
 import com.extjs.gxt.ui.client.widget.LayoutContainer;
 import com.extjs.gxt.ui.client.widget.MessageBox;
 import com.extjs.gxt.ui.client.widget.button.Button;
@@ -31,7 +32,6 @@ import com.extjs.gxt.ui.client.widget.form.FormPanel;
 import com.extjs.gxt.ui.client.widget.form.FormPanel.Encoding;
 import com.extjs.gxt.ui.client.widget.form.FormPanel.Method;
 import com.extjs.gxt.ui.client.widget.form.HiddenField;
-import com.extjs.gxt.ui.client.widget.form.TextArea;
 import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.extjs.gxt.ui.client.widget.layout.FitLayout;
 import com.extjs.gxt.ui.client.widget.layout.FormData;
@@ -89,7 +89,7 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
     private Button resetButton;
 
     private LayoutContainer commandOutput;
-    private TextArea result;
+    private Label result;
 
     protected boolean resetProcess;
 
@@ -135,6 +135,7 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
         add(devicesCommandPanel);
         layout(true);
         result.setStyleAttribute("border-top", "0px none");
+        result.setStyleAttribute("white-space", "pre-wrap");
         Element el = result.getElement();
         Node node0 = el.getChild(0);
         if (node0.getNodeType() == Node.ELEMENT_NODE) {
@@ -231,7 +232,7 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
 
                     String output = htmlResult.substring(outputMessageStartIndex, outputMessageEndIndex);
 
-                    result.setValue(KapuaSafeHtmlUtils.htmlUnescape(output));
+                    result.setText(KapuaSafeHtmlUtils.htmlUnescape(output));
                     commandInput.unmask();
                 }
             }
@@ -296,7 +297,7 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
             @Override
             public void componentSelected(ButtonEvent ce) {
                 if (formPanel.isValid()) {
-                    result.clear();
+                    result.clearState();
                     commandInput.mask(DEVICE_MSGS.deviceCommandExecuting());
                     accountField.setValue(selectedEntity.getScopeId());
                     deviceIdField.setValue(selectedEntity.getId());
@@ -338,14 +339,11 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
 
     private void initCommandOutput() {
         commandOutput = new LayoutContainer();
-        commandOutput.setBorders(false);
+        commandOutput.setBorders(true);
         commandOutput.setWidth("99.5%");
         commandOutput.setLayout(new FitLayout());
 
-        result = new TextArea();
-        result.setBorders(false);
-        result.setReadOnly(true);
-        result.setEmptyText(DEVICE_MSGS.deviceCommandNoOutput());
+        result = new Label();
         result.setBorders(false);
         commandOutput.add(result);
     }
@@ -366,7 +364,7 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
 
     private void clearAll() {
         formPanel.reset();
-        result.reset();
+        result.setText(DEVICE_MSGS.deviceCommandNoOutput());
     }
 
     // --------------------------------------------------------------------------------------


### PR DESCRIPTION
Brief description of the PR.
Changed the field type for the Command Output

**Related Issue**
This PR fixes/closes #2014 

**Description of the solution adopted**
Changed the field type from `TextArea` to `Label` for the result field, and set its properties.
Added border for the commandOutput  container.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>