### PR TITLE
Corner case in job schedule add dialog

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -225,6 +225,16 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
             }
         }
 
+        endsOn.addListener(Events.OnBlur, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                if (endsOn.getValue() == null) {
+                    endsOnTime.clearInvalid();
+                }
+            }
+        });
+
         if (endsOnTime.getValue() != null) {
             if (endsOn.getValue() == null) {
                 endsOn.setAllowBlank(false);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -223,6 +223,8 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
                     endsOnTime.clearInvalid();
                 }
             }
+        } else {
+            endsOnTime.setAllowBlank(true);
         }
 
         endsOn.addListener(Events.OnBlur, new Listener<BaseEvent>() {


### PR DESCRIPTION
Brief description of the PR.
Fixed 2 corner cases for validation fields in JobScheduleAdd dialog.

**Related Issue**
This PR is fix for #2147 

**Description of the solution adopted**
Just added one listener and  else part in which allow blank for end time field.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
