### PR TITLE
Fix for date field value changes not enabling the Submit button

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -60,7 +60,7 @@ public class AccountAddDialog extends EntityAddEditDialog {
     protected final KapuaTextField<String> accountNameField = new KapuaTextField<String>();
     protected final KapuaTextField<String> accountPassword = new KapuaTextField<String>();
     protected final KapuaTextField<String> confirmPassword = new KapuaTextField<String>();
-    protected final KapuaDateField expirationDateField = new KapuaDateField();
+    protected final KapuaDateField expirationDateField = new KapuaDateField(this);
 
     // broker cluster
     protected final NumberField optlock = new NumberField();

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -53,6 +53,7 @@ public abstract class ActionDialog extends KapuaDialog {
 
     protected Boolean exitStatus;
     protected String exitMessage;
+    private Boolean dateValueNotNull = false;
 
     public ActionDialog() {
         super();
@@ -221,10 +222,14 @@ public abstract class ActionDialog extends KapuaDialog {
     }
 
     public void setSubmitButtonState() {
-        if (formPanel.isDirty()) {
+        if (formPanel.isDirty() || dateValueNotNull) {
             submitButton.enable();
         } else {
             submitButton.disable();
         }
+    }
+
+    public void setDateValueNotNull(Boolean dateValueNotNull) {
+        this.dateValueNotNull = dateValueNotNull;
     }
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaDateField.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaDateField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,10 +11,32 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.api.client.ui.widget;
 
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.ActionDialog;
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.ComponentEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.util.KeyNav;
 import com.extjs.gxt.ui.client.widget.form.DateField;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Timer;
 
 public class KapuaDateField extends DateField {
+
+    private ActionDialog dialog;
+    private Boolean enabledDateFieldEvents = false;
+
+    public KapuaDateField() {
+        super();
+    }
+
+    public KapuaDateField(ActionDialog actionDialog) {
+        super();
+        this.dialog = actionDialog;
+        this.enabledDateFieldEvents = true;
+    }
 
     @Override
     public void setMaxLength(int maxLength) {
@@ -28,5 +50,55 @@ public class KapuaDateField extends DateField {
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         getInputEl().setElementAttribute("maxLength", getMaxLength());
+
+        Listener<BaseEvent> dateListener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                setDateFieldState();
+            }
+        };
+
+        final Listener<BaseEvent> pasteEventListener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                if (be.getType() == Events.OnPaste) {
+                    final Timer timer = new Timer() {
+
+                        @Override
+                        public void run() {
+                            setDateFieldState();
+                        }
+                    };
+                    timer.schedule(100);
+                };
+            }
+        };
+
+        KeyNav<ComponentEvent> keyNav = new KeyNav<ComponentEvent>(KapuaDateField.this) {
+            public void onKeyPress(ComponentEvent ce) {
+                if (ce.getKeyCode() == KeyCodes.KEY_TAB || ce.getKeyCode() == KeyCodes.KEY_ENTER ) {
+                    setDateFieldState();
+                }
+            }
+        };
+
+        if (enabledDateFieldEvents) {
+            KapuaDateField.this.addListener(Events.KeyUp, dateListener);
+            KapuaDateField.this.addListener(Events.OnMouseUp, dateListener);
+            KapuaDateField.this.addListener(Events.OnPaste, pasteEventListener);
+            sinkEvents(Event.ONPASTE);
+        }
+    }
+
+    private void setDateFieldState() {
+        if (dialog != null) {
+            if (!KapuaDateField.this.getRawValue().isEmpty() && KapuaDateField.this.getOriginalValue() == null) {
+                dialog.setDateValueNotNull(true);
+            } else {
+                dialog.setDateValueNotNull(false);
+            }
+        }
     }
 }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -165,7 +165,7 @@ public class CredentialAddDialog extends EntityAddEditDialog {
         passwordTooltip.setStyleAttribute("font-size", "10px");
         credentialFormPanel.add(passwordTooltip);
         passwordTooltip.hide();
-        expirationDate = new KapuaDateField();
+        expirationDate = new KapuaDateField(this);
         expirationDate.setEmptyText(MSGS.dialogAddNoExpiration());
         expirationDate.setFieldLabel(MSGS.dialogAddFieldExpirationDate());
         expirationDate.setFormatValue(true);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -68,12 +68,12 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         this.jobId = jobId;
 
         triggerName = new KapuaTextField<String>();
-        startsOn = new KapuaDateField();
+        startsOn = new KapuaDateField(this);
         startsOn.setMaxLength(10);
         startsOn.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         startsOnTime = new TimeField();
         startsOnTime.setEditable(false);
-        endsOn = new KapuaDateField();
+        endsOn = new KapuaDateField(this);
         endsOn.setMaxLength(10);
         endsOn.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));
         endsOnTime = new TimeField();

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -202,7 +202,7 @@ public class UserAddDialog extends EntityAddEditDialog {
         userStatus.setSimpleValue(GwtUserStatus.ENABLED);
         statusFieldSet.add(userStatus, subFieldsetFormData);
 
-        expirationDate = new KapuaDateField();
+        expirationDate = new KapuaDateField(this);
         expirationDate.setName("expirationDate");
         expirationDate.setFormatValue(true);
         expirationDate.getPropertyEditor().setFormat(DateTimeFormat.getFormat("dd/MM/yyyy"));


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for date field value changes not enabling the Submit button

**Related Issue**
This PR fixes/closes #2298 

**Description of the solution adopted**
This PR solves problem regarding Submit button not being enabled if invalid Date value is entered in the KapuaDateField. The cause for this was that the previously created logic for enabling the Submit button depended only on the set value of the field - if the newly set value  of the field is different from its original value (isDirty).  With the DateField if the entered raw value is not a valid Date it will not be set, and this comparison would not work as the value for the field would stay null. 
This PR adds additional check for raw values being entered in the dateFields if the original value is null. Also new constructor and listener methods were added to the KapuaDateField. Affected Add/Edit dialogs were updated as well.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
