### PR TITLE
Refactor Eclipselink Dependencies

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -158,7 +158,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -191,7 +191,11 @@
                 <include>org.apache.shiro:shiro-core</include>
                 <include>org.bitbucket.b_c:jose4j</include>
                 <include>org.eclipse.paho:org.eclipse.paho.client.mqttv3</include>
-                <include>org.eclipse.persistence:eclipselink</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.jpa</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.jpa.jpql</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.core</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.asm</include>
+                <include>org.eclipse.persistence:org.eclipse.persistence.moxy</include>
                 <include>org.eclipse.persistence:javax.persistence</include>
                 <include>org.elasticsearch.client:rest</include>
                 <include>org.elasticsearch.client:transport</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -233,7 +233,23 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.asm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.moxy</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -451,7 +467,35 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.eclipse.persistence</groupId>
-                                    <artifactId>eclipselink</artifactId>
+                                    <artifactId>org.eclipse.persistence.jpa</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/broker_dependency</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.persistence</groupId>
+                                    <artifactId>org.eclipse.persistence.core</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/broker_dependency</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.persistence</groupId>
+                                    <artifactId>org.eclipse.persistence.asm</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/broker_dependency</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.persistence</groupId>
+                                    <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/broker_dependency</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.persistence</groupId>
+                                    <artifactId>org.eclipse.persistence.moxy</artifactId>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>target/broker_dependency</outputDirectory>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -157,7 +157,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -60,7 +60,7 @@
         <!-- External JPA dependencies -->
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.h2database/h2 -->

--- a/pom.xml
+++ b/pom.xml
@@ -1134,7 +1134,22 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
-                <artifactId>eclipselink</artifactId>
+                <artifactId>org.eclipse.persistence.jpa</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.core</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.asm</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
                 <version>${eclipselink.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR refactors all the Eclipselink dependencies. Currently we're including the whole Eclipselink package, containing a lot of not needed classes; some of them are also conflicting with other dependencies, causing the Jetty based containers to print thousands of warnings. The aim of this PR is to only use the Eclipselink jars we actually need for each container.

After this PR we still have some (~30) warnings from Jetty, but other dependencies are involved so we need to discuss about them.

In order to make sure that everything is still ok we should test database interaction and XML/JSON serialization in all containers.

**Related Issue**
No related issue

**Description of the solution adopted**
No significant addition

**Any side note on the changes made**
No side changes