### PR TITLE
Fix for selected service highlighting on Configuration tab

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -40,6 +40,7 @@ import com.extjs.gxt.ui.client.widget.toolbar.ToolBar;
 import com.extjs.gxt.ui.client.widget.treepanel.TreePanel;
 import com.extjs.gxt.ui.client.widget.treepanel.TreePanelSelectionModel;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.StyleInjector;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -336,6 +337,16 @@ public class DeviceConfigComponents extends LayoutContainer {
                 }
             }
         });
+
+        tree.getSelectionModel().addListener(Events.SelectionChange, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                String customWidth = tree.getElement().getScrollWidth() + "px";
+                StyleInjector.inject(".x-tree3-node { width: " + customWidth + "}");
+            }
+        });
+
     }
 
     // --------------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for selected service highlighting on Configuration tab.

**Related Issue**
This PR fixes/closes #2184

**Description of the solution adopted**
Dynamically set the `width` CSS property of the highlighted area (_.x-tree3-node_) using `StyleInjector`. The width of the highlighted row now equals the row with the largest number of characters, and it remains the same for all listed items.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
