### PR TITLE
fix Travis-ci malformed configuration file and set the build to use the openjdk 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 sudo: false
 dist: trusty
@@ -37,54 +37,54 @@ jobs:
     script:
     - $M2_HOME/bin/mvn -v
     - $M2_HOME/bin/mvn -B -f external/pom.xml install
-        - $M2_HOME/bin/mvn -B ${BUILD_OPTS} -DskipTests clean install
+    - $M2_HOME/bin/mvn -B ${BUILD_OPTS} -DskipTests clean install
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @default"  verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @default"  verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @brokerAcl" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @brokerAcl" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @tag" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @tag" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @broker" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @broker" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @device" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @device" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @connection" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @connection" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @datastore" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @datastore" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @user" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @user" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @security" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @security" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @jobs" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcucumber.options="--tags @jobs" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-        - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.test.junit.JUnitTests' verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.test.junit.JUnitTests' verify
     - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - $M2_HOME/bin/mvn -B -DskipTests install javadoc:jar
+  - stage: test
+    script:
+    - $M2_HOME/bin/mvn -B -DskipTests install javadoc:jar
 
 # The following upgrades Java during the build in
 # order to work around an older Java 8 compiler issue
@@ -94,4 +94,4 @@ jobs:
 addons:
   apt:
     packages:
-    - oracle-java8-installer
+    - openjdk-8-jdk

--- a/build-tools/src/main/toolchains/travis-ci.xml
+++ b/build-tools/src/main/toolchains/travis-ci.xml
@@ -38,7 +38,7 @@
             <version>8</version>
         </provides>
         <configuration>
-            <jdkHome>/usr/lib/jvm/java-8-oracle/jre</jdkHome>
+            <jdkHome>/usr/lib/jvm/java-8-openjdk-amd64/jre</jdkHome>
         </configuration>
     </toolchain>
 </toolchains>


### PR DESCRIPTION
Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>

Brief description of the PR.
Fix travis build due to a malformed yaml configuration file and switch jvm 8 to openjdk
This fix should be ported on 1.0.x branche otherwise it doesn't build on Travis-ci.
@Coduz could you check if there are other branches  to be updated with this fix?

**Related Issue** 
none

**Description of the solution adopted**
none

**Screenshots**
none

**Any side note on the changes made**
none
