### PR TITLE
Always use default Dropwizard registry

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.JmxReporter.Builder;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
 import com.codahale.metrics.Timer;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
@@ -39,7 +40,7 @@ public class MetricsServiceImpl implements MetricsService {
 
     public static final String METRICS_NAME_FORMAT = "{0}.{1}.{2}";
 
-    private final MetricRegistry metricRegistry;
+    private MetricRegistry metricRegistry;
 
     private JmxReporter jmxReporter;
 
@@ -47,7 +48,13 @@ public class MetricsServiceImpl implements MetricsService {
      * Default metric service constructor
      */
     MetricsServiceImpl() {
-        metricRegistry = new MetricRegistry();
+        try {
+            metricRegistry = SharedMetricRegistries.getDefault();
+            logger.info("Default Metric Registry loaded");
+        } catch (IllegalStateException e) {
+            metricRegistry = new MetricRegistry();
+            logger.warn("Unable to load Default Metric Registry - creating a new one");
+        }
 
         if (isJmxEnabled()) {
             enableJmxSupport();

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <commons-lang.version>3.4</commons-lang.version>
         <commons-pool.version>2.3</commons-pool.version>
         <cucumber.version>1.2.4</cucumber.version>
-        <dropwizard.version>3.1.2</dropwizard.version>
+        <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
         <eclipselink.version>2.6.3</eclipselink.version>
         <elasticsearch.version>2.3.4</elasticsearch.version>
         <findbugs.version>2.0.1</findbugs.version>
@@ -1241,7 +1241,7 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
-                <version>${dropwizard.version}</version>
+                <version>${dropwizard-metrics.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR fixes an issue with the `MetricsRegistryServiceImpl`, which now always reuses the default Registry instead of creating a new one

**Related Issue**
No related issues

**Description of the solution adopted**
Now the MetricRegistry is created using `SharedMetricRegistry` instead of instantiating a new one.

**Screenshots**
N/A

**Any side note on the changes made**
Dropwizard Metrics upgraded to 3.2.2. [CQ Approved](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18912)