### PR TITLE
Set permissions for enabling Start button in Targets

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -90,7 +90,7 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
     protected void updateButtonEnablement() {
         super.updateButtonEnablement();
 
-        jobStartTargetButton.setEnabled(selectedEntity != null);
+        jobStartTargetButton.setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.execute()));
         addEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.write()));
         deleteEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.delete()));
     }
@@ -115,7 +115,7 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
                     }
 
                     if (jobStartTargetButton != null) {
-                        jobStartTargetButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null);
+                        jobStartTargetButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null && currentSession.hasPermission(JobSessionPermission.execute()));
                     }
                 }
             });


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Set permissions for enabling Start button in Targets

**Related Issue**
This PR fixes/closes #2386 

**Description of the solution adopted**
Added check for `JobSessionPermission.execute()` permission when enabling Start button in Jobs -> Targets.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
