### PR TITLE
Modified header message for Target delete dialog

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -34,7 +34,7 @@ public class JobTargetDeleteDialog extends EntityDeleteDialog {
 
     @Override
     public String getHeaderMessage() {
-        return JOB_MSGS.dialogDeleteTargetHeader(gwtJobTarget.getJobTargetId());
+        return JOB_MSGS.dialogDeleteTargetHeader(gwtJobTarget.getClientId());
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Modified header message for Target delete dialog.

**Related Issue**
This PR fixes/closes #2220 

**Description of the solution adopted**
Set `clientID` instead of the `jobTargetId` in the dialog header.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
