### PR TITLE
Removed Not available text in job targets if device is deleted

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobTargetServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobTargetServiceImpl.java
@@ -93,8 +93,11 @@ public class GwtJobTargetServiceImpl extends KapuaRemoteServiceServlet implement
 
             for (JobTarget jt : jobTargetList.getItems()) {
                 GwtJobTarget gwtJobTarget = KapuaGwtJobModelConverter.convertJobTarget(jt);
-                insertClientId(gwtJobTarget, deviceMap.get(jt.getJobTargetId()));
-                gwtJobTargetList.add(gwtJobTarget);
+                Device device = DEVICE_REGISTRY_SERVICE.find(KapuaEid.parseCompactId(gwtJobTarget.getScopeId()), KapuaEid.parseCompactId(gwtJobTarget.getJobTargetId()));
+                if (device != null) {
+                    insertClientId(gwtJobTarget, deviceMap.get(jt.getJobTargetId()));
+                    gwtJobTargetList.add(gwtJobTarget);
+                }
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Removed "Not available" text in job targets.

**Related Issue**
This PR fixes issue #2378. 

**Description of the solution adopted**
If device is deleted, "Not available" text is removed from client id column in job target grid.

**Screenshots**
/

**Any side note on the changes made**
/
