### PR TITLE
Role paging in Users fix

### DIFF
--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessRoleServiceImpl.java
@@ -146,27 +146,26 @@ public class GwtAccessRoleServiceImpl extends KapuaRemoteServiceServlet implemen
                     query.setSortCriteria(sortCriteria);
                     AccessRoleListResult accessRoleList = accessRoleService.query(query);
 
-                    if (!accessRoleList.isEmpty()) {
-                        totalLegnth = (int) accessRoleService.count(query);
-                    }
+                    totalLegnth = (int) accessRoleService.count(query);
+                    if (!accessRoleList.isEmpty()){
+                        for (AccessRole accessRole : accessRoleList.getItems()) {
+                            User createdByUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 
-                    for (AccessRole accessRole : accessRoleList.getItems()) {
-                        User createdByUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+                                @Override
+                                public User call() throws Exception {
+                                    return userService.find(scopeId, user.getCreatedBy());
+                                }
+                            });
+                            Role role = roleService.find(scopeId, accessRole.getRoleId());
 
-                            @Override
-                            public User call() throws Exception {
-                                return userService.find(scopeId, user.getCreatedBy());
+                            GwtAccessRole gwtAccessRole = KapuaGwtAuthorizationModelConverter.mergeRoleAccessRole(role, accessRole);
+
+                            if (createdByUser != null) {
+                                gwtAccessRole.setCreatedByName(createdByUser.getName());
                             }
-                        });
-                        Role role = roleService.find(scopeId, accessRole.getRoleId());
 
-                        GwtAccessRole gwtAccessRole = KapuaGwtAuthorizationModelConverter.mergeRoleAccessRole(role, accessRole);
-
-                        if (createdByUser != null) {
-                            gwtAccessRole.setCreatedByName(createdByUser.getName());
+                            gwtAccessRoles.add(gwtAccessRole);
                         }
-
-                        gwtAccessRoles.add(gwtAccessRole);
                     }
                 }
             } catch (Throwable t) {


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Role paging in Users fix

**Related Issue**
This PR fixes/closes #2174 

**Description of the solution adopted**
The `totalLegnth` property in `GwtAccessRoleServiceImpl` class is now always set to int value of `accessRoleService.count(query)`. This is one of the properties the `EntityGrid's` `entityLoader` needs for correct result display. 

**Screenshots**
_None_

**Any side note on the changes made**
Added `accessRoleList.isEmpty()` check in `findByUserId()` method of `GwtAccessRoleServiceImpl` class . 
