### PR TITLE
Set permission check for enabling Delete button in Schedules

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,7 @@ import com.google.gwt.user.client.Element;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.job.shared.model.permission.SchedulerSessionPermission;
 import org.eclipse.kapua.app.console.module.job.shared.model.scheduler.GwtTrigger;
 
 public class JobTabSchedulesToolbar extends EntityCRUDToolbar<GwtTrigger> {
@@ -64,5 +65,7 @@ public class JobTabSchedulesToolbar extends EntityCRUDToolbar<GwtTrigger> {
     protected void updateButtonEnablement() {
         super.updateButtonEnablement();
         addEntityButton.setEnabled(jobId != null);
+        deleteEntityButton.setEnabled(
+                selectedEntity != null && currentSession.hasPermission(SchedulerSessionPermission.delete()));
     }
 }


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Set permission check for enabling Delete button in Schedules

**Related Issue**
This PR fixes/closes #2426 

**Description of the solution adopted**
The `SchedulerSessionPermission.delete()` permission is now needed for enabling the Delete button in Schedules tab.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
