### PR TITLE
Fix for History and In Progress tabs not refreshed on render

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -207,6 +207,7 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
 
             @Override
             public void handleEvent(ComponentEvent be) {
+                setEntity(selectedEntity);
                 hideUninstallButton();
                 refresh();
             }
@@ -223,6 +224,7 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
 
             @Override
             public void handleEvent(ComponentEvent be) {
+                setEntity(selectedEntity);
                 hideUninstallButton();
                 refresh();
             }


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for History and In Progress tabs not refreshed on render

**Related Issue**
This PR fixes/closes #2349 

**Description of the solution adopted**
Set selected entity for History and In Progress tabs on render.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
