### PR TITLE
Fix for implicitly selected inputs

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -126,7 +126,7 @@ public class AccountConfigPanel extends LayoutContainer {
                             dirtyIcon.setStyleName("x-grid3-dirty-cell");
                             dirtyIcon.setStyleAttribute("top", "0");
                             dirtyIcon.setStyleAttribute("position", "absolute");
-                            dirtyIcon.setSize(10, 10);
+                            dirtyIcon.setSize(10, 5);
                             dirtyIcon.show();
                         }
                         thePanel.fireEvent(Events.Change);

--- a/console/web/src/main/webapp/css/console.css
+++ b/console/web/src/main/webapp/css/console.css
@@ -271,3 +271,11 @@ button::-moz-focus-inner, button::-moz-focus-outer, button:-moz-focusring, butto
 	display: block; 
 	overflow: hidden;
 }
+
+.x-form-cb-label, .x-form-item-label, .x-form-check-wrap {
+	pointer-events: none;
+}
+
+.x-form-radio {
+	pointer-events: all;
+}


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for implicitly selected inputs.

**Related Issue**
This PR fixes/closes #1402, #1405, #1406

**Description of the solution adopted**
Disabled `pointer-events` on problematic labels(_.x-form-cb-label_, ._x-form-item-label_) using CSS. 
The radio input fields and their labels are wrapped with _.x-form-check-wrap_ div on which the pointer-events were enabled as a whole. After disabling the pointer events on the mentioned wrap div, those events were then enabled on the radio inputs themselves. 
Also the height of the _dirtyPlugin_, the ComponentPlugin used on the AccountConfigPanel was changed from 10 to 5 px. There was some overlapping of the unneeded empty space added by those additional 5px and the radio fields causing problems with field selection.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
