### PR TITLE
Set permissions for showing History tab in Packages

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -43,6 +43,7 @@ import org.eclipse.kapua.app.console.module.device.client.device.packages.button
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeploymentPackage;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceManagementRegistrySessionPermission;
 import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceManagementSessionPermission;
 
 public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
@@ -229,7 +230,9 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
                 refresh();
             }
         });
-        tabsPanel.add(historyPackageTab);
+        if (currentSession.hasPermission(DeviceManagementRegistrySessionPermission.read())) {
+            tabsPanel.add(historyPackageTab);
+        }
 
         //
         // Tabs

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceManagementRegistrySessionPermission.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceManagementRegistrySessionPermission.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.shared.model.permission;
+
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSessionPermission;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSessionPermissionAction;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSessionPermissionScope;
+
+public class DeviceManagementRegistrySessionPermission extends GwtSessionPermission {
+
+    private static final long serialVersionUID = 1L;
+
+    public DeviceManagementRegistrySessionPermission() {
+        super();
+    }
+
+    private DeviceManagementRegistrySessionPermission(GwtSessionPermissionAction action) {
+        super("device_management_registry", action, GwtSessionPermissionScope.SELF);
+    }
+
+    public static DeviceManagementRegistrySessionPermission read() {
+        return new DeviceManagementRegistrySessionPermission(GwtSessionPermissionAction.read);
+    }
+
+    public static DeviceManagementRegistrySessionPermission write() {
+        return new DeviceManagementRegistrySessionPermission(GwtSessionPermissionAction.write);
+    }
+
+    public static DeviceManagementRegistrySessionPermission delete() {
+        return new DeviceManagementRegistrySessionPermission(GwtSessionPermissionAction.delete);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Set permissions for showing History tab in Packages

**Related Issue**
This PR fixes/closes #2363 

**Description of the solution adopted**
Created new `DeviceManagementRegistrySessionPermission` class.
Added check for `DeviceManagementRegistrySessionPermission.read()` when showing the History tab in Packages.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
