### PR TITLE
Fix release 1.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - openjdk8
+- openjdk8
 
 sudo: false
 dist: trusty
@@ -13,75 +13,74 @@ cache:
   - $HOME/.m2
 
 install:
-  - echo ==== Setting up toolchain.xml ====
-  - ls /usr/lib/jvm
-  - ls
-  - cp build-tools/src/main/toolchains/travis-ci.xml ~/.m2/toolchains.xml
-  - echo ==== Setting up Maven 3.3 for Travis ====
-  - wget -T 30 -t 3 -O maven.tar.gz http://www-eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz || wget -T 30 -t 3 -O maven.tar.gz http://www-us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
-  - mkdir maven
-  - cd maven ; tar --strip-components 1 -xzf ../maven.tar.gz ; cd ..
-  - chmod a+x maven/bin/mvn
+- echo ==== Setting up toolchain.xml ====
+- ls /usr/lib/jvm
+- ls
+- cp build-tools/src/main/toolchains/travis-ci.xml ~/.m2/toolchains.xml
+- echo ==== Setting up Maven 3.3 for Travis ====
+- wget -T 30 -t 3 -O maven.tar.gz http://www-eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz || wget -T 30 -t 3 -O maven.tar.gz http://www-us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+- mkdir maven
+- cd maven ; tar --strip-components 1 -xzf ../maven.tar.gz ; cd ..
+- chmod a+x maven/bin/mvn
 
 before_script:
   - export M2_HOME=$PWD/maven
   - export PATH=${M2_HOME}/bin:${PATH}
-  - export MAVEN_OPTS=-Xmx512m
+  - export BUILD_OPTS=""
+  - export CONFIG_OVERRIDES="-Dcommons.settings.hotswap=true"
+  - export MAVEN_OPTS="-Xmx1024m"
   - hash -r
 
 jobs:
   include:
-    - stage: build
-      script:
-        - $M2_HOME/bin/mvn -v
-        - $M2_HOME/bin/mvn -B -f external/pom.xml install
-    - stage: build
-      script:
-        - $M2_HOME/bin/mvn -v
-        - $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -DskipTests install
-    - stage: test
-      script:
-        - $M2_HOME/bin/mvn -B javadoc:jar
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @default" -Pdev verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @brokerAcl" verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @tag" verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @broker" verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @device" verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @connection" verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @datastore" -Dcommons.settings.hotswap=true verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @user" verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @security" verify
-        - bash <(curl -s https://codecov.io/bash)
-    - stage: test
-      script:
-        - ./travis.sh $M2_HOME/bin/mvn -B -Dgwt.compiler.localWorkers=2 -Dcommons.settings.hotswap=true -Dcucumber.options="--tags @jobs" verify
-        - bash <(curl -s https://codecov.io/bash)
+  - stage: build
+    script:
+    - $M2_HOME/bin/mvn -v
+    - $M2_HOME/bin/mvn -B -f external/pom.xml install
+    - $M2_HOME/bin/mvn -B ${BUILD_OPTS} -DskipTests clean install
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @default" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @brokerAcl" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @tag" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @broker" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @device" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @connection" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @datastore" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @user" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @security" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dcucumber.options="--tags @jobs" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - $M2_HOME/bin/mvn -B -DskipTests install javadoc:jar
 
 # The following upgrades Java during the build in
 # order to work around an older Java 8 compiler issue
@@ -91,4 +90,4 @@ jobs:
 addons:
   apt:
     packages:
-      - openjdk-8-jdk
+    - openjdk-8-jdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: false
 dist: trusty
@@ -91,4 +91,4 @@ jobs:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - openjdk-8-jdk

--- a/build-tools/src/main/toolchains/travis-ci.xml
+++ b/build-tools/src/main/toolchains/travis-ci.xml
@@ -38,7 +38,7 @@
             <version>8</version>
         </provides>
         <configuration>
-            <jdkHome>/usr/lib/jvm/java-8-oracle/jre</jdkHome>
+            <jdkHome>/usr/lib/jvm/java-8-openjdk-amd64/jre</jdkHome>
         </configuration>
     </toolchain>
 </toolchains>


### PR DESCRIPTION
This PR backports fixes from #2318 into `release-1.0.x` 
Cherry-pick was not an options since `travis.yml` has diverged in `develop`

Main fix needed was changing the JVM to use OpenJDK 8.

I've also added some improvement to the `travis.yml` that happened on `develop` branch.

**Related Issue**
_None_

**Description of the solution adopted**
Just replicated changes.

**Screenshots**
_None_

**Any side note on the changes made**
_None_