### PR TITLE
Fix wrong byte[] type and NPE in JsonDeviceManagementRequests

### DIFF
--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
@@ -25,6 +25,8 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Map;
 
+import io.swagger.annotations.ApiModelProperty;
+
 /**
  * Kapua {@link Message} {@link Payload} definition.
  *
@@ -60,6 +62,7 @@ public interface KapuaPayload extends Payload {
      */
     @XmlElement(name = "body")
     @XmlJavaTypeAdapter(BinaryXmlAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public byte[] getBody();
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequestsJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequestsJson.java
@@ -15,6 +15,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
+
 import org.eclipse.kapua.app.api.resources.v1.resources.marker.JsonSerializationFixed;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.EntityId;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
@@ -41,7 +42,7 @@ import javax.ws.rs.core.MediaType;
 /**
  * @see JsonSerializationFixed
  */
-@Api(value = "Devices", authorizations = {@Authorization(value = "kapuaAccessToken")})
+@Api(value = "Devices", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/devices/{deviceId}/requests")
 public class DeviceManagementRequestsJson extends AbstractKapuaResource implements JsonSerializationFixed {
 
@@ -60,8 +61,8 @@ public class DeviceManagementRequestsJson extends AbstractKapuaResource implemen
      * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
      */
     @POST
-    @Consumes({MediaType.APPLICATION_JSON})
-    @Produces({MediaType.APPLICATION_JSON})
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
     @ApiOperation(nickname = "deviceRequestSend", value = "Sends a request", notes = "Sends a request message to a device", response = DeviceCommandOutput.class)
     public JsonGenericResponseMessage sendRequest(
             @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
@@ -82,15 +83,18 @@ public class DeviceManagementRequestsJson extends AbstractKapuaResource implemen
         genericRequestMessage.setChannel(jsonGenericRequestMessage.getChannel());
 
         GenericRequestPayload kapuaDataPayload = new GenericRequestPayloadImpl();
-        kapuaDataPayload.setBody(jsonGenericRequestMessage.getPayload().getBody());
 
-        jsonGenericRequestMessage.getPayload().getMetrics().forEach(
-                jsonMetric -> {
-                    String name = jsonMetric.getName();
-                    Object value = ObjectValueConverter.fromString(jsonMetric.getValue(), jsonMetric.getValueType());
+        if (jsonGenericRequestMessage.getPayload() != null) {
+            kapuaDataPayload.setBody(jsonGenericRequestMessage.getPayload().getBody());
 
-                    kapuaDataPayload.getMetrics().put(name, value);
-                });
+            jsonGenericRequestMessage.getPayload().getMetrics().forEach(
+                    jsonMetric -> {
+                        String name = jsonMetric.getName();
+                        Object value = ObjectValueConverter.fromString(jsonMetric.getValue(), jsonMetric.getValueType());
+
+                        kapuaDataPayload.getMetrics().put(name, value);
+                    });
+        }
 
         genericRequestMessage.setPayload(kapuaDataPayload);
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/StreamsJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/StreamsJson.java
@@ -15,6 +15,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
+
 import org.eclipse.kapua.app.api.resources.v1.resources.marker.JsonSerializationFixed;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
 import org.eclipse.kapua.app.api.resources.v1.resources.model.data.JsonKapuaDataMessage;
@@ -35,7 +36,7 @@ import javax.ws.rs.core.Response;
 /**
  * @see JsonSerializationFixed
  */
-@Api(value = "Streams", authorizations = {@Authorization(value = "kapuaAccessToken")})
+@Api(value = "Streams", authorizations = { @Authorization(value = "kapuaAccessToken") })
 @Path("{scopeId}/streams")
 public class StreamsJson extends AbstractKapuaResource implements JsonSerializationFixed {
 
@@ -90,7 +91,7 @@ public class StreamsJson extends AbstractKapuaResource implements JsonSerializat
      */
     @POST
     @Path("messages")
-    @Consumes({MediaType.APPLICATION_JSON})
+    @Consumes({ MediaType.APPLICATION_JSON })
     @ApiOperation(nickname = "streamPublish", value = "Publishes a fire-and-forget message", notes = "Publishes a fire-and-forget message to a topic composed of [account-name] / [client-id] / [semtantic-parts]")
     public Response publish(
             @ApiParam(value = "The ScopeId of the device", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
@@ -109,15 +110,18 @@ public class StreamsJson extends AbstractKapuaResource implements JsonSerializat
         kapuaDataMessage.setChannel(jsonKapuaDataMessage.getChannel());
 
         KapuaDataPayload kapuaDataPayload = new KapuaDataPayloadImpl();
-        kapuaDataPayload.setBody(jsonKapuaDataMessage.getPayload().getBody());
 
-        jsonKapuaDataMessage.getPayload().getMetrics().forEach(
-                jsonMetric -> {
-                    String name = jsonMetric.getName();
-                    Object value = ObjectValueConverter.fromString(jsonMetric.getValue(), jsonMetric.getValueType());
+        if (jsonKapuaDataMessage.getPayload() != null) {
+            kapuaDataPayload.setBody(jsonKapuaDataMessage.getPayload().getBody());
 
-                    kapuaDataPayload.getMetrics().put(name, value);
-                });
+            jsonKapuaDataMessage.getPayload().getMetrics().forEach(
+                    jsonMetric -> {
+                        String name = jsonMetric.getName();
+                        Object value = ObjectValueConverter.fromString(jsonMetric.getValue(), jsonMetric.getValueType());
+
+                        kapuaDataPayload.getMetrics().put(name, value);
+                    });
+        }
 
         kapuaDataMessage.setPayload(kapuaDataPayload);
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
@@ -25,6 +25,8 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.annotations.ApiModelProperty;
+
 @XmlRootElement(name = "payload")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 public class JsonKapuaPayload {
@@ -69,6 +71,7 @@ public class JsonKapuaPayload {
 
     @XmlElement(name = "body")
     @XmlJavaTypeAdapter(BinaryXmlAdapter.class)
+    @ApiModelProperty(dataType = "string")
     public byte[] getBody() {
         return body;
     }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
@@ -64,6 +64,7 @@ public interface Certificate extends KapuaNamedEntity {
 
     @XmlElement(name = "signature")
     @XmlJavaTypeAdapter(BinaryXmlAdapter.class)
+    @ApiModelProperty(dataType = "string")
     byte[] getSignature();
 
     void setSignature(byte[] signature);


### PR DESCRIPTION
This PR makes SwaggerUI to serialize `byte[]` fields in models to `string` instead of `string[]`. Also, it fixes a `NullPointerException` in `DeviceManagementRequestsJson` and `StreamsJson`.

**Related Issue**
This PR fixes #2238, fixes #2239 