### PR TITLE
"Upload and Apply" tooltip position change

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
@@ -214,4 +214,8 @@ public class FileUploadDialog extends Dialog {
         status.show();
         formPanel.submit();
     }
+
+    public FileUploadField getFileUploadField() {
+        return fileUploadField;
+    }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
@@ -430,7 +430,13 @@ public class DeviceConfigSnapshots extends LayoutContainer {
             });
 
             fileUpload.setHeading(MSGS.upload());
-            fileUpload.setToolTip(DEVICE_MSGS.deviceSnapshotFileTooltip());
+            fileUpload.addListener(Events.Render, new Listener<BaseEvent>() {
+
+                @Override
+                public void handleEvent(BaseEvent be) {
+                    fileUpload.getFileUploadField().setToolTip(DEVICE_MSGS.deviceSnapshotFileTooltip());
+                }
+            });
             fileUpload.show();
         }
     }


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
"Upload and Apply" tooltip position change

**Related Issue**
This PR fixes/closes #2216 

**Description of the solution adopted**
Changed the position of the tooltip from the `fileUploadDialog ` itself to the `fileUploadField` on it.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
