### PR TITLE
Disabled unnecessary events on Job start/stop dialogs

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStartDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStartDialog.java
@@ -39,6 +39,7 @@ public class JobStartDialog extends SimpleDialog {
 
     @Override
     public void createBody() {
+        formPanel.disableEvents(true);
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStopDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStopDialog.java
@@ -39,6 +39,7 @@ public class JobStopDialog extends SimpleDialog {
 
     @Override
     public void createBody() {
+        formPanel.disableEvents(true);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Disabled unnecessary events on Job start/stop dialogs.

**Related Issue**
This PR fixes/closes #2232 

**Description of the solution adopted**
Disabled formPanel events inherited from the ActionDialog on `JobStartDialog `and `JobStopDialog`. These events disabled the Submit button depending on the dirty state of the inputs. As there are no inputs on those dialogs, they are not needed here and the submit button should always be enabled. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_