### PR TITLE
Changed error message if device user's permissions are revoked

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -43,6 +43,8 @@ import com.extjs.gxt.ui.client.widget.treepanel.TreePanelSelectionModel;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.DiscardButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
@@ -514,8 +516,9 @@ public class DeviceAssetsValues extends LayoutContainer {
 
         @Override
         public void loaderLoadException(LoadEvent le) {
-
-            if (le.exception != null) {
+            if (le.exception != null && le.exception instanceof GwtKapuaException) {
+                FailureHandler.handle(le.exception);
+            } else {
                 ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.assetNoAssetsErrorMessage());
             }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,6 +39,8 @@ import com.extjs.gxt.ui.client.widget.toolbar.ToolBar;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
@@ -418,9 +420,12 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
         @Override
         public void loaderLoadException(LoadEvent le) {
 
-            if (le.exception != null) {
-                ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
-            }
+                if (le.exception != null && le.exception instanceof GwtKapuaException) {
+                    FailureHandler.handle(le.exception);
+                } else {
+                    ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
+                }
+
             startButton.disable();
             stopButton.disable();
             grid.unmask();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -44,6 +44,8 @@ import com.google.gwt.dom.client.StyleInjector;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
@@ -507,7 +509,9 @@ public class DeviceConfigComponents extends LayoutContainer {
 
                                                 @Override
                                                 public void onFailure(Throwable caught) {
-                                                    ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
+                                                    if(!selectedDevice.isOnline()) {
+                                                        ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
+                                                    }
                                                     dirty = true;
                                                     refresh();
                                                 }
@@ -628,9 +632,11 @@ public class DeviceConfigComponents extends LayoutContainer {
         @Override
         public void loaderLoadException(LoadEvent le) {
 
-            if (le.exception != null) {
-                ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
-            }
+                if(le.exception != null && le.exception instanceof GwtKapuaException) {
+                    FailureHandler.handle(le.exception);
+                } else {
+                    ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
+                }
 
             List<ModelData> comps = new ArrayList<ModelData>();
             GwtConfigComponent comp = new GwtConfigComponent();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
@@ -14,20 +14,24 @@ package org.eclipse.kapua.app.console.module.device.client.device.packages;
 import java.util.Arrays;
 import java.util.List;
 
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
-import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.TabItem;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtBundleInfo;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeploymentPackage;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
 import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceManagementSessionPermission;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
+import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementServiceAsync;
 
-import com.extjs.gxt.ui.client.data.ModelData;
 import com.extjs.gxt.ui.client.Style.SelectionMode;
+import com.extjs.gxt.ui.client.data.ModelData;
 import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
 import com.extjs.gxt.ui.client.event.SelectionChangedListener;
 import com.extjs.gxt.ui.client.store.TreeStore;
@@ -38,8 +42,6 @@ import com.extjs.gxt.ui.client.widget.treegrid.TreeGridCellRenderer;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
-import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementServiceAsync;
 
 public class DeviceTabPackagesInstalled extends TabItem {
 
@@ -174,7 +176,11 @@ public class DeviceTabPackagesInstalled extends TabItem {
 
                     @Override
                     public void onFailure(Throwable caught) {
-                        ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
+                        if (caught instanceof GwtKapuaException) {
+                            FailureHandler.handle(caught);
+                        } else {
+                            ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
+                        }
                         treeGrid.unmask();
                         refreshing = false;
                     }


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed error message after device permission are revoked.

**Related Issue**
This PR fixes issue #2356. 

**Description of the solution adopted**
When user not have device permission's, error message is changed to show that user doesn't have proper permissions anymore.

**Screenshots**
/

**Any side note on the changes made**
/
