### PR TITLE
Enabled pointer-events on checkbox fields

### DIFF
--- a/console/web/src/main/webapp/css/console.css
+++ b/console/web/src/main/webapp/css/console.css
@@ -276,6 +276,6 @@ button::-moz-focus-inner, button::-moz-focus-outer, button:-moz-focusring, butto
 	pointer-events: none;
 }
 
-.x-form-radio {
+.x-form-radio, .x-form-checkbox {
 	pointer-events: all;
 }


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Enabled pointer-events on checkbox fields

**Related Issue**
This PR fixes/closes #2311 

**Description of the solution adopted**
Enabled pointer-events for `x-form-checkbox` fields. As those events were disabled for `x-form-check-wrap` div that wrapped the input in question, it was needed to enable pointer-events on the inputs themselves.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
