### PR TITLE
Tag list in devices is sorted by tag name

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,6 +35,8 @@ import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
 import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagService;
 import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagServiceAsync;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class DeviceTagAddDialog extends EntityAddEditDialog {
@@ -141,6 +143,13 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onSuccess(List<GwtTag> result) {
+                Collections.sort(result, new Comparator<GwtTag>() {
+
+                    @Override
+                    public int compare(GwtTag tag1, GwtTag tag2) {
+                        return tag1.getTagName().compareTo(tag2.getTagName());
+                    }
+                });
                 tagsCombo.getStore().add(result);
 
                 tagsCombo.setEmptyText(result.isEmpty() ? MSGS.dialogDeviceTagAddFieldTagEmptyTextNoTags() : MSGS.dialogDeviceTagAddFieldTagEmptyText());


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Sorted tag list in devices.

**Related Issue**
This PR fixes issue #2385 

**Description of the solution adopted**
Tag list in tag combo box in devices is sorted by tag name.

**Screenshots**
/

**Any side note on the changes made**
/
