### PR TITLE
Fix for permissions problems on Devices tab

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -188,20 +188,20 @@ public class DeviceAddDialog extends EntityAddEditDialog {
 
         fieldSet.add(statusCombo, formData);
 
+        groupCombo = new ComboBox<GwtGroup>();
+        groupCombo.setStore(new ListStore<GwtGroup>());
+        groupCombo.setFieldLabel("* " + DEVICE_MSGS.deviceFormGroup());
+        groupCombo.setToolTip(DEVICE_MSGS.deviceFormGroupTooltip());
+        groupCombo.setForceSelection(true);
+        groupCombo.setTypeAhead(false);
+        groupCombo.setTriggerAction(TriggerAction.ALL);
+        groupCombo.setAllowBlank(false);
+        groupCombo.setEditable(false);
+        groupCombo.setDisplayField("groupName");
+        groupCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={groupName}>{groupName}</div></tpl>");
+        groupCombo.setValueField("id");
+        groupCombo.setEmptyText(DEVICE_MSGS.deviceFilteringPanelGroupEmptyText());
         if (currentSession.hasPermission(GroupSessionPermission.read())) {
-            groupCombo = new ComboBox<GwtGroup>();
-            groupCombo.setStore(new ListStore<GwtGroup>());
-            groupCombo.setFieldLabel("* " + DEVICE_MSGS.deviceFormGroup());
-            groupCombo.setToolTip(DEVICE_MSGS.deviceFormGroupTooltip());
-            groupCombo.setForceSelection(true);
-            groupCombo.setTypeAhead(false);
-            groupCombo.setTriggerAction(TriggerAction.ALL);
-            groupCombo.setAllowBlank(false);
-            groupCombo.setEditable(false);
-            groupCombo.setDisplayField("groupName");
-            groupCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={groupName}>{groupName}</div></tpl>");
-            groupCombo.setValueField("id");
-            groupCombo.setEmptyText(DEVICE_MSGS.deviceFilteringPanelGroupEmptyText());
             groupCombo.addListener(Events.Select, comboBoxListener);
 
             gwtGroupService.findAll(currentSession.getSelectedAccountId(), new AsyncCallback<List<GwtGroup>>() {
@@ -219,6 +219,10 @@ public class DeviceAddDialog extends EntityAddEditDialog {
                 }
             });
             fieldSet.add(groupCombo, formData);
+        } else {
+            groupCombo.getStore().removeAll();
+            groupCombo.getStore().add(NO_GROUP);
+            groupCombo.setValue(NO_GROUP);
         }
 
         // Device Custom attributes fieldset
@@ -304,9 +308,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         gwtDeviceCreator.setScopeId(currentSession.getSelectedAccountId());
 
         gwtDeviceCreator.setClientId(clientIdField.getValue());
-        if (currentSession.hasPermission(GroupSessionPermission.read())) {
-            gwtDeviceCreator.setGroupId(groupCombo.getValue().getId());
-        }
+        gwtDeviceCreator.setGroupId(groupCombo.getValue().getId());
         gwtDeviceCreator.setDisplayName(displayNameField.getValue());
         gwtDeviceCreator.setDeviceStatus(statusCombo.getSimpleValue().name());
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -58,6 +58,7 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
         addExtraButton(export);
         super.onRender(target, index);
         getAddEntityButton().setEnabled(currentSession.hasPermission(DeviceSessionPermission.write()));
+        getEditEntityButton().setEnabled(currentSession.hasPermission(DeviceSessionPermission.write()));
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,8 +17,8 @@ import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaDialog;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.GwtDevice;
+import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceSessionPermission;
 import org.eclipse.kapua.app.console.module.tag.client.TagToolbarGrid;
-import org.eclipse.kapua.app.console.module.tag.shared.model.permission.TagSessionPermission;
 
 public class DeviceTagToolbar extends TagToolbarGrid {
 
@@ -57,10 +57,12 @@ public class DeviceTagToolbar extends TagToolbarGrid {
     @Override
     protected void updateButtonEnablement() {
         if (addEntityButton != null) {
-            addEntityButton.setEnabled(selectedDevice != null);
+            addEntityButton.setEnabled(selectedDevice != null 
+                    && currentSession.hasPermission(DeviceSessionPermission.write()));
         }
         if (deleteEntityButton != null) {
-            deleteEntityButton.setEnabled(selectedDevice != null && selectedEntity != null && currentSession.hasPermission(TagSessionPermission.delete()));
+            deleteEntityButton.setEnabled(selectedDevice != null && selectedEntity != null
+                    && currentSession.hasPermission(DeviceSessionPermission.write()));
         }
         if (addEntityButton != null) {
             refreshEntityButton.setEnabled(selectedDevice != null);
@@ -73,5 +75,7 @@ public class DeviceTagToolbar extends TagToolbarGrid {
         setBorders(true);
         addEntityButton.setText(DEVICE_MSGS.tabTagsAddButton());
         deleteEntityButton.setText(DEVICE_MSGS.tabTagsDeleteButton());
+        addEntityButton.setEnabled(selectedDevice != null 
+                && currentSession.hasPermission(DeviceSessionPermission.write()));
     }
 }


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for permissions problems on Devices tab

**Related Issue**
This PR fixes/closes part of the issue 1801

**Description of the solution adopted**
Add and Edit buttons one the Devices tab now work correctly, without errors if the user does not have group:read permissions. In that case, the group combo is hidden from the user and when creating a new Device NO_GROUP value is set for the field automatically.
Updated permissions for enabling the Edit button on the Devices tab.
Updated permissions for enabling Add and Delete buttons on the Devices->Tabs tab.

**Screenshots**
_None_

**Any side note on the changes made**
This PR solves a part of the issue 1801 - permissions problems concerning the Devices tab. Because of the issue complexity and the number of changes needed the solution will be divided on a few independent PRs.
