### PR TITLE
Removed error state from start and end dates if they are valid

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/AfterDateValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/AfterDateValidator.java
@@ -17,12 +17,12 @@ import com.extjs.gxt.ui.client.widget.form.Validator;
 import com.google.gwt.core.client.GWT;
 import org.eclipse.kapua.app.console.module.api.client.messages.ValidationMessages;
 
-public class BeforeDateValidator implements Validator {
+public class AfterDateValidator implements Validator {
 
     private final DateField otherDateField;
     private static final ValidationMessages VAL_MSGS = GWT.create(ValidationMessages.class);
 
-    public BeforeDateValidator(DateField otherDateField) {
+    public AfterDateValidator(DateField otherDateField) {
         this.otherDateField = otherDateField;
     }
 
@@ -30,12 +30,13 @@ public class BeforeDateValidator implements Validator {
     public String validate(Field<?> field, String s) {
         if (otherDateField.getValue() != null) {
             DateField thisDateField = (DateField) field;
-            if (thisDateField.getValue().after(otherDateField.getValue())) {
+            if (thisDateField.getValue().before(otherDateField.getValue())) {
                 otherDateField.clearInvalid();
             } else {
-                return VAL_MSGS.endsOnDateEarlierThanStartsOn();
+                return VAL_MSGS.startsOnDateLaterThanEndsOn();
             }
         }
         return null;
     }
 }
+

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -11,16 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.schedule;
 
-import com.extjs.gxt.ui.client.event.BaseEvent;
-import com.extjs.gxt.ui.client.event.Events;
-import com.extjs.gxt.ui.client.event.Listener;
-import com.extjs.gxt.ui.client.widget.HorizontalPanel;
-import com.extjs.gxt.ui.client.widget.Label;
-import com.extjs.gxt.ui.client.widget.form.TimeField;
-import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.i18n.client.DateTimeFormat;
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ValidationMessages;
@@ -32,6 +25,8 @@ import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.AfterDateValidator;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.BeforeDateValidator;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.scheduler.GwtTrigger;
@@ -39,10 +34,16 @@ import org.eclipse.kapua.app.console.module.job.shared.model.scheduler.GwtTrigge
 import org.eclipse.kapua.app.console.module.job.shared.model.scheduler.GwtTriggerProperty;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtTriggerService;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtTriggerServiceAsync;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.widget.HorizontalPanel;
+import com.extjs.gxt.ui.client.widget.Label;
+import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
+import com.extjs.gxt.ui.client.widget.form.TimeField;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public class JobScheduleAddDialog extends EntityAddEditDialog {
 
@@ -113,6 +114,8 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         startsOn.setEmptyText(JOB_MSGS.dialogAddScheduleDatePlaceholder());
         startsOn.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         startsOn.setToolTip(JOB_MSGS.dialogAddScheduleStartsOnTooltip());
+        startsOn.setValidator(new AfterDateValidator(endsOn));
+
         startsOn.getDatePicker().addListener(Events.Select, listener);
         startsOnLabel.setText("* " + JOB_MSGS.dialogAddScheduleStartsOnLabel());
         startsOnLabel.setWidth(FORM_LABEL_WIDTH);
@@ -140,6 +143,8 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         endsOn.setToolTip(JOB_MSGS.dialogAddScheduleEndsOnTooltip());
         endsOnLabel.setText(JOB_MSGS.dialogAddScheduleEndsOnLabel());
         endsOnLabel.setStyleAttribute("margin-left", "10px");
+        endsOn.setValidator(new BeforeDateValidator(startsOn));
+
         endsOnLabel.setWidth(FORM_LABEL_WIDTH);
         endsOnLabel.setStyleAttribute("padding", "0px 96px 0px 0px");
         endsOn.getDatePicker().addListener(Events.Select, listener);
@@ -224,6 +229,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
                 } else {
                     endsOn.clearInvalid();
                     endsOnTime.clearInvalid();
+                    startsOn.clearInvalid();
                 }
             }
         } else {


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Removed error state from fields.

**Related Issue**
This PR fixes issue #2288 

**Description of the solution adopted**
If end date and start date in Job Scedule Add dialog are valid, error state is removed.

**Screenshots**
/

**Any side note on the changes made**
/
