### PR TITLE
Fix for failing travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 before_script:
   - export M2_HOME=$PWD/maven
   - export PATH=${M2_HOME}/bin:${PATH}
-  - export MAVEN_OPTS=-Xmx256m
+  - export MAVEN_OPTS=-Xmx512m
   - hash -r
 
 jobs:


### PR DESCRIPTION
Brief description of the PR.
I increased max heap for java wile running maven.

**Related Issue**
This PR fixes/closes _2243_

**Description of the solution adopted**
Travis build itself was failing because java run out of heap. I incised Xmx to 512m.
I tested it locally and it worked. I am not sure why was max set to such a low value?

**Screenshots**
Not applicable.

**Any side note on the changes made**
This effects only Travis build. Most PR were failing because of this issue.
I hope this one won't :)