### PR TITLE
Set Remote IP column in Device grid

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGrid.java
@@ -178,7 +178,7 @@ public class DeviceGrid extends EntityGrid<GwtDevice> {
         column.setHidden(true);
         columnConfigs.add(column);
 
-        column = new ColumnConfig("connectionIp", DEVICE_MSGS.deviceTableIpAddress(), 100);
+        column = new ColumnConfig("clientIp", DEVICE_MSGS.deviceTableRemoteIpAddress(), 100);
         column.setSortable(false);
         column.setHidden(true);
         columnConfigs.add(column);

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -54,6 +54,7 @@ deviceTableOsVersion=Os Version
 deviceTableJvmVersion=Jvm Version
 deviceTableOsgiVersion=OSGi Version
 deviceTableIpAddress=IP Address
+deviceTableRemoteIpAddress=Remote IP
 deviceTableImei=IMEI
 deviceTableImsi=IMSI
 deviceTableIccid=ICCID


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Set Remote IP column in Device grid. 
This column now displays the `clientIp` property instead the `connectionIp` shown previously.

**Related Issue**
This PR fixes/closes #2228 

**Screenshots**
_None_

**Any side note on the changes made**
_None_