### PR TITLE
set max length to 50 for account name

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -126,7 +126,7 @@ public class AccountAddDialog extends EntityAddEditDialog {
         fieldSet.add(accountNameLabel, accountFieldsetFormData);
 
         accountNameField.setAllowBlank(false);
-        accountNameField.setMaxLength(255);
+        accountNameField.setMaxLength(50);
         accountNameField.setName("accountName");
         accountNameField.setFieldLabel("* " + MSGS.accountFormName());
         accountNameField.setValidator(new TextFieldValidator(accountNameField, FieldType.SIMPLE_NAME));


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Max length for account name reduced to 50.

**Related Issue**
This PR fixes issue #851 

**Description of the solution adopted**
/

**Screenshots**
/
**Any side note on the changes made**
/