### PR TITLE
Child account name not in error state fix

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -319,7 +319,8 @@ public class AccountAddDialog extends EntityAddEditDialog {
                         cancelButton.enable();
                         if (cause instanceof GwtKapuaException) {
                             GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                            if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME) 
+                                    || gwtCause.getCode().equals(GwtKapuaErrorCode.ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT)) {
                                 accountNameField.markInvalid(gwtCause.getMessage());
                             } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.ILLEGAL_ARGUMENT) && gwtCause.getArguments()[0].equals("expirationDate")) {
                                 expirationDateField.markInvalid(MSGS.conflictingExpirationDate());


### PR DESCRIPTION
Brief description of the PR.
Child account name not in error state fix

**Related Issue**
This PR fixes/closes #2172 

**Description of the solution adopted**
Added a check for `GwtKapuaErrorCode.ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT)` in the `onFailure` method of the `AccountAddDialog` class. This check was added to the already existing _if block_ as one of the conditions for marking the `accountNameField` invalid.

**Screenshots**
_None_

**Any side note on the changes made**
_None_

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>