### PR TITLE
Feature device operation provided

### DIFF
--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
@@ -19,6 +19,8 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.type.ObjectTypeConverter;
 import org.eclipse.kapua.model.type.ObjectValueConverter;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.message.notification.OperationStatus;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessage;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseMessage;
@@ -46,6 +48,9 @@ import java.util.Map;
 public abstract class AbstractDeviceManagementServiceImpl {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+
+    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
+    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     private static final DeviceEventService DEVICE_EVENT_SERVICE = LOCATOR.getService(DeviceEventService.class);
     private static final DeviceEventFactory DEVICE_EVENT_FACTORY = LOCATOR.getFactory(DeviceEventFactory.class);

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
@@ -47,10 +47,10 @@ import java.util.Map;
  */
 public abstract class AbstractDeviceManagementServiceImpl {
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    protected static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
-    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
-    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+    protected static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
+    protected static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     private static final DeviceEventService DEVICE_EVENT_SERVICE = LOCATOR.getService(DeviceEventService.class);
     private static final DeviceEventFactory DEVICE_EVENT_FACTORY = LOCATOR.getFactory(DeviceEventFactory.class);

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
@@ -13,12 +13,9 @@ package org.eclipse.kapua.service.device.management.asset.internal;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.AuthorizationService;
-import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
@@ -63,10 +60,7 @@ public class DeviceAssetManagementServiceImpl extends AbstractDeviceManagementSe
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request
@@ -127,10 +121,7 @@ public class DeviceAssetManagementServiceImpl extends AbstractDeviceManagementSe
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request
@@ -192,10 +183,7 @@ public class DeviceAssetManagementServiceImpl extends AbstractDeviceManagementSe
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Prepare the request

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
@@ -15,12 +15,9 @@ package org.eclipse.kapua.service.device.management.bundle.internal;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.AuthorizationService;
-import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundles;
@@ -60,10 +57,7 @@ public class DeviceBundleManagementServiceImpl extends AbstractDeviceManagementS
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request
@@ -133,10 +127,7 @@ public class DeviceBundleManagementServiceImpl extends AbstractDeviceManagementS
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
 
         //
         // Prepare the request
@@ -185,10 +176,7 @@ public class DeviceBundleManagementServiceImpl extends AbstractDeviceManagementS
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
 
         //
         // Prepare the request

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -36,7 +36,7 @@ import java.util.Date;
 /**
  * {@link DeviceCommandManagementService} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @KapuaProvider
 public class DeviceCommandManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceCommandManagementService {

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
@@ -13,12 +13,9 @@ package org.eclipse.kapua.service.device.management.command.internal;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.AuthorizationService;
-import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandInput;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService;
@@ -56,10 +53,7 @@ public class DeviceCommandManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
 
         //
         // Prepare the request

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -47,9 +47,9 @@ import java.io.StringWriter;
 import java.util.Date;
 
 /**
- * {@link DeviceConfigurationManagementService }implementation.
+ * {@link DeviceConfigurationManagementService} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @KapuaProvider
 public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceConfigurationManagementService {

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -15,12 +15,9 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.AuthorizationService;
-import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
 import org.eclipse.kapua.service.device.management.commons.AbstractDeviceManagementServiceImpl;
 import org.eclipse.kapua.service.device.management.commons.call.DeviceCallExecutor;
@@ -57,6 +54,8 @@ import java.util.Date;
 @KapuaProvider
 public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceConfigurationManagementService {
 
+    private static final DeviceConfigurationFactory DEVICE_CONFIGURATION_FACTORY = LOCATOR.getFactory(DeviceConfigurationFactory.class);
+
     @Override
     public DeviceConfiguration get(KapuaId scopeId, KapuaId deviceId, String configurationId, String configurationComponentPid, Long timeout)
             throws KapuaException {
@@ -67,10 +66,7 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request
@@ -144,10 +140,7 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Prepare the request
@@ -160,8 +153,7 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
         ConfigurationRequestPayload configurationRequestPayload = new ConfigurationRequestPayload();
 
         try {
-            DeviceConfigurationFactory deviceConfigurationFactory = locator.getFactory(DeviceConfigurationFactory.class);
-            DeviceConfiguration deviceConfiguration = deviceConfigurationFactory.newConfigurationInstance();
+            DeviceConfiguration deviceConfiguration = DEVICE_CONFIGURATION_FACTORY.newConfigurationInstance();
             deviceConfiguration.getComponentConfigurations().add(deviceComponentConfiguration);
 
             DeviceManagementSetting deviceManagementConfig = DeviceManagementSetting.getInstance();
@@ -226,10 +218,7 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Prepare the request

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
@@ -14,12 +14,9 @@ package org.eclipse.kapua.service.device.management.snapshot.internal;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.AuthorizationService;
-import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
 import org.eclipse.kapua.service.device.management.commons.AbstractDeviceManagementServiceImpl;
 import org.eclipse.kapua.service.device.management.commons.call.DeviceCallExecutor;
@@ -59,10 +56,7 @@ public class DeviceSnapshotManagementServiceImpl extends AbstractDeviceManagemen
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request
@@ -130,10 +124,7 @@ public class DeviceSnapshotManagementServiceImpl extends AbstractDeviceManagemen
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.execute, scopeId));
 
         //
         // Prepare the request

--- a/service/device/management/packages/api/pom.xml
+++ b/service/device/management/packages/api/pom.xml
@@ -30,7 +30,15 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-registry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-management-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-management-registry-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageFactory.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageFactory.java
@@ -17,42 +17,49 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackageB
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageBundleInfos;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackages;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOperation;
+import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOptions;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
+import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallRequest;
+import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 
 /**
- * Device package service definition.
+ * {@link DevicePackageFactory} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public interface DevicePackageFactory extends KapuaObjectFactory {
 
     /**
      * Creates a new {@link DevicePackages}
      *
-     * @return
+     * @return the newly created {@link DevicePackages}
+     * @since 1.0.0
      */
     DevicePackages newDeviceDeploymentPackages();
 
     /**
      * Creates a new {@link DevicePackage}
      *
-     * @return
+     * @return The newly created {@link DevicePackage}
+     * @since 1.0.0
      */
     DevicePackage newDeviceDeploymentPackage();
 
     /**
-     * Creates a new device package bundle information
+     * Creates a new {@link DevicePackageBundleInfo}
      *
-     * @return
+     * @return the newly created {@link DevicePackageBundleInfo}
+     * @since 1.0.0
      */
     DevicePackageBundleInfo newDevicePackageBundleInfo();
 
     /**
-     * Creates a new device package bundle informations
+     * Creates a new {@link DevicePackageBundleInfos}
      *
-     * @return
+     * @return the newly created {@link DevicePackageBundleInfos}
+     * @since 1.0.0
      */
     DevicePackageBundleInfos newDevicePackageBundleInfos();
 
@@ -61,16 +68,26 @@ public interface DevicePackageFactory extends KapuaObjectFactory {
     //
 
     /**
-     * Creates a new device package download request
+     * Creates a new {@link DevicePackageDownloadRequest}
      *
-     * @return
+     * @return The newly created {@link DevicePackageDownloadRequest}
+     * @since 1.0.0
      */
     DevicePackageDownloadRequest newPackageDownloadRequest();
 
     /**
-     * Creates a new device package download operation
+     * Creates a new {@link DevicePackageDownloadOptions}
      *
-     * @return
+     * @return the newly created {@link DevicePackageDownloadOptions}
+     * @since 1.1.0
+     */
+    DevicePackageDownloadOptions newDevicePackageDownloadOptions();
+
+    /**
+     * Creates a new {@link DevicePackageDownloadOperation}
+     *
+     * @return the newly created {@link DevicePackageDownloadOperation}
+     * @since 1.0.0
      */
     DevicePackageDownloadOperation newPackageDownloadOperation();
 
@@ -81,18 +98,37 @@ public interface DevicePackageFactory extends KapuaObjectFactory {
     /**
      * Creates a new {@link DevicePackageInstallRequest}
      *
-     * @return
+     * @return the newly created {@link DevicePackageInstallRequest}
+     * @since 1.0.0
      */
     DevicePackageInstallRequest newPackageInstallRequest();
+
+    /**
+     * Creates a new {@link DevicePackageInstallOptions}
+     *
+     * @return the newly created {@link DevicePackageInstallOptions}
+     * @since 1.1.0
+     */
+    DevicePackageInstallOptions newDevicePackageInstallOptions();
+
 
     //
     // Uninstall operation
     //
 
     /**
-     * Creates a new device package uninstall request
+     * Creates a new {@link DevicePackageUninstallRequest}
      *
-     * @return
+     * @return the newly created {@link DevicePackageUninstallRequest}
+     * @since 1.0.0
      */
     DevicePackageUninstallRequest newPackageUninstallRequest();
+
+    /**
+     * Creates a new {@link DevicePackageUninstallOptions}
+     *
+     * @return the newly created {@link DevicePackageUninstallOptions}
+     * @since 1.1.0
+     */
+    DevicePackageUninstallOptions newDevicePackageUninstallOptions();
 }

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
@@ -24,11 +24,13 @@ import org.eclipse.kapua.service.device.management.packages.model.install.Device
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOperation;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
+import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation;
+import org.eclipse.kapua.service.device.registry.Device;
 
 /**
  * {@link DevicePackageManagementService} definition.
  * <p>
- * The {@link DevicePackageManagementService} is used to interact with the DEPLOY-V2 device application.
+ * The {@link DevicePackageManagementService} is used to interact with the DEPLOY-V2 {@link org.eclipse.kapua.service.device.registry.Device} application.
  *
  * @since 1.0.0
  */
@@ -37,8 +39,8 @@ public interface DevicePackageManagementService extends KapuaService {
     /**
      * Gets the installed {@link DevicePackages}s
      *
-     * @param scopeId  The scope {@link KapuaId} of the target device
-     * @param deviceId The device {@link KapuaId} of the target device
+     * @param scopeId  The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId The {@link KapuaId} of the target {@link Device}
      * @param timeout  The timeout in milliseconds for the request to complete
      * @return The {@link DevicePackages}
      * @throws KapuaException if error occurs during processing
@@ -53,34 +55,36 @@ public interface DevicePackageManagementService extends KapuaService {
     /**
      * Downloads a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId                The scope {@link KapuaId} of the target device
-     * @param deviceId               The device {@link KapuaId} of the target device
+     * @param scopeId                The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId               The {@link KapuaId} of the target {@link Device}
      * @param packageDownloadRequest The {@link DevicePackageDownloadRequest} for this request
      * @param timeout                The timeout in milliseconds for the request to complete
+     * @return the {@link KapuaId} of the {@link DeviceManagementOperation} of this download
      * @throws KapuaException if error occurs during processing
      * @since 1.0.0
      * @deprecated since 1.1.0. Please make use of {@link #downloadExec(KapuaId, KapuaId, DevicePackageDownloadRequest, DevicePackageDownloadOptions)}.
      */
     @Deprecated
-    void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, Long timeout) throws KapuaException;
+    KapuaId downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, Long timeout) throws KapuaException;
 
     /**
      * Downloads a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId                The scope {@link KapuaId} of the target device
-     * @param deviceId               The device {@link KapuaId} of the target device
+     * @param scopeId                The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId               The {@link KapuaId} of the target {@link Device}
      * @param packageDownloadRequest The {@link DevicePackageDownloadRequest} for this request
      * @param packageDownloadOptions The {@link DevicePackageDownloadOptions} for this request
+     * @return the {@link KapuaId} of the {@link DeviceManagementOperation} of this download
      * @throws KapuaException if error occurs during processing
      * @since 1.1.0
      */
-    void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, DevicePackageDownloadOptions packageDownloadOptions) throws KapuaException;
+    KapuaId downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, DevicePackageDownloadOptions packageDownloadOptions) throws KapuaException;
 
     /**
      * Interrupts a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage} download operation
      *
-     * @param scopeId  The scope {@link KapuaId} of the target device
-     * @param deviceId The device {@link KapuaId} of the target device
+     * @param scopeId  The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId The {@link KapuaId} of the target {@link Device}
      * @param timeout  The timeout in milliseconds for the request to complete
      * @throws KapuaException
      * @since 1.0.0
@@ -90,10 +94,10 @@ public interface DevicePackageManagementService extends KapuaService {
     /**
      * Gets the {@link DevicePackageDownloadOperation} status.
      *
-     * @param scopeId  The scope {@link KapuaId} of the target device
-     * @param deviceId The device {@link KapuaId} of the target device
+     * @param scopeId  The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId The {@link KapuaId} of the target {@link Device}
      * @param timeout  The timeout in milliseconds for the request to complete
-     * @return
+     * @return The {@link DevicePackageDownloadOperation} from the {@link Device}
      * @throws KapuaException if error occurs during processing
      * @since 1.0.0
      */
@@ -106,36 +110,38 @@ public interface DevicePackageManagementService extends KapuaService {
     /**
      * Installs a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId               The scope {@link KapuaId} of the target device
-     * @param deviceId              The device {@link KapuaId} of the target device
+     * @param scopeId               The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId              The {@link KapuaId} of the target {@link Device}
      * @param packageInstallRequest The {@link DevicePackageInstallRequest} for this request
      * @param timeout               The timeout in milliseconds for the request to complete
+     * @return the {@link KapuaId} of the {@link DeviceManagementOperation} of this install
      * @throws KapuaException if error occurs during processing
      * @since 1.0.0
      * @deprecated since 1.1.0. Please make use of {@link #installExec(KapuaId, KapuaId, DevicePackageInstallRequest, DevicePackageInstallOptions)}.
      */
     @Deprecated
-    void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, Long timeout) throws KapuaException;
+    KapuaId installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, Long timeout) throws KapuaException;
 
     /**
      * Installs a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId               The scope {@link KapuaId} of the target device
-     * @param deviceId              The device {@link KapuaId} of the target device
+     * @param scopeId               The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId              The {@link KapuaId} of the target {@link Device}
      * @param packageInstallRequest The {@link DevicePackageInstallRequest} for this request
      * @param packageInstallOptions The {@link DevicePackageInstallOptions} for this request
+     * @return the {@link KapuaId} of the {@link DeviceManagementOperation} of this install
      * @throws KapuaException if error occurs during processing
      * @since 1.1.0
      */
-    void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, DevicePackageInstallOptions packageInstallOptions) throws KapuaException;
+    KapuaId installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, DevicePackageInstallOptions packageInstallOptions) throws KapuaException;
 
     /**
      * Gets the {@link DevicePackageInstallOperation} status.
      *
-     * @param scopeId  The scope {@link KapuaId} of the target device
-     * @param deviceId The device {@link KapuaId} of the target device
+     * @param scopeId  The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId The {@link KapuaId} of the target {@link Device}
      * @param timeout  The timeout in milliseconds for the request to complete
-     * @return
+     * @return The {@link DevicePackageInstallOperation} from the {@link Device}.
      * @throws KapuaException if error occurs during processing
      * @since 1.0.0
      */
@@ -148,36 +154,38 @@ public interface DevicePackageManagementService extends KapuaService {
     /**
      * Uninstalls a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId                 The scope {@link KapuaId} of the target device
-     * @param deviceId                The device {@link KapuaId} of the target device
+     * @param scopeId                 The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId                The {@link KapuaId} of the target {@link Device}
      * @param packageUninstallRequest The {@link DevicePackageUninstallRequest} for this request
      * @param timeout                 The timeout in milliseconds for the request to complete
+     * @return the {@link KapuaId} of the {@link DeviceManagementOperation} of this uninstall
      * @throws KapuaException if error occurs during processing
      * @since 1.0.0
      * @deprecated since 1.1.0. Please make use of {@link #uninstallExec(KapuaId, KapuaId, DevicePackageUninstallRequest, DevicePackageUninstallOptions)}.
      */
     @Deprecated
-    void uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, Long timeout) throws KapuaException;
+    KapuaId uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, Long timeout) throws KapuaException;
 
     /**
      * Uninstalls a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId                 The scope {@link KapuaId} of the target device
-     * @param deviceId                The device {@link KapuaId} of the target device
+     * @param scopeId                 The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId                The {@link KapuaId} of the target {@link Device}
      * @param packageUninstallRequest The {@link DevicePackageUninstallRequest} for this request
      * @param packageUninstallOptions The The {@link DevicePackageUninstallOptions} for this request
+     * @return the {@link KapuaId} of the {@link DeviceManagementOperation} of this uninstall
      * @throws KapuaException if error occurs during processing
      * @since 1.1.0
      */
-    void uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, DevicePackageUninstallOptions packageUninstallOptions) throws KapuaException;
+    KapuaId uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, DevicePackageUninstallOptions packageUninstallOptions) throws KapuaException;
 
     /**
      * Gets the {@link DevicePackageUninstallOperation}.
      *
-     * @param scopeId  The scope {@link KapuaId} of the target device
-     * @param deviceId The device {@link KapuaId} of the target device
+     * @param scopeId  The scope {@link KapuaId} of the target {@link Device}
+     * @param deviceId The {@link KapuaId} of the target {@link Device}
      * @param timeout  The timeout in milliseconds for the request to complete
-     * @return
+     * @return the {@link DevicePackageUninstallOperation} from the {@link Device}
      * @throws KapuaException if error occurs during processing
      * @since 1.0.0
      */

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,103 +16,170 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackages;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOperation;
+import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOptions;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallOperation;
+import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallRequest;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOperation;
+import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 
 /**
- * Device package service definition.
+ * {@link DevicePackageManagementService} definition.
+ * <p>
+ * The {@link DevicePackageManagementService} is used to interact with the DEPLOY-V2 device application.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public interface DevicePackageManagementService extends KapuaService {
 
     /**
-     * Get the installed packages list
+     * Gets the installed {@link DevicePackages}s
      *
-     * @param scopeId
-     * @param deviceId
-     * @param timeout
-     * @return
-     * @throws KapuaException
+     * @param scopeId  The scope {@link KapuaId} of the target device
+     * @param deviceId The device {@link KapuaId} of the target device
+     * @param timeout  The timeout in milliseconds for the request to complete
+     * @return The {@link DevicePackages}
+     * @throws KapuaException if error occurs during processing
+     * @since 1.0.0
      */
     DevicePackages getInstalled(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
+    //
+    // Download
+    //
+
     /**
-     * Starts a download package operation
+     * Downloads a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId
-     * @param deviceId
-     * @param packageDownloadRequest
-     * @param timeout
-     * @throws KapuaException
+     * @param scopeId                The scope {@link KapuaId} of the target device
+     * @param deviceId               The device {@link KapuaId} of the target device
+     * @param packageDownloadRequest The {@link DevicePackageDownloadRequest} for this request
+     * @param timeout                The timeout in milliseconds for the request to complete
+     * @throws KapuaException if error occurs during processing
+     * @since 1.0.0
+     * @deprecated since 1.1.0. Please make use of {@link #downloadExec(KapuaId, KapuaId, DevicePackageDownloadRequest, DevicePackageDownloadOptions)}.
      */
+    @Deprecated
     void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, Long timeout) throws KapuaException;
 
     /**
-     * Interrupt a download package operation
+     * Downloads a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId
-     * @param deviceId
-     * @param timeout
+     * @param scopeId                The scope {@link KapuaId} of the target device
+     * @param deviceId               The device {@link KapuaId} of the target device
+     * @param packageDownloadRequest The {@link DevicePackageDownloadRequest} for this request
+     * @param packageDownloadOptions The {@link DevicePackageDownloadOptions} for this request
+     * @throws KapuaException if error occurs during processing
+     * @since 1.1.0
+     */
+    void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, DevicePackageDownloadOptions packageDownloadOptions) throws KapuaException;
+
+    /**
+     * Interrupts a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage} download operation
+     *
+     * @param scopeId  The scope {@link KapuaId} of the target device
+     * @param deviceId The device {@link KapuaId} of the target device
+     * @param timeout  The timeout in milliseconds for the request to complete
      * @throws KapuaException
+     * @since 1.0.0
      */
     void downloadStop(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
     /**
-     * Gets the download package status
+     * Gets the {@link DevicePackageDownloadOperation} status.
      *
-     * @param scopeId
-     * @param deviceId
-     * @param timeout
+     * @param scopeId  The scope {@link KapuaId} of the target device
+     * @param deviceId The device {@link KapuaId} of the target device
+     * @param timeout  The timeout in milliseconds for the request to complete
      * @return
-     * @throws KapuaException
+     * @throws KapuaException if error occurs during processing
+     * @since 1.0.0
      */
     DevicePackageDownloadOperation downloadStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
+    //
+    // Install
+    //
+
     /**
-     * Installs a package
+     * Installs a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId
-     * @param deviceId
-     * @param packageInstallRequest
-     * @param timeout
-     * @throws KapuaException
+     * @param scopeId               The scope {@link KapuaId} of the target device
+     * @param deviceId              The device {@link KapuaId} of the target device
+     * @param packageInstallRequest The {@link DevicePackageInstallRequest} for this request
+     * @param timeout               The timeout in milliseconds for the request to complete
+     * @throws KapuaException if error occurs during processing
+     * @since 1.0.0
+     * @deprecated since 1.1.0. Please make use of {@link #installExec(KapuaId, KapuaId, DevicePackageInstallRequest, DevicePackageInstallOptions)}.
      */
+    @Deprecated
     void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, Long timeout) throws KapuaException;
 
     /**
-     * Gets the package installation status
+     * Installs a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId
-     * @param deviceId
-     * @param timeout
+     * @param scopeId               The scope {@link KapuaId} of the target device
+     * @param deviceId              The device {@link KapuaId} of the target device
+     * @param packageInstallRequest The {@link DevicePackageInstallRequest} for this request
+     * @param packageInstallOptions The {@link DevicePackageInstallOptions} for this request
+     * @throws KapuaException if error occurs during processing
+     * @since 1.1.0
+     */
+    void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, DevicePackageInstallOptions packageInstallOptions) throws KapuaException;
+
+    /**
+     * Gets the {@link DevicePackageInstallOperation} status.
+     *
+     * @param scopeId  The scope {@link KapuaId} of the target device
+     * @param deviceId The device {@link KapuaId} of the target device
+     * @param timeout  The timeout in milliseconds for the request to complete
      * @return
-     * @throws KapuaException
+     * @throws KapuaException if error occurs during processing
+     * @since 1.0.0
      */
     DevicePackageInstallOperation installStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 
+    //
+    // Uninstall
+    //
+
     /**
-     * Uninstalls a package
+     * Uninstalls a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId
-     * @param deviceId
-     * @param packageUninstallRequest
-     * @param timeout
-     * @throws KapuaException
+     * @param scopeId                 The scope {@link KapuaId} of the target device
+     * @param deviceId                The device {@link KapuaId} of the target device
+     * @param packageUninstallRequest The {@link DevicePackageUninstallRequest} for this request
+     * @param timeout                 The timeout in milliseconds for the request to complete
+     * @throws KapuaException if error occurs during processing
+     * @since 1.0.0
+     * @deprecated since 1.1.0. Please make use of {@link #uninstallExec(KapuaId, KapuaId, DevicePackageUninstallRequest, DevicePackageUninstallOptions)}.
      */
+    @Deprecated
     void uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, Long timeout) throws KapuaException;
 
     /**
-     * Gets the package uninstallation status
+     * Uninstalls a {@link org.eclipse.kapua.service.device.management.packages.model.DevicePackage}
      *
-     * @param scopeId
-     * @param deviceId
-     * @param timeout
+     * @param scopeId                 The scope {@link KapuaId} of the target device
+     * @param deviceId                The device {@link KapuaId} of the target device
+     * @param packageUninstallRequest The {@link DevicePackageUninstallRequest} for this request
+     * @param packageUninstallOptions The The {@link DevicePackageUninstallOptions} for this request
+     * @throws KapuaException if error occurs during processing
+     * @since 1.1.0
+     */
+    void uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, DevicePackageUninstallOptions packageUninstallOptions) throws KapuaException;
+
+    /**
+     * Gets the {@link DevicePackageUninstallOperation}.
+     *
+     * @param scopeId  The scope {@link KapuaId} of the target device
+     * @param deviceId The device {@link KapuaId} of the target device
+     * @param timeout  The timeout in milliseconds for the request to complete
      * @return
-     * @throws KapuaException
+     * @throws KapuaException if error occurs during processing
+     * @since 1.0.0
      */
     DevicePackageUninstallOperation uninstallStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException;
 }

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageOptions.java
@@ -12,14 +12,44 @@
 package org.eclipse.kapua.service.device.management.packages.model;
 
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation;
 
+/**
+ * {@link DevicePackageOptions} definition.
+ *
+ * @since 1.1.0
+ */
 public interface DevicePackageOptions {
 
-    void setTimeout(Long timeout);
-
+    /**
+     * The {@link DeviceManagementOperation} timeout.
+     *
+     * @return The {@link DeviceManagementOperation} timeout.
+     * @since 1.1.0
+     */
     Long getTimeout();
 
+    /**
+     * Sets the {@link DeviceManagementOperation} timeout.
+     *
+     * @param timeout The {@link DeviceManagementOperation} timeout.
+     * @since 1.1.0
+     */
+    void setTimeout(Long timeout);
+
+    /**
+     * Gets the {@link DeviceManagementOperation} forced {@link DeviceManagementOperation#getOperationId()}.
+     *
+     * @return The {@link DeviceManagementOperation} forced {@link DeviceManagementOperation#getOperationId()}.
+     * @since 1.1.0
+     */
     KapuaId getForcedOperationId();
 
+    /**
+     * The {@link DeviceManagementOperation} forced {@link DeviceManagementOperation#getOperationId()}.
+     *
+     * @param forcedOperationId The {@link DeviceManagementOperation} forced {@link DeviceManagementOperation#getOperationId()}.
+     * @since 1.1.0
+     */
     void setForcedOperationId(KapuaId forcedOperationId);
 }

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageOptions.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.model;
+
+import org.eclipse.kapua.model.id.KapuaId;
+
+public interface DevicePackageOptions {
+
+    void setTimeout(Long timeout);
+
+    Long getTimeout();
+
+    KapuaId getForcedOperationId();
+
+    void setForcedOperationId(KapuaId forcedOperationId);
+}

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOptions.java
@@ -13,5 +13,10 @@ package org.eclipse.kapua.service.device.management.packages.model.download;
 
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageOptions;
 
+/**
+ * {@link DevicePackageDownloadOptions} definition.
+ *
+ * @since 1.1.0
+ */
 public interface DevicePackageDownloadOptions extends DevicePackageOptions {
 }

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOptions.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.model.download;
+
+import org.eclipse.kapua.service.device.management.packages.model.DevicePackageOptions;
+
+public interface DevicePackageDownloadOptions extends DevicePackageOptions {
+}

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOptions.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.model.install;
+
+import org.eclipse.kapua.service.device.management.packages.model.DevicePackageOptions;
+
+public interface DevicePackageInstallOptions extends DevicePackageOptions {
+}

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOptions.java
@@ -13,5 +13,10 @@ package org.eclipse.kapua.service.device.management.packages.model.install;
 
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageOptions;
 
+/**
+ * {@link DevicePackageInstallOptions} definition.
+ *
+ * @since 1.1.0
+ */
 public interface DevicePackageInstallOptions extends DevicePackageOptions {
 }

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOptions.java
@@ -13,5 +13,10 @@ package org.eclipse.kapua.service.device.management.packages.model.uninstall;
 
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageOptions;
 
+/**
+ * {@link DevicePackageUninstallOptions} definition.
+ *
+ * @since 1.1.0
+ */
 public interface DevicePackageUninstallOptions extends DevicePackageOptions {
 }

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOptions.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.model.uninstall;
+
+import org.eclipse.kapua.service.device.management.packages.model.DevicePackageOptions;
+
+public interface DevicePackageUninstallOptions extends DevicePackageOptions {
+}

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -37,7 +37,7 @@ import org.eclipse.kapua.service.device.management.packages.model.uninstall.inte
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.internal.DevicePackageUninstallRequestImpl;
 
 /**
- * Device package service implementation.
+ * {@link DevicePackageFactory} implementation.
  *
  * @since 1.0
  */

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
@@ -18,23 +18,28 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackageB
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageBundleInfos;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackages;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOperation;
+import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOptions;
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
 import org.eclipse.kapua.service.device.management.packages.model.download.internal.DevicePackageDownloadOperationImpl;
+import org.eclipse.kapua.service.device.management.packages.model.download.internal.DevicePackageDownloadOptionsImpl;
 import org.eclipse.kapua.service.device.management.packages.model.download.internal.DevicePackageDownloadRequestImpl;
+import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallRequest;
+import org.eclipse.kapua.service.device.management.packages.model.install.internal.DevicePackageInstallOptionsImpl;
 import org.eclipse.kapua.service.device.management.packages.model.install.internal.DevicePackageInstallRequestImpl;
 import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageBundleInfoImpl;
 import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageBundleInfosImpl;
 import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageImpl;
 import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackagesImpl;
+import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
+import org.eclipse.kapua.service.device.management.packages.model.uninstall.internal.DevicePackageUninstallOptionsImpl;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.internal.DevicePackageUninstallRequestImpl;
 
 /**
  * Device package service implementation.
- * 
- * @since 1.0
  *
+ * @since 1.0
  */
 @KapuaProvider
 public class DevicePackageFactoryImpl implements DevicePackageFactory {
@@ -72,12 +77,22 @@ public class DevicePackageFactoryImpl implements DevicePackageFactory {
         return new DevicePackageDownloadOperationImpl();
     }
 
+    @Override
+    public DevicePackageDownloadOptions newDevicePackageDownloadOptions() {
+        return new DevicePackageDownloadOptionsImpl();
+    }
+
     //
     // Install operation
     //
     @Override
     public DevicePackageInstallRequest newPackageInstallRequest() {
         return new DevicePackageInstallRequestImpl();
+    }
+
+    @Override
+    public DevicePackageInstallOptions newDevicePackageInstallOptions() {
+        return new DevicePackageInstallOptionsImpl();
     }
 
     //
@@ -88,4 +103,8 @@ public class DevicePackageFactoryImpl implements DevicePackageFactory {
         return new DevicePackageUninstallRequestImpl();
     }
 
+    @Override
+    public DevicePackageUninstallOptions newDevicePackageUninstallOptions() {
+        return new DevicePackageUninstallOptionsImpl();
+    }
 }

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -63,7 +63,7 @@ import org.eclipse.kapua.service.device.management.packages.model.uninstall.inte
 import java.util.Date;
 
 /**
- * Device package service implementation.
+ * {@link DevicePackageManagementService} implementation.
  *
  * @since 1.0.0
  */
@@ -572,7 +572,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         packageRequestChannel.setAppName(PackageAppProperties.APP_NAME);
         packageRequestChannel.setVersion(PackageAppProperties.APP_VERSION);
         packageRequestChannel.setMethod(KapuaMethod.READ);
-        packageRequestChannel.setPackageResource(PackageResource.INSTALL);
+        packageRequestChannel.setPackageResource(PackageResource.UNINSTALL);
 
         PackageRequestPayload packageRequestPayload = new PackageRequestPayload();
 

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -17,12 +17,9 @@ import org.eclipse.kapua.commons.model.id.IdGenerator;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.AuthorizationService;
-import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
 import org.eclipse.kapua.service.device.management.commons.AbstractDeviceManagementServiceImpl;
 import org.eclipse.kapua.service.device.management.commons.call.DeviceCallExecutor;
@@ -73,17 +70,14 @@ import java.util.Date;
 @KapuaProvider
 public class DevicePackageManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DevicePackageManagementService {
 
-    private static final KapuaLocator KAPUA_LOCATOR = KapuaLocator.getInstance();
-
-    private static final DevicePackageFactory DEVICE_PACKAGE_FACTORY = KAPUA_LOCATOR.getFactory(DevicePackageFactory.class);
+    private static final DevicePackageFactory DEVICE_PACKAGE_FACTORY = LOCATOR.getFactory(DevicePackageFactory.class);
 
     //
     // Installed
     //
 
     @Override
-    public DevicePackages getInstalled(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException {
+    public DevicePackages getInstalled(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -91,10 +85,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request
@@ -115,8 +106,8 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Do get
-        DeviceCallExecutor deviceApplicationCall = new DeviceCallExecutor(packageRequestMessage, timeout);
-        PackageResponseMessage responseMessage = (PackageResponseMessage) deviceApplicationCall.send();
+        DeviceCallExecutor<?, ?, ?, PackageResponseMessage> deviceApplicationCall = new DeviceCallExecutor<>(packageRequestMessage, timeout);
+        PackageResponseMessage responseMessage = deviceApplicationCall.send();
 
         //
         // Create event
@@ -170,8 +161,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
     }
 
     @Override
-    public void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, DevicePackageDownloadOptions packageDownloadOptions)
-            throws KapuaException {
+    public void downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, DevicePackageDownloadOptions packageDownloadOptions) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -184,10 +174,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Generate requestId
@@ -241,8 +228,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
     }
 
     @Override
-    public DevicePackageDownloadOperation downloadStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException {
+    public DevicePackageDownloadOperation downloadStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -250,10 +236,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request
@@ -301,8 +284,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
     }
 
     @Override
-    public void downloadStop(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException {
+    public void downloadStop(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -310,10 +292,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Prepare the request
@@ -363,8 +342,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
     }
 
     @Override
-    public void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest deployInstallRequest, DevicePackageInstallOptions packageInstallOptions)
-            throws KapuaException {
+    public void installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest deployInstallRequest, DevicePackageInstallOptions packageInstallOptions) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -374,10 +352,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Generate requestId
@@ -428,8 +403,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
     }
 
     @Override
-    public DevicePackageInstallOperation installStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException {
+    public DevicePackageInstallOperation installStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -437,10 +411,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request
@@ -523,10 +494,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.write, scopeId));
 
         //
         // Generate requestId
@@ -579,8 +547,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
     }
 
     @Override
-    public DevicePackageUninstallOperation uninstallStatus(KapuaId scopeId, KapuaId deviceId, Long timeout)
-            throws KapuaException {
+    public DevicePackageUninstallOperation uninstallStatus(KapuaId scopeId, KapuaId deviceId, Long timeout) throws KapuaException {
         //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -588,10 +555,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
         //
         // Check Access
-        KapuaLocator locator = KapuaLocator.getInstance();
-        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
-        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
-        authorizationService.checkPermission(permissionFactory.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementDomains.DEVICE_MANAGEMENT_DOMAIN, Actions.read, scopeId));
 
         //
         // Prepare the request

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOptionsImpl.java
@@ -14,5 +14,10 @@ package org.eclipse.kapua.service.device.management.packages.model.download.inte
 import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOptions;
 import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageOptionsImpl;
 
+/**
+ * {@link DevicePackageDownloadOptions} implementation.
+ *
+ * @since 1.1.0
+ */
 public class DevicePackageDownloadOptionsImpl extends DevicePackageOptionsImpl implements DevicePackageDownloadOptions {
 }

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOptionsImpl.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.model.download.internal;
+
+import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadOptions;
+import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageOptionsImpl;
+
+public class DevicePackageDownloadOptionsImpl extends DevicePackageOptionsImpl implements DevicePackageDownloadOptions {
+}

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOptionsImpl.java
@@ -14,5 +14,10 @@ package org.eclipse.kapua.service.device.management.packages.model.install.inter
 import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageOptionsImpl;
 
+/**
+ * {@link DevicePackageInstallOptions} implementation
+ *
+ * @since 1.1.0
+ */
 public class DevicePackageInstallOptionsImpl extends DevicePackageOptionsImpl implements DevicePackageInstallOptions {
 }

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOptionsImpl.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.model.install.internal;
+
+import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallOptions;
+import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageOptionsImpl;
+
+public class DevicePackageInstallOptionsImpl extends DevicePackageOptionsImpl implements DevicePackageInstallOptions {
+}

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageOptionsImpl.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.model.internal;
+
+import org.eclipse.kapua.model.id.KapuaId;
+
+public abstract class DevicePackageOptionsImpl {
+
+    Long timeout;
+
+    private KapuaId forcedOperationId;
+
+    public Long getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Long timeout) {
+        this.timeout = timeout;
+    }
+
+    public KapuaId getForcedOperationId() {
+        return forcedOperationId;
+    }
+
+    public void setForcedOperationId(KapuaId forcedOperationId) {
+        this.forcedOperationId = forcedOperationId;
+    }
+}

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageOptionsImpl.java
@@ -12,25 +12,34 @@
 package org.eclipse.kapua.service.device.management.packages.model.internal;
 
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.device.management.packages.model.DevicePackageOptions;
 
-public abstract class DevicePackageOptionsImpl {
+/**
+ * {@link DevicePackageOptions} {@code abstract} implementation.
+ *
+ * @since 1.1.0
+ */
+public abstract class DevicePackageOptionsImpl implements DevicePackageOptions {
 
-    Long timeout;
-
+    private Long timeout;
     private KapuaId forcedOperationId;
 
+    @Override
     public Long getTimeout() {
         return timeout;
     }
 
+    @Override
     public void setTimeout(Long timeout) {
         this.timeout = timeout;
     }
 
+    @Override
     public KapuaId getForcedOperationId() {
         return forcedOperationId;
     }
 
+    @Override
     public void setForcedOperationId(KapuaId forcedOperationId) {
         this.forcedOperationId = forcedOperationId;
     }

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOptionsImpl.java
@@ -14,5 +14,10 @@ package org.eclipse.kapua.service.device.management.packages.model.uninstall.int
 import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageOptionsImpl;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOptions;
 
+/**
+ * {@link DevicePackageUninstallOptions} implementation.
+ *
+ * @since 1.1.0
+ */
 public class DevicePackageUninstallOptionsImpl extends DevicePackageOptionsImpl implements DevicePackageUninstallOptions {
 }

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOptionsImpl.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.model.uninstall.internal;
+
+import org.eclipse.kapua.service.device.management.packages.model.internal.DevicePackageOptionsImpl;
+import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOptions;
+
+public class DevicePackageUninstallOptionsImpl extends DevicePackageOptionsImpl implements DevicePackageUninstallOptions {
+}

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.service.device.management.request;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
 import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
@@ -21,10 +22,26 @@ public interface DeviceRequestManagementService extends KapuaService {
     /**
      * Execute the given device request with the provided options
      *
-     * @param requestInput request input
-     * @param timeout      request timeout
-     * @return response output
-     * @throws KapuaException
+     * @param requestInput The {@link GenericRequestMessage} for this request
+     * @param timeout      The timeout in milliseconds for the request to complete
+     * @return the response from the device.
+     * @throws KapuaException if error occurs during processing
+     * @since 1.0.0
+     * @deprecated since 1.1.0. Please make use of {@link #exec(KapuaId, KapuaId, GenericRequestMessage, Long)}.
      */
+    @Deprecated
     GenericResponseMessage exec(GenericRequestMessage requestInput, Long timeout) throws KapuaException;
+
+    /**
+     * Execute the given device request with the provided options
+     *
+     * @param scopeId      The scope {@link KapuaId} of the target device
+     * @param deviceId     The device {@link KapuaId} of the target device
+     * @param requestInput The {@link GenericRequestMessage} for this request
+     * @param timeout      The timeout in milliseconds for the request to complete
+     * @return the response from the device
+     * @throws KapuaException if error occurs during processing
+     * @since 1.1.0
+     */
+    GenericResponseMessage exec(KapuaId scopeId, KapuaId deviceId, GenericRequestMessage requestInput, Long timeout) throws KapuaException;
 }

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,11 @@ import org.eclipse.kapua.service.device.management.request.message.response.Gene
 
 import java.util.Date;
 
+/**
+ * {@link DeviceRequestManagementService} implementation.
+ *
+ * @since 1.0.0
+ */
 @KapuaProvider
 public class DeviceRequestManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceRequestManagementService {
 


### PR DESCRIPTION
Added the capability for the user to provide a `operationId` for the DeviceManagementOperation linked to the device management operation

**Related Issue**
_None_

**Description of the solution adopted**
Changed the DevicePackageManagement API to deprecate the current signatures:

```
 KapuaId downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, Long timeout) throws KapuaException;
 KapuaId installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, Long timeout) throws KapuaException;
 KapuaId uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, Long timeout) throws KapuaException;
```

switching to 

```
 KapuaId downloadExec(KapuaId scopeId, KapuaId deviceId, DevicePackageDownloadRequest packageDownloadRequest, DevicePackageDownloadOptions devicePackageDownloadOptions) throws KapuaException;
 KapuaId installExec(KapuaId scopeId, KapuaId deviceId, DevicePackageInstallRequest packageInstallRequest, DevicePackageInstallOptions devicePackageInstallOptions) throws KapuaException;
 KapuaId uninstallExec(KapuaId scopeId, KapuaId deviceId, DevicePackageUninstallRequest packageUninstallRequest, DevicePackageUninstallOptions devicePackageUninstallOptions) throws KapuaException;
```

**Screenshots**
_None_

**Any side note on the changes made**
Javadoc and small code improvements applied. 