### PR TITLE
Feature job execution log

### DIFF
--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
@@ -1,0 +1,286 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.job.engine.commons.logger;
+
+import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.execution.JobExecution;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Logger for {@link org.eclipse.kapua.service.job.Job} processing.
+ * <p>
+ * This {@link JobLogger} logs to the standard {@link Logger} of the current Java class (after setting it using {@link #setClassLog(Logger)})
+ * and keeps a copy of the log inside. Then, by invoking {@link #flush()} method it is possible to retrieve the copy of the log and store it
+ * into the {@link org.eclipse.kapua.service.job.execution.JobExecution#setLog(String)}.
+ */
+public class JobLogger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JobLogger.class);
+
+    private static final String LF = "\n";
+
+    private static final String PRE_STD_LOG_FORMAT_SCOPE_ID = "ScopeId: {} - ";
+    private static final String PRE_STD_LOG_FORMAT_JOB_ID = "JobId: {} - ";
+    private static final String PRE_STD_LOG_FORMAT_JOB_NAME = "JobName: {} - ";
+    private static final String PRE_STD_LOG_FORMAT_EXECUTION_ID = "ExecutionId: {} - ";
+
+    private static final String PRE_EXEC_LOG_FORMAT_LEVEL_INFO = "[INFO] ";
+    private static final String PRE_EXEC_LOG_FORMAT_LEVEL_ERROR = "[ERROR] ";
+    private static final String PRE_EXEC_LOG_FORMAT_DATE = "{} - ";
+    private static final String POST_EXEC_LOG_FORMAT_ERROR = " {}";
+
+    private Logger containerClassLog;
+
+    private StringBuilder logSb = new StringBuilder();
+
+    private KapuaId scopeId;
+    private KapuaId jobId;
+    private KapuaId jobExecutionId;
+    private String jobName;
+
+    /**
+     * Initialize the mandatory info of the {@link JobExecution} to use when logging.
+     *
+     * @param scopeId The current {@link JobExecution#getScopeId()}
+     * @param jobId   The current {@link JobExecution#getJobId()}
+     * @param jobName The current jBatch Job Name.
+     */
+    public JobLogger(KapuaId scopeId, KapuaId jobId, String jobName) {
+        this.scopeId = scopeId;
+        this.jobId = jobId;
+        this.jobName = jobName;
+    }
+
+    /**
+     * Sets the {@link JobExecution#getId()} into the {@link JobLogger} to be printed into the {@link Logger}.
+     *
+     * @param jobExecutionId The current {@link JobExecution#getId()}
+     */
+    public void setJobExecutionId(KapuaId jobExecutionId) {
+        this.jobExecutionId = jobExecutionId;
+    }
+
+    /**
+     * Sets the {@link Logger} of the class that is invoking this {@link JobLogger}.
+     * <p>
+     * The current set {@link Logger} will be used to print to the standard log of the application
+     *
+     * @param classLog The {@link Logger} to use to print log.
+     */
+    public void setClassLog(Logger classLog) {
+        this.containerClassLog = classLog;
+    }
+
+    /**
+     * Logs a log line of {@link java.util.logging.Level#INFO}.
+     *
+     * @param message The {@link String} to log.
+     */
+    public void info(String message) {
+        info(message, Collections.emptyList().toArray());
+    }
+
+    /**
+     * Logs a log line of {@link java.util.logging.Level#INFO} with the given arguments.
+     *
+     * @param format    The {@link String} format for the log line.
+     * @param arguments The {@link java.util.Objects}... to populate the given format.
+     */
+    public void info(String format, Object... arguments) {
+
+        if (StringUtils.countMatches(format, "{}") != arguments.length) {
+            LOG.warn("Format string tokens do not match number of arguments");
+        }
+        try {
+            //
+            // Standard Logging
+            if (containerClassLog.isInfoEnabled()) {
+                StringBuilder formatSb = new StringBuilder();
+                List<Object> finalArguments = new ArrayList<>();
+
+                buildStdLogFormatArguments(format, arguments, formatSb, finalArguments);
+
+                containerClassLog.info(formatSb.toString(), finalArguments.toArray());
+            }
+
+            //
+            // Job Execution Logging
+            StringBuilder formatSb = new StringBuilder();
+            formatSb.append(PRE_EXEC_LOG_FORMAT_LEVEL_INFO);
+            formatSb.append(PRE_EXEC_LOG_FORMAT_DATE);
+            formatSb.append(format);
+
+            List<Object> finalArguments = new ArrayList<>();
+            finalArguments.add(new Date());
+            finalArguments.addAll(Arrays.asList(arguments));
+
+            tokenizeFormat(formatSb);
+
+            logSb.append(MessageFormat.format(formatSb.toString(), finalArguments.toArray())).append(LF);
+        } catch (Exception e) {
+            LOG.error("Cannot log this line: " + format, e);
+        }
+    }
+
+    /**
+     * Logs a log line of {@link java.util.logging.Level#SEVERE}.
+     *
+     * @param message The {@link String} to log.
+     */
+    public void error(String message) {
+        error(null, message);
+    }
+
+    /**
+     * Logs a log line of {@link java.util.logging.Level#SEVERE} with the relative {@link Exception}.
+     * <p>
+     * Into the {@link JobExecution} log only {@link Exception#getMessage()} will be logged.
+     *
+     * @param exception The {@link Exception} to log.
+     * @param message   The {@link String} to log.
+     */
+    public void error(Exception exception, String message) {
+        error(exception, message, Collections.emptyList().toArray());
+    }
+
+    /**
+     * Logs a log line of {@link java.util.logging.Level#SEVERE} with the relative {@link Exception} with the given arguments.
+     * <p>
+     * Into the {@link JobExecution} log only {@link Exception#getMessage()} will be logged.
+     *
+     * @param exception The {@link Exception} to log.
+     * @param format    The {@link String} to log.
+     * @param arguments The {@link java.util.Objects}... to populate the given format.
+     */
+    public void error(Exception exception, String format, Object... arguments) {
+        if (StringUtils.countMatches(format, "{}") != arguments.length) {
+            LOG.warn("Format string tokens do not match number of arguments");
+        }
+
+        try {
+            //
+            // Standard Logging
+            if (containerClassLog.isErrorEnabled()) {
+                StringBuilder formatSb = new StringBuilder();
+                List<Object> finalArguments = new ArrayList<>();
+
+                buildStdLogFormatArguments(format, arguments, formatSb, finalArguments);
+
+                tokenizeFormat(formatSb);
+
+                containerClassLog.error(MessageFormat.format(formatSb.toString(), finalArguments.toArray()), exception);
+            }
+
+            //
+            // Job Execution Logging
+            StringBuilder formatSb = new StringBuilder();
+            formatSb.append(PRE_EXEC_LOG_FORMAT_LEVEL_ERROR);
+            formatSb.append(PRE_EXEC_LOG_FORMAT_DATE);
+            formatSb.append(format);
+
+            List<Object> finalArguments = new ArrayList<>();
+            finalArguments.add(new Date());
+            finalArguments.addAll(Arrays.asList(arguments));
+
+            if (exception != null) {
+                formatSb.append(POST_EXEC_LOG_FORMAT_ERROR);
+                finalArguments.add(exception.getMessage());
+            }
+
+            tokenizeFormat(formatSb);
+
+            logSb.append(MessageFormat.format(formatSb.toString(), finalArguments.toArray())).append(LF);
+        } catch (Exception e) {
+            LOG.error("Cannot log this line: " + format, e);
+        }
+    }
+
+    /**
+     * Returns all the log stored into {@code this} JobLogger and clears the current content.
+     *
+     * @return The current stored log.
+     */
+    public synchronized String flush() {
+        String log = logSb.toString();
+
+        logSb = new StringBuilder();
+
+        return log;
+    }
+
+    //
+    // Private methods
+    //
+
+    /**
+     * Build the log line for the standard log of the application.
+     * <p>
+     * It prepends some {@link org.eclipse.kapua.service.job.Job} info to the log line,
+     * appends the given {@link String} format, building also the {@link List} of argument to pass to the {@link Logger}
+     *
+     * @param format         The user-provided {@link String} format to log.
+     * @param arguments      The user-provided {@link List} of arguments to log.
+     * @param formatSb       The {@link StringBuilder} to populate, it must be empty.
+     * @param finalArguments The {@link List} to populate, it must be empty.
+     */
+    private void buildStdLogFormatArguments(String format, Object[] arguments, StringBuilder formatSb, List<Object> finalArguments) {
+
+        formatSb.append(PRE_STD_LOG_FORMAT_SCOPE_ID);
+        formatSb.append(PRE_STD_LOG_FORMAT_JOB_ID);
+
+        finalArguments.add(scopeId);
+        finalArguments.add(jobId);
+
+        if (!Strings.isNullOrEmpty(jobName)) {
+            formatSb.append(PRE_STD_LOG_FORMAT_JOB_NAME);
+            finalArguments.add(jobName);
+        }
+
+        if (jobExecutionId != null) {
+            formatSb.append(PRE_STD_LOG_FORMAT_EXECUTION_ID);
+            finalArguments.add(jobExecutionId);
+        }
+
+        formatSb.append(format);
+        finalArguments.addAll(Arrays.asList(arguments));
+    }
+
+    /**
+     * Adapts the {@link String} format required by {@link Logger} to the {@link String} format required by {@link MessageFormat#format(String, Object...)}
+     * <p>
+     * Example format for {@link Logger}:
+     * "This is a log line: {}"
+     * Example adaptation for {@link MessageFormat#format(String, Object...)}:
+     * "This is a log line: {0}"
+     * </p>
+     *
+     * @param formatSb The {@link String} format to adapt.
+     */
+    private void tokenizeFormat(StringBuilder formatSb) {
+        int i = 0;
+        int offset;
+        while (formatSb.indexOf("{}") != -1) {
+            offset = formatSb.indexOf("{}");
+            formatSb.insert(offset + 1, i++);
+        }
+    }
+}

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
@@ -32,6 +32,8 @@ import java.util.List;
  * This {@link JobLogger} logs to the standard {@link Logger} of the current Java class (after setting it using {@link #setClassLog(Logger)})
  * and keeps a copy of the log inside. Then, by invoking {@link #flush()} method it is possible to retrieve the copy of the log and store it
  * into the {@link org.eclipse.kapua.service.job.execution.JobExecution#setLog(String)}.
+ *
+ * @since 1.1.0
  */
 public class JobLogger {
 
@@ -65,6 +67,7 @@ public class JobLogger {
      * @param scopeId The current {@link JobExecution#getScopeId()}
      * @param jobId   The current {@link JobExecution#getJobId()}
      * @param jobName The current jBatch Job Name.
+     * @since 1.1.0
      */
     public JobLogger(KapuaId scopeId, KapuaId jobId, String jobName) {
         this.scopeId = scopeId;
@@ -76,6 +79,7 @@ public class JobLogger {
      * Sets the {@link JobExecution#getId()} into the {@link JobLogger} to be printed into the {@link Logger}.
      *
      * @param jobExecutionId The current {@link JobExecution#getId()}
+     * @since 1.1.0
      */
     public void setJobExecutionId(KapuaId jobExecutionId) {
         this.jobExecutionId = jobExecutionId;
@@ -87,6 +91,7 @@ public class JobLogger {
      * The current set {@link Logger} will be used to print to the standard log of the application
      *
      * @param classLog The {@link Logger} to use to print log.
+     * @since 1.1.0
      */
     public void setClassLog(Logger classLog) {
         this.containerClassLog = classLog;
@@ -96,6 +101,7 @@ public class JobLogger {
      * Logs a log line of {@link Level#INFO}.
      *
      * @param message The {@link String} to log.
+     * @since 1.1.0
      */
     public void info(String message) {
         info(message, Collections.emptyList().toArray());
@@ -106,6 +112,7 @@ public class JobLogger {
      *
      * @param format    The {@link String} format for the log line.
      * @param arguments The {@link java.util.Objects}... to populate the given format.
+     * @since 1.1.0
      */
     public void info(String format, Object... arguments) {
 
@@ -146,6 +153,7 @@ public class JobLogger {
      * Logs a log line of {@link Level#WARN}.
      *
      * @param message The {@link String} to log.
+     * @since 1.1.0
      */
     public void warn(String message) {
         warn(null, message);
@@ -158,6 +166,7 @@ public class JobLogger {
      *
      * @param exception The {@link Exception} to log.
      * @param message   The {@link String} to log.
+     * @since 1.1.0
      */
     public void warn(Exception exception, String message) {
         warn(exception, message, Collections.emptyList().toArray());
@@ -171,6 +180,7 @@ public class JobLogger {
      * @param exception The {@link Exception} to log.
      * @param format    The {@link String} to log.
      * @param arguments The {@link java.util.Objects}... to populate the given format.
+     * @since 1.1.0
      */
     public void warn(Exception exception, String format, Object... arguments) {
 
@@ -218,6 +228,7 @@ public class JobLogger {
      * Logs a log line of {@link Level#ERROR}.
      *
      * @param message The {@link String} to log.
+     * @since 1.1.0
      */
     public void error(String message) {
         error(null, message);
@@ -230,6 +241,7 @@ public class JobLogger {
      *
      * @param exception The {@link Exception} to log.
      * @param message   The {@link String} to log.
+     * @since 1.1.0
      */
     public void error(Exception exception, String message) {
         error(exception, message, Collections.emptyList().toArray());
@@ -243,6 +255,7 @@ public class JobLogger {
      * @param exception The {@link Exception} to log.
      * @param format    The {@link String} to log.
      * @param arguments The {@link java.util.Objects}... to populate the given format.
+     * @since 1.1.0
      */
     public void error(Exception exception, String format, Object... arguments) {
 
@@ -290,6 +303,7 @@ public class JobLogger {
      * Returns all the log stored into {@code this} JobLogger and clears the current content.
      *
      * @return The current stored log.
+     * @since 1.1.0
      */
     public synchronized String flush() {
         String log = logSb.toString();
@@ -313,6 +327,7 @@ public class JobLogger {
      *
      * @param format    The {@link String} format to check.
      * @param arguments The {@link List} of arguments to check.
+     * @since 1.1.0
      */
     private void checkFormatAndArguments(String format, Object... arguments) {
         if (StringUtils.countMatches(format, "{}") != arguments.length) {
@@ -330,6 +345,7 @@ public class JobLogger {
      * @param arguments      The user-provided {@link List} of arguments to log.
      * @param formatSb       The {@link StringBuilder} to populate, it must be empty.
      * @param finalArguments The {@link List} to populate, it must be empty.
+     * @since 1.1.0
      */
     private void buildStdLogFormatArguments(String format, Object[] arguments, StringBuilder formatSb, List<Object> finalArguments) {
 
@@ -363,6 +379,7 @@ public class JobLogger {
      * </p>
      *
      * @param formatSb The {@link String} format to adapt.
+     * @since 1.1.0
      */
     private void tokenizeFormat(StringBuilder formatSb) {
         int i = 0;

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTransientUserData.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTransientUserData.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.job.engine.commons.model;
+
+import org.eclipse.kapua.job.engine.commons.logger.JobLogger;
+
+public class JobTransientUserData {
+
+    private JobLogger jobLogger;
+
+
+    public JobLogger getJobLogger() {
+        return jobLogger;
+    }
+
+    public void setJobLogger(JobLogger jobLogger) {
+        this.jobLogger = jobLogger;
+    }
+}

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTransientUserData.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTransientUserData.java
@@ -13,15 +13,36 @@ package org.eclipse.kapua.job.engine.commons.model;
 
 import org.eclipse.kapua.job.engine.commons.logger.JobLogger;
 
+import javax.batch.runtime.context.JobContext;
+
+/**
+ * {@link JobTransientUserData} offers utilities over the {@link JobContext#getTransientUserData()}.
+ * <p>
+ * Using this class in the {@link JobContext#getTransientUserData()} ease the access to the stored data.
+ *
+ * @since 1.1.0
+ */
 public class JobTransientUserData {
 
     private JobLogger jobLogger;
 
 
+    /**
+     * Gets the {@link JobLogger}.
+     *
+     * @return The {@link JobLogger}.
+     * @since 1.1.0
+     */
     public JobLogger getJobLogger() {
         return jobLogger;
     }
 
+    /**
+     * Sets the {@link JobLogger}.
+     *
+     * @param jobLogger The {@link JobLogger}.
+     * @since 1.1.0
+     */
     public void setJobLogger(JobLogger jobLogger) {
         this.jobLogger = jobLogger;
     }

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/AbstractTargetProcessor.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/AbstractTargetProcessor.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.job.engine.commons.operation;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.job.engine.commons.logger.JobLogger;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobContextWrapper;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.job.engine.commons.wrappers.StepContextWrapper;
@@ -43,22 +44,30 @@ public abstract class AbstractTargetProcessor implements TargetOperation {
     public final Object processItem(Object item) throws Exception {
         JobTargetWrapper wrappedJobTarget = (JobTargetWrapper) item;
 
+        initProcessing(wrappedJobTarget);
+
+        JobLogger jobLogger = jobContextWrapper.getJobLogger();
+        jobLogger.setClassLog(LOG);
+
         JobTarget jobTarget = wrappedJobTarget.getJobTarget();
-        LOG.info("Processing item: {}", wrappedJobTarget.getJobTarget().getId());
+        jobLogger.info("Processing item: {}", wrappedJobTarget.getJobTarget().getId());
         try {
             processTarget(jobTarget);
 
             jobTarget.setStatus(JobTargetStatus.PROCESS_OK);
 
-            LOG.info("Processing item: {} - Done!", jobTarget.getId());
+            jobLogger.info("Processing item: {} - Done!", jobTarget.getId());
         } catch (Exception e) {
-            LOG.info("Processing item: {} - Error!", jobTarget.getId(), e);
+            jobLogger.error(e, "Processing item: {} - Error!", jobTarget.getId());
+
             jobTarget.setStatus(JobTargetStatus.PROCESS_FAILED);
             wrappedJobTarget.setProcessingException(e);
         }
 
         return wrappedJobTarget;
     }
+
+    protected abstract void initProcessing(JobTargetWrapper wrappedJobTarget);
 
     public abstract void processTarget(JobTarget jobTarget) throws KapuaException;
 

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/AbstractTargetProcessor.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/AbstractTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -67,11 +67,31 @@ public abstract class AbstractTargetProcessor implements TargetOperation {
         return wrappedJobTarget;
     }
 
+    /**
+     * Actions before {@link #processTarget(JobTarget)} invokation.
+     *
+     * @param wrappedJobTarget The current {@link JobTargetWrapper}
+     * @since 1.1.0
+     */
     protected abstract void initProcessing(JobTargetWrapper wrappedJobTarget);
 
+    /**
+     * Action of the actual processing of the {@link JobTarget}.
+     *
+     * @param jobTarget The current {@link JobTarget}
+     * @throws KapuaException in case of exceptions during the processing.
+     * @since 1.0.0
+     */
     public abstract void processTarget(JobTarget jobTarget) throws KapuaException;
 
-    public void setContext(JobContext jobContext, StepContext stepContext) {
+    /**
+     * Sets {@link #jobContextWrapper} and {@link #stepContextWrapper} wrapping the given {@link JobContext} and the {@link StepContext}.
+     *
+     * @param jobContext  The {@code inject}ed {@link JobContext}.
+     * @param stepContext The {@code inject}ed {@link StepContext}.
+     * @since 1.0.0
+     */
+    protected void setContext(JobContext jobContext, StepContext stepContext) {
         jobContextWrapper = new JobContextWrapper(jobContext);
         stepContextWrapper = new StepContextWrapper(stepContext);
     }

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetReader.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetReader.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.job.engine.commons.operation;
 
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.job.engine.commons.logger.JobLogger;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobContextWrapper;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.job.engine.commons.wrappers.StepContextWrapper;
@@ -68,7 +69,11 @@ public class DefaultTargetReader extends AbstractItemReader implements TargetRea
     public void open(Serializable arg0) throws Exception {
         JobContextWrapper jobContextWrapper = new JobContextWrapper(jobContext);
         StepContextWrapper stepContextWrapper = new StepContextWrapper(stepContext);
-        LOG.info("JOB {} - Opening cursor...", jobContextWrapper.getJobId());
+
+        JobLogger jobLogger = jobContextWrapper.getJobLogger();
+        jobLogger.setClassLog(LOG);
+
+        jobLogger.info("Opening cursor...");
 
         //
         // Job Id and JobTarget status filtering
@@ -96,20 +101,24 @@ public class DefaultTargetReader extends AbstractItemReader implements TargetRea
         // Wrap the JobTargets in a wrapper object to store additional informations
         jobTargets.getItems().forEach(jt -> wrappedJobTargets.add(new JobTargetWrapper(jt)));
 
-        LOG.info("JOB {} - Opening cursor... Done!", jobContextWrapper.getJobId());
+        jobLogger.info("Opening cursor... Done!");
     }
 
     @Override
     public Object readItem() throws Exception {
         JobContextWrapper jobContextWrapper = new JobContextWrapper(jobContext);
-        LOG.info("JOB {} - Reading item...", jobContextWrapper.getJobId());
+
+        JobLogger jobLogger = jobContextWrapper.getJobLogger();
+        jobLogger.setClassLog(LOG);
+
+        jobLogger.info("Reading item...");
 
         JobTargetWrapper currentWrappedJobTarget = null;
         if (jobTargetIndex < wrappedJobTargets.size()) {
             currentWrappedJobTarget = wrappedJobTargets.get(jobTargetIndex++);
         }
 
-        LOG.info("JOB {} - Reading item... Done!", jobContextWrapper.getJobId());
+        jobLogger.info("Reading item... Done!");
         return currentWrappedJobTarget;
     }
 

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetWriter.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetWriter.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.job.engine.commons.operation;
 
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.job.engine.commons.logger.JobLogger;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobContextWrapper;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.job.engine.commons.wrappers.StepContextWrapper;
@@ -54,7 +55,11 @@ public class DefaultTargetWriter extends AbstractItemWriter implements TargetWri
 
         JobContextWrapper jobContextWrapper = new JobContextWrapper(jobContext);
         StepContextWrapper stepContextWrapper = new StepContextWrapper(stepContext);
-        LOG.info("JOB {} - Writing items...", jobContextWrapper.getJobId());
+
+        JobLogger jobLogger = jobContextWrapper.getJobLogger();
+        jobLogger.setClassLog(LOG);
+
+        jobLogger.info("Writing items...");
 
         for (Object item : items) {
             JobTargetWrapper processedWrappedJobTarget = (JobTargetWrapper) item;
@@ -79,6 +84,6 @@ public class DefaultTargetWriter extends AbstractItemWriter implements TargetWri
             KapuaSecurityUtils.doPrivileged(() -> JOB_TARGET_SERVICE.update(jobTarget));
         }
 
-        LOG.info("JOB {} - Writing items... Done!", jobContextWrapper.getJobId());
+        jobLogger.info("Writing items... Done!");
     }
 }

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
@@ -19,6 +19,7 @@ import org.eclipse.kapua.job.engine.commons.logger.JobLogger;
 import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
 import org.eclipse.kapua.job.engine.commons.model.JobTransientUserData;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.execution.JobExecution;
 import org.xml.sax.SAXException;
 
 import javax.batch.runtime.BatchStatus;
@@ -38,22 +39,48 @@ public class JobContextWrapper {
 
     private JobContext jobContext;
 
+    /**
+     * Constructor from the {@code inject}ed {@link JobContext}.
+     * <p>
+     * Wraps the given {@link JobContext}
+     *
+     * @param jobContext The {@link JobContext} to wrap.
+     * @since 1.1.0
+     */
     public JobContextWrapper(JobContext jobContext) {
         this.jobContext = jobContext;
     }
 
+    /**
+     * Gets the scope {@link KapuaId} of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     *
+     * @return The current scope {@link KapuaId} of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     * @since 1.0.0
+     */
     public KapuaId getScopeId() {
         Properties jobContextProperties = jobContext.getProperties();
         String scopeIdString = jobContextProperties.getProperty(JobContextPropertyNames.JOB_SCOPE_ID);
         return scopeIdString != null ? KapuaEid.parseCompactId(scopeIdString) : null;
     }
 
+    /**
+     * Gets the {@link org.eclipse.kapua.service.job.Job} {@link KapuaId} of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     *
+     * @return The current {@link org.eclipse.kapua.service.job.Job} {@link KapuaId} of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     * @since 1.0.0
+     */
     public KapuaId getJobId() {
         Properties jobContextProperties = jobContext.getProperties();
         String jobIdString = jobContextProperties.getProperty(JobContextPropertyNames.JOB_ID);
         return jobIdString != null ? KapuaEid.parseCompactId(jobIdString) : null;
     }
 
+    /**
+     * Gets the {@link JobTargetSublist} of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     *
+     * @return The current {@link JobTargetSublist} of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     * @since 1.0.0
+     */
     public JobTargetSublist getTargetSublist() {
         Properties jobContextProperties = jobContext.getProperties();
         String jobTargetSublistString = jobContextProperties.getProperty(JobContextPropertyNames.JOB_TARGET_SUBLIST);
@@ -65,6 +92,12 @@ public class JobContextWrapper {
         }
     }
 
+    /**
+     * Gets the start step index of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     *
+     * @return The start step index of the {@link org.eclipse.kapua.service.job.execution.JobExecution}.
+     * @since 1.0.0
+     */
     public Integer getFromStepIndex() {
         Properties jobContextProperties = jobContext.getProperties();
         String fromStepIndexString = jobContextProperties.getProperty(JobContextPropertyNames.JOB_STEP_FROM_INDEX);
@@ -72,6 +105,12 @@ public class JobContextWrapper {
         return Strings.isNullOrEmpty(fromStepIndexString) ? null : Integer.valueOf(fromStepIndexString);
     }
 
+    /**
+     * Gets the {@link JobTransientUserData}.
+     *
+     * @return The {@link JobTransientUserData}.
+     * @since 1.1.0
+     */
     public JobTransientUserData getJobTransientUserData() {
         JobTransientUserData transientUserData = (JobTransientUserData) getTransientUserData();
 
@@ -82,6 +121,14 @@ public class JobContextWrapper {
         return transientUserData;
     }
 
+    /**
+     * Gets the {@link JobLogger}.
+     * <p>
+     * If it does not exist, it instantiates a new one.
+     *
+     * @return The {@link JobLogger}.
+     * @since 1.1.0
+     */
     public JobLogger getJobLogger() {
 
         JobLogger jobLogger = getJobTransientUserData().getJobLogger();
@@ -94,46 +141,103 @@ public class JobContextWrapper {
         return jobLogger;
     }
 
+    /**
+     * @return {@link JobContext#getJobName()}.
+     * @see JobContext#getJobName
+     * @since 1.0.0
+     */
     public String getJobName() {
         return jobContext.getJobName();
     }
 
-    public Object getTransientUserData() {
+    /**
+     * @return {@link JobContext#getTransientUserData()}.
+     * @see JobContext#getTransientUserData().
+     * @since 1.0.0
+     */
+    private Object getTransientUserData() {
         return jobContext.getTransientUserData();
     }
 
-    public void setTransientUserData(Object data) {
+    /**
+     * @param data {@link JobContext#setTransientUserData(Object)}.
+     * @see JobContext#setTransientUserData(Object).
+     * @since 1.0.0
+     */
+    private void setTransientUserData(Object data) {
         jobContext.setTransientUserData(data);
     }
 
+    /**
+     * @return {@link JobContext#getInstanceId()}.
+     * @see JobContext#getInstanceId
+     * @since 1.0.0
+     */
     public long getInstanceId() {
         return jobContext.getInstanceId();
     }
 
+    /**
+     * @return {@link JobContext#getExecutionId()}.
+     * @see JobContext#getExecutionId
+     * @since 1.0.0
+     */
     public long getExecutionId() {
         return jobContext.getExecutionId();
     }
 
+    /**
+     * @return {@link JobContext#getProperties()}.
+     * @see JobContext#getProperties
+     * @since 1.0.0
+     */
     public Properties getProperties() {
         return jobContext.getProperties();
     }
 
+    /**
+     * @return {@link JobContext#getBatchStatus()}.
+     * @see JobContext#getBatchStatus
+     * @since 1.0.0
+     */
     public BatchStatus getBatchStatus() {
         return jobContext.getBatchStatus();
     }
 
+    /**
+     * @return {@link JobContext#getExitStatus()}.
+     * @see JobContext#getExitStatus
+     * @since 1.0.0
+     */
     public String getExitStatus() {
         return jobContext.getExitStatus();
     }
 
+    /**
+     * @param status {@link JobContext#setExitStatus(String)}.
+     * @see JobContext#setExitStatus(String)
+     * @since 1.0.0
+     */
     public void setExitStatus(String status) {
         jobContext.setExitStatus(status);
     }
 
+    /**
+     * Gets the current {@link JobExecution#getId()}.
+     *
+     * @return The current {@link JobExecution#getId()}.
+     * @since 1.0.0
+     */
     public KapuaId getKapuaExecutionId() {
         return (KapuaId) getProperties().get(KAPUA_EXECUTION_ID);
     }
 
+    /**
+     * Sets the current {@link JobExecution#getId()}.
+     *
+     * @param kapuaExecutionId The current {@link JobExecution#getId()}.
+     * @since 1.0.0
+     */
     public void setKapuaExecutionId(KapuaId kapuaExecutionId) {
         getProperties().put(KAPUA_EXECUTION_ID, kapuaExecutionId);
     }

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
@@ -15,7 +15,9 @@ import com.google.common.base.Strings;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.job.engine.commons.exception.ReadJobPropertyException;
+import org.eclipse.kapua.job.engine.commons.logger.JobLogger;
 import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
+import org.eclipse.kapua.job.engine.commons.model.JobTransientUserData;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.xml.sax.SAXException;
 
@@ -68,6 +70,28 @@ public class JobContextWrapper {
         String fromStepIndexString = jobContextProperties.getProperty(JobContextPropertyNames.JOB_STEP_FROM_INDEX);
 
         return Strings.isNullOrEmpty(fromStepIndexString) ? null : Integer.valueOf(fromStepIndexString);
+    }
+
+    public JobTransientUserData getJobTransientUserData() {
+        JobTransientUserData transientUserData = (JobTransientUserData) getTransientUserData();
+
+        if (transientUserData == null) {
+            transientUserData = new JobTransientUserData();
+            setTransientUserData(transientUserData);
+        }
+        return transientUserData;
+    }
+
+    public JobLogger getJobLogger() {
+
+        JobLogger jobLogger = getJobTransientUserData().getJobLogger();
+
+        if (jobLogger == null) {
+            jobLogger = new JobLogger(getScopeId(), getJobId(), getJobName());
+            getJobTransientUserData().setJobLogger(jobLogger);
+        }
+
+        return jobLogger;
     }
 
     public String getJobName() {

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
@@ -45,6 +45,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * {@link JobListener} implementations.
+ * <p>
+ * Listener for all {@link Job}.
+ *
+ * @since 1.0.0
+ */
 public class KapuaJobListener extends AbstractJobListener implements JobListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(KapuaJobListener.class);

--- a/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/DeviceAssetWriteTargetProcessor.java
+++ b/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/DeviceAssetWriteTargetProcessor.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.management.asset.job;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
+import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
@@ -37,8 +38,12 @@ public class DeviceAssetWriteTargetProcessor extends AbstractTargetProcessor imp
     StepContext stepContext;
 
     @Override
-    public void processTarget(JobTarget jobTarget) throws KapuaException {
+    protected void initProcessing(JobTargetWrapper wrappedJobTarget) {
         setContext(jobContext, stepContext);
+    }
+
+    @Override
+    public void processTarget(JobTarget jobTarget) throws KapuaException {
 
         DeviceAssets assets = stepContextWrapper.getStepProperty(DeviceAssetWritePropertyKeys.ASSETS, DeviceAssets.class);
         Long timeout = stepContextWrapper.getStepProperty(DeviceAssetWritePropertyKeys.TIMEOUT, Long.class);

--- a/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/DeviceAssetWriteTargetProcessor.java
+++ b/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/DeviceAssetWriteTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
 import org.eclipse.kapua.service.device.management.asset.job.definition.DeviceAssetWritePropertyKeys;
@@ -26,6 +27,11 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
+/**
+ * {@link TargetOperation} for {@link DeviceAssetManagementService#write(KapuaId, KapuaId, DeviceAssets, Long)}
+ *
+ * @since 1.0.0
+ */
 public class DeviceAssetWriteTargetProcessor extends AbstractTargetProcessor implements TargetOperation {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStartTargetProcessor.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStartTargetProcessor.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.management.bundle.job;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
+import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
 import org.eclipse.kapua.service.device.management.bundle.job.definition.DeviceBundlePropertyKeys;
@@ -36,8 +37,12 @@ public class DeviceBundleStartTargetProcessor extends AbstractTargetProcessor im
     StepContext stepContext;
 
     @Override
-    public void processTarget(JobTarget jobTarget) throws KapuaException {
+    protected void initProcessing(JobTargetWrapper wrappedJobTarget) {
         setContext(jobContext, stepContext);
+    }
+
+    @Override
+    public void processTarget(JobTarget jobTarget) throws KapuaException {
 
         String bundleId = stepContextWrapper.getStepProperty(DeviceBundlePropertyKeys.BUNDLE_ID, String.class);
         Long timeout = stepContextWrapper.getStepProperty(DeviceBundlePropertyKeys.TIMEOUT, Long.class);

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStartTargetProcessor.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStartTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
 import org.eclipse.kapua.service.device.management.bundle.job.definition.DeviceBundlePropertyKeys;
 import org.eclipse.kapua.service.job.operation.TargetOperation;
@@ -25,6 +26,11 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
+/**
+ * {@link TargetOperation} for {@link DeviceBundleManagementService#start(KapuaId, KapuaId, String, Long)}
+ *
+ * @since 1.0.0
+ */
 public class DeviceBundleStartTargetProcessor extends AbstractTargetProcessor implements TargetOperation {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStopTargetProcessor.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStopTargetProcessor.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.management.bundle.job;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
+import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
 import org.eclipse.kapua.service.device.management.bundle.job.definition.DeviceBundlePropertyKeys;
@@ -36,8 +37,12 @@ public class DeviceBundleStopTargetProcessor extends AbstractTargetProcessor imp
     StepContext stepContext;
 
     @Override
-    public void processTarget(JobTarget jobTarget) throws KapuaException {
+    protected void initProcessing(JobTargetWrapper wrappedJobTarget) {
         setContext(jobContext, stepContext);
+    }
+
+    @Override
+    public void processTarget(JobTarget jobTarget) throws KapuaException {
 
         String bundleId = stepContextWrapper.getStepProperty(DeviceBundlePropertyKeys.BUNDLE_ID, String.class);
         Long timeout = stepContextWrapper.getStepProperty(DeviceBundlePropertyKeys.TIMEOUT, Long.class);

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStopTargetProcessor.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStopTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
 import org.eclipse.kapua.service.device.management.bundle.job.definition.DeviceBundlePropertyKeys;
 import org.eclipse.kapua.service.job.operation.TargetOperation;
@@ -25,6 +26,11 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
+/**
+ * {@link TargetOperation} for {@link DeviceBundleManagementService#stop(KapuaId, KapuaId, String, Long)}.
+ *
+ * @since 1.0.0
+ */
 public class DeviceBundleStopTargetProcessor extends AbstractTargetProcessor implements TargetOperation {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/DeviceCommandExecTargetProcessor.java
+++ b/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/DeviceCommandExecTargetProcessor.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.management.command.job;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
+import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandInput;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService;
@@ -37,8 +38,12 @@ public class DeviceCommandExecTargetProcessor extends AbstractTargetProcessor im
     StepContext stepContext;
 
     @Override
-    public void processTarget(JobTarget jobTarget) throws KapuaException {
+    protected void initProcessing(JobTargetWrapper wrappedJobTarget) {
         setContext(jobContext, stepContext);
+    }
+
+    @Override
+    public void processTarget(JobTarget jobTarget) throws KapuaException {
 
         DeviceCommandInput commandInput = stepContextWrapper.getStepProperty(DeviceCommandExecPropertyKeys.COMMAND_INPUT, DeviceCommandInput.class);
         Long timeout = stepContextWrapper.getStepProperty(DeviceCommandExecPropertyKeys.TIMEOUT, Long.class);

--- a/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/DeviceCommandExecTargetProcessor.java
+++ b/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/DeviceCommandExecTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandInput;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService;
 import org.eclipse.kapua.service.device.management.command.job.definition.DeviceCommandExecPropertyKeys;
@@ -26,6 +27,11 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
+/**
+ * {@link TargetOperation} for {@link DeviceCommandManagementService#exec(KapuaId, KapuaId, DeviceCommandInput, Long)}.
+ *
+ * @since 1.0.0
+ */
 public class DeviceCommandExecTargetProcessor extends AbstractTargetProcessor implements TargetOperation {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/DeviceConfigurationPutTargetProcessor.java
+++ b/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/DeviceConfigurationPutTargetProcessor.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.management.configuration.job;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
+import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService;
@@ -37,8 +38,12 @@ public class DeviceConfigurationPutTargetProcessor extends AbstractTargetProcess
     StepContext stepContext;
 
     @Override
-    public void processTarget(JobTarget jobTarget) throws KapuaException {
+    protected void initProcessing(JobTargetWrapper wrappedJobTarget) {
         setContext(jobContext, stepContext);
+    }
+
+    @Override
+    public void processTarget(JobTarget jobTarget) throws KapuaException {
 
         DeviceConfiguration configuration = stepContextWrapper.getStepProperty(DeviceConfigurationPutPropertyKeys.CONFIGURATION, DeviceConfiguration.class);
         Long timeout = stepContextWrapper.getStepProperty(DeviceConfigurationPutPropertyKeys.TIMEOUT, Long.class);

--- a/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/DeviceConfigurationPutTargetProcessor.java
+++ b/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/DeviceConfigurationPutTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService;
 import org.eclipse.kapua.service.device.management.configuration.job.definition.DeviceConfigurationPutPropertyKeys;
@@ -26,6 +27,11 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
+/**
+ * {@link TargetOperation} for {@link DeviceConfigurationManagementService#put(KapuaId, KapuaId, DeviceConfiguration, Long)}.
+ *
+ * @since 1.0.0
+ */
 public class DeviceConfigurationPutTargetProcessor extends AbstractTargetProcessor implements TargetOperation {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageDownloadTargetProcessor.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageDownloadTargetProcessor.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.management.packages.job;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
+import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService;
 import org.eclipse.kapua.service.device.management.packages.job.definition.DevicePackageDownloadPropertyKeys;
@@ -37,8 +38,12 @@ public class DevicePackageDownloadTargetProcessor extends AbstractTargetProcesso
     StepContext stepContext;
 
     @Override
-    public void processTarget(JobTarget jobTarget) throws KapuaException {
+    protected void initProcessing(JobTargetWrapper wrappedJobTarget) {
         setContext(jobContext, stepContext);
+    }
+
+    @Override
+    public void processTarget(JobTarget jobTarget) throws KapuaException {
 
         DevicePackageDownloadRequest packageDownloadRequest = stepContextWrapper.getStepProperty(DevicePackageDownloadPropertyKeys.PACKAGE_DOWNLOAD_REQUEST, DevicePackageDownloadRequest.class);
         Long timeout = stepContextWrapper.getStepProperty(DevicePackageDownloadPropertyKeys.TIMEOUT, Long.class);

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageDownloadTargetProcessor.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageDownloadTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService;
 import org.eclipse.kapua.service.device.management.packages.job.definition.DevicePackageDownloadPropertyKeys;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
@@ -26,6 +27,11 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
+/**
+ * {@link TargetOperation} for {@link DevicePackageManagementService#downloadExec(KapuaId, KapuaId, DevicePackageDownloadRequest, Long)}.
+ *
+ * @since 1.0.0
+ */
 public class DevicePackageDownloadTargetProcessor extends AbstractTargetProcessor implements TargetOperation {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageUninstallTargetProcessor.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageUninstallTargetProcessor.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.device.management.packages.job;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
+import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService;
 import org.eclipse.kapua.service.device.management.packages.job.definition.DevicePackageUninstallPropertyKeys;
@@ -37,8 +38,12 @@ public class DevicePackageUninstallTargetProcessor extends AbstractTargetProcess
     StepContext stepContext;
 
     @Override
-    public void processTarget(JobTarget jobTarget) throws KapuaException {
+    protected void initProcessing(JobTargetWrapper wrappedJobTarget) {
         setContext(jobContext, stepContext);
+    }
+
+    @Override
+    public void processTarget(JobTarget jobTarget) throws KapuaException {
 
         DevicePackageUninstallRequest packageUninstallRequest = stepContextWrapper.getStepProperty(DevicePackageUninstallPropertyKeys.PACKAGE_UNINSTALL_REQUEST, DevicePackageUninstallRequest.class);
         Long timeout = stepContextWrapper.getStepProperty(DevicePackageUninstallPropertyKeys.TIMEOUT, Long.class);

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageUninstallTargetProcessor.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageUninstallTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
 import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService;
 import org.eclipse.kapua.service.device.management.packages.job.definition.DevicePackageUninstallPropertyKeys;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
@@ -26,6 +27,11 @@ import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
+/**
+ * {@link TargetOperation} for {@link DevicePackageManagementService#uninstallExec(KapuaId, KapuaId, DevicePackageUninstallRequest, Long)}.
+ *
+ * @since 1.0.0
+ */
 public class DevicePackageUninstallTargetProcessor extends AbstractTargetProcessor implements TargetOperation {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -93,7 +93,15 @@ public interface JobExecution extends KapuaUpdatableEntity {
      */
     void setTargetIds(Set<KapuaId> tagTargetIds);
 
+    /**
+     * @return
+     * @since 1.1.0
+     */
     String getLog();
 
+    /**
+     * @param log
+     * @since 1.1.0
+     */
     void setLog(String log);
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -92,4 +92,8 @@ public interface JobExecution extends KapuaUpdatableEntity {
      * @since 1.1.0
      */
     void setTargetIds(Set<KapuaId> tagTargetIds);
+
+    String getLog();
+
+    void setLog(String log);
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -79,7 +79,7 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     /**
      * Constructor.
      *
-     * @param scopeId The scope {@link KapuaId} to set into the {@link JobExecution}
+     * @param scopeId The scope {@link KapuaId} to set into the {@link JobExecution}.
      * @since 1.0.0
      */
     public JobExecutionImpl(KapuaId scopeId) {
@@ -89,7 +89,7 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     /**
      * Clone constructor.
      *
-     * @param jobExecution
+     * @param jobExecution The {@link JobExecution} to clone.
      * @since 1.1.0
      */
     public JobExecutionImpl(JobExecution jobExecution) {

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -24,6 +24,7 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
@@ -63,6 +64,10 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
     })
     private Set<KapuaEid> targetIds;
 
+    @Lob
+    @Column(name = "log", nullable = true, updatable = true)
+    private String log;
+
     /**
      * Constructor.
      *
@@ -94,6 +99,7 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
         setStartedOn(jobExecution.getStartedOn());
         setEndedOn(jobExecution.getEndedOn());
         setTargetIds(jobExecution.getTargetIds());
+        setLog(jobExecution.getLog());
     }
 
     @Override
@@ -149,5 +155,15 @@ public class JobExecutionImpl extends AbstractKapuaUpdatableEntity implements Jo
         }
 
         return tagIds;
+    }
+
+    @Override
+    public String getLog() {
+        return log;
+    }
+
+    @Override
+    public void setLog(String log) {
+        this.log = log;
     }
 }

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution-log.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution-log.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution-log.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution-log.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -9,16 +9,21 @@
 
     Contributors:
         Eurotech - initial API and implementation
- -->
+-->
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
         logicalFilePath="KapuaDB/changelog-job-1.1.0.xml">
 
-    <include relativeToChangelogFile="true" file="./job_execution-log.xml"/>
-    <include relativeToChangelogFile="true" file="./job_execution_target.xml"/>
-    <include relativeToChangelogFile="true" file="./job_target-status_message.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-job_execution-1.1.0_addLog" author="eurotech">
+        <addColumn tableName="job_job_execution">
+            <column name="log" type="text"/>
+        </addColumn>
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds the `JobExecution` log.
 
**Related Issue**
_None_

**Description of the solution adopted**
Now the log done in the `Job` processing using `JobLogger` is splitted between the JobExecution and the standard application logging. 

Still missing the console dialog to show it.

**Screenshots**
_None_

**Any side note on the changes made**
This PR is based on `feature-jobTargetErrorMessage` which has its own PR #2342 