### PR TITLE
Stop Endpoint Info fallback if there are Endpoints specified in scope

### DIFF
--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -62,6 +62,8 @@ public class EndpointInfoServiceImpl
     private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
     private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
+    private static final EndpointInfoFactory ENDPOINT_INFO_FACTORY = LOCATOR.getFactory(EndpointInfoFactory.class);
+
     public EndpointInfoServiceImpl() {
         super(EndpointInfoService.class.getName(), EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, EndpointEntityManagerFactory.getInstance(), EndpointInfoService.class, EndpointInfoFactory.class);
     }
@@ -180,6 +182,15 @@ public class EndpointInfoServiceImpl
             EndpointInfoListResult endpointInfoListResult = EndpointInfoDAO.query(em, query);
 
             if (endpointInfoListResult.isEmpty() && query.getScopeId() != null) {
+
+                // First check if there are any endpoint specified at all
+                EndpointInfoQuery totalQuery = ENDPOINT_INFO_FACTORY.newQuery(query.getScopeId());
+                long totalCount = EndpointInfoDAO.count(em, totalQuery);
+
+                if (totalCount != 0) {
+                    // if there are endpoints (even not matching the query), return the empty list
+                    return endpointInfoListResult;
+                }
 
                 KapuaId originalScopeId = query.getScopeId();
 

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
@@ -184,10 +185,7 @@ public class EndpointInfoServiceImpl
             if (endpointInfoListResult.isEmpty() && query.getScopeId() != null) {
 
                 // First check if there are any endpoint specified at all
-                EndpointInfoQuery totalQuery = ENDPOINT_INFO_FACTORY.newQuery(query.getScopeId());
-                long totalCount = EndpointInfoDAO.count(em, totalQuery);
-
-                if (totalCount != 0) {
+                if (countAllEndpointsInScope(em, query.getScopeId())){
                     // if there are endpoints (even not matching the query), return the empty list
                     return endpointInfoListResult;
                 }
@@ -228,6 +226,12 @@ public class EndpointInfoServiceImpl
             long endpointInfoCount = EndpointInfoDAO.count(em, query);
 
             if (endpointInfoCount == 0 && query.getScopeId() != null) {
+
+                // First check if there are any endpoint specified at all
+                if (countAllEndpointsInScope(em, query.getScopeId())) {
+                    // if there are endpoints (even not matching the query), return 0
+                    return endpointInfoCount;
+                }
 
                 KapuaId originalScopeId = query.getScopeId();
 
@@ -289,5 +293,11 @@ public class EndpointInfoServiceImpl
 
             throw new KapuaEntityUniquenessException(EndpointInfo.TYPE, uniquesFieldValues);
         }
+    }
+
+    private boolean countAllEndpointsInScope(EntityManager em, KapuaId scopeId) throws KapuaException {
+        EndpointInfoQuery totalQuery = ENDPOINT_INFO_FACTORY.newQuery(scopeId);
+        long totalCount = EndpointInfoDAO.count(em, totalQuery);
+        return totalCount != 0;
     }
 }


### PR DESCRIPTION
This PR changes the way `EndpointInfoServiceImpl` uses the fallback mechanism, reflecting on parent accounts only if the current one has no entries.

**Related Issue**
N/A

**Description of the solution adopted**
Before this one, when an Endpoint wasn't found in an account, the query was repeated for parent account, scaling up the hierarchy up to the root. This meant that a query could return no entries for a specific filter, even if there were endpoints available that didn't match the filter, and scale up the hierarchy.

Now, before activating the fallback mechanism, an additional query is performed to be sure that the current account contains no endpoints at all.

**Screenshots**
N/A

**Any side note on the changes made**
N/A