### PR TITLE
Added permission check when enabling fields on Assets tab

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
@@ -19,9 +19,11 @@ import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDevice
 import org.eclipse.kapua.app.console.module.api.client.util.Constants;
 import org.eclipse.kapua.app.console.module.api.client.util.FormUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.UserAgentUtils;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.shared.model.device.management.assets.GwtDeviceAsset;
 import org.eclipse.kapua.app.console.module.device.shared.model.device.management.assets.GwtDeviceAssetChannel;
 import org.eclipse.kapua.app.console.module.device.shared.model.device.management.assets.GwtDeviceAssetChannel.GwtDeviceAssetChannelMode;
+import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceManagementSessionPermission;
 
 import com.extjs.gxt.ui.client.Style.LayoutRegion;
 import com.extjs.gxt.ui.client.Style.Scroll;
@@ -63,13 +65,15 @@ public class DeviceAssetsPanel extends LayoutContainer {
     private FieldSet actionFieldSet;
 
     private ComponentPlugin dirtyPlugin;
+    private GwtSession currentSession;
 
-    public DeviceAssetsPanel(GwtDeviceAsset asset) {
+    public DeviceAssetsPanel(GwtDeviceAsset asset, GwtSession currentSession) {
         super(new FitLayout());
         setScrollMode(Scroll.AUTO);
         setBorders(false);
 
         this.asset = asset;
+        this.currentSession = currentSession;
 
         final DeviceAssetsPanel thePanel = this;
         dirtyPlugin = new ComponentPlugin() {
@@ -234,6 +238,7 @@ public class DeviceAssetsPanel extends LayoutContainer {
         if (asset != null) {
             for (GwtDeviceAssetChannel channel : asset.getChannels()) {
                 field = paintChannel(channel);
+                field.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.write()));
                 actionFieldSet.add(field, formData);
             }
         }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -370,7 +370,7 @@ public class DeviceAssetsValues extends LayoutContainer {
         }
         if (asset != null) {
 
-            assetValuesPanel = new DeviceAssetsPanel(asset);
+            assetValuesPanel = new DeviceAssetsPanel(asset, currentSession);
             assetValuesPanel.addListener(Events.Change, new Listener<BaseEvent>() {
 
                 @Override
@@ -381,7 +381,7 @@ public class DeviceAssetsValues extends LayoutContainer {
             });
 
         } else {
-            assetValuesPanel = new DeviceAssetsPanel(null);
+            assetValuesPanel = new DeviceAssetsPanel(null, currentSession);
         }
         assetValuesContainer.add(assetValuesPanel, centerData);
         assetValuesContainer.layout();

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
@@ -195,7 +195,7 @@ public class DeviceAssetManagementServiceImpl extends AbstractDeviceManagementSe
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Prepare the request


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Added permission check when enabling fields on Assets tab.

**Related Issue**
This PR fixes/closes #2357 

**Description of the solution adopted**
Permission `DeviceManagementSessionPermission.write()` is now needed for enabling input fields on the Assets tab in Devices. 
Also, `DeviceAssetManagementServiceImpl`'s write method is updated with check for the `DeviceManagementSessionPermission.write()` for consistency. 

**Screenshots**
_None_

**Any side note on the changes made**
 _None_
