### PR TITLE
Window resize display fix

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaViewport.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaViewport.java
@@ -42,6 +42,7 @@ public class KapuaViewport extends Viewport {
 
         setMonitorWindowResize(true);
         infoPopup = new InfoPopup(MSGS.browserWindowTooSmall());
+        infoPopup.setGlassStyleName("kapua-PopupPanelGlass");
         int clientHeight = Window.getClientHeight();
         int clientWidth = Window.getClientWidth();
         // React at browser size at login, before any resize is made

--- a/console/web/src/main/webapp/css/console.css
+++ b/console/web/src/main/webapp/css/console.css
@@ -37,7 +37,15 @@ h1 {
     border: 3px solid #F0F0F0;
     padding: 3px;
     background: #F0F0F0;
+    z-index: 10000;
 }
+
+.kapua-PopupPanelGlass {
+    background-color: rgb(0, 0, 0);
+    opacity: 0.3;
+    z-index: 9999;
+}
+
 .serverResponseLabelError {
     color: red;
 }


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Window resize display fix

**Related Issue**
This PR fixes/closes #1854 

**Description of the solution adopted**
Created new CSS class `kapua-PopupPanelGlass`,  with background-color, opacity and z-index properties. The main change here was adding the z-index that defines the level on which `kapua-PopupPanelGlass` and `kapua-popupPanel` are positioned. This resolved the problem of dialogues not being grayed out on window resize.  

**Screenshots**
![resize](https://user-images.githubusercontent.com/35954696/50078519-801d7c80-01e7-11e9-9e16-8917c787a88b.png)

**Any side note on the changes made**
_None_
