### PR TITLE
Set permissions checks for enabling Start and Stop buttons in Bundles

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -234,7 +234,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
                 }
             }
         });
-        startButton.setEnabled(true);
+        startButton.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.execute()));
         toolBar.add(startButton);
         toolBar.add(new SeparatorToolItem());
 
@@ -293,7 +293,7 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
                 }
             }
         });
-        stopButton.setEnabled(true);
+        stopButton.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.execute()));
         toolBar.add(stopButton);
         toolBar.add(new SeparatorToolItem());
 
@@ -354,10 +354,10 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
                     GwtBundle selectedBundle = grid.getSelectionModel().getSelectedItem();
                     if ("bndActive".equals(selectedBundle.getStatus())) {
                         startButton.disable();
-                        stopButton.enable();
+                        stopButton.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.execute()));
                     } else {
                         stopButton.disable();
-                        startButton.enable();
+                        startButton.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.execute()));
                     }
                 } else {
                     startButton.disable();


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Set permissions checks for enabling Start and Stop buttons in Bundles

**Related Issue**
This PR fixes/closes #2410 

**Description of the solution adopted**
Permission `DeviceManagementSessionPermission.execute()` is now needed for enabling Start and Stop button in Bundles.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
