### PR TITLE
Set permissions for enabling install and uninstall buttons

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -183,7 +183,7 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
 
         //
         // Packages installed tab
-        installedPackageTab = new DeviceTabPackagesInstalled(this);
+        installedPackageTab = new DeviceTabPackagesInstalled(currentSession, this);
         installedPackageTab.setBorders(false);
         installedPackageTab.setLayout(new FitLayout());
 
@@ -362,6 +362,7 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
             // Manage buttons
             if (selectedEntity != null && selectedEntity.isOnline()) {
                 toolBar.enable();
+                installButton.disable();
                 uninstallButton.disable();
             } else {
                 toolBar.disable();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,9 +20,11 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.TabItem;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtBundleInfo;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeploymentPackage;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceManagementSessionPermission;
 
 import com.extjs.gxt.ui.client.data.ModelData;
 import com.extjs.gxt.ui.client.Style.SelectionMode;
@@ -52,14 +54,16 @@ public class DeviceTabPackagesInstalled extends TabItem {
     private TreeGrid<ModelData> treeGrid;
     private TreeStore<ModelData> treeStore = new TreeStore<ModelData>();
     private boolean refreshing;
+    private GwtSession currentSession;
 
-    public DeviceTabPackagesInstalled(DeviceTabPackages rootTabPanel) {
+    public DeviceTabPackagesInstalled(GwtSession currentSession, DeviceTabPackages rootTabPanel) {
         super(DEVICE_MSGS.deviceInstallTabInstalled(), null);
 
         KapuaIcon icon = new KapuaIcon(IconSet.INBOX);
         setIcon(icon);
 
         this.rootTabPanel = rootTabPanel;
+        this.currentSession = currentSession;
     }
 
     public GwtDeploymentPackage getSelectedDeploymentPackage() {
@@ -109,7 +113,8 @@ public class DeviceTabPackagesInstalled extends TabItem {
 
                 // Check if it's a package or a bundle
                 if (selectedItem instanceof GwtDeploymentPackage) {
-                    rootTabPanel.getUninstallButton().enable();
+                    rootTabPanel.getUninstallButton().setEnabled(
+                        currentSession.hasPermission(DeviceManagementSessionPermission.write()));
                 } else {
                     rootTabPanel.getUninstallButton().disable();
                 }
@@ -162,7 +167,8 @@ public class DeviceTabPackagesInstalled extends TabItem {
 
                         treeGrid.unmask();
                         rootTabPanel.getRefreshButton().enable();
-                        rootTabPanel.getInstallButton().enable();
+                        rootTabPanel.getInstallButton().setEnabled(
+                            currentSession.hasPermission(DeviceManagementSessionPermission.write()));
                         refreshing = false;
                     }
 


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Set permissions for enabling install and uninstall buttons on Packages tab

**Related Issue**
This PR fixes/closes #2354 

**Description of the solution adopted**
Permission `DeviceManagementSessionPermission.write()` is now needed for enabling install and uninstall buttons on Packages tab.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
