### PR TITLE
Mark invalid combo box field when tag is deleted

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -83,6 +83,8 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
                     GwtKapuaException gwtCause = (GwtKapuaException) cause;
                     if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
                         tagsCombo.markInvalid(gwtCause.getMessage());
+                    } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.ENTITY_NOT_FOUND)) {
+                        tagsCombo.markInvalid(gwtCause.getMessage());
                     }
                 }
             }


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Set combo box in error state when tag is deleted.

**Related Issue**
This PR fixes/issue #2222 

**Description of the solution adopted**
If selected tag is deleted combo box is set in error state in submit method in DeviceTagAddDialog.

**Screenshots**
/

**Any side note on the changes made**
/
