### PR TITLE
Removed error state when start and end date are the same

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/AfterDateValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/AfterDateValidator.java
@@ -30,7 +30,7 @@ public class AfterDateValidator implements Validator {
     public String validate(Field<?> field, String s) {
         if (otherDateField.getValue() != null) {
             DateField thisDateField = (DateField) field;
-            if (thisDateField.getValue().before(otherDateField.getValue())) {
+            if (thisDateField.getValue().before(otherDateField.getValue()) || thisDateField.getValue().equals(otherDateField.getValue())) {
                 otherDateField.clearInvalid();
             } else {
                 return VAL_MSGS.startsOnDateLaterThanEndsOn();

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/BeforeDateValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/BeforeDateValidator.java
@@ -30,7 +30,7 @@ public class BeforeDateValidator implements Validator {
     public String validate(Field<?> field, String s) {
         if (otherDateField.getValue() != null) {
             DateField thisDateField = (DateField) field;
-            if (thisDateField.getValue().after(otherDateField.getValue())) {
+            if (thisDateField.getValue().after(otherDateField.getValue()) || thisDateField.getValue().equals(otherDateField.getValue())) {
                 otherDateField.clearInvalid();
             } else {
                 return VAL_MSGS.endsOnDateEarlierThanStartsOn();


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Removed error state from start and end date fields.

**Related Issue**
This PR is additional fix for PR #2303.

**Description of the solution adopted**
When start date and end date fields are the same, error state from fields disapeares.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
