### PR TITLE
add error msg when no assets are available

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -240,6 +240,9 @@ public class DeviceAssetsPanel extends LayoutContainer {
                 field = paintChannel(channel);
                 field.setEnabled(currentSession.hasPermission(DeviceManagementSessionPermission.write()));
                 actionFieldSet.add(field, formData);
+            }
+            if (asset.getDescription() != null) {
+                actionFieldSet.addText(asset.getDescription());
             }
         }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -522,6 +522,7 @@ public class DeviceAssetsValues extends LayoutContainer {
             List<ModelData> assets = new ArrayList<ModelData>();
             GwtDeviceAsset asset = new GwtDeviceAsset();
             asset.setName(DEVICE_MSGS.assetNoAssets());
+            asset.setDescription(DEVICE_MSGS.noAsset());
             assets.add(asset);
             treeStore.removeAll();
             treeStore.add(assets, false);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/assets/GwtDeviceAsset.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/assets/GwtDeviceAsset.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,6 +31,14 @@ public class GwtDeviceAsset extends KapuaBaseModel implements Serializable {
 
     public void setName(String name) {
         set("name", name);
+    }
+
+    public String getDescription() {
+        return get("description");
+    }
+
+    public void setDescription(String description) {
+        set("description", description);
     }
 
     public List<GwtDeviceAssetChannel> getChannels() {

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -22,6 +22,7 @@ assetValue=Value
 assetAction=Action
 assetReadAll=READ ALL
 assetWriteAll=WRITE ALL
+noAsset=This device has no available assets.
 channelButton=CHANNELS
 channelId=ID
 channelName=Name


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added new message where there are no assets available in Devices.

**Related Issue**
This PR fixes issue #2409

**Description of the solution adopted**
Added new attribute description in GwtDeviceAsset and showed description message where there are no available assets.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
