### PR TITLE
Disabled multiselect on treeGrid in DeviceTabPackagesInstalled class

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
@@ -25,6 +25,7 @@ import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeploymentPac
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
 
 import com.extjs.gxt.ui.client.data.ModelData;
+import com.extjs.gxt.ui.client.Style.SelectionMode;
 import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
 import com.extjs.gxt.ui.client.event.SelectionChangedListener;
 import com.extjs.gxt.ui.client.store.TreeStore;
@@ -90,6 +91,7 @@ public class DeviceTabPackagesInstalled extends TabItem {
         ColumnModel cm = new ColumnModel(Arrays.asList(name, version));
 
         treeGrid = new TreeGrid<ModelData>(treeStore, cm);
+        treeGrid.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         treeGrid.setBorders(false);
         treeGrid.setLoadMask(true);
         treeGrid.setAutoExpandColumn("name");


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Disabled multiselect on treeGrid in DeviceTabPackagesInstalled class.

**Related Issue**
This PR fixes/closes #2178 

**Description of the solution adopted**
Set SelectionMode to SINGLE for the `treeGrid `on the `DeviceTabPackagesInstalled `class.
As most of the functionalities in this class (like enabling/disabling the Uninstall button) actually use a single and last selected value on the treeGrid  all other selected values are ignored.  Setting the selectionMode like this solved the confusion caused by multiselect. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_