### PR TITLE
Disabled edit button in devices when nothing is selected

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
@@ -58,7 +58,7 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
         addExtraButton(export);
         super.onRender(target, index);
         getAddEntityButton().setEnabled(currentSession.hasPermission(DeviceSessionPermission.write()));
-        getEditEntityButton().setEnabled(currentSession.hasPermission(DeviceSessionPermission.write()));
+        getEditEntityButton().disable();
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Disabled edit button in devices.

**Related Issue**
This PR fixes issue #2391. 

**Description of the solution adopted**
Edit button in devices is disabled if no one device is selected.

**Screenshots**
/

**Any side note on the changes made**
/
