### PR TITLE
Fix initialization in KapuaIllegalArgumentException

### DIFF
--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalArgumentException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalArgumentException.java
@@ -32,9 +32,6 @@ public class KapuaIllegalArgumentException extends KapuaException {
      */
     public KapuaIllegalArgumentException(String argName, String argValue) {
         this(KapuaErrorCodes.ILLEGAL_ARGUMENT, argName, argValue);
-
-        this.argumentName = argName;
-        this.argumentValue = argValue;
     }
 
     /**
@@ -46,6 +43,9 @@ public class KapuaIllegalArgumentException extends KapuaException {
      */
     protected KapuaIllegalArgumentException(KapuaErrorCodes code, String argName, String argValue) {
         super(code, argName, argValue);
+
+        this.argumentName = argName;
+        this.argumentValue = argValue;
     }
 
     public String getArgumentName() {


### PR DESCRIPTION
A small fix for `KapuaIllegalArgumentException`, where its child classes would not correctly init the `argumentName` and `argumentValue` fields

**Related Issue**
No related issues

**Description of the solution adopted**
N/A

**Screenshots**
N/A

**Any side note on the changes made**
N/A