### PR TITLE
Fix for permissions problems in Roles tabs

### DIFF
--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +33,8 @@ import org.eclipse.kapua.app.console.module.authorization.client.messages.Consol
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRolePermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.DomainSessionPermission;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.RoleSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRoleService;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRoleServiceAsync;
 
@@ -136,7 +138,11 @@ public class RolePermissionGrid extends EntityGrid<GwtRolePermission> {
     @Override
     protected void selectionChangedEvent(GwtRolePermission selectedItem) {
         super.selectionChangedEvent(selectedItem);
-        rolePermissionToolBar.getAddEntityButton().setEnabled(currentSession.hasPermission(AccessInfoSessionPermission.write()));
+        rolePermissionToolBar.getAddEntityButton().setEnabled(selectedRole != null 
+                && currentSession.hasPermission(AccessInfoSessionPermission.read())
+                && currentSession.hasPermission(AccessInfoSessionPermission.write())
+                && currentSession.hasPermission(DomainSessionPermission.read())
+                && currentSession.hasPermission(RoleSessionPermission.write()));
         if (selectedItem == null) {
             rolePermissionToolBar.getDeleteEntityButton().disable();
         } else {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,8 @@ import org.eclipse.kapua.app.console.module.authorization.client.role.dialog.Rol
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRolePermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.DomainSessionPermission;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.RoleSessionPermission;
 
 public class RolePermissionToolbar extends EntityCRUDToolbar<GwtRolePermission> {
 
@@ -54,7 +56,11 @@ public class RolePermissionToolbar extends EntityCRUDToolbar<GwtRolePermission> 
 
     private void checkAddButton() {
         if (getAddEntityButton() != null) {
-            getAddEntityButton().setEnabled(selectedRole != null && currentSession.hasPermission(AccessInfoSessionPermission.write()));
+            getAddEntityButton().setEnabled(selectedRole != null 
+                    && currentSession.hasPermission(AccessInfoSessionPermission.read())
+                    && currentSession.hasPermission(AccessInfoSessionPermission.write())
+                    && currentSession.hasPermission(DomainSessionPermission.read())
+                    && currentSession.hasPermission(RoleSessionPermission.write()));
         }
     }
 

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UsersRoleTabItemDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UsersRoleTabItemDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.Abstra
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.client.role.RoleView;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.RoleSessionPermission;
 import org.eclipse.kapua.app.console.module.user.shared.model.permission.UserSessionPermission;
 
@@ -37,6 +38,8 @@ public class UsersRoleTabItemDescriptor extends AbstractEntityTabDescriptor<GwtR
 
     @Override
     public Boolean isEnabled(GwtSession currentSession) {
-        return currentSession.hasPermission(UserSessionPermission.read()) && currentSession.hasPermission(RoleSessionPermission.read());
+        return currentSession.hasPermission(UserSessionPermission.read())
+                && currentSession.hasPermission(RoleSessionPermission.read())
+                && currentSession.hasPermission(AccessInfoSessionPermission.read());
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -128,7 +128,7 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
         KapuaLocator locator = KapuaLocator.getInstance();
         AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ROLE_DOMAIN, Actions.delete, scopeId));
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.delete, scopeId));
 
         entityManagerSession.onTransactedAction(em -> {
             if (RolePermissionDAO.find(em, scopeId, rolePermissionId) == null) {


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for permissions problems in Roles tabs

**Related Issue**
This PR fixes/closes part of issue 1801

**Description of the solution adopted**
Updated delete method in `RolePermissionServiceImpl` class, to check for _ACCESS_INFO_DOMAIN delete_ instead of _ROLE_DOMAIN delete_ permission. 
Set permissions needed for enabling the Add button in Roles->Permissions to reflect those already set on the service side (access_info:read, access_info:write, domain:read i role:write).
Updated permissions needed for enabling the Granted Users tab. 

**Screenshots**
_None_

**Any side note on the changes made**
This PR solves another part of issue 1801. The rest of the issue will be solved in the upcoming PRs.
