### PR TITLE
 Snapshot upload error message handling

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/FileServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/FileServlet.java
@@ -15,6 +15,7 @@ import org.apache.commons.fileupload.FileItem;
 import org.eclipse.kapua.DeviceMenagementException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaIllegalAccessException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.KapuaUnauthenticatedException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.setting.ConsoleSetting;
@@ -126,6 +127,10 @@ public class FileServlet extends KapuaHttpServlet {
         } catch (DeviceMenagementException edme) {
             logger.error("Device menagement exception", edme);
             resp.sendError(404, edme.getMessage());
+            return;
+        } catch (KapuaIllegalArgumentException kiae) {
+            logger.error("Illegal argument exception", kiae);
+            resp.sendError(400, kiae.getArgumentName());
             return;
         } catch (Exception e) {
             logger.error("Generic error", e);

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
@@ -39,6 +39,8 @@ import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldValidator;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldValidator.FieldType;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.api.shared.service.GwtSecurityTokenService;
 import org.eclipse.kapua.app.console.module.api.shared.service.GwtSecurityTokenServiceAsync;
@@ -105,7 +107,10 @@ public class FileUploadDialog extends Dialog {
                     int endIndex = htmlResponse.indexOf("</pre>");
                     if (startIdx != -1 && endIndex != -1) {
                         errMsg = htmlResponse.substring(startIdx + 5, endIndex);
-                    }
+                        if (("xmlDeviceConfig").equals(errMsg)) {
+                            errMsg = MSGS.fileUploadInvalidShapshotFailure();
+                        }
+                    } 
                     MessageBox.alert(MSGS.error(), MSGS.fileUploadFailure() + ": " + errMsg, null);
                 }
                 hide();
@@ -118,6 +123,8 @@ public class FileUploadDialog extends Dialog {
         fieldSet.setLayout(layout);
 
         fileUploadField = new FileUploadField();
+        fileUploadField.setAccept("application/xml");
+        fileUploadField.setValidator(new TextFieldValidator(fileUploadField, FieldType.SNAPSHOT_FILE));
         fileUploadField.setAllowBlank(false);
         fileUploadField.setName("uploadedFile");
         fileUploadField.setFieldLabel("File");

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
@@ -60,7 +60,7 @@ public class TextFieldValidator implements Validator {
 
         SIMPLE_NAME("simple_name", "^[a-zA-Z0-9\\-]{3,}$"),
         DEVICE_CLIENT_ID("device_client_id", "^[a-zA-Z0-9\\:\\_\\-]{1,}$"),
-        SNAPSHOT_FILE("snapshot_file", "^([a-zA-Z0-9\\:\\_\\-\\\\]){1,64}(\\.xml)"),
+        SNAPSHOT_FILE("snapshot_file", "^([a-zA-Z0-9\\:\\_\\-\\\\]){1,255}(\\.xml)"),
         NAME("name", "^[a-zA-Z0-9\\_\\-]{3,}$"),
         NAME_SPACE("name_space", "^[a-zA-Z0-9\\ \\_\\-]{3,}$"),
         PASSWORD("password", "^.*(?=.{12,})(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!\\~\\|]).*$"),

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
@@ -60,6 +60,7 @@ public class TextFieldValidator implements Validator {
 
         SIMPLE_NAME("simple_name", "^[a-zA-Z0-9\\-]{3,}$"),
         DEVICE_CLIENT_ID("device_client_id", "^[a-zA-Z0-9\\:\\_\\-]{1,}$"),
+        SNAPSHOT_FILE("snapshot_file", "^([a-zA-Z0-9\\:\\_\\-\\\\]){1,64}(\\.xml)"),
         NAME("name", "^[a-zA-Z0-9\\_\\-]{3,}$"),
         NAME_SPACE("name_space", "^[a-zA-Z0-9\\ \\_\\-]{3,}$"),
         PASSWORD("password", "^.*(?=.{12,})(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=!\\~\\|]).*$"),

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -477,6 +477,7 @@ filteringPanelReset=Reset
 
 fileUploadSuccess=File was successfully uploaded.
 fileUploadFailure=File upload failed
+fileUploadInvalidShapshotFailure=the file provided is not a valid Kura Snapshot. Please review the file and try again.
 
 commandExecutionFailure=Command execution failed
 

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -42,6 +42,8 @@ phoneRegexMsg=Phone number is shorter than 6 digits or it contains invalid chara
 
 editableComboRegexMsg=Invalid provided value. Must be a number or '0 - Disabled'.
 
+snapshot_fileRegexMsg=Only files with .xml extension are allowed. Name can contain only alphanumeric characters combined with dash and/or underscore.
+
 dateRangeValidatorAfter1Jan1970=This date comes before Thursday January 01 01:00:00 CET 1970
 dateRangeValidatorEndDateBeforeStartDate=The end date comes before the start date. If not set the start date is automatically set to the current date.
 

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -211,7 +211,7 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
                     XmlUtil.unmarshal(xmlDeviceConfig, DeviceConfigurationImpl.class),
                     timeout);
         } catch (JAXBException | XMLStreamException | FactoryConfigurationError | SAXException e) {
-            throw new KapuaIllegalArgumentException(xmlDeviceConfig, xmlDeviceConfig);
+            throw new KapuaIllegalArgumentException("xmlDeviceConfig", xmlDeviceConfig);
         }
     }
 


### PR DESCRIPTION
Brief description of the PR.
 Snapshot upload error message handling.

**Related Issue**
This PR fixes/closes #2175 

**Description of the solution adopted**
Handled exception thrown when the file chosen for upload is not a valid Snapshot.
Added a new regex for fileUploadField.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
