### PR TITLE
Input fields in device configuration are resized

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -329,6 +329,7 @@ public class DeviceConfigPanel extends LayoutContainer {
         multiField.setFieldLabel(param.getName());
         multiField.addPlugin(dirtyPlugin);
         multiField.setOrientation(Orientation.VERTICAL);
+        multiField.setResizeFields(true);
         if (param.isRequired()) {
             multiField.setFieldLabel("* " + param.getName());
         }


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Input fields are resized in device configuration.

**Related Issue**
This PR fixes issue #2210 

**Description of the solution adopted**
Input fields in rest service in device configuration tab are streched as much as they can.

**Screenshots**
/

**Any side note on the changes made**
/
