### PR TITLE
Fix for permissions problems on Permissions tabs

### DIFF
--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
@@ -34,6 +34,7 @@ import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRolePermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.DomainSessionPermission;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.GroupSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.RoleSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRoleService;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtRoleServiceAsync;
@@ -102,9 +103,11 @@ public class RolePermissionGrid extends EntityGrid<GwtRolePermission> {
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
-        columnConfig = new ColumnConfig("groupName", ROLE_MSGS.gridRolePermissionColumnHeaderTargetGroup(), 100);
-        columnConfig.setSortable(false);
-        columnConfigs.add(columnConfig);
+        if (currentSession.hasPermission(GroupSessionPermission.read())) {
+            columnConfig = new ColumnConfig("groupName", ROLE_MSGS.gridRolePermissionColumnHeaderTargetGroup(), 100);
+            columnConfig.setSortable(false);
+            columnConfigs.add(columnConfig);
+        }
 
         columnConfig = new ColumnConfig("forwardable", ROLE_MSGS.gridRolePermissionColumnHeaderForwardable(), 200);
         columnConfig.setRenderer(new GridCellRenderer<GwtRolePermission>() {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,6 +39,7 @@ import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtDomain
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtPermission.GwtAction;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.GroupSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtAccessInfoService;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtAccessInfoServiceAsync;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtAccessPermissionService;
@@ -216,35 +217,41 @@ public class PermissionAddDialog extends EntityAddEditDialog {
         groupsCombo.setTriggerAction(TriggerAction.ALL);
         groupsCombo.setEmptyText(MSGS.dialogAddPermissionLoading());
         groupsCombo.disable();
-        GWT_GROUP_SERVICE.findAll(currentSession.getSelectedAccountId(), new AsyncCallback<List<GwtGroup>>() {
+        if (currentSession.hasPermission(GroupSessionPermission.read())) {
+            GWT_GROUP_SERVICE.findAll(currentSession.getSelectedAccountId(), new AsyncCallback<List<GwtGroup>>() {
 
-            @Override
-            public void onFailure(Throwable caught) {
-                exitMessage = MSGS.dialogAddPermissionErrorGroups(caught.getLocalizedMessage());
-                exitStatus = false;
-                hide();
-            }
+                @Override
+                public void onFailure(Throwable caught) {
+                    exitMessage = MSGS.dialogAddPermissionErrorGroups(caught.getLocalizedMessage());
+                    exitStatus = false;
+                    hide();
+                }
 
-            @Override
-            public void onSuccess(List<GwtGroup> result) {
-                groupsCombo.getStore().removeAll();
-                groupsCombo.getStore().add(allGroup);
-                groupsCombo.getStore().add(result);
-                groupsCombo.setValue(allGroup);
-                groupsCombo.enable();
-            }
-        });
+                @Override
+                public void onSuccess(List<GwtGroup> result) {
+                    groupsCombo.getStore().removeAll();
+                    groupsCombo.getStore().add(allGroup);
+                    groupsCombo.getStore().add(result);
+                    groupsCombo.setValue(allGroup);
+                    groupsCombo.enable();
+                }
+            });
 
-        groupsCombo.addSelectionChangedListener(new SelectionChangedListener<GwtGroup>() {
+            groupsCombo.addSelectionChangedListener(new SelectionChangedListener<GwtGroup>() {
 
-            @Override
-            public void selectionChanged(SelectionChangedEvent<GwtGroup> se) {
-                domainsCombo.clearInvalid();
-                actionsCombo.clearInvalid();
-                groupsCombo.clearInvalid();
-            }
-        });
-        permissionFormPanel.add(groupsCombo);
+                @Override
+                public void selectionChanged(SelectionChangedEvent<GwtGroup> se) {
+                    domainsCombo.clearInvalid();
+                    actionsCombo.clearInvalid();
+                    groupsCombo.clearInvalid();
+                }
+            });
+            permissionFormPanel.add(groupsCombo);
+        } else {
+            groupsCombo.getStore().removeAll();
+            groupsCombo.getStore().add(allGroup);
+            groupsCombo.setValue(allGroup);
+        }
 
         //
         // Forwardable

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,7 +32,7 @@ import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsolePermissionMessages;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtAccessPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
-import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.DomainSessionPermission;
+import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.GroupSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtAccessPermissionService;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtAccessPermissionServiceAsync;
 
@@ -74,7 +74,7 @@ public class UserTabPermissionGrid extends EntityGrid<GwtAccessPermission> {
         if (selectedItem == null) {
             toolbar.getDeleteEntityButton().disable();
         } else {
-            toolbar.getDeleteEntityButton().setEnabled(currentSession.hasPermission(AccessInfoSessionPermission.delete()) && currentSession.hasPermission(DomainSessionPermission.delete()));
+            toolbar.getDeleteEntityButton().setEnabled(currentSession.hasPermission(AccessInfoSessionPermission.delete()));
         }
     }
 
@@ -96,9 +96,11 @@ public class UserTabPermissionGrid extends EntityGrid<GwtAccessPermission> {
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
-        columnConfig = new ColumnConfig("groupName", PERMISSION_MSGS.gridAccessRoleColumnHeaderGroupName(), 200);
-        columnConfig.setSortable(false);
-        columnConfigs.add(columnConfig);
+        if (currentSession.hasPermission(GroupSessionPermission.read())) {
+            columnConfig = new ColumnConfig("groupName", PERMISSION_MSGS.gridAccessRoleColumnHeaderGroupName(), 200);
+            columnConfig.setSortable(false);
+            columnConfigs.add(columnConfig);
+        }
 
         columnConfig = new ColumnConfig("permissionForwardable", PERMISSION_MSGS.gridAccessRoleColumnHeaderForwardable(), 200);
         columnConfig.setRenderer(new GridCellRenderer<GwtAccessPermission>() {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,7 +20,6 @@ import org.eclipse.kapua.app.console.module.authorization.client.messages.Consol
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtAccessPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.DomainSessionPermission;
-import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.GroupSessionPermission;
 
 public class UserTabPermissionToolbar extends EntityCRUDToolbar<GwtAccessPermission> {
 
@@ -59,9 +58,10 @@ public class UserTabPermissionToolbar extends EntityCRUDToolbar<GwtAccessPermiss
         super.onRender(target, index);
         addEntityButton.setText(PERMISSION_MSGS.dialogAddPermissionButton());
         deleteEntityButton.setText(PERMISSION_MSGS.dialogDeletePermissionButton());
-        addEntityButton.setEnabled(userId != null && currentSession.hasPermission(AccessInfoSessionPermission.read())
-                && currentSession.hasPermission(AccessInfoSessionPermission.write()) && currentSession.hasPermission(DomainSessionPermission.read()) 
-                && currentSession.hasPermission(DomainSessionPermission.write()) && currentSession.hasPermission(GroupSessionPermission.read()));
+        addEntityButton.setEnabled(userId != null 
+                && currentSession.hasPermission(AccessInfoSessionPermission.read())
+                && currentSession.hasPermission(AccessInfoSessionPermission.write()) 
+                && currentSession.hasPermission(DomainSessionPermission.read()));
         deleteEntityButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null);
         refreshEntityButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null);
     }
@@ -70,7 +70,7 @@ public class UserTabPermissionToolbar extends EntityCRUDToolbar<GwtAccessPermiss
     protected void updateButtonEnablement() {
         super.updateButtonEnablement();
         addEntityButton.setEnabled(userId != null && currentSession.hasPermission(AccessInfoSessionPermission.read())
-                && currentSession.hasPermission(AccessInfoSessionPermission.write()) && currentSession.hasPermission(DomainSessionPermission.read()) 
-                && currentSession.hasPermission(DomainSessionPermission.write()) && currentSession.hasPermission(GroupSessionPermission.read()));
+                && currentSession.hasPermission(AccessInfoSessionPermission.write())
+                && currentSession.hasPermission(DomainSessionPermission.read()));
     }
 }

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermission.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,6 @@ import org.eclipse.kapua.app.console.module.authorization.client.tabs.permission
 import org.eclipse.kapua.app.console.module.authorization.client.tabs.permission.UserTabPermissionToolbar;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.DomainSessionPermission;
-import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.GroupSessionPermission;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
 
 public class UserTabItemPermission extends KapuaTabItem<GwtUser> {
@@ -67,9 +66,10 @@ public class UserTabItemPermission extends KapuaTabItem<GwtUser> {
     @Override
     protected void doRefresh() {
         permissionGrid.refresh();
-        permissionGrid.getToolbar().getAddEntityButton().setEnabled(selectedEntity != null && currentSession.hasPermission(AccessInfoSessionPermission.read())
-                && currentSession.hasPermission(AccessInfoSessionPermission.write()) && currentSession.hasPermission(DomainSessionPermission.read()) 
-                && currentSession.hasPermission(DomainSessionPermission.write()) && currentSession.hasPermission(GroupSessionPermission.read()));
+        permissionGrid.getToolbar().getAddEntityButton().setEnabled(selectedEntity != null 
+                && currentSession.hasPermission(AccessInfoSessionPermission.read())
+                && currentSession.hasPermission(AccessInfoSessionPermission.write()) 
+                && currentSession.hasPermission(DomainSessionPermission.read()));
         permissionGrid.getToolbar().getRefreshEntityButton().setEnabled(selectedEntity != null);
     }
 

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermissionDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermissionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,7 +15,6 @@ import org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.Abstra
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.DomainSessionPermission;
-import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.GroupSessionPermission;
 import org.eclipse.kapua.app.console.module.user.client.UserView;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
 
@@ -39,7 +38,6 @@ public class UserTabItemPermissionDescriptor extends AbstractEntityTabDescriptor
     @Override
     public Boolean isEnabled(GwtSession currentSession) {
         return currentSession.hasPermission(AccessInfoSessionPermission.read()) 
-            && currentSession.hasPermission(DomainSessionPermission.read()) 
-            && currentSession.hasPermission(GroupSessionPermission.read());
+            && currentSession.hasPermission(DomainSessionPermission.read());
     }
 }


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for permissions problems on Permissions tabs.

**Related Issue**
This PR fixes/closes part of issue 1801

**Description of the solution adopted**
Updated permissions needed for enabling Grant and Revoke buttons in Users-> Permissions tab, as well as enabling that tab itself. There is no more dependency on the `group:read` permission on the Add/Delete permission dialogues and the result displaying grid, as the groups combobox and the relevant column on the permissions grid are now hidden if the user does not have the needed permission. For consistency, the Roles->Permissions dialogues and result grid are updated as well regarding displaying the group information depending on the `group:read` permission.

**Screenshots**
_None_

**Any side note on the changes made**
This PR solves another part of issue 1801. The rest of the issue will be solved in the upcoming PRs.