### PR TITLE
Fix for escaped characters on Configuration tab

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -296,7 +296,7 @@ public class DeviceConfigPanel extends LayoutContainer {
         actionFieldSet.setScrollMode(Scroll.AUTO);
         if (configComponent.getComponentDescription() != null &&
                 configComponent.getComponentDescription().trim().length() > 0) {
-            actionFieldSet.addText(KapuaSafeHtmlUtils.htmlEscape(configComponent.getComponentDescription()));
+            actionFieldSet.addText(KapuaSafeHtmlUtils.htmlUnescape(configComponent.getComponentDescription()));
         }
 
         FormLayout layout = new FormLayout();


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for escaped characters on Configuration tab.

**Related Issue**
This PR fixes/closes #2213 

**Description of the solution adopted**
The correct text containing `'` was sent by the device. The problem happened on the console side, when that character was escaped by using `KapuaSafeHtmlUtils.htmlEscape` method and the text displayed on the Configuration tab. This was solved using `KapuaSafeHtmlUtils.htmlUnescape` instead.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
