### PR TITLE
id column removed from history tab in device packages

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesHistory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -118,15 +118,6 @@ public class DeviceTabPackagesHistory extends KapuaTabItem<GwtDevice> {
         List<ColumnConfig> configs = new ArrayList<ColumnConfig>();
 
         ColumnConfig column = new ColumnConfig();
-        column.setId("id");
-        column.setHeader(DEVICES_MSGS.deviceInstallTabHistoryTableId());
-        column.setAlignment(HorizontalAlignment.CENTER);
-        column.setWidth(60);
-        column.setSortable(false);
-        column.setHidden(true);
-        configs.add(column);
-
-        column = new ColumnConfig();
         column.setId("startedOnFormatted");
         column.setHeader(DEVICES_MSGS.deviceInstallTabHistoryTableStartedOn());
         column.setWidth(200);


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Just removed "id" column in History tab in Devices Packages tab.

**Related Issue**
This PR fixes issue #2293 

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
