### PR TITLE
Fix for error message shown when creating existing user

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.user.client.dialog;
 
-import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
@@ -262,8 +261,13 @@ public class UserAddDialog extends EntityAddEditDialog {
                 cancelButton.enable();
                 if (cause instanceof GwtKapuaException) {
                     GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                    switch (gwtCause.getCode()) {
+                    case DUPLICATE_NAME:
+                    case ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT:
                         username.markInvalid(gwtCause.getMessage());
+                        break;
+                    default:
+                        break;
                     }
                 }
             }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -103,7 +103,8 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
             throw new KapuaDuplicateNameException(userCreator.getName());
         }
 
-        if (findByName(userCreator.getName()) != null) {
+        User userByName = KapuaSecurityUtils.doPrivileged(() -> findByName(userCreator.getName()));
+        if (userByName != null) {
             throw new KapuaDuplicateNameInAnotherAccountError(userCreator.getName());
         }
 


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for error message shown when creating existing user.

**Related Issue**
This PR fixes/closes #2186

**Description of the solution adopted**
Added a new `KapuaSecurityUtils.doPrivileged` call in `UserServiceImpl` class's `create()` method when checking for a user with specific name using findByName() method.

**Screenshots**
_None_

**Any side note on the changes made**
Did some code refactoring in the `UserAddDialog` class. Instead of adding yet another else if block a new switch/case block was added for all exception cases.
