### PR TITLE
Fix for Paging toolbar getting disabled after multiple refresh

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -215,7 +215,7 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
 
         //
         // History packages tab
-        historyPackageTab = new DeviceTabPackagesHistory(currentSession);
+        historyPackageTab = new DeviceTabPackagesHistory(currentSession, this);
         historyPackageTab.setBorders(false);
         historyPackageTab.setLayout(new FitLayout());
 


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for Paging toolbar getting disabled after multiple refresh

**Related Issue**
This PR fixes/closes #2320 

**Description of the solution adopted**
Added new `HistoryLoadListener` (overriding the default loaderLoadException, loaderBeforeLoad and loaderLoad methods) to the `DeviceTabPackagesHistory `class. Added boolean variable whose state will be changed if loading is in progress or not. The Refresh button will be masked and new grid refresh will not be started until the previous one is finished. 

**Screenshots**
_None_

**Any side note on the changes made**
Did some minor code clean up (removed unused imports and buttons).
