### PR TITLE
Fixed missing QueryParam in DeviceConnections.simpleQuery()

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnections.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnections.java
@@ -76,7 +76,7 @@ public class DeviceConnections extends AbstractKapuaResource {
     @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
     public DeviceConnectionListResult simpleQuery(
             @ApiParam(value = "The ScopeId in which to search results.", required = true, defaultValue = DEFAULT_SCOPE_ID) @PathParam("scopeId") ScopeId scopeId,
-            @ApiParam(value = "The client id to filter results.") String clientId,
+            @ApiParam(value = "The client id to filter results.") @QueryParam("clientId") String clientId,
             @ApiParam(value = "The connection status to filter results.") @QueryParam("status") DeviceConnectionStatus status,
             @ApiParam(value = "The result set offset.", defaultValue = "0") @QueryParam("offset") @DefaultValue("0") int offset,
             @ApiParam(value = "The result set limit.", defaultValue = "50") @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {


### PR DESCRIPTION
A `@QueryParam` annotation was missing for the `clientId` in `DeviceConnections.simpleQuery()` REST API. This PR fixes it.

**Related Issue**
No related issues

**Description of the solution adopted**
N/A

**Screenshots**
N/A

**Any side note on the changes made**
N/A