### PR TITLE
Concurrent jobs execution

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model;
 
-import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.PropertiesUtils;
@@ -93,10 +92,11 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
      * <p>
      * It can be used to clone the {@link KapuaUpdatableEntity}
      *
-     * @throws KapuaException if {@link KapuaUpdatableEntity#getEntityAttributes()} and/or {@link KapuaUpdatableEntity#getEntityProperties()} cannot be parsed.
+     * @throws EntityPropertiesReadException  see {@link #getEntityProperties()} and {@link #getEntityAttributes()}
+     * @throws EntityPropertiesWriteException see {@link #setEntityProperties(Properties)} and {@link #setEntityAttributes(Properties)}
      * @since 1.0.0
      */
-    protected AbstractKapuaUpdatableEntity(KapuaUpdatableEntity entity) throws KapuaException {
+    protected AbstractKapuaUpdatableEntity(KapuaUpdatableEntity entity) {
         super(entity);
 
         setModifiedOn(entity.getModifiedOn());

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AndPredicateImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AndPredicateImpl.java
@@ -30,7 +30,7 @@ public class AndPredicateImpl implements AndPredicate {
     private List<QueryPredicate> predicates;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @since 1.0.0
      */

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionStopDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionStopDialog.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.client.execution;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.SimpleDialog;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
+import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecution;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobEngineService;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobEngineServiceAsync;
+
+public class JobExecutionStopDialog extends SimpleDialog {
+
+    private static final ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
+
+    private static final GwtJobEngineServiceAsync JOB_ENGINE_SERVICE = GWT.create(GwtJobEngineService.class);
+
+    private final GwtJobExecution gwtJobExecution;
+
+    public JobExecutionStopDialog(GwtJobExecution gwtJobExecution) {
+        this.gwtJobExecution = gwtJobExecution;
+
+        DialogUtils.resizeDialog(this, 300, 135);
+    }
+
+    @Override
+    public void createBody() {
+        formPanel.disableEvents(true);
+    }
+
+    @Override
+    protected void addListeners() {
+    }
+
+    @Override
+    public void submit() {
+        JOB_ENGINE_SERVICE.stopExecution(gwtJobExecution.getScopeId(), gwtJobExecution.getJobId(), gwtJobExecution.getId(), new AsyncCallback<Void>() {
+
+            @Override
+            public void onFailure(Throwable caught) {
+                ConsoleInfo.display(MSGS.popupError(), JOB_MSGS.jobExecutionStopErrorMessage());
+                unmask();
+                hide();
+            }
+
+            @Override
+            public void onSuccess(Void result) {
+                ConsoleInfo.display(MSGS.popupInfo(), JOB_MSGS.jobExecutionStopStoppedMessage());
+                unmask();
+                hide();
+            }
+        });
+    }
+
+    @Override
+    public String getHeaderMessage() {
+        return JOB_MSGS.jobStopDialogHeader(gwtJobExecution.getId());
+    }
+
+    @Override
+    public KapuaIcon getInfoIcon() {
+        return new KapuaIcon(IconSet.WARNING);
+    }
+
+    @Override
+    public String getInfoMessage() {
+        return JOB_MSGS.jobStopDialogInfo();
+    }
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsGrid.java
@@ -34,40 +34,40 @@ import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingTool
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtExecution;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtExecutionQuery;
-import org.eclipse.kapua.app.console.module.job.shared.service.GwtExecutionService;
-import org.eclipse.kapua.app.console.module.job.shared.service.GwtExecutionServiceAsync;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecution;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecutionQuery;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobExecutionService;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobExecutionServiceAsync;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class JobTabExecutionsGrid extends EntityGrid<GwtExecution> {
+public class JobTabExecutionsGrid extends EntityGrid<GwtJobExecution> {
 
-    private static final GwtExecutionServiceAsync EXECUTION_SERVICE = GWT.create(GwtExecutionService.class);
+    private static final GwtJobExecutionServiceAsync EXECUTION_SERVICE = GWT.create(GwtJobExecutionService.class);
     private static final ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
     private static final ConsoleMessages C_MSGS = GWT.create(ConsoleMessages.class);
     private static final String EXECUTION = "execution";
 
     private String jobId;
-    private GwtExecutionQuery query;
+    private GwtJobExecutionQuery query;
 
     private JobTabExecutionsToolbar toolbar;
 
-    public JobTabExecutionsGrid(AbstractEntityView<GwtExecution> entityView, GwtSession currentSession) {
+    public JobTabExecutionsGrid(AbstractEntityView<GwtJobExecution> entityView, GwtSession currentSession) {
         super(entityView, currentSession);
     }
 
     @Override
-    protected RpcProxy<PagingLoadResult<GwtExecution>> getDataProxy() {
-        return new RpcProxy<PagingLoadResult<GwtExecution>>() {
+    protected RpcProxy<PagingLoadResult<GwtJobExecution>> getDataProxy() {
+        return new RpcProxy<PagingLoadResult<GwtJobExecution>>() {
 
             @Override
-            protected void load(Object o, AsyncCallback<PagingLoadResult<GwtExecution>> asyncCallback) {
+            protected void load(Object o, AsyncCallback<PagingLoadResult<GwtJobExecution>> asyncCallback) {
                 if (jobId != null) {
                     EXECUTION_SERVICE.findByJobId((PagingLoadConfig) o, currentSession.getSelectedAccountId(), jobId, asyncCallback);
                 } else {
-                    asyncCallback.onSuccess(new BasePagingLoadResult<GwtExecution>(new ArrayList<GwtExecution>()));
+                    asyncCallback.onSuccess(new BasePagingLoadResult<GwtJobExecution>(new ArrayList<GwtJobExecution>()));
                 }
             }
         };
@@ -79,13 +79,13 @@ public class JobTabExecutionsGrid extends EntityGrid<GwtExecution> {
 
         ColumnConfig columnConfig = new ColumnConfig("status", JOB_MSGS.gridJobExecutionColumnHeaderStatus(), 30);
         columnConfig.setSortable(false);
-        columnConfig.setRenderer(new GridCellRenderer<GwtExecution>() {
+        columnConfig.setRenderer(new GridCellRenderer<GwtJobExecution>() {
 
             @Override
-            public Object render(GwtExecution gwtExecution, String s, ColumnData columnData, int i, int i1, ListStore listStore, Grid grid) {
+            public Object render(GwtJobExecution gwtJobExecution, String s, ColumnData columnData, int i, int i1, ListStore listStore, Grid grid) {
                 KapuaIcon icon;
 
-                if (gwtExecution.getEndedOn() == null) {
+                if (gwtJobExecution.getEndedOn() == null) {
                     icon = new KapuaIcon(IconSet.CIRCLE_O_NOTCH);
                     icon.setSpin(true);
                 } else {
@@ -115,7 +115,7 @@ public class JobTabExecutionsGrid extends EntityGrid<GwtExecution> {
 
     @Override
     public void setFilterQuery(GwtQuery filterQuery) {
-        this.query = (GwtExecutionQuery) filterQuery;
+        this.query = (GwtJobExecutionQuery) filterQuery;
     }
 
     public String getJobId() {
@@ -138,7 +138,7 @@ public class JobTabExecutionsGrid extends EntityGrid<GwtExecution> {
     }
 
     @Override
-    protected void selectionChangedEvent(GwtExecution selectedItem) {
+    protected void selectionChangedEvent(GwtJobExecution selectedItem) {
         super.selectionChangedEvent(selectedItem);
     }
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsToolbar.java
@@ -11,14 +11,25 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.execution;
 
+import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtExecution;
+import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecution;
 
-public class JobTabExecutionsToolbar extends EntityCRUDToolbar<GwtExecution> {
+public class JobTabExecutionsToolbar extends EntityCRUDToolbar<GwtJobExecution> {
+
+    private static final ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
 
     private String jobId;
+
+    private Button stopJobButton;
 
     public JobTabExecutionsToolbar(GwtSession currentSession) {
         super(currentSession, true);
@@ -35,13 +46,37 @@ public class JobTabExecutionsToolbar extends EntityCRUDToolbar<GwtExecution> {
 
     @Override
     protected void onRender(Element target, int index) {
+
+        stopJobButton = new Button(JOB_MSGS.jobStopButton(), new KapuaIcon(IconSet.STOP), new SelectionListener<ButtonEvent>() {
+
+            @Override
+            public void componentSelected(ButtonEvent buttonEvent) {
+                JobExecutionStopDialog dialog = new JobExecutionStopDialog(gridSelectionModel.getSelectedItem());
+                dialog.show();
+            }
+        });
+        stopJobButton.disable();
+        addExtraButton(stopJobButton);
+
         super.onRender(target, index);
+
+        checkButtons();
+    }
+
+    @Override
+    protected void updateButtonEnablement() {
+        super.updateButtonEnablement();
+
         checkButtons();
     }
 
     private void checkButtons() {
         if (refreshEntityButton != null) {
             refreshEntityButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null);
+        }
+
+        if (stopJobButton != null) {
+            stopJobButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null && gridSelectionModel.getSelectedItem().getEndedOn() == null);
         }
     }
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobEngineServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobEngineServiceImpl.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.server;
 
-import java.util.ArrayList;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
@@ -25,6 +23,8 @@ import org.eclipse.kapua.job.engine.JobEngineService;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
+
+import java.util.ArrayList;
 
 public class GwtJobEngineServiceImpl extends KapuaRemoteServiceServlet implements GwtJobEngineService {
 
@@ -56,11 +56,17 @@ public class GwtJobEngineServiceImpl extends KapuaRemoteServiceServlet implement
 
     @Override
     public void stop(String gwtScopeId, String gwtJobId) throws GwtKapuaException {
+        stopExecution(gwtScopeId, gwtJobId, null);
+    }
+
+    @Override
+    public void stopExecution(String gwtScopeId, String gwtJobId, String gwtJobExecutionId) throws GwtKapuaException {
         KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(gwtScopeId);
         KapuaId jobId = GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobId);
+        KapuaId jobExecutionId = GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobExecutionId);
 
         try {
-            JOB_ENGINE_SERVICE.stopJob(scopeId, jobId);
+            JOB_ENGINE_SERVICE.stopJobExecution(scopeId, jobId, jobExecutionId);
         } catch (KapuaException kaex) {
             KapuaExceptionHandler.handle(kaex);
         }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobExecutionServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobExecutionServiceImpl.java
@@ -17,9 +17,9 @@ import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtExecution;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtExecutionQuery;
-import org.eclipse.kapua.app.console.module.job.shared.service.GwtExecutionService;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecution;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecutionQuery;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobExecutionService;
 import org.eclipse.kapua.app.console.module.job.shared.util.GwtKapuaJobModelConverter;
 import org.eclipse.kapua.app.console.module.job.shared.util.KapuaGwtJobModelConverter;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -31,32 +31,32 @@ import org.eclipse.kapua.service.job.execution.JobExecutionService;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GwtExecutionServiceImpl extends KapuaRemoteServiceServlet implements GwtExecutionService {
+public class GwtJobExecutionServiceImpl extends KapuaRemoteServiceServlet implements GwtJobExecutionService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
     private static final JobExecutionService EXECUTION_SERVICE = LOCATOR.getService(JobExecutionService.class);
 
     @Override
-    public PagingLoadResult<GwtExecution> findByJobId(PagingLoadConfig loadConfig, String scopeId, String jobId) throws GwtKapuaException {
+    public PagingLoadResult<GwtJobExecution> findByJobId(PagingLoadConfig loadConfig, String scopeId, String jobId) throws GwtKapuaException {
         int totalLength = 0;
-        List<GwtExecution> gwtExecutionList = new ArrayList<GwtExecution>();
+        List<GwtJobExecution> gwtJobExecutionList = new ArrayList<GwtJobExecution>();
         try {
-            GwtExecutionQuery gwtExecutionQuery = new GwtExecutionQuery();
-            gwtExecutionQuery.setScopeId(scopeId);
-            gwtExecutionQuery.setJobId(jobId);
+            GwtJobExecutionQuery gwtJobExecutionQuery = new GwtJobExecutionQuery();
+            gwtJobExecutionQuery.setScopeId(scopeId);
+            gwtJobExecutionQuery.setJobId(jobId);
 
-            JobExecutionQuery executionQuery = GwtKapuaJobModelConverter.convertJobExecutionQuery(loadConfig, gwtExecutionQuery);
+            JobExecutionQuery executionQuery = GwtKapuaJobModelConverter.convertJobExecutionQuery(loadConfig, gwtJobExecutionQuery);
             JobExecutionListResult jobExecutionList = EXECUTION_SERVICE.query(executionQuery);
             totalLength = (int) EXECUTION_SERVICE.count(executionQuery);
 
             // Converto to GWT entity
             for (JobExecution jobExecution : jobExecutionList.getItems()) {
-                gwtExecutionList.add(KapuaGwtJobModelConverter.convertJobExecution(jobExecution));
+                gwtJobExecutionList.add(KapuaGwtJobModelConverter.convertJobExecution(jobExecution));
             }
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
         }
 
-        return new BasePagingLoadResult<GwtExecution>(gwtExecutionList, loadConfig.getOffset(), totalLength);
+        return new BasePagingLoadResult<GwtJobExecution>(gwtJobExecutionList, loadConfig.getOffset(), totalLength);
     }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecution.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecution.java
@@ -16,10 +16,9 @@ import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityM
 
 import java.util.Date;
 
-public class GwtExecution extends GwtUpdatableEntityModel {
+public class GwtJobExecution extends GwtUpdatableEntityModel {
 
     @Override
-    @SuppressWarnings({ "unchecked" })
     public <X> X get(String property) {
         if ("startedOnFormatted".equals(property)) {
             return (X) (DateUtils.formatDateTime(getStartedOn()));
@@ -28,6 +27,14 @@ public class GwtExecution extends GwtUpdatableEntityModel {
         } else {
             return super.get(property);
         }
+    }
+
+    public String getJobId() {
+        return get("jobId");
+    }
+
+    public void setJobId(String jobId) {
+        set("jobId", jobId);
     }
 
     public Date getStartedOn() {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecutionQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecutionQuery.java
@@ -13,7 +13,7 @@ package org.eclipse.kapua.app.console.module.job.shared.model;
 
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
 
-public class GwtExecutionQuery extends GwtQuery {
+public class GwtJobExecutionQuery extends GwtQuery {
 
     private String jobId;
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobEngineService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobEngineService.java
@@ -28,6 +28,9 @@ public interface GwtJobEngineService extends RemoteService {
     void stop(String gwtScopeId, String gwtJobId)
             throws GwtKapuaException;
 
+    void stopExecution(String gwtScopeId, String gwtJobId, String gwtJobExecutionId)
+            throws GwtKapuaException;
+
     void restart(String gwtScopeId, String gwtJobId)
             throws GwtKapuaException;
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobExecutionService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobExecutionService.java
@@ -16,10 +16,10 @@ import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtExecution;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecution;
 
 @RemoteServiceRelativePath("execution")
-public interface GwtExecutionService extends RemoteService {
+public interface GwtJobExecutionService extends RemoteService {
 
     /**
      * Returns the list of executions by their jobId
@@ -29,6 +29,6 @@ public interface GwtExecutionService extends RemoteService {
      * @return
      * @throws GwtKapuaException
      */
-    PagingLoadResult<GwtExecution> findByJobId(PagingLoadConfig loadConfig, String scopeId, String jobId)
+    PagingLoadResult<GwtJobExecution> findByJobId(PagingLoadConfig loadConfig, String scopeId, String jobId)
             throws GwtKapuaException;
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -15,8 +15,8 @@ import com.extjs.gxt.ui.client.Style.SortDir;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.app.console.module.api.shared.util.GwtKapuaCommonsModelConverter;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtExecutionQuery;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecutionQuery;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobQuery;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobStartOptions;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobStep;
@@ -294,9 +294,9 @@ public class GwtKapuaJobModelConverter {
         return triggerPropertyList;
     }
 
-    public static JobExecutionQuery convertJobExecutionQuery(PagingLoadConfig pagingLoadConfig, GwtExecutionQuery gwtExecutionQuery) {
-        JobExecutionQuery query = JOB_EXECUTION_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtExecutionQuery.getScopeId()));
-        query.setPredicate(query.attributePredicate(JobExecutionAttributes.JOB_ID, GwtKapuaCommonsModelConverter.convertKapuaId(gwtExecutionQuery.getJobId())));
+    public static JobExecutionQuery convertJobExecutionQuery(PagingLoadConfig pagingLoadConfig, GwtJobExecutionQuery gwtJobExecutionQuery) {
+        JobExecutionQuery query = JOB_EXECUTION_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobExecutionQuery.getScopeId()));
+        query.setPredicate(query.attributePredicate(JobExecutionAttributes.JOB_ID, GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobExecutionQuery.getJobId())));
         String sortField = StringUtils.isEmpty(pagingLoadConfig.getSortField()) ? JobAttributes.NAME : pagingLoadConfig.getSortField();
         if (sortField.equals("startedOnFormatted")) {
             sortField = JobAttributes.STARTED_ON;

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -60,7 +60,9 @@ import org.eclipse.kapua.service.scheduler.trigger.TriggerProperty;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class GwtKapuaJobModelConverter {
 
@@ -317,8 +319,8 @@ public class GwtKapuaJobModelConverter {
         return jobStartOptions;
     }
 
-    private static List<KapuaId> convertTargetIdSublist(List<String> gwtTargetIdSublist) {
-        List<KapuaId> targetIdSublist = new ArrayList<KapuaId>();
+    private static Set<KapuaId> convertTargetIdSublist(List<String> gwtTargetIdSublist) {
+        Set<KapuaId> targetIdSublist = new HashSet<KapuaId>();
         for (String gwtKapuaId : gwtTargetIdSublist) {
             targetIdSublist.add(GwtKapuaCommonsModelConverter.convertKapuaId(gwtKapuaId));
         }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
@@ -12,8 +12,8 @@
 package org.eclipse.kapua.app.console.module.job.shared.util;
 
 import org.eclipse.kapua.app.console.module.api.shared.util.KapuaGwtCommonsModelConverter;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtExecution;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecution;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobStep;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobStepDefinition;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobStepProperty;
@@ -127,12 +127,15 @@ public class KapuaGwtJobModelConverter {
         return gwtTriggerPropertyList;
     }
 
-    public static GwtExecution convertJobExecution(JobExecution jobExecution) {
-        GwtExecution gwtExecution = new GwtExecution();
-        KapuaGwtCommonsModelConverter.convertUpdatableEntity(jobExecution, gwtExecution);
-        gwtExecution.setStartedOn(jobExecution.getStartedOn());
-        gwtExecution.setEndedOn(jobExecution.getEndedOn());
-        return gwtExecution;
+    public static GwtJobExecution convertJobExecution(JobExecution jobExecution) {
+        GwtJobExecution gwtJobExecution = new GwtJobExecution();
+        KapuaGwtCommonsModelConverter.convertUpdatableEntity(jobExecution, gwtJobExecution);
+
+        gwtJobExecution.setJobId(KapuaGwtCommonsModelConverter.convertKapuaId(jobExecution.getJobId()));
+        gwtJobExecution.setStartedOn(jobExecution.getStartedOn());
+        gwtJobExecution.setEndedOn(jobExecution.getEndedOn());
+
+        return gwtJobExecution;
     }
 
 }

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -190,6 +190,14 @@ gridJobExecutionsColumnHeaderStartedOnFormatted=Started on
 gridJobExecutionsColumnHeaderEndedOnFormatted=Ended on
 
 #
+# Stop Job Execution dialog
+jobExecutionStopButton=Stop
+jobExecutionStopDialogHeader=Stop job execution: {0}
+jobExecutionStopDialogInfo=Stop the selected job execution?
+jobExecutionStopStoppedMessage=Job execution successfully stopped.
+jobExecutionStopErrorMessage=Selected job execution could not be stopped. Either job execution has not been started or it could not be stopped. Please check console log for errors.
+
+#
 # Job Filter
 filterHeader=Job Filter
 filterFieldJobNameLabel=Name

--- a/console/web/src/main/webapp/WEB-INF/web.xml
+++ b/console/web/src/main/webapp/WEB-INF/web.xml
@@ -390,7 +390,7 @@
 
     <servlet>
         <servlet-name>executionServlet</servlet-name>
-        <servlet-class>org.eclipse.kapua.app.console.module.job.server.GwtExecutionServiceImpl</servlet-class>
+        <servlet-class>org.eclipse.kapua.app.console.module.job.server.GwtJobExecutionServiceImpl</servlet-class>
     </servlet>
     <servlet-mapping>
         <servlet-name>executionServlet</servlet-name>

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
@@ -66,6 +66,22 @@ public interface JobEngineService extends KapuaService {
     void stopJob(KapuaId scopeId, KapuaId jobId) throws KapuaException;
 
     /**
+     * Stops the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     * <p>
+     * This method does not wait for the {@link org.eclipse.kapua.service.job.execution.JobExecution} to completely stop.
+     * It ask the {@link org.eclipse.kapua.service.job.execution.JobExecution} to stop but it can take some time to completely stop,
+     * depending on the current status of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     * <p>
+     * {@link JobEngineService#isRunning(KapuaId, KapuaId)} can be used to check the actual running status of the {@link org.eclipse.kapua.service.job.Job}
+     *
+     * @param scopeId        The scopeId of the {@link org.eclipse.kapua.service.job.Job}
+     * @param jobId          The id of the {@link org.eclipse.kapua.service.job.Job}
+     * @param jobExecutionId The id of the {@link org.eclipse.kapua.service.job.execution.JobExecution} to stop
+     * @throws KapuaException if something goes bad when checking the status of the job
+     */
+    void stopJobExecution(KapuaId scopeId, KapuaId jobId, KapuaId jobExecutionId) throws KapuaException;
+
+    /**
      * Cleans all the Job related data from the data structures supporting the {@link JobEngineService}
      *
      * @param scopeId The scopeId of the {@link org.eclipse.kapua.service.job.Job}

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
@@ -50,11 +50,11 @@ public interface JobEngineService extends KapuaService {
     boolean isRunning(KapuaId scopeId, KapuaId jobId) throws KapuaException;
 
     /**
-     * Stops the {@link org.eclipse.kapua.service.job.Job}.
+     * Stops all the running {@link org.eclipse.kapua.service.job.execution.JobExecution} of the {@link org.eclipse.kapua.service.job.Job}.
      * <p>
-     * This method does not wait fot the {@link org.eclipse.kapua.service.job.Job} to completely stop.
-     * It ask the {@link org.eclipse.kapua.service.job.Job} to stop but it can take some time to completely stop,
-     * depending on the current status of the {@link org.eclipse.kapua.service.job.Job}.
+     * This method does not wait for the {@link org.eclipse.kapua.service.job.execution.JobExecution} to completely stop.
+     * It ask the {@link org.eclipse.kapua.service.job.execution.JobExecution} to stop but it can take some time to completely stop,
+     * depending on the current status of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
      * <p>
      * {@link JobEngineService#isRunning(KapuaId, KapuaId)} can be used to check the actual running status of the {@link org.eclipse.kapua.service.job.Job}
      *

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2098 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,11 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 
+/**
+ * {@link JobEngineService} definition.
+ *
+ * @since 1.0.0
+ */
 public interface JobEngineService extends KapuaService {
 
     /**
@@ -78,6 +83,7 @@ public interface JobEngineService extends KapuaService {
      * @param jobId          The id of the {@link org.eclipse.kapua.service.job.Job}
      * @param jobExecutionId The id of the {@link org.eclipse.kapua.service.job.execution.JobExecution} to stop
      * @throws KapuaException if something goes bad when checking the status of the job
+     * @since 1.1.0
      */
     void stopJobExecution(KapuaId scopeId, KapuaId jobId, KapuaId jobExecutionId) throws KapuaException;
 

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptions.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptions.java
@@ -23,7 +23,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.List;
+import java.util.Set;
 
 @XmlRootElement(name = "jobStartOptions")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -33,9 +33,9 @@ public interface JobStartOptions extends KapuaSerializable {
     @XmlElementWrapper(name = "targetIdSublist")
     @XmlElement(name = "targetId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
-    List<KapuaId> getTargetIdSublist();
+    Set<KapuaId> getTargetIdSublist();
 
-    void setTargetIdSublist(List<KapuaId> targetSublist);
+    void setTargetIdSublist(Set<KapuaId> targetSublist);
 
     @XmlTransient
     void removeTargetIdToSublist(KapuaId targetId);

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptions.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,25 +25,54 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Set;
 
+/**
+ * {@link JobStartOptions} definition.
+ *
+ * @since 1.0.0
+ */
 @XmlRootElement(name = "jobStartOptions")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobEngineXmlRegistry.class, factoryMethod = "newJobStartOptions")
 public interface JobStartOptions extends KapuaSerializable {
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     @XmlElementWrapper(name = "targetIdSublist")
     @XmlElement(name = "targetId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     Set<KapuaId> getTargetIdSublist();
 
+    /**
+     * @param targetSublist
+     * @since 1.0.0
+     */
     void setTargetIdSublist(Set<KapuaId> targetSublist);
 
+    /**
+     * @param targetId
+     * @since 1.0.0
+     */
     @XmlTransient
     void removeTargetIdToSublist(KapuaId targetId);
 
+    /**
+     * @param targetId
+     * @since 1.0.0
+     */
     @XmlTransient
     void addTargetIdToSublist(KapuaId targetId);
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     Integer getFromStepIndex();
 
+    /**
+     * @param fromStepIndex
+     * @since 1.0.0
+     */
     void setFromStepIndex(Integer fromStepIndex);
 }

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTargetSublist.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTargetSublist.java
@@ -20,9 +20,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Set;
 
 @XmlRootElement(name = "jobTargetSublist")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -31,24 +31,24 @@ public class JobTargetSublist implements Iterable<KapuaId> {
 
     @XmlElement(name = "targetId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
-    private List<KapuaId> targetIds = new ArrayList<>();
+    private Set<KapuaId> targetIds = new HashSet<>();
 
     public JobTargetSublist() {
     }
 
-    public JobTargetSublist(List<KapuaId> targetIds) {
+    public JobTargetSublist(Set<KapuaId> targetIds) {
         this.targetIds.addAll(targetIds);
     }
 
-    public List<KapuaId> getTargetIds() {
+    public Set<KapuaId> getTargetIds() {
         if (targetIds == null) {
-            targetIds = new ArrayList<>();
+            targetIds = new HashSet<>();
         }
 
         return targetIds;
     }
 
-    public void setTargetIds(List<KapuaId> targetIds) {
+    public void setTargetIds(Set<KapuaId> targetIds) {
         this.targetIds = targetIds;
     }
 

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.job.engine.JobEngineService;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.job.engine.jbatch.driver.JbatchDriver;
 import org.eclipse.kapua.job.engine.jbatch.exception.CleanJobDataException;
-import org.eclipse.kapua.job.engine.jbatch.exception.JobAlreadyRunningException;
 import org.eclipse.kapua.job.engine.jbatch.exception.JobCheckRunningException;
 import org.eclipse.kapua.job.engine.jbatch.exception.JobInvalidTargetException;
 import org.eclipse.kapua.job.engine.jbatch.exception.JobNotRunningException;
@@ -114,12 +113,6 @@ public class JobEngineServiceJbatch implements JobEngineService {
         jobStepQuery.setPredicate(jobStepQuery.attributePredicate(JobStepAttributes.JOB_ID, jobId));
         if (JOB_STEP_SERVICE.count(jobStepQuery) <= 0) {
             throw new KapuaJobEngineException(KapuaJobEngineErrorCodes.JOB_STEP_MISSING);
-        }
-
-        //
-        // Check job running
-        if (JbatchDriver.isRunningJob(scopeId, jobId)) {
-            throw new JobAlreadyRunningException(scopeId, jobId);
         }
 
         //

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
@@ -35,6 +35,7 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.job.Job;
 import org.eclipse.kapua.service.job.JobDomains;
 import org.eclipse.kapua.service.job.JobService;
+import org.eclipse.kapua.service.job.execution.JobExecutionService;
 import org.eclipse.kapua.service.job.step.JobStepAttributes;
 import org.eclipse.kapua.service.job.step.JobStepFactory;
 import org.eclipse.kapua.service.job.step.JobStepQuery;
@@ -53,6 +54,8 @@ public class JobEngineServiceJbatch implements JobEngineService {
     private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     private static final JobService JOB_SERVICE = LOCATOR.getService(JobService.class);
+
+    private static final JobExecutionService JOB_EXECUTION_SERVICE = LOCATOR.getService(JobExecutionService.class);
 
     private static final JobStepService JOB_STEP_SERVICE = LOCATOR.getService(JobStepService.class);
     private static final JobStepFactory JOB_STEP_FACTORY = LOCATOR.getFactory(JobStepFactory.class);
@@ -183,6 +186,7 @@ public class JobEngineServiceJbatch implements JobEngineService {
             throw new JobStopppingException(e, scopeId, jobId);
         }
     }
+
 
     @Override
     public void cleanJobData(KapuaId scopeId, KapuaId jobId) throws KapuaException {

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
@@ -14,12 +14,12 @@ package org.eclipse.kapua.job.engine.jbatch;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.model.id.KapuaId;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public class JobStartOptionsImpl implements JobStartOptions {
 
-    private List<KapuaId> targetIdSublist;
+    private Set<KapuaId> targetIdSublist;
 
     private Integer fromStepIndex;
 
@@ -27,16 +27,16 @@ public class JobStartOptionsImpl implements JobStartOptions {
     }
 
     @Override
-    public List<KapuaId> getTargetIdSublist() {
+    public Set<KapuaId> getTargetIdSublist() {
         if (targetIdSublist == null) {
-            targetIdSublist = new ArrayList<>();
+            targetIdSublist = new HashSet<>();
         }
 
         return targetIdSublist;
     }
 
     @Override
-    public void setTargetIdSublist(List<KapuaId> targetIdSublist) {
+    public void setTargetIdSublist(Set<KapuaId> targetIdSublist) {
         this.targetIdSublist = targetIdSublist;
     }
 

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,12 +17,21 @@ import org.eclipse.kapua.model.id.KapuaId;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * {@link JobStartOptions} implementation.
+ *
+ * @since 1.0.0
+ */
 public class JobStartOptionsImpl implements JobStartOptions {
 
     private Set<KapuaId> targetIdSublist;
-
     private Integer fromStepIndex;
 
+    /**
+     * Constructor.
+     *
+     * @since 1.0.0
+     */
     public JobStartOptionsImpl() {
     }
 

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
@@ -69,6 +69,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * Driver class for Java Batch API
@@ -199,12 +200,6 @@ public class JbatchDriver {
         }
 
         //
-        // Check job running
-//        if (isRunningJob(scopeId, jobId)) {
-//            throw new JobExecutionIsRunningDriverException(JbatchDriver.getJbatchJobName(scopeId, jobId));
-//        }
-
-        //
         // Start job
         try {
             JOB_OPERATOR.start(jobXmlDefinitionFile.getAbsolutePath().replaceAll("\\.xml$", ""), new Properties());
@@ -233,19 +228,21 @@ public class JbatchDriver {
 
         //
         // Check running
-        JobExecution runningExecution = getRunningJobExecution(scopeId, jobId);
-        if (runningExecution == null) {
+        List<JobExecution> runningExecutions = getRunningJobExecutions(scopeId, jobId);
+        if (runningExecutions.isEmpty()) {
             throw new ExecutionNotRunningDriverException(jobName);
         }
 
         //
         // Do stop
         try {
-            JOB_OPERATOR.stop(runningExecution.getExecutionId());
+            runningExecutions.forEach((runningExecution -> {
+                JOB_OPERATOR.stop(runningExecution.getExecutionId());
 
-            if (JOB_ENGINE_SETTING.getBoolean(KapuaJobEngineSettingKeys.JOB_ENGINE_STOP_WAIT_CHECK)) {
-                JbatchUtil.waitForStop(runningExecution, () -> JOB_OPERATOR.abandon(runningExecution.getExecutionId()));
-            }
+                if (JOB_ENGINE_SETTING.getBoolean(KapuaJobEngineSettingKeys.JOB_ENGINE_STOP_WAIT_CHECK)) {
+                    JbatchUtil.waitForStop(runningExecution, () -> JOB_OPERATOR.abandon(runningExecution.getExecutionId()));
+                }
+            }));
         } catch (NoSuchJobExecutionException e) {
             throw new ExecutionNotFoundDriverException(e, jobName);
         } catch (JobExecutionNotRunningException e) {
@@ -263,7 +260,7 @@ public class JbatchDriver {
      * @return {@code true} if the jBatch {@link Job} is running, {@code false} otherwise,
      */
     public static boolean isRunningJob(@NotNull KapuaId scopeId, @NotNull KapuaId jobId) {
-        return getRunningJobExecution(scopeId, jobId) != null;
+        return !getRunningJobExecutions(scopeId, jobId).isEmpty();
     }
 
     public static void cleanJobData(@NotNull KapuaId scopeId, @NotNull KapuaId jobId) throws CleanJobDataDriverException {
@@ -278,8 +275,8 @@ public class JbatchDriver {
     //
     // Private methods
     //
-    private static JobExecution getRunningJobExecution(@NotNull KapuaId scopeId, @NotNull KapuaId jobId) {
-        return getJobExecutions(scopeId, jobId).stream().filter(je -> JbatchJobRunningStatuses.getStatuses().contains(je.getBatchStatus())).findFirst().orElse(null);
+    private static List<JobExecution> getRunningJobExecutions(@NotNull KapuaId scopeId, @NotNull KapuaId jobId) {
+        return getJobExecutions(scopeId, jobId).stream().filter(je -> JbatchJobRunningStatuses.getStatuses().contains(je.getBatchStatus())).collect(Collectors.toList());
     }
 
     private static List<JobExecution> getJobExecutions(@NotNull KapuaId scopeId, @NotNull KapuaId jobId) {

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
@@ -200,9 +200,9 @@ public class JbatchDriver {
 
         //
         // Check job running
-        if (isRunningJob(scopeId, jobId)) {
-            throw new JobExecutionIsRunningDriverException(JbatchDriver.getJbatchJobName(scopeId, jobId));
-        }
+//        if (isRunningJob(scopeId, jobId)) {
+//            throw new JobExecutionIsRunningDriverException(JbatchDriver.getJbatchJobName(scopeId, jobId));
+//        }
 
         //
         // Start job

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
@@ -129,6 +129,7 @@ public class JbatchDriver {
      * @throws CannotWriteJobDefFileDriverException if the XML job definition file cannot be created and written in the tmp directory
      * @throws JobExecutionIsRunningDriverException if the jBatch job has another {@link JobExecution} running
      * @throws JobStartingDriverException           if invoking {@link JobOperator#start(String, Properties)} throws an {@link Exception}
+     * @since 1.0.0
      */
     public static void startJob(@NotNull KapuaId scopeId, @NotNull KapuaId jobId, @NotNull JobStartOptions jobStartOptions)
             throws JbatchDriverException {
@@ -228,6 +229,7 @@ public class JbatchDriver {
      * @param toStopJobExecutionId The optional {@link org.eclipse.kapua.service.job.execution.JobExecution#getId()} to stop.
      * @throws ExecutionNotFoundDriverException   when there isn't a corresponding job execution in jBatch tables
      * @throws ExecutionNotRunningDriverException when the corresponding job execution is not running.
+     * @since 1.0.0
      */
     public static void stopJob(@NotNull KapuaId scopeId, @NotNull KapuaId jobId, KapuaId toStopJobExecutionId) throws JbatchDriverException, KapuaException {
 
@@ -274,7 +276,8 @@ public class JbatchDriver {
      *
      * @param scopeId The scopeId of the {@link Job}
      * @param jobId   The id of the {@link Job}
-     * @return {@code true} if the jBatch {@link Job} is running, {@code false} otherwise,
+     * @return {@code true} if the jBatch {@link Job} is running, {@code false} otherwise.
+     * @since 1.0.0
      */
     public static boolean isRunningJob(@NotNull KapuaId scopeId, @NotNull KapuaId jobId) {
         return !getRunningJobExecutions(scopeId, jobId).isEmpty();

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobAlreadyRunningException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobAlreadyRunningException.java
@@ -13,9 +13,11 @@ package org.eclipse.kapua.job.engine.jbatch.exception;
 
 import org.eclipse.kapua.model.id.KapuaId;
 
+import java.util.Set;
+
 public class JobAlreadyRunningException extends JobEngineException {
 
-    public JobAlreadyRunningException(KapuaId scopeId, KapuaId jobId) {
-        super(KapuaJobEngineErrorCodes.JOB_ALREADY_RUNNING, scopeId, jobId);
+    public JobAlreadyRunningException(KapuaId scopeId, KapuaId jobId, Set<KapuaId> jobTargetIdSubset) {
+        super(KapuaJobEngineErrorCodes.JOB_ALREADY_RUNNING, scopeId, jobId, jobTargetIdSubset);
     }
 }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobAlreadyRunningException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobAlreadyRunningException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobInvalidTargetException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobInvalidTargetException.java
@@ -13,11 +13,11 @@ package org.eclipse.kapua.job.engine.jbatch.exception;
 
 import org.eclipse.kapua.model.id.KapuaId;
 
-import java.util.List;
+import java.util.Set;
 
 public class JobInvalidTargetException extends JobEngineException {
 
-    public JobInvalidTargetException(KapuaId scopeId, KapuaId jobId, List<KapuaId> targetSublist) {
+    public JobInvalidTargetException(KapuaId scopeId, KapuaId jobId, Set<KapuaId> targetSublist) {
         super(KapuaJobEngineErrorCodes.JOB_TARGET_INVALID, scopeId, jobId, targetSublist);
     }
 }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobInvalidTargetException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobInvalidTargetException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobStopppingException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobStopppingException.java
@@ -16,6 +16,10 @@ import org.eclipse.kapua.model.id.KapuaId;
 public class JobStopppingException extends JobEngineException {
 
     public JobStopppingException(Throwable t, KapuaId scopeId, KapuaId jobId) {
-        super(KapuaJobEngineErrorCodes.JOB_STOPPING, t, scopeId, jobId);
+        this(t, scopeId, jobId, null);
+    }
+
+    public JobStopppingException(Throwable t, KapuaId scopeId, KapuaId jobId, KapuaId jobExecutionId) {
+        super(KapuaJobEngineErrorCodes.JOB_STOPPING, t, scopeId, jobId, jobExecutionId);
     }
 }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobStopppingException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobStopppingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
@@ -12,14 +12,23 @@
 package org.eclipse.kapua.job.engine.jbatch.listener;
 
 import org.eclipse.kapua.KapuaIllegalStateException;
+import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
+import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.context.JobContextWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.execution.JobExecution;
+import org.eclipse.kapua.service.job.execution.JobExecutionAttributes;
 import org.eclipse.kapua.service.job.execution.JobExecutionCreator;
 import org.eclipse.kapua.service.job.execution.JobExecutionFactory;
+import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
 import org.eclipse.kapua.service.job.execution.JobExecutionService;
+import org.eclipse.kapua.service.job.targets.JobTargetAttributes;
+import org.eclipse.kapua.service.job.targets.JobTargetFactory;
+import org.eclipse.kapua.service.job.targets.JobTargetListResult;
+import org.eclipse.kapua.service.job.targets.JobTargetQuery;
+import org.eclipse.kapua.service.job.targets.JobTargetService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +38,9 @@ import javax.batch.runtime.BatchRuntime;
 import javax.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class KapuaJobListener extends AbstractJobListener implements JobListener {
 
@@ -41,6 +52,10 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
 
     private static final JobExecutionService JOB_EXECUTION_SERVICE = LOCATOR.getService(JobExecutionService.class);
     private static final JobExecutionFactory JOB_EXECUTION_FACTORY = LOCATOR.getFactory(JobExecutionFactory.class);
+
+    private static final JobTargetService JOB_TARGET_SERVICE = LOCATOR.getService(JobTargetService.class);
+    private static final JobTargetFactory JOB_TARGET_FACTORY = LOCATOR.getFactory(JobTargetFactory.class);
+
 
     @Inject
     private JobContext jobContext;
@@ -56,7 +71,25 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
         jobExecutionCreator.setJobId(jobContextWrapper.getJobId());
         jobExecutionCreator.setStartedOn(new Date());
         jobExecutionCreator.getEntityAttributes().put(JBATCH_EXECUTION_ID, Long.toString(jobContextWrapper.getExecutionId()));
-        jobExecutionCreator.setTargetIds(jobContextWrapper.getTargetSublist().getTargetIds());
+
+        if (jobContextWrapper.getTargetSublist().isEmpty()) {
+            JobTargetQuery jobTargetQuery = JOB_TARGET_FACTORY.newQuery(jobContextWrapper.getScopeId());
+
+            jobTargetQuery.setPredicate(
+                    new AndPredicateImpl(
+                            new AttributePredicateImpl<>(JobTargetAttributes.JOB_ID, jobContextWrapper.getJobId())
+                    )
+            );
+
+            JobTargetListResult jobTargets = KapuaSecurityUtils.doPrivileged(() -> JOB_TARGET_SERVICE.query(jobTargetQuery));
+
+            Set<KapuaId> targetIds = new HashSet<>();
+            jobTargets.getItems().forEach(jt -> targetIds.add(jt.getId()));
+
+            jobExecutionCreator.setTargetIds(new HashSet<>(targetIds));
+        } else {
+            jobExecutionCreator.setTargetIds(jobContextWrapper.getTargetSublist().getTargetIds());
+        }
 
         JobExecution jobExecution = KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.create(jobExecutionCreator));
 
@@ -66,7 +99,22 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
         // at that point, if there are more than 1 job execution in running state (so STARTING, STARTED, STOPPING) it means that another instance is already running.
         List<Long> runningExecutionsIds = BatchRuntime.getJobOperator().getRunningExecutions(jobContextWrapper.getJobName());
         if (runningExecutionsIds.size() > 1) {
-            throw new KapuaIllegalStateException(String.format("Cannot start job [%s]. Another instance of this job is running.", jobContextWrapper.getJobName()));
+
+            JobExecutionQuery jobExecutionQuery = JOB_EXECUTION_FACTORY.newQuery(jobContextWrapper.getScopeId());
+
+            jobExecutionQuery.setPredicate(
+                    new AndPredicateImpl(
+                            new AttributePredicateImpl<>(JobExecutionAttributes.JOB_ID, jobContextWrapper.getJobId()),
+                            new AttributePredicateImpl<>(JobExecutionAttributes.ENDED_ON, null),
+                            new AttributePredicateImpl<>(JobExecutionAttributes.TARGET_IDS, jobExecutionCreator.getTargetIds().toArray())
+                    )
+            );
+
+            long runningExecutionWithTargets = KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.count(jobExecutionQuery));
+
+            if (runningExecutionWithTargets > 1) {
+                throw new KapuaIllegalStateException(String.format("Cannot start job [%s]. Another instance of this job is running.", jobContextWrapper.getJobName()));
+            }
         }
 
         LOG.info("JOB {} - {} - Running before job... DONE!", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
@@ -56,6 +56,7 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
         jobExecutionCreator.setJobId(jobContextWrapper.getJobId());
         jobExecutionCreator.setStartedOn(new Date());
         jobExecutionCreator.getEntityAttributes().put(JBATCH_EXECUTION_ID, Long.toString(jobContextWrapper.getExecutionId()));
+        jobExecutionCreator.setTargetIds(jobContextWrapper.getTargetSublist().getTargetIds());
 
         JobExecution jobExecution = KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.create(jobExecutionCreator));
 
@@ -64,7 +65,7 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
         // prevent another instance running for the same job name (once a job is submitted its status is changed to STARTING by jbatch so,
         // at that point, if there are more than 1 job execution in running state (so STARTING, STARTED, STOPPING) it means that another instance is already running.
         List<Long> runningExecutionsIds = BatchRuntime.getJobOperator().getRunningExecutions(jobContextWrapper.getJobName());
-        if (runningExecutionsIds != null && runningExecutionsIds.size() > 1) {
+        if (runningExecutionsIds.size() > 1) {
             throw new KapuaIllegalStateException(String.format("Cannot start job [%s]. Another instance of this job is running.", jobContextWrapper.getJobName()));
         }
 

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
@@ -104,17 +104,17 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
 
         KapuaId kapuaExecutionId = jobContextWrapper.getKapuaExecutionId();
         if (kapuaExecutionId == null) {
-            // don't send any exception to prevent the job engine to set the job exit status as failed
-            String msg = String.format("Cannot update job execution (internal reference [%d]). Cannot find execution id", jobContextWrapper.getExecutionId());
+            String msg = String.format("Cannot update job execution (internal reference [%d]). Cannot find 'executionId' in JobContext", jobContextWrapper.getExecutionId());
             LOG.error(msg);
+            // Don't send any exception to prevent the job engine to set the job exit status as failed!
             // TODO will send service events when the feature will be implemented
+        } else {
+            JobExecution jobExecution = KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.find(jobContextWrapper.getScopeId(), kapuaExecutionId));
+
+            jobExecution.setEndedOn(new Date());
+
+            KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.update(jobExecution));
         }
-        JobExecution jobExecution = KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.find(jobContextWrapper.getScopeId(), kapuaExecutionId));
-
-        jobExecution.setEndedOn(new Date());
-
-        KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.update(jobExecution));
-
         LOG.info("JOB {} - {} - Running after job... DONE!", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());
     }
 

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
@@ -11,13 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.job.engine.jbatch.listener;
 
-import org.eclipse.kapua.KapuaIllegalStateException;
+import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.job.engine.commons.context.JobContextWrapper;
+import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
+import org.eclipse.kapua.job.engine.jbatch.exception.JobAlreadyRunningException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.Job;
 import org.eclipse.kapua.service.job.execution.JobExecution;
 import org.eclipse.kapua.service.job.execution.JobExecutionAttributes;
 import org.eclipse.kapua.service.job.execution.JobExecutionCreator;
@@ -61,66 +65,38 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
     private JobContext jobContext;
 
     @Override
+    /**
+     * Before starting the actual {@link org.eclipse.kapua.service.job.Job} processing, create the {@link JobExecution} to track progress and
+     * check if there are other {@link JobExecution} running with the same {@link JobExecution#getTargetIds()}.
+     */
     public void beforeJob() throws Exception {
         JobContextWrapper jobContextWrapper = new JobContextWrapper(jobContext);
 
         LOG.info("JOB {} - {} - Running before job...", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());
 
-        JobExecutionCreator jobExecutionCreator = JOB_EXECUTION_FACTORY.newCreator(jobContextWrapper.getScopeId());
-
-        jobExecutionCreator.setJobId(jobContextWrapper.getJobId());
-        jobExecutionCreator.setStartedOn(new Date());
-        jobExecutionCreator.getEntityAttributes().put(JBATCH_EXECUTION_ID, Long.toString(jobContextWrapper.getExecutionId()));
-
-        if (jobContextWrapper.getTargetSublist().isEmpty()) {
-            JobTargetQuery jobTargetQuery = JOB_TARGET_FACTORY.newQuery(jobContextWrapper.getScopeId());
-
-            jobTargetQuery.setPredicate(
-                    new AndPredicateImpl(
-                            new AttributePredicateImpl<>(JobTargetAttributes.JOB_ID, jobContextWrapper.getJobId())
-                    )
-            );
-
-            JobTargetListResult jobTargets = KapuaSecurityUtils.doPrivileged(() -> JOB_TARGET_SERVICE.query(jobTargetQuery));
-
-            Set<KapuaId> targetIds = new HashSet<>();
-            jobTargets.getItems().forEach(jt -> targetIds.add(jt.getId()));
-
-            jobExecutionCreator.setTargetIds(new HashSet<>(targetIds));
-        } else {
-            jobExecutionCreator.setTargetIds(jobContextWrapper.getTargetSublist().getTargetIds());
-        }
-
-        JobExecution jobExecution = KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.create(jobExecutionCreator));
+        JobExecution jobExecution = createJobExecution(
+                jobContextWrapper.getScopeId(),
+                jobContextWrapper.getJobId(),
+                jobContextWrapper.getTargetSublist(),
+                jobContextWrapper.getExecutionId());
 
         jobContextWrapper.setKapuaExecutionId(jobExecution.getId());
 
         // prevent another instance running for the same job name (once a job is submitted its status is changed to STARTING by jbatch so,
         // at that point, if there are more than 1 job execution in running state (so STARTING, STARTED, STOPPING) it means that another instance is already running.
-        List<Long> runningExecutionsIds = BatchRuntime.getJobOperator().getRunningExecutions(jobContextWrapper.getJobName());
-        if (runningExecutionsIds.size() > 1) {
-
-            JobExecutionQuery jobExecutionQuery = JOB_EXECUTION_FACTORY.newQuery(jobContextWrapper.getScopeId());
-
-            jobExecutionQuery.setPredicate(
-                    new AndPredicateImpl(
-                            new AttributePredicateImpl<>(JobExecutionAttributes.JOB_ID, jobContextWrapper.getJobId()),
-                            new AttributePredicateImpl<>(JobExecutionAttributes.ENDED_ON, null),
-                            new AttributePredicateImpl<>(JobExecutionAttributes.TARGET_IDS, jobExecutionCreator.getTargetIds().toArray())
-                    )
-            );
-
-            long runningExecutionWithTargets = KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.count(jobExecutionQuery));
-
-            if (runningExecutionWithTargets > 1) {
-                throw new KapuaIllegalStateException(String.format("Cannot start job [%s]. Another instance of this job is running.", jobContextWrapper.getJobName()));
-            }
-        }
+        checkJobRunning(
+                jobExecution.getScopeId(),
+                jobExecution.getJobId(),
+                jobContextWrapper.getJobName(),
+                jobExecution.getTargetIds());
 
         LOG.info("JOB {} - {} - Running before job... DONE!", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());
     }
 
     @Override
+    /**
+     * Close the {@link JobExecution} setting the {@link JobExecution#getEndedOn()}.
+     */
     public void afterJob() throws Exception {
         JobContextWrapper jobContextWrapper = new JobContextWrapper(jobContext);
 
@@ -140,5 +116,88 @@ public class KapuaJobListener extends AbstractJobListener implements JobListener
         KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.update(jobExecution));
 
         LOG.info("JOB {} - {} - Running after job... DONE!", jobContextWrapper.getJobId(), jobContextWrapper.getJobName());
+    }
+
+    /**
+     * Creates the {@link JobExecution} from the data in the {@link JobContextWrapper}.
+     * <p>
+     * If the {@link org.eclipse.kapua.service.job.Job} has started without a defined set of {@link JobStartOptions#getTargetIdSublist()}
+     * all {@link org.eclipse.kapua.service.job.targets.JobTarget}s will be added to the {@link JobExecution#getTargetIds()}.
+     *
+     * @param scopeId           The {@link Job#getScopeId()}
+     * @param jobId             The {@link Job#getId()}
+     * @param jobTargetSublist  The {@link JobStartOptions#getTargetIdSublist()} of the targeted items
+     * @param jBatchExecutionId The {@link JobContext#getExecutionId()}
+     * @return The newly created {@link JobExecution}
+     * @throws KapuaException If any error happens during the processing
+     */
+    private JobExecution createJobExecution(KapuaId scopeId, KapuaId jobId, JobTargetSublist jobTargetSublist, Long jBatchExecutionId) throws KapuaException {
+        JobExecutionCreator jobExecutionCreator = JOB_EXECUTION_FACTORY.newCreator(scopeId);
+
+        jobExecutionCreator.setJobId(jobId);
+        jobExecutionCreator.setStartedOn(new Date());
+        jobExecutionCreator.getEntityAttributes().put(JBATCH_EXECUTION_ID, Long.toString(jBatchExecutionId));
+
+        if (jobTargetSublist.isEmpty()) {
+            JobTargetQuery jobTargetQuery = JOB_TARGET_FACTORY.newQuery(scopeId);
+
+            jobTargetQuery.setPredicate(
+                    new AndPredicateImpl(
+                            new AttributePredicateImpl<>(JobTargetAttributes.JOB_ID, jobId)
+                    )
+            );
+
+            JobTargetListResult jobTargets = KapuaSecurityUtils.doPrivileged(() -> JOB_TARGET_SERVICE.query(jobTargetQuery));
+
+            Set<KapuaId> targetIds = new HashSet<>();
+            jobTargets.getItems().forEach(jt -> targetIds.add(jt.getId()));
+
+            jobExecutionCreator.setTargetIds(new HashSet<>(targetIds));
+        } else {
+            jobExecutionCreator.setTargetIds(jobTargetSublist.getTargetIds());
+        }
+
+        return KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.create(jobExecutionCreator));
+    }
+
+    /**
+     * Checks if there are other {@link JobExecution}s running in this moment.
+     * <p>
+     * First it checks for an execution running from the {@link BatchRuntime}.
+     * This will return the jBatch execution ids that are currently active.
+     * <p>
+     * If 0, no execution is currently running so the new execution can continue.
+     * <p>
+     * If greater than 0, it checks if the running {@link JobExecution} has a subset of {@link org.eclipse.kapua.service.job.targets.JobTarget}s compatible with the current {@link JobTargetSublist}.
+     * If the current {@link JobTargetSublist} doesn't match {@link org.eclipse.kapua.service.job.targets.JobTarget}s of any other running JobExecution, this execution can continue.
+     * <p>
+     * In any other case, {@link JobAlreadyRunningException} is thrown.
+     *
+     * @param scopeId           The current {@link JobExecution#getScopeId()}
+     * @param jobId             The current {@link JobExecution#getJobId()}
+     * @param jobName           The current {@link JobContextWrapper#getJobName()}
+     * @param jobTargetIdSubset The current {@link JobExecution#getTargetIds()} }
+     * @throws KapuaException If any error happens during the processing.
+     */
+    private void checkJobRunning(KapuaId scopeId, KapuaId jobId, String jobName, Set<KapuaId> jobTargetIdSubset) throws KapuaException {
+        List<Long> runningExecutionsIds = BatchRuntime.getJobOperator().getRunningExecutions(jobName);
+        if (runningExecutionsIds.size() > 1) {
+
+            JobExecutionQuery jobExecutionQuery = JOB_EXECUTION_FACTORY.newQuery(scopeId);
+
+            jobExecutionQuery.setPredicate(
+                    new AndPredicateImpl(
+                            new AttributePredicateImpl<>(JobExecutionAttributes.JOB_ID, jobId),
+                            new AttributePredicateImpl<>(JobExecutionAttributes.ENDED_ON, null),
+                            new AttributePredicateImpl<>(JobExecutionAttributes.TARGET_IDS, jobTargetIdSubset.toArray())
+                    )
+            );
+
+            long runningExecutionWithTargets = KapuaSecurityUtils.doPrivileged(() -> JOB_EXECUTION_SERVICE.count(jobExecutionQuery));
+
+            if (runningExecutionWithTargets > 1) {
+                throw new JobAlreadyRunningException(scopeId, jobId, jobTargetIdSubset);
+            }
+        }
     }
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -11,14 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.execution;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
+import java.util.Set;
 
 /**
  * {@link JobExecution} entity.
@@ -49,4 +54,10 @@ public interface JobExecution extends KapuaUpdatableEntity {
 
     void setEndedOn(Date endedOn);
 
+    @XmlElement(name = "targetIds")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
+    <I extends KapuaId> Set<I> getTargetIds();
+
+    void setTargetIds(Set<KapuaId> tagTargetIds);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -26,9 +26,9 @@ import java.util.Date;
 import java.util.Set;
 
 /**
- * {@link JobExecution} entity.
+ * {@link JobExecution} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "jobExecution")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -42,22 +42,54 @@ public interface JobExecution extends KapuaUpdatableEntity {
         return TYPE;
     }
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     KapuaId getJobId();
 
+    /**
+     * @param jobId
+     * @since 1.0.0
+     */
     void setJobId(KapuaId jobId);
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     Date getStartedOn();
 
+    /**
+     * @param startedOn
+     * @since 1.0.0
+     */
     void setStartedOn(Date startedOn);
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     Date getEndedOn();
 
+    /**
+     * @param endedOn
+     * @since 1.0.0
+     */
     void setEndedOn(Date endedOn);
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     @XmlElement(name = "targetIds")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
     <I extends KapuaId> Set<I> getTargetIds();
 
+    /**
+     * @param tagTargetIds
+     * @since 1.1.0
+     */
     void setTargetIds(Set<KapuaId> tagTargetIds);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionAttributes.java
@@ -18,4 +18,5 @@ public class JobExecutionAttributes extends KapuaUpdatableEntityAttributes {
     public static final String JOB_ID = "jobId";
     public static final String STARTED_ON = "startedOn";
     public static final String ENDED_ON = "endedOn";
+    public static final String TARGET_IDS = "targetIds";
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
@@ -11,14 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.execution;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
+import java.util.Set;
 
 /**
  * {@link JobExecutionCreator} encapsulates all the information needed to create a new JobExecution in the system.<br>
@@ -38,4 +43,11 @@ public interface JobExecutionCreator extends KapuaUpdatableEntityCreator<JobExec
     Date getStartedOn();
 
     void setStartedOn(Date startedOn);
+
+    @XmlElement(name = "targetIds")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    @ApiModelProperty(dataType = "string")
+    <I extends KapuaId> Set<I> getTargetIds();
+
+    void setTargetIds(Set<KapuaId> tagTargetIds);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -26,8 +26,7 @@ import java.util.Date;
 import java.util.Set;
 
 /**
- * {@link JobExecutionCreator} encapsulates all the information needed to create a new JobExecution in the system.<br>
- * The data provided will be used to seed the new JobExecution.
+ * {@link JobExecutionCreator} defintion.
  *
  * @since 1.0.0
  */
@@ -36,18 +35,42 @@ import java.util.Set;
 @XmlType(factoryClass = JobExecutionXmlRegistry.class, factoryMethod = "newJobExecutionCreator")
 public interface JobExecutionCreator extends KapuaUpdatableEntityCreator<JobExecution> {
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     KapuaId getJobId();
 
+    /**
+     * @param jobId
+     * @since 1.0.0
+     */
     void setJobId(KapuaId jobId);
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     Date getStartedOn();
 
+    /**
+     * @param startedOn
+     * @since 1.0.0
+     */
     void setStartedOn(Date startedOn);
 
+    /**
+     * @return
+     * @since 1.1.0
+     */
     @XmlElement(name = "targetIds")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     @ApiModelProperty(dataType = "string")
     <I extends KapuaId> Set<I> getTargetIds();
 
+    /**
+     * @param tagTargetIds
+     * @since 1.1.0
+     */
     void setTargetIds(Set<KapuaId> tagTargetIds);
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionCreatorImpl.java
@@ -11,13 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.execution.internal;
 
-import java.util.Date;
-
 import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntityCreator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.execution.JobExecution;
 import org.eclipse.kapua.service.job.execution.JobExecutionCreator;
+
+import java.util.Date;
+import java.util.Set;
 
 @KapuaProvider
 public class JobExecutionCreatorImpl extends AbstractKapuaUpdatableEntityCreator<JobExecution> implements JobExecutionCreator {
@@ -26,6 +27,7 @@ public class JobExecutionCreatorImpl extends AbstractKapuaUpdatableEntityCreator
 
     private KapuaId jobId;
     private Date startedOn;
+    private Set<KapuaId> targetIds;
 
     protected JobExecutionCreatorImpl(KapuaId scopeId) {
         super(scopeId);
@@ -49,5 +51,15 @@ public class JobExecutionCreatorImpl extends AbstractKapuaUpdatableEntityCreator
     @Override
     public void setStartedOn(Date startedOn) {
         this.startedOn = startedOn;
+    }
+
+    @Override
+    public Set<KapuaId> getTargetIds() {
+        return targetIds;
+    }
+
+    @Override
+    public void setTargetIds(Set<KapuaId> targetIds) {
+        this.targetIds = targetIds;
     }
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,6 @@
 package org.eclipse.kapua.service.job.execution.internal;
 
 import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntityCreator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.execution.JobExecution;
 import org.eclipse.kapua.service.job.execution.JobExecutionCreator;
@@ -20,7 +19,11 @@ import org.eclipse.kapua.service.job.execution.JobExecutionCreator;
 import java.util.Date;
 import java.util.Set;
 
-@KapuaProvider
+/**
+ * {@link JobExecutionCreator} implementation
+ *
+ * @since 1.0.0
+ */
 public class JobExecutionCreatorImpl extends AbstractKapuaUpdatableEntityCreator<JobExecution> implements JobExecutionCreator {
 
     private static final long serialVersionUID = 3119071638220738358L;

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionDAO.java
@@ -23,9 +23,8 @@ import org.eclipse.kapua.service.job.execution.JobExecutionListResult;
 
 /**
  * JobExecution DAO
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 public class JobExecutionDAO {
 
@@ -34,7 +33,7 @@ public class JobExecutionDAO {
 
     /**
      * Creates and return new JobExecution
-     * 
+     *
      * @param em
      * @param jobExecutionCreator
      * @return
@@ -49,13 +48,14 @@ public class JobExecutionDAO {
         jobExecutionImpl.setJobId(jobExecutionCreator.getJobId());
         jobExecutionImpl.setStartedOn(jobExecutionCreator.getStartedOn());
         jobExecutionImpl.setEntityAttributes(jobExecutionCreator.getEntityAttributes());
+        jobExecutionImpl.setTargetIds(jobExecutionCreator.getTargetIds());
 
         return ServiceDAO.create(em, jobExecutionImpl);
     }
 
     /**
      * Updates the provided jobExecution
-     * 
+     *
      * @param em
      * @param jobExecution
      * @return
@@ -125,8 +125,7 @@ public class JobExecutionDAO {
      * @param em
      * @param scopeId
      * @param jobExecutionId
-     * @throws KapuaEntityNotFoundException
-     *             If the {@link JobExecution} is not found
+     * @throws KapuaEntityNotFoundException If the {@link JobExecution} is not found
      */
     public static void delete(EntityManager em, KapuaId scopeId, KapuaId jobExecutionId) throws KapuaEntityNotFoundException {
         ServiceDAO.delete(em, JobExecutionImpl.class, scopeId, jobExecutionId);

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,9 +22,9 @@ import org.eclipse.kapua.service.job.execution.JobExecutionCreator;
 import org.eclipse.kapua.service.job.execution.JobExecutionListResult;
 
 /**
- * JobExecution DAO
+ * {@link JobExecution} {@link ServiceDAO}.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class JobExecutionDAO {
 
@@ -38,11 +38,10 @@ public class JobExecutionDAO {
      * @param jobExecutionCreator
      * @return
      * @throws KapuaException
+     * @since 1.0.0
      */
     public static JobExecution create(EntityManager em, JobExecutionCreator jobExecutionCreator)
             throws KapuaException {
-        //
-        // Create JobExecution
 
         JobExecutionImpl jobExecutionImpl = new JobExecutionImpl(jobExecutionCreator.getScopeId());
         jobExecutionImpl.setJobId(jobExecutionCreator.getJobId());
@@ -60,6 +59,7 @@ public class JobExecutionDAO {
      * @param jobExecution
      * @return
      * @throws KapuaException
+     * @since 1.0.0
      */
     public static JobExecution update(EntityManager em, JobExecution jobExecution)
             throws KapuaException {
@@ -77,6 +77,7 @@ public class JobExecutionDAO {
      * @param scopeId
      * @param jobExecutionId
      * @return
+     * @since 1.0.0
      */
     public static JobExecution find(EntityManager em, KapuaId scopeId, KapuaId jobExecutionId) {
         return ServiceDAO.find(em, JobExecutionImpl.class, scopeId, jobExecutionId);
@@ -88,6 +89,7 @@ public class JobExecutionDAO {
      * @param em
      * @param name
      * @return
+     * @since 1.0.0
      */
     public static JobExecution findByName(EntityManager em, String name) {
         return ServiceDAO.findByField(em, JobExecutionImpl.class, "name", name);
@@ -100,6 +102,7 @@ public class JobExecutionDAO {
      * @param jobExecutionQuery
      * @return
      * @throws KapuaException
+     * @since 1.0.0
      */
     public static JobExecutionListResult query(EntityManager em, KapuaQuery<JobExecution> jobExecutionQuery)
             throws KapuaException {
@@ -113,6 +116,7 @@ public class JobExecutionDAO {
      * @param jobExecutionQuery
      * @return
      * @throws KapuaException
+     * @since 1.0.0
      */
     public static long count(EntityManager em, KapuaQuery<JobExecution> jobExecutionQuery)
             throws KapuaException {
@@ -126,6 +130,7 @@ public class JobExecutionDAO {
      * @param scopeId
      * @param jobExecutionId
      * @throws KapuaEntityNotFoundException If the {@link JobExecution} is not found
+     * @since 1.0.0
      */
     public static void delete(EntityManager em, KapuaId scopeId, KapuaId jobExecutionId) throws KapuaEntityNotFoundException {
         ServiceDAO.delete(em, JobExecutionImpl.class, scopeId, jobExecutionId);

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -46,11 +46,11 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
 
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "started_on", nullable = false, updatable = false)
-    public Date startedOn;
+    private Date startedOn;
 
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "ended_on", nullable = true, updatable = true)
-    public Date endedOn;
+    private Date endedOn;
 
     @ElementCollection
     @CollectionTable(name = "job_job_execution_target", joinColumns = @JoinColumn(name = "execution_id", referencedColumnName = "id"))

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.execution.internal;
 
-import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -32,6 +31,11 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * {@link JobExecution} implementation
+ *
+ * @since 1.0.0
+ */
 @Entity(name = "JobExecution")
 @Table(name = "job_job_execution")
 public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements JobExecution {
@@ -81,15 +85,15 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
      * Clone constructor.
      *
      * @param jobExecution
-     * @throws KapuaException
      * @since 1.1.0
      */
-    public JobExecutionImpl(JobExecution jobExecution) throws KapuaException {
+    public JobExecutionImpl(JobExecution jobExecution) {
         super(jobExecution);
 
         setJobId(jobExecution.getJobId());
         setStartedOn(jobExecution.getStartedOn());
         setEndedOn(jobExecution.getEndedOn());
+        setTargetIds(jobExecution.getTargetIds());
     }
 
     @Override

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -19,13 +19,18 @@ import org.eclipse.kapua.service.job.execution.JobExecution;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity(name = "JobExecution")
 @Table(name = "job_job_execution")
@@ -46,6 +51,13 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "ended_on", nullable = true, updatable = true)
     public Date endedOn;
+
+    @ElementCollection
+    @CollectionTable(name = "job_job_execution_target", joinColumns = @JoinColumn(name = "execution_id", referencedColumnName = "id"))
+    @AttributeOverrides({
+            @AttributeOverride(name = "eid", column = @Column(name = "target_id", nullable = false, updatable = false))
+    })
+    private Set<KapuaEid> targetIds;
 
     /**
      * Constructor.
@@ -110,4 +122,26 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
         this.endedOn = endedOn;
     }
 
+
+    @Override
+    public void setTargetIds(Set<KapuaId> tagIds) {
+        this.targetIds = new HashSet<>();
+
+        for (KapuaId id : tagIds) {
+            this.targetIds.add(KapuaEid.parseKapuaId(id));
+        }
+    }
+
+    @Override
+    public Set<KapuaId> getTargetIds() {
+        Set<KapuaId> tagIds = new HashSet<>();
+
+        if (this.targetIds != null) {
+            for (KapuaId deviceTagId : this.targetIds) {
+                tagIds.add(new KapuaEid(deviceTagId));
+            }
+        }
+
+        return tagIds;
+    }
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -127,8 +127,10 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     public void setTargetIds(Set<KapuaId> tagIds) {
         this.targetIds = new HashSet<>();
 
-        for (KapuaId id : tagIds) {
-            this.targetIds.add(KapuaEid.parseKapuaId(id));
+        if (tagIds != null) {
+            for (KapuaId id : tagIds) {
+                this.targetIds.add(KapuaEid.parseKapuaId(id));
+            }
         }
     }
 

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/changelog-job-1.1.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/changelog-job-1.1.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2018 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-1.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="./job_execution_target.xml"/>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/changelog-job-1.1.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/changelog-job-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution_target.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution_target.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+        logicalFilePath="KapuaDB/changelog-job-1.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-job_execution_target-1.1.0_createTable" author="eurotech">
+        <createTable tableName="job_job_execution_target">
+            <column name="execution_id" type="bigint(21) unsigned">
+                <constraints nullable="false" primaryKey="true" checkConstraint=">= 0"/>
+            </column>
+            <column name="target_id" type="bigint(21) unsigned">
+                <constraints nullable="false" primaryKey="true" checkConstraint=">= 0"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint constraintName="execution_id_fk" baseTableName="job_job_execution_target" baseColumnNames="execution_id" referencedTableName="job_job_execution" referencedColumnNames="id" onDelete="CASCADE"/>
+
+        <rollback>
+            <dropTable tableName="job_job_execution_target"/>
+        </rollback>
+    </changeSet>
+
+
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution_target.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution_target.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -30,13 +30,16 @@
             </column>
         </createTable>
 
-        <addForeignKeyConstraint constraintName="execution_id_fk" baseTableName="job_job_execution_target" baseColumnNames="execution_id" referencedTableName="job_job_execution" referencedColumnNames="id" onDelete="CASCADE"/>
+        <addForeignKeyConstraint constraintName="execution_id_fk"
+                                 baseTableName="job_job_execution_target"
+                                 baseColumnNames="execution_id"
+                                 referencedTableName="job_job_execution"
+                                 referencedColumnNames="id" onDelete="CASCADE"/>
 
         <rollback>
             <dropTable tableName="job_job_execution_target"/>
         </rollback>
     </changeSet>
-
 
 
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-job-0.3.0.xml" />
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-job-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-1.1.0.xml"/>
 
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-job-0.3.0.xml" />
+    <include relativeToChangelogFile="true" file="./0.3.0/changelog-job-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-job-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-1.1.0.xml"/>
 

--- a/service/job/internal/src/main/sql/H2/job_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_drop.sql
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *  
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/sql/H2/job_execution_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_execution_drop.sql
@@ -10,6 +10,7 @@
  *     Eurotech - initial API and implementation
  *******************************************************************************/
 
+DROP TABLE IF EXISTS job_job_execution_target;
 DROP TABLE IF EXISTS job_job_execution;
 
 DROP TABLE IF EXISTS DATABASECHANGELOG;

--- a/service/job/internal/src/main/sql/H2/job_execution_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_execution_drop.sql
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *  
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/sql/H2/job_execution_target_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_execution_target_drop.sql
@@ -10,12 +10,6 @@
  *     Eurotech - initial API and implementation
  *******************************************************************************/
 
-DROP TABLE IF EXISTS job_job_step_properties;
-DROP TABLE IF EXISTS sys_configuration;
 DROP TABLE IF EXISTS job_job_execution_target;
-DROP TABLE IF EXISTS job_job_execution;
-DROP TABLE IF EXISTS job_job_step;
-DROP TABLE IF EXISTS job_job_target;
-DROP TABLE IF EXISTS job_job;
 
 DROP TABLE IF EXISTS DATABASECHANGELOG;

--- a/service/job/internal/src/main/sql/H2/job_execution_target_drop.sql
+++ b/service/job/internal/src/main/sql/H2/job_execution_target_drop.sql
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
  *  
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
This PR introduces the feature of running concurrent JobExecutions of the same job when they have a different set of sub-target.

**Related Issue**
_None_

**Description of the solution adopted**
A list of target processed for each execution has been added.

If a new JobExecution starts, the list of target to process will be compared to the list of targets of any running JobExecution of the same Job. If at least one element matches, the JobExecution will exit because there is conflict between the executions. 

This required changes also to the stop feature. 
Now you can 
- Ask the job to stop: this will cause stop to all running JobExecutions.
- Ask to a specific JobExecution to stop: this will cause only the selected JobExecution to be stopped, while others will continue the processing.

**Screenshots**
_None_

**Any side note on the changes made**
Some refactoring on Gwt models has been done to uniform object names
