### PR TITLE
Submit button gets disabled fix

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,7 @@ public class AccountDeleteDialog extends EntityDeleteDialog {
         super();
         this.selectedAccount = selectedAccount;
         DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
     }
 
     @Override

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
@@ -54,6 +54,7 @@ public abstract class ActionDialog extends KapuaDialog {
     protected Boolean exitStatus;
     protected String exitMessage;
     private Boolean dateValueNotNull = false;
+    private Boolean disabledFormPanelEvents = false;
 
     public ActionDialog() {
         super();
@@ -117,6 +118,10 @@ public abstract class ActionDialog extends KapuaDialog {
         formPanel.addListener(Events.OnKeyUp, listener);
         formPanel.addListener(Events.OnPaste, pasteEventListener);
         sinkEvents(Event.ONPASTE);
+
+        if (disabledFormPanelEvents) {
+            formPanel.disableEvents(true);
+        }
 
         //
         // Buttons setup
@@ -233,4 +238,7 @@ public abstract class ActionDialog extends KapuaDialog {
         this.dateValueNotNull = dateValueNotNull;
     }
 
+    public void setDisabledFormPanelEvents(Boolean disabledFormPanelEvents) {
+        this.disabledFormPanelEvents = disabledFormPanelEvents;
+    }
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,7 @@ public class GroupDeleteDialog extends EntityDeleteDialog {
     public GroupDeleteDialog(GwtGroup gwtGroup) {
         this.gwtGroup = gwtGroup;
         DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
     }
 
     @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +33,7 @@ public class RoleDeleteDialog extends EntityDeleteDialog {
         this.gwtRole = gwtRole;
 
         DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceDeleteDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -34,6 +34,7 @@ public class DeviceDeleteDialog extends EntityDeleteDialog {
         this.gwtDevice = gwtUser;
 
         DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
     }
 
     @Override

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointDeleteDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,7 @@ public class EndpointDeleteDialog extends EntityDeleteDialog {
     public EndpointDeleteDialog(GwtEndpoint gwtEndpoint) {
         this.gwtEndpoint = gwtEndpoint;
         DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,6 +30,7 @@ public class JobDeleteDialog extends EntityDeleteDialog {
     public JobDeleteDialog(GwtJob selectedJob) {
         this.selectedJob = selectedJob;
         DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
     }
 
     @Override

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagDeleteDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,7 @@ public class TagDeleteDialog extends EntityDeleteDialog {
     public TagDeleteDialog(GwtTag gwtTag) {
         this.gwtTag = gwtTag;
         DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
     }
 
     @Override

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserDeleteDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +33,7 @@ public class UserDeleteDialog extends EntityDeleteDialog {
         this.gwtUser = gwtUser;
 
         DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Submit button gets disabled fix

**Related Issue**
This PR fixes/closes #2382 

**Description of the solution adopted**
Disabled unneeded form panel events on confirm delete dialogs. 
Those events were needed when checking the state of input fields and are not needed here.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
