### PR TITLE
Fix for test failures on Travis

### DIFF
--- a/qa/src/test/resources/features/broker/DeviceBrokerIpSysEnvI9n.feature
+++ b/qa/src/test/resources/features/broker/DeviceBrokerIpSysEnvI9n.feature
@@ -16,6 +16,9 @@ Feature: Device Broker connection ip with System environment variable
   @StartDatastore
   Scenario: Start datastore for all scenarios
 
+  @StartEventBroker
+  Scenario: Start event broker for all scenarios
+
   @StartBroker
   Scenario: Start broker for all scenarios
 
@@ -34,6 +37,9 @@ Feature: Device Broker connection ip with System environment variable
 
   @StopBroker
   Scenario: Stop broker after all scenarios
+
+  @StopEventBroker
+  Scenario: Stop event broker after all scenarios
 
   @StopDatastore
   Scenario: Stop datastore after all scenarios


### PR DESCRIPTION
This test was failing because event broker was not started.
**Related Issue**
None

**Description of the solution adopted**
Embedded event broker is started before message broker.

**Screenshots**
Not applicable.

**Any side note on the changes made**
None.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>
