### PR TITLE
Fix for Install button getting disabled

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -367,7 +367,7 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
             // Manage buttons
             if (selectedEntity != null && selectedEntity.isOnline()) {
                 toolBar.enable();
-                installButton.disable();
+                installButton.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.write()));
                 uninstallButton.disable();
             } else {
                 toolBar.disable();


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for Install button getting disabled after changing tabs or closing dialogues.

**Related Issue**
This PR fixes/closes #2365 

**Screenshots**
_None_

**Any side note on the changes made**
_None_
