### PR TITLE
Prevent setting the expiration date for an admin account

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,6 @@ import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtOrganization;
-import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
@@ -117,10 +116,19 @@ public class AccountEditDialog extends AccountAddDialog {
                         cancelButton.enable();
                         if (caught instanceof GwtKapuaException) {
                             GwtKapuaException gwtCause = (GwtKapuaException) caught;
-                            if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            switch (gwtCause.getCode()) {
+                            case DUPLICATE_NAME:
                                 accountNameField.markInvalid(gwtCause.getMessage());
-                            } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.ILLEGAL_ARGUMENT) && gwtCause.getArguments()[0].equals("expirationDate")) {
-                                expirationDateField.markInvalid(MSGS.conflictingExpirationDate());
+                                break;
+                            case ILLEGAL_ARGUMENT:
+                                if (gwtCause.getArguments()[0].equals("expirationDate")) {
+                                    expirationDateField.markInvalid(MSGS.conflictingExpirationDate());
+                                } else if (gwtCause.getArguments()[0].equals("notAllowedExpirationDate")) {
+                                    expirationDateField.markInvalid(MSGS.notAllowedExpirationDate());
+                                }
+                                break;
+                            default:
+                                break;
                             }
                         }
                     }

--- a/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/client/messages/ConsoleAccountMessages.properties
+++ b/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/client/messages/ConsoleAccountMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -123,3 +123,4 @@ accountFilterOrgStateProvince=State/Province
 accountFilterOrgCountry=Country
 
 conflictingExpirationDate=The expiration date conflicts with either its parent expiration date or one of its children expiration date
+notAllowedExpirationDate=The expiration date can not be set for an admin account.

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 , 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011 , 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -181,8 +181,14 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
             }
         }
 
-        // check that expiration date is after all the children account
         if (account.getExpirationDate() != null) {
+            SystemSetting setting = SystemSetting.getInstance();
+            //check if the updated account is an admin account
+            if (setting.getString(SystemSettingKey.SYS_ADMIN_ACCOUNT).equals(account.getName())) {
+                //throw exception if trying to set an expiration date for an admin account
+                throw new KapuaIllegalArgumentException("notAllowedExpirationDate", account.getExpirationDate().toString());
+            }
+            // check that expiration date is after all the children account
             // if expiration date is null it means the account never expires, so it will be obviously later its children
             AccountListResult childrenAccounts = findChildsRecursively(account.getId());
             if (childrenAccounts.getItems().stream().anyMatch(childAccount -> {


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Prevent setting the expiration date for an admin account.

**Related Issue**
This PR fixes/closes #2149

**Description of the solution adopted**
Added check to see if the `account.getName()` property equals `SystemSettingKey.SYS_ADMIN_ACCOUNT` . If true, `KapuaIllegalArgumentException` with "notAllowedExpirationDate" property will be thrown. Added a new error message.

**Screenshots**
_None_

**Any side note on the changes made**
Did some code refactoring in the `AccountEditDialog` class. Instead of adding yet another _else if block_ a new _switch/case block_ was added for all exception cases.