### PR TITLE
Added permission check for Allow User Change checkbox in Connections

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -126,6 +126,13 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         reservedUserCombo.setValueField("id");
         reservedUserCombo.addListener(Events.Select, comboBoxListener);
 
+        // Allow credential change
+        allowUserChangeCheckbox = new CheckBox();
+        allowUserChangeCheckbox.setName("connectionUserAllowUserChangeCheckbox");
+        allowUserChangeCheckbox.setFieldLabel(MSGS.connectionFormAllowUserChange());
+        allowUserChangeCheckbox.setToolTip(MSGS.connectionFormAllowUserChangeTooltip());
+        allowUserChangeCheckbox.setBoxLabel("");
+
         if (currentSession.hasPermission(UserSessionPermission.read())) {
             // Device User
             GWT_USER_SERVICE.findAll(currentSession.getSelectedAccountId(), new AsyncCallback<ListLoadResult<GwtUser>>() {
@@ -148,20 +155,14 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
             });
 
             groupFormPanel.add(reservedUserCombo);
+            groupFormPanel.add(allowUserChangeCheckbox);
+
         } else {
             GwtUser selectedUser = new GwtUser();
             selectedUser.setId(selectedDeviceConnection.getReservedUserId());
             reservedUserCombo.getStore().add(selectedUser);
             reservedUserCombo.setValue(selectedUser);
         }
-
-        // Allow credential change
-        allowUserChangeCheckbox = new CheckBox();
-        allowUserChangeCheckbox.setName("connectionUserAllowUserChangeCheckbox");
-        allowUserChangeCheckbox.setFieldLabel(MSGS.connectionFormAllowUserChange());
-        allowUserChangeCheckbox.setToolTip(MSGS.connectionFormAllowUserChangeTooltip());
-        allowUserChangeCheckbox.setBoxLabel("");
-        groupFormPanel.add(allowUserChangeCheckbox);
 
         bodyPanel.add(groupFormPanel);
         populateEditDialog(selectedDeviceConnection);


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Added permission check for Allow User Change checkbox in Connections.

**Related Issue**
This PR fixes/closes #2401 

**Description of the solution adopted**
The `allowUserChangeCheckbox` is no longer shown if the user does not have `user:read` permission.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
