### PR TITLE
Add Job Targets via Tag and Rename JobStepDefinitions names

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceFilterPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceFilterPanel.java
@@ -40,6 +40,7 @@ import org.eclipse.kapua.app.console.module.tag.shared.model.permission.TagSessi
 import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagService;
 import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagServiceAsync;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
@@ -431,7 +432,9 @@ public class DeviceFilterPanel extends EntityFilterPanel<GwtDevice> {
             predicates.setGroupDevice("NO_GROUP");
         }
         if (tagsCombo != null && !tagsCombo.getValue().equals(allTag)) {
-            predicates.setTagId(tagsCombo.getValue().getId());
+            List<String> tagIds = new ArrayList<String>();
+            tagIds.add(tagsCombo.getValue().getId());
+            predicates.setTagIds(tagIds);
         }
 
         query.setPredicates(predicates);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
@@ -130,9 +130,9 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
                     .append(URL.encodeQueryString(query.getPredicates().getGroupId()));
         }
 
-        if (query.getPredicates().getTagId() != null) {
+        if (query.getPredicates().getTagIds().get(0) != null) {
             sbUrl.append("&tag=")
-                    .append(URL.encodeQueryString(query.getPredicates().getTagId()));
+                    .append(URL.encodeQueryString(query.getPredicates().getTagIds().get(0)));
         }
 
         Window.open(sbUrl.toString(), "_blank", "location=no");

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/TagSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/TagSubjectGrid.java
@@ -110,7 +110,9 @@ public class TagSubjectGrid extends EntityGrid<GwtDevice> {
         if (gwtTag != null) {
             selectedTag = gwtTag;
             GwtDeviceQueryPredicates predicates = new GwtDeviceQueryPredicates();
-            predicates.setTagId(selectedTag.getId());
+            List<String> tagIds = new ArrayList<String>();
+            tagIds.add(selectedTag.getId());
+            predicates.setTagIds(tagIds);
             query.setPredicates(predicates);
         }
         refresh();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDevice.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDevice.java
@@ -23,7 +23,14 @@ import com.google.gwt.user.client.rpc.IsSerializable;
 
 public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
 
-    private static final long serialVersionUID = -7670819589361945552L;
+    private static final String CLIENT_ID = "clientId";
+    private static final String GROUP_ID = "groupId";
+    private static final String DISPLAY_NAME = "displayName";
+    private static final String CUSTOM_ATTRIBUTE_1 = "customAttribute1";
+    private static final String CUSTOM_ATTRIBUTE_2 = "customAttribute2";
+    private static final String CUSTOM_ATTRIBUTE_3 = "customAttribute3";
+    private static final String CUSTOM_ATTRIBUTE_4 = "customAttribute4";
+    private static final String CUSTOM_ATTRIBUTE_5 = "customAttribute5";
 
     public enum GwtDeviceApplication implements IsSerializable {
 
@@ -72,31 +79,28 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
         }
     }
 
-    public GwtDevice() {
-    }
-
     public String getClientId() {
-        return (String) get("clientId");
+        return get(CLIENT_ID);
     }
 
     public String getUnescapedClientId() {
-        return (String) getUnescaped("clientId");
+        return getUnescaped(CLIENT_ID);
     }
 
     public void setClientId(String clientId) {
-        set("clientId", clientId);
+        set(CLIENT_ID, clientId);
     }
 
     public String getGroupId() {
-        return (String) get("groupId");
+        return get(GROUP_ID);
     }
 
     public String getUnescapedGroupId() {
-        return (String) getUnescaped("groupId");
+        return getUnescaped(GROUP_ID);
     }
 
     public void setGroupId(String groupId) {
-        set("groupId", groupId);
+        set(GROUP_ID, groupId);
     }
 
     public List<String> getTagIds() {
@@ -108,11 +112,11 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public Long getUptime() {
-        return (Long) get("uptime");
+        return get("uptime");
     }
 
     public String getUptimeFormatted() {
-        return (String) get("uptimeFormatted");
+        return get("uptimeFormatted");
     }
 
     public void setUptime(Long uptime) {
@@ -120,7 +124,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getGwtDeviceStatus() {
-        return (String) get("gwtDeviceStatus");
+        return get("gwtDeviceStatus");
     }
 
     public void setGwtDeviceStatus(String gwtDeviceStatus) {
@@ -152,19 +156,19 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getDisplayName() {
-        return (String) get("displayName");
+        return get(DISPLAY_NAME);
     }
 
     public String getUnescapedDisplayName() {
-        return (String) getUnescaped("displayName");
+        return getUnescaped(DISPLAY_NAME);
     }
 
     public void setDisplayName(String displayName) {
-        set("displayName", displayName);
+        set(DISPLAY_NAME, displayName);
     }
 
     public String getModelName() {
-        return (String) get("modelName");
+        return get("modelName");
     }
 
     public void setModelName(String modelName) {
@@ -172,7 +176,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getModelId() {
-        return (String) get("modelId");
+        return get("modelId");
     }
 
     public void setModelId(String modelId) {
@@ -180,7 +184,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getPartNumber() {
-        return (String) get("partNumber");
+        return get("partNumber");
     }
 
     public void setPartNumber(String partNumber) {
@@ -188,7 +192,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getSerialNumber() {
-        return (String) get("serialNumber");
+        return get("serialNumber");
     }
 
     public void setSerialNumber(String serialNumber) {
@@ -196,7 +200,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getAvailableProcessors() {
-        return (String) get("availableProcessors");
+        return get("availableProcessors");
     }
 
     public void setAvailableProcessors(String availableProcessors) {
@@ -204,7 +208,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getTotalMemory() {
-        return (String) get("totalMemory");
+        return get("totalMemory");
     }
 
     public void setTotalMemory(String totalMemory) {
@@ -212,7 +216,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getFirmwareVersion() {
-        return (String) get("firmwareVersion");
+        return get("firmwareVersion");
     }
 
     public void setFirmwareVersion(String firmwareVersion) {
@@ -220,7 +224,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getBiosVersion() {
-        return (String) get("biosVersion");
+        return get("biosVersion");
     }
 
     public void setBiosVersion(String biosVersion) {
@@ -228,7 +232,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getOs() {
-        return (String) get("os");
+        return get("os");
     }
 
     public void setOs(String os) {
@@ -236,7 +240,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getOsVersion() {
-        return (String) get("osVersion");
+        return get("osVersion");
     }
 
     public void setOsVersion(String osVersion) {
@@ -244,7 +248,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getOsArch() {
-        return (String) get("osArch");
+        return get("osArch");
     }
 
     public void setOsArch(String osArch) {
@@ -252,7 +256,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getJvmName() {
-        return (String) get("jvmName");
+        return get("jvmName");
     }
 
     public void setJvmName(String jvmName) {
@@ -260,7 +264,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getJvmVersion() {
-        return (String) get("jvmVersion");
+        return get("jvmVersion");
     }
 
     public void setJvmVersion(String jvmVersion) {
@@ -268,7 +272,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getJvmProfile() {
-        return (String) get("jvmProfile");
+        return get("jvmProfile");
     }
 
     public void setJvmProfile(String jvmProfile) {
@@ -276,7 +280,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getIotFrameworkVersion() {
-        return (String) get("iotFrameworkVersion");
+        return get("iotFrameworkVersion");
     }
 
     public void setIotFrameworkVersion(String iotFrameworkVersion) {
@@ -284,7 +288,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getOsgiFramework() {
-        return (String) get("osgiFramework");
+        return get("osgiFramework");
     }
 
     public void setOsgiFramework(String osgiFramework) {
@@ -292,7 +296,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getOsgiVersion() {
-        return (String) get("osgiVersion");
+        return get("osgiVersion");
     }
 
     public void setOsgiVersion(String osgiFrameworkVersion) {
@@ -300,7 +304,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getClientIp() {
-        return (String) get("clientIp");
+        return get("clientIp");
     }
 
     public void setClientIp(String clientIp) {
@@ -308,7 +312,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getConnectionInterface() {
-        return (String) get("connectionInterface");
+        return get("connectionInterface");
     }
 
     public void setConnectionInterface(String connectionInterface) {
@@ -316,7 +320,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getConnectionIp() {
-        return (String) get("connectionIp");
+        return get("connectionIp");
     }
 
     public void setConnectionIp(String connectionIp) {
@@ -324,7 +328,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getAcceptEncoding() {
-        return (String) get("acceptEncoding");
+        return get("acceptEncoding");
     }
 
     public void setAcceptEncoding(String acceptEncoding) {
@@ -332,7 +336,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getApplicationIdentifiers() {
-        return (String) get("applicationIdentifiers");
+        return get("applicationIdentifiers");
     }
 
     public void setApplicationIdentifiers(String applicationIdentifiers) {
@@ -340,7 +344,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public Double getGpsLatitude() {
-        return (Double) get("gpsLatitude");
+        return get("gpsLatitude");
     }
 
     public void setGpsLatitude(Double gpsLatitude) {
@@ -348,7 +352,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public Double getGpsLongitude() {
-        return (Double) get("gpsLongitude");
+        return get("gpsLongitude");
     }
 
     public void setGpsLongitude(Double gpsLongitude) {
@@ -356,7 +360,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public Double getGpsAltitude() {
-        return (Double) get("gpsAltitude");
+        return get("gpsAltitude");
     }
 
     public void setGpsAltitude(Double gpsAltitude) {
@@ -364,7 +368,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getGpsAddress() {
-        return (String) get("gpsAddress");
+        return get("gpsAddress");
     }
 
     public void setGpsAddress(String gpsAddress) {
@@ -372,11 +376,11 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public Date getLastEventOn() {
-        return (Date) get("lastEventOn");
+        return get("lastEventOn");
     }
 
     public String getLastEventOnFormatted() {
-        return (String) get("lastEventOnFormatted");
+        return get("lastEventOnFormatted");
     }
 
     public void setLastEventOn(Date lastEventDate) {
@@ -384,7 +388,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getLastEventType() {
-        return (String) get("lastEventType");
+        return get("lastEventType");
     }
 
     public void setLastEventType(String lastEventType) {
@@ -392,7 +396,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getDeviceUserId() {
-        return (String) get("deviceUserId");
+        return get("deviceUserId");
     }
 
     public void setDeviceUserId(String deviceUserId) {
@@ -400,7 +404,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getIccid() {
-        return (String) get("iccid");
+        return get("iccid");
     }
 
     public void setIccid(String iccid) {
@@ -408,7 +412,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getImei() {
-        return (String) get("imei");
+        return get("imei");
     }
 
     public void setImei(String imei) {
@@ -416,7 +420,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getImsi() {
-        return (String) get("imsi");
+        return get("imsi");
     }
 
     public void setCertificateCommonName(String certificateCommonName) {
@@ -424,7 +428,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getCertificateCommonName() {
-        return (String) get("certificateCommonName");
+        return get("certificateCommonName");
     }
 
     public void setImsi(String imsi) {
@@ -432,7 +436,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public Long getBrokerClusterId() {
-        return (Long) get("brokerClusterId");
+        return get("brokerClusterId");
     }
 
     public void setBrokerClusterId(long brokerClusterId) {
@@ -440,7 +444,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getBrokerNodeId() {
-        return (String) get("brokerNodeId");
+        return get("brokerNodeId");
     }
 
     public void setBrokerNodeId(String brokerNodeId) {
@@ -448,63 +452,63 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     }
 
     public String getCustomAttribute1() {
-        return (String) get("customAttribute1");
+        return get(CUSTOM_ATTRIBUTE_1);
     }
 
     public String getUnescapedCustomAttribute1() {
-        return (String) getUnescaped("customAttribute1");
+        return getUnescaped(CUSTOM_ATTRIBUTE_1);
     }
 
     public void setCustomAttribute1(String customAttribute1) {
-        set("customAttribute1", customAttribute1);
+        set(CUSTOM_ATTRIBUTE_1, customAttribute1);
     }
 
     public String getCustomAttribute2() {
-        return (String) get("customAttribute2");
+        return get(CUSTOM_ATTRIBUTE_2);
     }
 
     public String getUnescapedCustomAttribute2() {
-        return (String) getUnescaped("customAttribute2");
+        return getUnescaped(CUSTOM_ATTRIBUTE_2);
     }
 
     public void setCustomAttribute2(String customAttribute2) {
-        set("customAttribute2", customAttribute2);
+        set(CUSTOM_ATTRIBUTE_2, customAttribute2);
     }
 
     public String getCustomAttribute3() {
-        return (String) get("customAttribute3");
+        return get(CUSTOM_ATTRIBUTE_3);
     }
 
     public String getUnescapedCustomAttribute3() {
-        return (String) getUnescaped("customAttribute3");
+        return getUnescaped(CUSTOM_ATTRIBUTE_3);
     }
 
     public void setCustomAttribute3(String customAttribute3) {
-        set("customAttribute3", customAttribute3);
+        set(CUSTOM_ATTRIBUTE_3, customAttribute3);
     }
 
     public String getCustomAttribute4() {
-        return (String) get("customAttribute4");
+        return get(CUSTOM_ATTRIBUTE_4);
     }
 
     public String getUnescapedCustomAttribute4() {
-        return (String) getUnescaped("customAttribute4");
+        return getUnescaped(CUSTOM_ATTRIBUTE_4);
     }
 
     public void setCustomAttribute4(String customAttribute4) {
-        set("customAttribute4", customAttribute4);
+        set(CUSTOM_ATTRIBUTE_4, customAttribute4);
     }
 
     public String getCustomAttribute5() {
-        return (String) get("customAttribute5");
+        return get(CUSTOM_ATTRIBUTE_5);
     }
 
     public String getUnescapedCustomAttribute5() {
-        return (String) getUnescaped("customAttribute5");
+        return getUnescaped(CUSTOM_ATTRIBUTE_5);
     }
 
     public void setCustomAttribute5(String customAttribute5) {
-        set("customAttribute5", customAttribute5);
+        set(CUSTOM_ATTRIBUTE_5, customAttribute5);
     }
 
     public boolean isOnline() {
@@ -514,7 +518,7 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
     // CertificateID
 
     public Long getSignedCertificateId() {
-        return (Long) get("signedCertificateId");
+        return get("signedCertificateId");
     }
 
     public void setSignedCertificateId(Long accountId) {
@@ -539,5 +543,18 @@ public class GwtDevice extends GwtUpdatableEntityModel implements Serializable {
         }
 
         return false;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof GwtDevice) {
+            return ((GwtDevice)obj).getId().equals(getId());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return getId().hashCode();
     }
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceQueryPredicates.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceQueryPredicates.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.app.console.module.device.shared.model;
 
 import java.io.Serializable;
+import java.util.List;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
 import org.eclipse.kapua.app.console.module.api.shared.model.KapuaBaseModel;
@@ -291,12 +292,12 @@ public class GwtDeviceQueryPredicates extends KapuaBaseModel implements Serializ
         set("groupId", groupId);
     }
 
-    public String getTagId() {
-        return (String) get("tagId");
+    public List<String> getTagIds() {
+        return (List<String>) get("tagIds");
     }
 
-    public void setTagId(String tagId) {
-        set("tagId", tagId);
+    public void setTagIds(List<String> tagIds) {
+        set("tagIds", tagIds);
     }
 
 }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
@@ -216,8 +216,12 @@ public class GwtKapuaDeviceModelConverter {
                     }
             }
         }
-        if (predicates.getTagId() != null) {
-            andPred = andPred.and(new AttributePredicateImpl<KapuaId[]>(DeviceAttributes.TAG_IDS, new KapuaId[]{GwtKapuaCommonsModelConverter.convertKapuaId(predicates.getTagId())}));
+        if (predicates.getTagIds() != null) {
+            List<KapuaId> tagIds = new ArrayList<KapuaId>();
+            for (String gwtTagId : predicates.getTagIds()) {
+                tagIds.add(GwtKapuaCommonsModelConverter.convertKapuaId(gwtTagId));
+            }
+            andPred = andPred.and(new AttributePredicateImpl<KapuaId[]>(DeviceAttributes.TAG_IDS, tagIds.toArray(new KapuaId[0])));
         }
         if (predicates.getSortAttribute() != null && loadConfig != null) {
             String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? DeviceAttributes.CLIENT_ID : loadConfig.getSortField();

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsGrid.java
@@ -27,6 +27,7 @@ import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessag
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobTarget;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobTargetQuery;
+import org.eclipse.kapua.app.console.module.job.shared.model.permission.JobSessionPermission;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobService;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobServiceAsync;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobTargetService;
@@ -143,11 +144,11 @@ public class JobTabTargetsGrid extends EntityGrid<GwtJobTarget> {
             @Override
             public void onSuccess(GwtJob result) {
                 if (result.getJobXmlDefinition() == null) {
-                    JobTabTargetsGrid.this.toolbar.getAddEntityButton().enable();
+                    JobTabTargetsGrid.this.toolbar.getAddEntityButton().setEnabled(currentSession.hasPermission(JobSessionPermission.write()));
                     if (selectedItem == null) {
                         JobTabTargetsGrid.this.toolbar.getDeleteEntityButton().disable();
                     } else {
-                        JobTabTargetsGrid.this.toolbar.getDeleteEntityButton().enable();
+                        JobTabTargetsGrid.this.toolbar.getDeleteEntityButton().setEnabled(currentSession.hasPermission(JobSessionPermission.delete()));
                     }
                 } else {
                     JobTabTargetsGrid.this.toolbar.getAddEntityButton().disable();

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
@@ -25,6 +25,7 @@ import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobTarget;
+import org.eclipse.kapua.app.console.module.job.shared.model.permission.JobSessionPermission;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobService;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobServiceAsync;
 
@@ -90,6 +91,8 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
         super.updateButtonEnablement();
 
         jobStartTargetButton.setEnabled(selectedEntity != null);
+        addEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.write()));
+        deleteEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.delete()));
     }
 
     private void checkButtons() {
@@ -104,11 +107,11 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
                 @Override
                 public void onSuccess(GwtJob result) {
                     if (addEntityButton != null) {
-                        addEntityButton.setEnabled(result.getJobXmlDefinition() == null);
+                        addEntityButton.setEnabled(result.getJobXmlDefinition() == null && currentSession.hasPermission(JobSessionPermission.write()));
                     }
 
                     if (deleteEntityButton != null) {
-                        deleteEntityButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null && result.getJobXmlDefinition() == null);
+                        deleteEntityButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null && result.getJobXmlDefinition() == null && currentSession.hasPermission(JobSessionPermission.delete()));
                     }
 
                     if (jobStartTargetButton != null) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDeviceGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDeviceGrid.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.client.targets;
+
+import com.extjs.gxt.ui.client.Style;
+import com.extjs.gxt.ui.client.data.ModelData;
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
+import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
+import com.extjs.gxt.ui.client.widget.grid.ColumnData;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
+import com.extjs.gxt.ui.client.widget.toolbar.PagingToolBar;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGridCheckBoxSelectionModel;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingToolBar;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
+import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
+import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQuery;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceService;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceServiceAsync;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JobTargetAddDeviceGrid extends EntityGrid<GwtDevice> {
+
+    private static final GwtDeviceServiceAsync GWT_DEVICE_SERVICE = GWT.create(GwtDeviceService.class);
+    private static final ConsoleDeviceMessages DVC_MSGS = GWT.create(ConsoleDeviceMessages.class);
+
+    private final EntityGridCheckBoxSelectionModel<GwtDevice> selectionModel = new EntityGridCheckBoxSelectionModel<GwtDevice>();
+
+    private static final int ENTITY_PAGE_SIZE = 10;
+
+    private final GwtJob gwtSelectedJob;
+    private GwtDeviceQuery query;
+
+    public JobTargetAddDeviceGrid(GwtSession currentSession, GwtJob gwtSelectedJob) {
+        super(null, currentSession);
+
+        this.gwtSelectedJob = gwtSelectedJob;
+
+        query = new GwtDeviceQuery();
+        query.setScopeId(currentSession.getSelectedAccountId());
+
+        // Configure grid options
+        selectionMode = Style.SelectionMode.SIMPLE;
+        keepSelectedItemsAfterLoad = false;
+    }
+
+    @Override
+    public CheckBoxSelectionModel<GwtDevice> getSelectionModel() {
+        return selectionModel;
+    }
+
+    @Override
+    protected RpcProxy<PagingLoadResult<GwtDevice>> getDataProxy() {
+        return new RpcProxy<PagingLoadResult<GwtDevice>>() {
+
+            @Override
+            protected void load(Object loadConfig, AsyncCallback<PagingLoadResult<GwtDevice>> callback) {
+                GWT_DEVICE_SERVICE.query((PagingLoadConfig) loadConfig, query, callback);
+            }
+
+        };
+    }
+
+    @Override
+    protected PagingToolBar getPagingToolbar() {
+        return new KapuaPagingToolBar(ENTITY_PAGE_SIZE);
+    }
+
+    @Override
+    protected EntityCRUDToolbar<GwtDevice> getToolbar() {
+        EntityCRUDToolbar<GwtDevice> toolbar = super.getToolbar();
+        toolbar.setAddButtonVisible(false);
+        toolbar.setEditButtonVisible(false);
+        toolbar.setDeleteButtonVisible(false);
+        toolbar.setRefreshButtonVisible(true);
+
+        return toolbar;
+    }
+
+    @Override
+    protected List<ColumnConfig> getColumns() {
+        List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
+
+        ColumnConfig column = selectionModel.getColumn();
+        columnConfigs.add(column);
+
+        column = new ColumnConfig("clientId", DVC_MSGS.deviceTableClientID(), 175);
+        column.setSortable(true);
+        columnConfigs.add(column);
+        column.setRenderer(gridCellRenderer);
+
+        column = new ColumnConfig("displayName", DVC_MSGS.deviceTableDisplayName(), 150);
+        column.setSortable(true);
+        columnConfigs.add(column);
+        column.setRenderer(gridCellRenderer);
+
+        return columnConfigs;
+    }
+
+    @Override
+    protected void onRender(Element target, int index) {
+        configureEntityGrid();
+
+        entityGrid.addPlugin(selectionModel);
+        entityGrid.setSelectionModel(selectionModel);
+
+        super.onRender(target, index);
+    }
+
+    @Override
+    public GwtQuery getFilterQuery() {
+        return query;
+    }
+
+    @Override
+    public void setFilterQuery(GwtQuery filterQuery) {
+        this.query = (GwtDeviceQuery) filterQuery;
+    }
+
+    GridCellRenderer<ModelData> gridCellRenderer = new GridCellRenderer<ModelData>() {
+
+        @Override
+        public Object render(ModelData model, String property, ColumnData config, int rowIndex, int colIndex,
+                ListStore<ModelData> store, Grid<ModelData> grid) {
+            String value = model.get(KapuaSafeHtmlUtils.htmlUnescape(property));
+            if (value != null) {
+                return "<tpl for=\".\"><div title=" + value + ">" + value + "</div></tpl>";
+            }
+            return value;
+        }
+    };
+
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
@@ -40,6 +40,7 @@ import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobTargetCreator
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobTargetService;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobTargetServiceAsync;
 import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
+import org.eclipse.kapua.app.console.module.tag.shared.model.permission.TagSessionPermission;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -117,17 +118,21 @@ public class JobTargetAddDialog extends EntityAddEditDialog {
         bodyPanel.add(targetDevicePanel, new MarginData(10, 0, 10, 0));
 
         targetTagGrid = new JobTargetAddTagGrid(currentSession, gwtSelectedJob);
-        targetTagGrid.setDeselectable();
-        targetTagGrid.disable();
-        targetTagGrid.setHeight(255);
+        if (currentSession.hasPermission(TagSessionPermission.read())) {
+            targetTagGrid.setDeselectable();
+            targetTagGrid.disable();
+            targetTagGrid.setHeight(255);
 
-        ContentPanel targetTagPanel = new ContentPanel(new FitLayout());
-        targetTagPanel.add(targetTagGrid);
-        targetTagPanel.setHeading("Tags");
-        targetTagPanel.setIcon(new KapuaIcon(IconSet.SORT_AMOUNT_ASC));
-        targetTagPanel.setBorders(false);
-        targetTagPanel.setBodyBorder(false);
-        bodyPanel.add(targetTagPanel, new MarginData(20, 0, 0, 0));
+            ContentPanel targetTagPanel = new ContentPanel(new FitLayout());
+            targetTagPanel.add(targetTagGrid);
+            targetTagPanel.setHeading("Tags");
+            targetTagPanel.setIcon(new KapuaIcon(IconSet.SORT_AMOUNT_ASC));
+            targetTagPanel.setBorders(false);
+            targetTagPanel.setBodyBorder(false);
+            bodyPanel.add(targetTagPanel, new MarginData(20, 0, 0, 0));
+        } else {
+            DialogUtils.resizeDialog(this, 600, 432);
+        }
 
     }
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddTagGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddTagGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -10,6 +10,23 @@
  *     Eurotech - initial API and implementation
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.targets;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGridCheckBoxSelectionModel;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingToolBar;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
+import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+import org.eclipse.kapua.app.console.module.tag.client.messages.ConsoleTagMessages;
+import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
+import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTagQuery;
+import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagService;
+import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagServiceAsync;
 
 import com.extjs.gxt.ui.client.Style;
 import com.extjs.gxt.ui.client.data.ModelData;
@@ -26,41 +43,25 @@ import com.extjs.gxt.ui.client.widget.toolbar.PagingToolBar;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
-import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGridCheckBoxSelectionModel;
-import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
-import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingToolBar;
-import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
-import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
-import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
-import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
-import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
-import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQuery;
-import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceService;
-import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceServiceAsync;
-import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
 
-import java.util.ArrayList;
-import java.util.List;
+public class JobTargetAddTagGrid extends EntityGrid<GwtTag> {
 
-public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
+    private static final GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
+    private static final ConsoleTagMessages TAG_MSGS = GWT.create(ConsoleTagMessages.class);
 
-    private static final GwtDeviceServiceAsync GWT_DEVICE_SERVICE = GWT.create(GwtDeviceService.class);
-    private static final ConsoleDeviceMessages DVC_MSGS = GWT.create(ConsoleDeviceMessages.class);
-
-    private final EntityGridCheckBoxSelectionModel<GwtDevice> selectionModel = new EntityGridCheckBoxSelectionModel<GwtDevice>();
+    private final EntityGridCheckBoxSelectionModel<GwtTag> selectionModel = new EntityGridCheckBoxSelectionModel<GwtTag>();
 
     private static final int ENTITY_PAGE_SIZE = 10;
 
     private final GwtJob gwtSelectedJob;
-    private GwtDeviceQuery query;
+    private GwtTagQuery query;
 
-    public JobTargetAddGrid(GwtSession currentSession, GwtJob gwtSelectedJob) {
+    public JobTargetAddTagGrid(GwtSession currentSession, GwtJob gwtSelectedJob) {
         super(null, currentSession);
 
         this.gwtSelectedJob = gwtSelectedJob;
 
-        query = new GwtDeviceQuery();
+        query = new GwtTagQuery();
         query.setScopeId(currentSession.getSelectedAccountId());
 
         // Configure grid options
@@ -69,17 +70,17 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     }
 
     @Override
-    public CheckBoxSelectionModel<GwtDevice> getSelectionModel() {
+    public CheckBoxSelectionModel<GwtTag> getSelectionModel() {
         return selectionModel;
     }
 
     @Override
-    protected RpcProxy<PagingLoadResult<GwtDevice>> getDataProxy() {
-        return new RpcProxy<PagingLoadResult<GwtDevice>>() {
+    protected RpcProxy<PagingLoadResult<GwtTag>> getDataProxy() {
+        return new RpcProxy<PagingLoadResult<GwtTag>>() {
 
             @Override
-            protected void load(Object loadConfig, AsyncCallback<PagingLoadResult<GwtDevice>> callback) {
-                GWT_DEVICE_SERVICE.query((PagingLoadConfig) loadConfig, query, callback);
+            protected void load(Object loadConfig, AsyncCallback<PagingLoadResult<GwtTag>> callback) {
+                GWT_TAG_SERVICE.query((PagingLoadConfig) loadConfig, query, callback);
             }
 
         };
@@ -91,8 +92,8 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
     }
 
     @Override
-    protected EntityCRUDToolbar<GwtDevice> getToolbar() {
-        EntityCRUDToolbar<GwtDevice> toolbar = super.getToolbar();
+    protected EntityCRUDToolbar<GwtTag> getToolbar() {
+        EntityCRUDToolbar<GwtTag> toolbar = super.getToolbar();
         toolbar.setAddButtonVisible(false);
         toolbar.setEditButtonVisible(false);
         toolbar.setDeleteButtonVisible(false);
@@ -108,12 +109,7 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
         ColumnConfig column = selectionModel.getColumn();
         columnConfigs.add(column);
 
-        column = new ColumnConfig("clientId", DVC_MSGS.deviceTableClientID(), 175);
-        column.setSortable(true);
-        columnConfigs.add(column);
-        column.setRenderer(gridCellRenderer);
-
-        column = new ColumnConfig("displayName", DVC_MSGS.deviceTableDisplayName(), 150);
+        column = new ColumnConfig("tagName", TAG_MSGS.gridTagColumnHeaderTagName(), 175);
         column.setSortable(true);
         columnConfigs.add(column);
         column.setRenderer(gridCellRenderer);
@@ -138,7 +134,7 @@ public class JobTargetAddGrid extends EntityGrid<GwtDevice> {
 
     @Override
     public void setFilterQuery(GwtQuery filterQuery) {
-        this.query = (GwtDeviceQuery) filterQuery;
+        this.query = (GwtTagQuery) filterQuery;
     }
 
     GridCellRenderer<ModelData> gridCellRenderer = new GridCellRenderer<ModelData>() {

--- a/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/definition/DeviceAssetWriteStepDefinition.java
+++ b/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/definition/DeviceAssetWriteStepDefinition.java
@@ -31,7 +31,7 @@ public class DeviceAssetWriteStepDefinition extends AbstractTargetJobStepDefinit
 
     @Override
     public String getName() {
-        return "Device Asset Management Write";
+        return "Asset Write";
     }
 
     @Override

--- a/service/device/management/asset/job/src/main/resources/liquibase/1.0.4/asset_job_step_definition_name_update.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/1.0.4/asset_job_step_definition_name_update.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/asset_job_step_definition_name_update.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+
+    <changeSet id="asset_job_step_definition_name_update" author="eurotech">
+        <update tableName="job_job_step_definition">
+            <column name="name" value="Asset Write"/>
+            <where>name LIKE 'Device Asset Management Write'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/device/management/asset/job/src/main/resources/liquibase/1.0.4/changelog-asset-job-1.0.4.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/1.0.4/changelog-asset-job-1.0.4.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./asset_job_step_definition_name_update.xml"/>
+
+</databaseChangeLog>

--- a/service/device/management/asset/job/src/main/resources/liquibase/changelog-asset-job-master.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/changelog-asset-job-master.xml
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-asset-job-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-asset-job-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.0.4/changelog-asset-job-1.0.4.xml"/>
 
 </databaseChangeLog>

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStartStepDefinition.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStartStepDefinition.java
@@ -31,7 +31,7 @@ public class DeviceBundleStartStepDefinition extends AbstractTargetJobStepDefini
 
     @Override
     public String getName() {
-        return "Device Bundle Management Start";
+        return "Bundle Start";
     }
 
     @Override

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStopStepDefinition.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStopStepDefinition.java
@@ -31,7 +31,7 @@ public class DeviceBundleStopStepDefinition extends AbstractTargetJobStepDefinit
 
     @Override
     public String getName() {
-        return "Device Bundle Management Stop";
+        return "Bundle Stop";
     }
 
     @Override

--- a/service/device/management/bundle/job/src/main/resources/liquibase/1.0.4/bundle_job_step_definition_name_update.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/1.0.4/bundle_job_step_definition_name_update.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/bundle_job_step_definition_name_update.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+
+    <changeSet id="bundle_job_step_definition_name_update" author="eurotech">
+        <update tableName="job_job_step_definition">
+            <column name="name" value="Bundle Start"/>
+            <where>name LIKE 'Device Bundle Management Start'</where>
+        </update>
+        <update tableName="job_job_step_definition">
+            <column name="name" value="Bundle Stop"/>
+            <where>name LIKE 'Device Bundle Management Stop'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/device/management/bundle/job/src/main/resources/liquibase/1.0.4/changelog-bundle-job-1.0.4.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/1.0.4/changelog-bundle-job-1.0.4.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./bundle_job_step_definition_name_update.xml"/>
+
+</databaseChangeLog>

--- a/service/device/management/bundle/job/src/main/resources/liquibase/changelog-bundle-job-master.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/changelog-bundle-job-master.xml
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-bundle-job-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-bundle-job-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.0.4/changelog-bundle-job-1.0.4.xml"/>
 
 </databaseChangeLog>

--- a/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/definition/DeviceCommandExecStepDefinition.java
+++ b/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/definition/DeviceCommandExecStepDefinition.java
@@ -31,7 +31,7 @@ public class DeviceCommandExecStepDefinition extends AbstractTargetJobStepDefini
 
     @Override
     public String getName() {
-        return "Device Command Management Execution";
+        return "Command Execution";
     }
 
     @Override

--- a/service/device/management/command/job/src/main/resources/liquibase/1.0.4/changelog-command-job-1.0.4.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/1.0.4/changelog-command-job-1.0.4.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./command_job_step_definition_name_update.xml"/>
+
+</databaseChangeLog>

--- a/service/device/management/command/job/src/main/resources/liquibase/1.0.4/command_job_step_definition_name_update.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/1.0.4/command_job_step_definition_name_update.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/command_job_step_definition_name_update.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+
+    <changeSet id="command_job_step_definition_name_update" author="eurotech">
+        <update tableName="job_job_step_definition">
+            <column name="name" value="Command Execution"/>
+            <where>name LIKE 'Device Command Management Execution'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/device/management/command/job/src/main/resources/liquibase/changelog-command-job-master.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/changelog-command-job-master.xml
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-command-job-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-command-job-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.0.4/changelog-command-job-1.0.4.xml"/>
 
 </databaseChangeLog>

--- a/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/definition/DeviceConfigurationPutStepDefinition.java
+++ b/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/definition/DeviceConfigurationPutStepDefinition.java
@@ -31,7 +31,7 @@ public class DeviceConfigurationPutStepDefinition extends AbstractTargetJobStepD
 
     @Override
     public String getName() {
-        return "Device Configuration Management Configuration";
+        return "Configuration Put";
     }
 
     @Override

--- a/service/device/management/configuration/job/src/main/resources/liquibase/1.0.4/changelog-configuration-job-1.0.4.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/1.0.4/changelog-configuration-job-1.0.4.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./configuration_job_step_definition_name_update.xml"/>
+
+</databaseChangeLog>

--- a/service/device/management/configuration/job/src/main/resources/liquibase/1.0.4/configuration_job_step_definition_name_update.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/1.0.4/configuration_job_step_definition_name_update.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/configuration_job_step_definition_name_update.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+
+    <changeSet id="configuration_job_step_definition_name_update" author="eurotech">
+        <update tableName="job_job_step_definition">
+            <column name="name" value="Configuration Put"/>
+            <where>name LIKE 'Device Configuration Management Configuration'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/device/management/configuration/job/src/main/resources/liquibase/changelog-configuration-job-master.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/changelog-configuration-job-master.xml
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-configuration-job-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-configuration-job-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.0.4/changelog-configuration-job-1.0.4.xml"/>
 
 </databaseChangeLog>

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackagesDownloadStepDefinition.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackagesDownloadStepDefinition.java
@@ -31,7 +31,7 @@ public class DevicePackagesDownloadStepDefinition extends AbstractTargetJobStepD
 
     @Override
     public String getName() {
-        return "Device Packages Management Download Execution";
+        return "Package Download / Install";
     }
 
     @Override

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackagesUninstallStepDefinition.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackagesUninstallStepDefinition.java
@@ -31,7 +31,7 @@ public class DevicePackagesUninstallStepDefinition extends AbstractTargetJobStep
 
     @Override
     public String getName() {
-        return "Device Packages Management Uninstall Execution";
+        return "Package Uninstall";
     }
 
     @Override

--- a/service/device/management/packages/job/src/main/resources/liquibase/1.0.4/changelog-packages-job-1.0.4.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/1.0.4/changelog-packages-job-1.0.4.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./packages_job_step_definition_name_update.xml"/>
+
+</databaseChangeLog>

--- a/service/device/management/packages/job/src/main/resources/liquibase/1.0.4/packages_job_step_definition_name_update.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/1.0.4/packages_job_step_definition_name_update.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/packages_job_step_definition_name_update.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+
+    <changeSet id="packages_job_step_definition_name_update" author="eurotech">
+        <update tableName="job_job_step_definition">
+            <column name="name" value="Package Download / Install"/>
+            <where>name LIKE 'Device Packages Management Download Execution'</where>
+        </update>
+        <update tableName="job_job_step_definition">
+            <column name="name" value="Package Uninstall"/>
+            <where>name LIKE 'Device Packages Management Uninstall Execution'</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/device/management/packages/job/src/main/resources/liquibase/changelog-packages-job-master.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/changelog-packages-job-master.xml
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-packages-job-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-packages-job-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.0.4/changelog-packages-job-1.0.4.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds a new table in the Target Add dialog, allowing a user to add multiple devices by selecting one or more tags, in addition to adding targets just by selecting individual devices.

It also renames some Job Step Definitions to easier to read names.

**Related Issue**
No related issues

**Screenshots**

![schermata 2019-02-05 alle 14 33 21](https://user-images.githubusercontent.com/8140139/52276652-08501080-2953-11e9-8c6c-de036e83e5db.png)

![schermata 2019-02-05 alle 14 33 58](https://user-images.githubusercontent.com/8140139/52276681-1b62e080-2953-11e9-80c1-a52507a103ee.png)
