### PR TITLE
password field not coloured after failed login

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -302,6 +302,7 @@ public class LoginDialog extends Dialog {
         status.hide();
         getButtonBar().enable();
         login.disable();
+        password.clearInvalid();
     }
 
 }


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added clearInvalid() method for password field after reset.

**Related Issue**
This PR fixes issue #1963 

**Description of the solution adopted**
Password field is cleared after reset.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
