### PR TITLE
Solved button permissions problems on Steps tab

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabSteps.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+import org.eclipse.kapua.app.console.module.job.shared.model.permission.JobSessionPermission;
 
 public class JobTabSteps extends KapuaTabItem<GwtJob> {
 
@@ -56,7 +57,9 @@ public class JobTabSteps extends KapuaTabItem<GwtJob> {
     @Override
     protected void doRefresh() {
         stepsGrid.refresh();
-        stepsGrid.getToolbar().getAddEntityButton().setEnabled(selectedEntity != null && selectedEntity.getJobXmlDefinition() == null);
+        stepsGrid.getToolbar().getAddEntityButton()
+                .setEnabled(selectedEntity != null && selectedEntity.getJobXmlDefinition() == null
+                        && currentSession.hasPermission(JobSessionPermission.write()));
         stepsGrid.getToolbar().getRefreshEntityButton().setEnabled(selectedEntity != null);
     }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -132,6 +132,8 @@ public class JobTabStepsGrid extends EntityGrid<GwtJobStep> {
     @Override
     protected void selectionChangedEvent(final GwtJobStep selectedItem) {
         super.selectionChangedEvent(selectedItem);
+        JobTabStepsGrid.this.toolbar.getEditEntityButton().setEnabled(false);
+        JobTabStepsGrid.this.toolbar.getDeleteEntityButton().setEnabled(false);
         JOB_SERVICE.find(currentSession.getSelectedAccountId(), jobId, new AsyncCallback<GwtJob>() {
 
             @Override


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Solved button permissions problems on Steps tab

**Related Issue**
This PR fixes/closes part of the issue 1801

**Description of the solution adopted**
Solved problems with Add/Edit and Delete buttons being temporary enabled when changing items selected on jobs/job steps grid when the user does not have correct permissions.

**Screenshots**
_None_

**Any side note on the changes made**
This PR solves another part of issue 1801. The rest of the issue will be solved in the upcoming PRs.
