### PR TITLE
Added error message info when setting date for kapua-sys

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
@@ -123,8 +123,10 @@ public class AccountEditDialog extends AccountAddDialog {
                             case ILLEGAL_ARGUMENT:
                                 if (gwtCause.getArguments()[0].equals("expirationDate")) {
                                     expirationDateField.markInvalid(MSGS.conflictingExpirationDate());
+                                    ConsoleInfo.display("Error", MSGS.conflictingExpirationDate());
                                 } else if (gwtCause.getArguments()[0].equals("notAllowedExpirationDate")) {
                                     expirationDateField.markInvalid(MSGS.notAllowedExpirationDate());
+                                    ConsoleInfo.display("Error", MSGS.notAllowedExpirationDate());
                                 }
                                 break;
                             default:


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Added error message info in bottom right corner for invalid expiration date.

**Related Issue**
This PR fixes issue #2324 

**Description of the solution adopted**
When expiration date on account edit dialog is set for kapua-sys admin account, field is marked invalid and message info is shown in bottom right corner.

**Screenshots**
/

**Any side note on the changes made**
/
