### PR TITLE
Handled exceptions when adding/editing Users

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -68,6 +68,7 @@ public class UserAddDialog extends EntityAddEditDialog {
     protected NumberField optlock;
 
     private String specificAccountId;
+    private Boolean passwordIsShown = false;
 
     private GwtUserServiceAsync gwtUserService = GWT.create(GwtUserService.class);
 
@@ -132,32 +133,34 @@ public class UserAddDialog extends EntityAddEditDialog {
         username.setToolTip(USER_MSGS.dialogAddFieldNameTooltip());
         infoFieldSet.add(username, subFieldsetFormData);
 
+        password = new KapuaTextField<String>();
+        password.setAllowBlank(false);
+        password.setName("password");
+        password.setFieldLabel("* " + USER_MSGS.dialogAddFieldPassword());
+        password.setValidator(new PasswordFieldValidator(password));
+        password.setToolTip(USER_MSGS.dialogAddTooltipPassword());
+        password.setPassword(true);
+        password.setMaxLength(255);
+
+        confirmPassword = new KapuaTextField<String>();
+        confirmPassword.setAllowBlank(false);
+        confirmPassword.setName("confirmPassword");
+        confirmPassword.setFieldLabel("* " + USER_MSGS.dialogAddFieldConfirmPassword());
+        confirmPassword.setValidator(new ConfirmPasswordFieldValidator(confirmPassword, password));
+        confirmPassword.setToolTip(USER_MSGS.dialogAddTooltipPassword());
+        confirmPassword.setPassword(true);
+        confirmPassword.setMaxLength(255);
+
+        passwordTooltip = new LabelField();
+        passwordTooltip.setValue(USER_MSGS.dialogAddTooltipPassword());
+        passwordTooltip.setStyleAttribute("margin-top", "-5px");
+        passwordTooltip.setStyleAttribute("color", "gray");
+        passwordTooltip.setStyleAttribute("font-size", "10px");
+
         if (currentSession.hasPermission(CredentialSessionPermission.write())) {
-            password = new KapuaTextField<String>();
-            password.setAllowBlank(false);
-            password.setName("password");
-            password.setFieldLabel("* " + USER_MSGS.dialogAddFieldPassword());
-            password.setValidator(new PasswordFieldValidator(password));
-            password.setToolTip(USER_MSGS.dialogAddTooltipPassword());
-            password.setPassword(true);
-            password.setMaxLength(255);
+            passwordIsShown = true;
             infoFieldSet.add(password, subFieldsetFormData);
-
-            confirmPassword = new KapuaTextField<String>();
-            confirmPassword.setAllowBlank(false);
-            confirmPassword.setName("confirmPassword");
-            confirmPassword.setFieldLabel("* " + USER_MSGS.dialogAddFieldConfirmPassword());
-            confirmPassword.setValidator(new ConfirmPasswordFieldValidator(confirmPassword, password));
-            confirmPassword.setToolTip(USER_MSGS.dialogAddTooltipPassword());
-            confirmPassword.setPassword(true);
-            confirmPassword.setMaxLength(255);
             infoFieldSet.add(confirmPassword, subFieldsetFormData);
-
-            passwordTooltip = new LabelField();
-            passwordTooltip.setValue(USER_MSGS.dialogAddTooltipPassword());
-            passwordTooltip.setStyleAttribute("margin-top", "-5px");
-            passwordTooltip.setStyleAttribute("color", "gray");
-            passwordTooltip.setStyleAttribute("font-size", "10px");
             infoFieldSet.add(passwordTooltip);
         }
         displayName = new KapuaTextField<String>();
@@ -230,11 +233,11 @@ public class UserAddDialog extends EntityAddEditDialog {
     }
 
     public void validateUser() {
-        if (username.getValue() == null || (password.getValue() == null && password.isVisible()) || (confirmPassword.getValue() == null && confirmPassword.isVisible())) {
+        if (username.getValue() == null || (passwordIsShown && password.getValue() == null) || (passwordIsShown && confirmPassword.getValue() == null)) {
             ConsoleInfo.display("Error", CMSGS.allFieldsRequired());
-        } else if (!password.isValid()) {
+        } else if (passwordIsShown && !password.isValid()) {
             ConsoleInfo.display("Error", password.getErrorMessage());
-        } else if ((password.isVisible() && confirmPassword.isVisible()) && !password.getValue().equals(confirmPassword.getValue())) {
+        } else if (passwordIsShown && !password.getValue().equals(confirmPassword.getValue())) {
             ConsoleInfo.display("Error", confirmPassword.getErrorMessage());
         } else if (!email.isValid()) {
             ConsoleInfo.display("Error", email.getErrorMessage());


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Handled exceptions when adding/editing Users

**Related Issue**
This PR fixes/closes #2419 

**Description of the solution adopted**
Handled `NullPointerException`s in Add/ Edit User dialogues for password and confirm password fields when the user does not have `CredentialSessionPermission.write()` permission and those fields are hidden.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
