### PR TITLE
Sorted group list in devices

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -52,6 +52,8 @@ import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQueryPr
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceService;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceServiceAsync;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class DeviceAddDialog extends EntityAddEditDialog {
@@ -215,6 +217,14 @@ public class DeviceAddDialog extends EntityAddEditDialog {
                 public void onSuccess(List<GwtGroup> result) {
                     groupCombo.getStore().removeAll();
                     groupCombo.getStore().add(NO_GROUP);
+
+                    Collections.sort(result, new Comparator<GwtGroup>() {
+
+                        @Override
+                        public int compare(GwtGroup group1, GwtGroup group2) {
+                            return group1.getGroupName().compareTo(group2.getGroupName());
+                        }
+                    });
                     groupCombo.getStore().add(result);
                 }
             });


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Group list in devices is sorted.

**Related Issue**
This PR fixes issue #2402

**Description of the solution adopted**
Sorted group list in device add dialog by group name.

**Screenshots**
/

**Any side note on the changes made**
/
