### PR TITLE
Set permissions for enabling rollback button on Configuration tab

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -60,6 +60,7 @@ import org.eclipse.kapua.app.console.module.api.shared.service.GwtSecurityTokenS
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtSnapshot;
+import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceManagementSessionPermission;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementServiceAsync;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceService;
@@ -214,7 +215,7 @@ public class DeviceConfigSnapshots extends LayoutContainer {
 
                     rollbackSnapshot();
 
-                    rollbackButton.setEnabled(true);
+                    rollbackButton.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.execute()));
                     rollbackProcess = false;
                 }
             }
@@ -301,7 +302,7 @@ public class DeviceConfigSnapshots extends LayoutContainer {
             public void selectionChanged(SelectionChangedEvent<GwtSnapshot> se) {
                 if (se.getSelectedItem() != null) {
                     downloadButton.setEnabled(true);
-                    rollbackButton.setEnabled(true);
+                    rollbackButton.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.execute()));
                 } else {
                     downloadButton.setEnabled(false);
                     rollbackButton.setEnabled(false);


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Set permissions for enabling rollback button on Configuration tab.

**Related Issue**
This PR fixes/closes #2355 

**Description of the solution adopted**
Permission `DeviceManagementSessionPermission.execute()` is now needed for enabling the rollback button on the Configuration tab.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
