### PR TITLE
Updated CreatedBy/ModifiedBy grid properties

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountGrid.java
@@ -31,6 +31,7 @@ import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountSer
 import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountServiceAsync;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.ModifiedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -142,6 +143,7 @@ public class AccountGrid extends EntityGrid<GwtAccount> {
         configs.add(column);
 
         column = new ColumnConfig("modifiedByName", ACCOUNT_MSGS.accountTableModifiedBy(), 130);
+        column.setRenderer(new ModifiedByNameCellRenderer<GwtAccount>());
         column.setAlignment(HorizontalAlignment.CENTER);
         configs.add(column);
 

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
@@ -77,9 +77,8 @@ public class AccountChildUserGrid extends EntityGrid<GwtUser> {
                 if (query.getScopeId() == null) {
                     callback.onSuccess(new BasePagingLoadResult<GwtUser>(new ArrayList<GwtUser>()));
                 } else {
-                    GWT_USER_SERVICE.query((PagingLoadConfig) loadConfig,
-                            query,
-                            callback);
+                    GWT_USER_SERVICE.getUsersForAccount((PagingLoadConfig) loadConfig, query,
+                            currentSession.getSelectedAccountId(), callback);
                 }
             }
         };

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
@@ -28,6 +28,7 @@ import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.color.Color;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -156,7 +157,8 @@ public class AccountChildUserGrid extends EntityGrid<GwtUser> {
         columnConfig.setRenderer(setExpirationDate);
         columnConfigs.add(columnConfig);
 
-        columnConfig = new ColumnConfig("createdBy", MSGS.gridUserColumnHeaderCreatedBy(), 200);
+        columnConfig = new ColumnConfig("createdByName", MSGS.gridUserColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new CreatedByNameCellRenderer<GwtUser>());
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("createdOnFormatted", MSGS.gridUserColumnHeaderCreatedOn(), 200);

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/CreatedByNameCellRenderer.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/CreatedByNameCellRenderer.java
@@ -12,7 +12,7 @@
 package org.eclipse.kapua.app.console.module.api.client.ui.grid;
 
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
-import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityModel;
+import org.eclipse.kapua.app.console.module.api.shared.model.GwtEntityModel;
 
 import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.grid.ColumnData;
@@ -20,7 +20,7 @@ import com.extjs.gxt.ui.client.widget.grid.Grid;
 import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.google.gwt.core.client.GWT;
 
-public class CreatedByNameCellRenderer<M extends GwtUpdatableEntityModel> implements GridCellRenderer<M> {
+public class CreatedByNameCellRenderer<M extends GwtEntityModel> implements GridCellRenderer<M> {
 
     private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
 

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/CreatedByNameCellRenderer.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/CreatedByNameCellRenderer.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.api.client.ui.grid;
+
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityModel;
+
+import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.grid.ColumnData;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
+import com.google.gwt.core.client.GWT;
+
+public class CreatedByNameCellRenderer<M extends GwtUpdatableEntityModel> implements GridCellRenderer<M> {
+
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
+
+    @Override
+    public Object render(M model, String property, ColumnData config, int rowIndex, int colIndex, ListStore<M> store,
+            Grid<M> grid) {
+        return model.getCreatedByName() != null ? model.getCreatedByName() : CMSGS.notAvailable();
+    }
+}

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/ModifiedByNameCellRenderer.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/ModifiedByNameCellRenderer.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.api.client.ui.grid;
+
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityModel;
+
+import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.grid.ColumnData;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
+import com.google.gwt.core.client.GWT;
+
+public class ModifiedByNameCellRenderer<M extends GwtUpdatableEntityModel> implements GridCellRenderer<M> {
+
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
+
+    @Override
+    public Object render(M model, String property, ColumnData config, int rowIndex, int colIndex, ListStore<M> store,
+            Grid<M> grid) {
+        return model.getModifiedByName() != null ? model.getModifiedByName() : CMSGS.notAvailable();
+    }
+}

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -105,6 +105,7 @@ alwaysPassed=Always Passed
 sometimesFailed=Sometimes Failed
 alwaysFailed=Currently Down
 noData=No Data
+notAvailable=N/A
 isDefault = Is Default
 isNotDefault = Is Not Default
 unknown=Unknown

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
@@ -29,6 +29,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.color.Color;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.ModifiedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.util.DateUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -179,6 +180,7 @@ public class CredentialGrid extends EntityGrid<GwtCredential> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("modifiedByName", CREDENTIAL_MSGS.gridCredentialColumnHeaderModifiedBy(), 200);
+        columnConfig.setRenderer(new ModifiedByNameCellRenderer<GwtCredential>());
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
@@ -14,9 +14,14 @@ package org.eclipse.kapua.app.console.module.authorization.client.group;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
+import com.extjs.gxt.ui.client.widget.grid.ColumnData;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -35,6 +40,8 @@ public class GroupGrid extends EntityGrid<GwtGroup> {
 
     private static final GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
     private static final ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
+
     private GwtGroupQuery query;
     private GroupToolbarGrid toolbar;
 
@@ -86,6 +93,13 @@ public class GroupGrid extends EntityGrid<GwtGroup> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("userName", MSGS.gridGroupColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new GridCellRenderer<GwtGroup>() {
+
+            @Override
+            public Object render(GwtGroup gwtGroup, String property, ColumnData config, int rowIndex, int colIndex, ListStore<GwtGroup> store, Grid<GwtGroup> grid) {
+                return gwtGroup.getUserName() != null ? gwtGroup.getUserName() : CMSGS.notAvailable();
+            }
+        });
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
@@ -14,14 +14,11 @@ package org.eclipse.kapua.app.console.module.authorization.client.group;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
-import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
-import com.extjs.gxt.ui.client.widget.grid.ColumnData;
-import com.extjs.gxt.ui.client.widget.grid.Grid;
-import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -92,14 +89,8 @@ public class GroupGrid extends EntityGrid<GwtGroup> {
         columnConfig = new ColumnConfig("createdOnFormatted", MSGS.gridGroupColumnHeaderCreatedOn(), 200);
         columnConfigs.add(columnConfig);
 
-        columnConfig = new ColumnConfig("userName", MSGS.gridGroupColumnHeaderCreatedBy(), 200);
-        columnConfig.setRenderer(new GridCellRenderer<GwtGroup>() {
-
-            @Override
-            public Object render(GwtGroup gwtGroup, String property, ColumnData config, int rowIndex, int colIndex, ListStore<GwtGroup> store, Grid<GwtGroup> grid) {
-                return gwtGroup.getUserName() != null ? gwtGroup.getUserName() : CMSGS.notAvailable();
-            }
-        });
+        columnConfig = new ColumnConfig("createdByName", MSGS.gridGroupColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new CreatedByNameCellRenderer<GwtGroup>());
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
@@ -18,6 +18,7 @@ import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.ModifiedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
@@ -91,6 +92,7 @@ public class RoleGrid extends EntityGrid<GwtRole> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("modifiedByName", ROLE_MSGS.gridRoleColumnHeaderModifiedBy(), 200);
+        columnConfig.setRenderer(new ModifiedByNameCellRenderer<GwtRole>());
         columnConfigs.add(columnConfig);
 
         return columnConfigs;

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
@@ -23,6 +23,7 @@ import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
@@ -118,6 +119,7 @@ public class RolePermissionGrid extends EntityGrid<GwtRolePermission> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("createdByName", ROLE_MSGS.gridRolePermissionColumnHeaderCreatedBy(), 100);
+        columnConfig.setRenderer(new CreatedByNameCellRenderer<GwtRolePermission>());
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
@@ -23,6 +23,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
@@ -114,6 +115,7 @@ public class UserTabPermissionGrid extends EntityGrid<GwtAccessPermission> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("createdByName", PERMISSION_MSGS.gridAccessRoleColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new CreatedByNameCellRenderer<GwtAccessPermission>());
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
@@ -19,6 +19,7 @@ import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
@@ -92,8 +93,9 @@ public class UserTabAccessRoleGrid extends EntityGrid<GwtAccessRole> {
         columnConfig = new ColumnConfig("createdOnFormatted", MSGS.gridRoleColumnHeaderCreatedOn(), 200);
         columnConfigs.add(columnConfig);
 
-        columnConfig = new ColumnConfig("createdByName", MSGS.gridRoleColumnHeaderCreatedBy(), 200);
+        columnConfig = new ColumnConfig("createdByName", MSGS.gridRoleColumnHeaderGrantedBy(), 200);
         columnConfig.setSortable(false);
+        columnConfig.setRenderer(new CreatedByNameCellRenderer<GwtAccessRole>());
         columnConfigs.add(columnConfig);
 
         return columnConfigs;

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessRoleServiceImpl.java
@@ -148,12 +148,12 @@ public class GwtAccessRoleServiceImpl extends KapuaRemoteServiceServlet implemen
 
                     totalLegnth = (int) accessRoleService.count(query);
                     if (!accessRoleList.isEmpty()){
-                        for (AccessRole accessRole : accessRoleList.getItems()) {
+                        for (final AccessRole accessRole : accessRoleList.getItems()) {
                             User createdByUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 
                                 @Override
                                 public User call() throws Exception {
-                                    return userService.find(scopeId, user.getCreatedBy());
+                                    return userService.find(accessRole.getScopeId(), accessRole.getCreatedBy());
                                 }
                             });
                             Role role = roleService.find(scopeId, accessRole.getRoleId());

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
@@ -142,7 +142,7 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
 
                 for (Group g : groups.getItems()) {
                     GwtGroup gwtGroup = KapuaGwtAuthorizationModelConverter.convertGroup(g);
-                    gwtGroup.setUserName(usernameMap.get(g.getCreatedBy().toCompactId()));
+                    gwtGroup.setCreatedByName(usernameMap.get(g.getCreatedBy().toCompactId()));
                     gwtGroupList.add(gwtGroup);
                 }
             }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroup.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroup.java
@@ -30,12 +30,4 @@ public class GwtGroup extends GwtUpdatableEntityModel {
     public String toString() {
         return getGroupName();
     }
-
-    public String getUserName() {
-        return get("userName");
-    }
-
-    public void setUserName(String userName) {
-        set("userName", userName);
-    }
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRolePermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRolePermission.java
@@ -11,10 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authorization.shared.model;
 
-import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityModel;
+import org.eclipse.kapua.app.console.module.api.shared.model.GwtEntityModel;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtPermission.GwtAction;
 
-public class GwtRolePermission extends GwtUpdatableEntityModel {
+public class GwtRolePermission extends GwtEntityModel {
 
     private static final long serialVersionUID = 6331197556606146242L;
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRolePermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRolePermission.java
@@ -11,10 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authorization.shared.model;
 
-import org.eclipse.kapua.app.console.module.api.shared.model.GwtEntityModel;
+import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityModel;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtPermission.GwtAction;
 
-public class GwtRolePermission extends GwtEntityModel {
+public class GwtRolePermission extends GwtUpdatableEntityModel {
 
     private static final long serialVersionUID = 6331197556606146242L;
 

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
@@ -20,6 +20,7 @@ gridRoleColumnHeaderId=Id
 gridRoleColumnHeaderName=Name
 gridRoleColumnHeaderCreatedBy=Created By
 gridRoleColumnHeaderModifiedBy=Modified By
+gridRoleColumnHeaderGrantedBy=Granted By
 gridRoleColumnHeaderCreatedOn=Created On
 gridRoleColumnHeaderModifiedOn=Modified On
 

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointGrid.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointGrid.java
@@ -18,6 +18,7 @@ import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -87,6 +88,7 @@ public class EndpointGrid extends EntityGrid<GwtEndpoint> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("createdByName", MSGS.gridEndpointColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new CreatedByNameCellRenderer<GwtEndpoint>());
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
@@ -14,14 +14,10 @@ package org.eclipse.kapua.app.console.module.job.client;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
-import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
-import com.extjs.gxt.ui.client.widget.grid.ColumnData;
-import com.extjs.gxt.ui.client.widget.grid.Grid;
-import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
@@ -40,7 +36,6 @@ import java.util.List;
 public class JobGrid extends EntityGrid<GwtJob> {
 
     private static final ConsoleJobMessages MSGS = GWT.create(ConsoleJobMessages.class);
-    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
 
     private static final GwtJobServiceAsync GWT_JOB_SERVICE = GWT.create(GwtJobService.class);
 
@@ -94,15 +89,8 @@ public class JobGrid extends EntityGrid<GwtJob> {
         columnConfig = new ColumnConfig("description", MSGS.gridJobColumnHeaderDescription(), 400);
         columnConfigs.add(columnConfig);
 
-        columnConfig = new ColumnConfig("userName", MSGS.gridJobColumnHeaderCreatedBy(), 200);
-        columnConfig.setRenderer(new GridCellRenderer<GwtJob>() {
-
-            @Override
-            public Object render(GwtJob gwtJob, String property, ColumnData config, int rowIndex, int colIndex,
-                    ListStore<GwtJob> store, Grid<GwtJob> grid) {
-                return gwtJob.getUserName() != null ? gwtJob.getUserName() : CMSGS.notAvailable();
-            }
-        });
+        columnConfig = new ColumnConfig("createdByName", MSGS.gridJobColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new CreatedByNameCellRenderer<GwtJob>());
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
@@ -14,9 +14,14 @@ package org.eclipse.kapua.app.console.module.job.client;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
+import com.extjs.gxt.ui.client.widget.grid.ColumnData;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
@@ -35,6 +40,7 @@ import java.util.List;
 public class JobGrid extends EntityGrid<GwtJob> {
 
     private static final ConsoleJobMessages MSGS = GWT.create(ConsoleJobMessages.class);
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
 
     private static final GwtJobServiceAsync GWT_JOB_SERVICE = GWT.create(GwtJobService.class);
 
@@ -89,6 +95,14 @@ public class JobGrid extends EntityGrid<GwtJob> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("userName", MSGS.gridJobColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new GridCellRenderer<GwtJob>() {
+
+            @Override
+            public Object render(GwtJob gwtJob, String property, ColumnData config, int rowIndex, int colIndex,
+                    ListStore<GwtJob> store, Grid<GwtJob> grid) {
+                return gwtJob.getUserName() != null ? gwtJob.getUserName() : CMSGS.notAvailable();
+            }
+        });
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -91,7 +91,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
                 // Converto to GWT entity
                 for (Job j : jobs.getItems()) {
                     GwtJob gwtJob = KapuaGwtJobModelConverter.convertJob(j);
-                    gwtJob.setUserName(usernameMap.get(j.getCreatedBy().toCompactId()));
+                    gwtJob.setCreatedByName(usernameMap.get(j.getCreatedBy().toCompactId()));
                     gwtJobs.add(gwtJob);
                 }
             }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJob.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJob.java
@@ -53,13 +53,4 @@ public class GwtJob extends GwtUpdatableEntityModel implements IsSerializable {
     public void setJobXmlDefinition(String xmlJobDefinition) {
         set("jobXmlDefinition", xmlJobDefinition);
     }
-
-    public String getUserName() {
-        return get("userName");
-    }
-
-    public void setUserName(String userName) {
-        set("userName", userName);
-    }
-
 }

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
@@ -14,15 +14,11 @@ package org.eclipse.kapua.app.console.module.tag.client;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
-import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
-import com.extjs.gxt.ui.client.widget.grid.ColumnData;
-import com.extjs.gxt.ui.client.widget.grid.Grid;
-import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -40,7 +36,6 @@ import java.util.List;
 public class TagGrid extends EntityGrid<GwtTag> {
 
     private static final ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
-    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
 
     private TagToolbarGrid toolbar;
 
@@ -101,15 +96,8 @@ public class TagGrid extends EntityGrid<GwtTag> {
         columnConfig = new ColumnConfig("createdOnFormatted", MSGS.gridTagColumnHeaderCreatedOn(), 200);
         columnConfigs.add(columnConfig);
 
-        columnConfig = new ColumnConfig("userName", MSGS.gridTagColumnHeaderCreatedBy(), 200);
-        columnConfig.setRenderer(new GridCellRenderer<GwtTag>() {
-
-            @Override
-            public Object render(GwtTag gwtTag, String property, ColumnData config, int rowIndex, int colIndex,
-                    ListStore<GwtTag> store, Grid<GwtTag> grid) {
-                return gwtTag.getUserName() != null ? gwtTag.getUserName() : CMSGS.notAvailable();
-            }
-        });
+        columnConfig = new ColumnConfig("createdByName", MSGS.gridTagColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new CreatedByNameCellRenderer<GwtTag>());
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
@@ -14,10 +14,15 @@ package org.eclipse.kapua.app.console.module.tag.client;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
+import com.extjs.gxt.ui.client.widget.grid.ColumnData;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -35,6 +40,8 @@ import java.util.List;
 public class TagGrid extends EntityGrid<GwtTag> {
 
     private static final ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
+
     private TagToolbarGrid toolbar;
 
     protected static final GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
@@ -95,6 +102,14 @@ public class TagGrid extends EntityGrid<GwtTag> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("userName", MSGS.gridTagColumnHeaderCreatedBy(), 200);
+        columnConfig.setRenderer(new GridCellRenderer<GwtTag>() {
+
+            @Override
+            public Object render(GwtTag gwtTag, String property, ColumnData config, int rowIndex, int colIndex,
+                    ListStore<GwtTag> store, Grid<GwtTag> grid) {
+                return gwtTag.getUserName() != null ? gwtTag.getUserName() : CMSGS.notAvailable();
+            }
+        });
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -146,7 +146,7 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
 
                 for (Tag g : tags.getItems()) {
                     GwtTag gwtTag = KapuaGwtTagModelConverter.convertTag(g);
-                    gwtTag.setUserName(usernameMap.get(g.getCreatedBy().toCompactId()));
+                    gwtTag.setCreatedByName(usernameMap.get(g.getCreatedBy().toCompactId()));
                     gwtTagList.add(gwtTag);
                 }
             }

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTag.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTag.java
@@ -30,12 +30,4 @@ public class GwtTag extends GwtUpdatableEntityModel {
     public String toString() {
         return getTagName();
     }
-
-    public String getUserName() {
-        return get("userName");
-    }
-
-    public void setUserName(String userName) {
-        set("userName", userName);
-    }
 }

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGrid.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGrid.java
@@ -27,6 +27,7 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.color.Color;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.ModifiedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
@@ -162,6 +163,7 @@ public class UserGrid extends EntityGrid<GwtUser> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("modifiedByName", USER_MSGS.gridUserColumnHeaderModifiedBy(), 200);
+        columnConfig.setRenderer(new ModifiedByNameCellRenderer<GwtUser>());
         columnConfigs.add(columnConfig);
 
         return columnConfigs;

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/service/GwtUserService.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/service/GwtUserService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -96,4 +96,6 @@ public interface GwtUserService extends RemoteService {
     public ListLoadResult<GwtGroupedNVPair> getUserDescription(String shortScopeId, String shortUserId) throws GwtKapuaException;
 
     PagingLoadResult<GwtUser> getUsersForRole(PagingLoadConfig pagingLoadConfig, GwtAccessRoleQuery query) throws GwtKapuaException;
+
+    public PagingLoadResult<GwtUser> getUsersForAccount(PagingLoadConfig loadConfig, GwtUserQuery gwtUserQuery, String accountId) throws GwtKapuaException;
 }


### PR DESCRIPTION
Brief description of the PR.
Updated CreatedBy/ModifiedBy grid properties

**Related Issue**
This PR fixes/closes #2207 

**Description of the solution adopted**
- Set _N/A_ as the value displayed on the grid when the true value is hidden from the logged in user.
- Replaced the _Created By_ property in Users->Roles grid with _Granted By_ property and added the necessary implementation in the `GwtAccessRoleServiceImpl` class. 
- Added new `getUsersForAccount()` method to `GwtUserServiceImpl `class that returns results displayed on the Child Accounts -> Users grid. This method uses two accountIds:  `accountId` of the currently selected account for listing Users and another `currentSession.getSelectedAccountId()`  used for setting the _Created By_ property for each individual User. This method replaced the previously used `query` method of the same class that used only `accountId` for both queries and as a result hid some of the values from the currently logged user.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
