### PR TITLE
Fix swagger ui credentials plain key

### DIFF
--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -285,11 +285,6 @@
                                 </includes>
                             </resource>
                         </webResources>
-                        <!-- exclude slf4j-api and logback as the web container has to provide this -->
-                        <packagingExcludes>
-                            WEB-INF/lib/slf4j-api-*.jar,
-                            WEB-INF/lib/logback*.jar
-                        </packagingExcludes>
                     </configuration>
                 </plugin>
             </plugins>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -328,11 +328,6 @@
                             </includes>
                         </resource>
                     </webResources>
-                    <!-- exclude slf4j-api and logback as the web container has to provide this -->
-                    <packagingExcludes>
-                        WEB-INF/lib/slf4j-api-*.jar,
-                        WEB-INF/lib/logback*.jar
-                    </packagingExcludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
@@ -85,6 +85,7 @@ public interface CredentialCreator extends KapuaEntityCreator<Credential> {
      *
      * @param plainKey
      */
+    @ApiModelProperty(name = "credentialKey")
     void setCredentialPlainKey(String plainKey);
 
     @XmlElement(name = "expirationDate")


### PR DESCRIPTION
This PR fixes the name of `credentialKey` in `POST /credential` when browsing the API in SwaggerUI

**Related Issue**
This PR #2181

**Description of the solution adopted**
N/A

**Screenshots**
N/A

**Any side note on the changes made**
N/A