### PR TITLE
change error message for assigning unexisting role to the User

### DIFF
--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
@@ -52,7 +52,7 @@ roleTabSubjectGridTitle=Subject
 dialogAddHeader=Create new role
 dialogAddInfo=Create a new role. 
 dialogAddConfirmation=Permission successfully added.
-dialogAddError=Role creation failed: {0}
+dialogAddError=Role assigning failed: {0}
 
 dialogAddFieldName=Name
 dialogAddFieldNameTooltip=The name of the new role. It must be unique.


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Changed error message for assigning unexisting role 

**Related Issue**
This PR fixes issue #2223 

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/