### PR TITLE
Add 'description' to KapuaNamedEntity definition

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
@@ -11,8 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model;
 
-import java.io.Serializable;
-import java.util.Date;
+import org.eclipse.kapua.commons.model.id.IdGenerator;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -25,22 +29,15 @@ import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-
-import org.eclipse.kapua.commons.model.id.IdGenerator;
-import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
-import org.eclipse.kapua.model.KapuaEntity;
-import org.eclipse.kapua.model.id.KapuaId;
+import java.io.Serializable;
+import java.util.Date;
 
 /**
- * {@link KapuaEntity} reference abstract implementation.
- * 
- * @see KapuaEntity
- * 
- * @since 1.0.0
+ * {@link KapuaEntity} {@code abstract} implementation.
  *
+ * @see KapuaEntity
+ * @since 1.0.0
  */
-@SuppressWarnings("serial")
 @MappedSuperclass
 @Access(AccessType.FIELD)
 public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
@@ -70,7 +67,7 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
     /**
      * Protected default constructor.<br>
      * Required by JPA.
-     * 
+     *
      * @since 1.0.0
      */
     protected AbstractKapuaEntity() {
@@ -79,9 +76,8 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
 
     /**
      * Constructor.
-     * 
-     * @param scopeId
-     *            The scope {@link KapuaId} to set for this {@link KapuaEntity}.
+     *
+     * @param scopeId The scope {@link KapuaId} to set for this {@link KapuaEntity}.
      * @since 1.0.0
      */
     public AbstractKapuaEntity(KapuaId scopeId) {
@@ -92,6 +88,10 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
 
     /**
      * Constructor.
+     * <p>
+     * It can be used to clone the {@link KapuaUpdatableEntity}
+     *
+     * @since 1.0.0
      */
     protected AbstractKapuaEntity(KapuaEntity entity) {
         this();
@@ -128,9 +128,10 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
     }
 
     /**
-     * Sets the created on date
-     * 
-     * @param createdOn
+     * Sets the date of creation.
+     *
+     * @param createdOn the date of creation.
+     * @since 1.0.0
      */
     public void setCreatedOn(Date createdOn) {
         this.createdOn = createdOn;
@@ -142,9 +143,10 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
     }
 
     /**
-     * Sets the created by identifier
-     * 
-     * @param createdBy
+     * Sets the identity {@link KapuaId} who has created this {@link KapuaEntity}
+     *
+     * @param createdBy the identity {@link KapuaId} who has created this {@link KapuaEntity}
+     * @since 1.0.0
      */
     public void setCreatedBy(KapuaId createdBy) {
         this.createdBy = KapuaEid.parseKapuaId(createdBy);
@@ -152,7 +154,7 @@ public abstract class AbstractKapuaEntity implements KapuaEntity, Serializable {
 
     /**
      * Before create action sets the {@link KapuaEntity} {@link #id}, {@link #createdBy} and {@link #createdOn}.
-     * 
+     *
      * @since 1.0.0
      */
     @PrePersist

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaNamedEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaNamedEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,22 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model;
 
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 
-import org.eclipse.kapua.model.KapuaNamedEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-
 /**
- * Kapua named-updatable entity default abstract implementation.
- * 
- * @since 1.0
+ * {@link KapuaNamedEntity} {@code abstract} implementation.
  *
+ * @since 1.0.0
  */
-@SuppressWarnings("serial")
 @MappedSuperclass
 @Access(AccessType.FIELD)
 public abstract class AbstractKapuaNamedEntity extends AbstractKapuaUpdatableEntity implements KapuaNamedEntity {
@@ -35,8 +35,14 @@ public abstract class AbstractKapuaNamedEntity extends AbstractKapuaUpdatableEnt
     @Column(name = "name", nullable = false, updatable = true)
     protected String name;
 
+    @Basic
+    @Column(name = "description", nullable = true, updatable = true)
+    protected String description;
+
     /**
      * Constructor
+     *
+     * @since 1.0.0
      */
     protected AbstractKapuaNamedEntity() {
         super();
@@ -44,8 +50,9 @@ public abstract class AbstractKapuaNamedEntity extends AbstractKapuaUpdatableEnt
 
     /**
      * Constructor
-     * 
-     * @param scopeId
+     *
+     * @param scopeId The scope {@link KapuaId}.
+     * @since 1.0.0
      */
     public AbstractKapuaNamedEntity(KapuaId scopeId) {
         super(scopeId);
@@ -53,14 +60,30 @@ public abstract class AbstractKapuaNamedEntity extends AbstractKapuaUpdatableEnt
 
     /**
      * Constructor
-     * 
-     * @param scopeId
-     * @param name
+     *
+     * @param scopeId The scope {@link KapuaId}.
+     * @param name    The name of this {@link org.eclipse.kapua.model.KapuaEntity}
+     * @since 1.0.0
      */
-    public AbstractKapuaNamedEntity(KapuaId scopeId,
-            String name) {
+    public AbstractKapuaNamedEntity(KapuaId scopeId, String name) {
         super(scopeId);
-        this.name = name;
+
+        setName(name);
+    }
+
+    /**
+     * Constructor.
+     * <p>
+     * It can be used to clone the {@link KapuaUpdatableEntity}
+     *
+     * @throws KapuaException if {@link KapuaUpdatableEntity#getEntityAttributes()} and/or {@link KapuaUpdatableEntity#getEntityProperties()} cannot be parsed.
+     * @since 1.0.0
+     */
+    protected AbstractKapuaNamedEntity(KapuaNamedEntity kapuaNamedEntity) throws KapuaException {
+        super(kapuaNamedEntity);
+
+        setName(kapuaNamedEntity.getName());
+        setDescription(kapuaNamedEntity.getDescription());
     }
 
     @Override
@@ -73,4 +96,13 @@ public abstract class AbstractKapuaNamedEntity extends AbstractKapuaUpdatableEnt
         this.name = name;
     }
 
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaNamedEntityCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaNamedEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,29 +16,27 @@ import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 
 /**
- * Kapua entity named creator service (reference abstract implementation).
+ * {@link KapuaNamedEntityCreator} {@code abstract} implementation.
  *
- * @param <E>
- *            entity type
- * 
- * @since 1.0
- *
+ * @param <E> {@link KapuaEntity} which this {@link AbstractKapuaUpdatableEntityCreator} is for
+ * @since 1.0.0
  */
-@SuppressWarnings("serial")
 public abstract class AbstractKapuaNamedEntityCreator<E extends KapuaEntity> extends AbstractKapuaUpdatableEntityCreator<E> implements KapuaNamedEntityCreator<E> {
 
     protected String name;
+    protected String description;
 
     /**
      * Constructor
-     * 
-     * @param scopeId
-     * @param name
+     *
+     * @param scopeId the scope {@link KapuaId}
+     * @param name    the name
+     * @since 1.0.0
      */
-    protected AbstractKapuaNamedEntityCreator(KapuaId scopeId,
-            String name) {
+    protected AbstractKapuaNamedEntityCreator(KapuaId scopeId, String name) {
         super(scopeId);
-        this.name = name;
+
+        setName(name);
     }
 
     public AbstractKapuaNamedEntityCreator(KapuaId scopeId) {
@@ -53,5 +51,15 @@ public abstract class AbstractKapuaNamedEntityCreator<E extends KapuaEntity> ext
     @Override
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,11 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.util.Date;
-import java.util.Properties;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -29,22 +30,17 @@ import javax.persistence.PreUpdate;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.Version;
-
-import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
-import org.eclipse.kapua.model.KapuaEntity;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
-import org.eclipse.kapua.model.id.KapuaId;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Date;
+import java.util.Properties;
 
 /**
- * {@link KapuaUpdatableEntity} reference abstract implementation.
- *
- * @see KapuaUpdatableEntity
+ * {@link KapuaUpdatableEntity} {@code abstract} implementation.
  *
  * @since 1.0.0
  */
-@SuppressWarnings("serial")
 @MappedSuperclass
 @Access(AccessType.FIELD)
 public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity implements KapuaUpdatableEntity {
@@ -74,7 +70,7 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
     /**
      * Protected default constructor.<br>
      * Required by JPA.
-     * 
+     *
      * @since 1.0.0
      */
     protected AbstractKapuaUpdatableEntity() {
@@ -83,9 +79,8 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
 
     /**
      * Constructor.
-     * 
-     * @param scopeId
-     *            The scope {@link KapuaId} to set for this {@link KapuaUpdatableEntity}
+     *
+     * @param scopeId The scope {@link KapuaId} to set for this {@link KapuaUpdatableEntity}
      * @since 1.0.0
      */
     public AbstractKapuaUpdatableEntity(KapuaId scopeId) {
@@ -94,13 +89,14 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
 
     /**
      * Constructor.
-     * 
-     * @throws KapuaException
-     *             if {@link KapuaUpdatableEntity#getEntityAttributes()} and/or {@link KapuaUpdatableEntity#getEntityProperties()} cannot be parsed.
+     * <p>
+     * It can be used to clone the {@link KapuaUpdatableEntity}
+     *
+     * @throws KapuaException if {@link KapuaUpdatableEntity#getEntityAttributes()} and/or {@link KapuaUpdatableEntity#getEntityProperties()} cannot be parsed.
      * @since 1.0.0
      */
     protected AbstractKapuaUpdatableEntity(KapuaUpdatableEntity entity) throws KapuaException {
-        super((KapuaEntity) entity);
+        super(entity);
 
         setModifiedOn(entity.getModifiedOn());
         setModifiedBy(entity.getModifiedBy());
@@ -115,9 +111,10 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
     }
 
     /**
-     * Set the modified on date
-     * 
-     * @param modifiedOn
+     * Sets the date of the last update
+     *
+     * @param modifiedOn the date of the last update
+     * @since 1.0.0
      */
     public void setModifiedOn(Date modifiedOn) {
         this.modifiedOn = modifiedOn;
@@ -129,9 +126,10 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
     }
 
     /**
-     * Set the modified by identifier
-     * 
-     * @param modifiedBy
+     * Sets the identity {@link KapuaId} who has updated this {@link KapuaEntity}
+     *
+     * @param modifiedBy the identity {@link KapuaId} who has updated this {@link KapuaEntity}
+     * @since 1.0.0
      */
     public void setModifiedBy(KapuaId modifiedBy) {
         this.modifiedBy = KapuaEid.parseKapuaId(modifiedBy);
@@ -216,9 +214,9 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
     }
 
     /**
-     * Before create action call super(){@link AbstractKapuaEntity#prePersistsAction()} and
-     * the {@link KapuaUpdatableEntity} {@link #modifiedBy} and {@link #modifiedOn}.
-     * 
+     * Before create action invokes {@link AbstractKapuaEntity#prePersistsAction()} and
+     * sets {@link KapuaUpdatableEntity} {@link #modifiedBy} and {@link #modifiedOn}.
+     *
      * @since 1.0.0
      */
     @Override
@@ -231,7 +229,7 @@ public abstract class AbstractKapuaUpdatableEntity extends AbstractKapuaEntity i
 
     /**
      * Before update action sets the {@link KapuaUpdatableEntity} {@link #modifiedBy} and {@link #modifiedOn}.
-     * 
+     *
      * @since 1.0.0
      */
     @PreUpdate

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntityCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,41 +11,29 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model;
 
-import java.util.Properties;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.KapuaUpdatableEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 
+import java.util.Properties;
+
 /**
- * Kapua updatable entity creator service (reference abstract implementation).
+ * {@link KapuaUpdatableEntityCreator} {@code abstract} implementation
  *
- * @param <E>
- *            entity type
- * 
- * @since 1.0
- *
+ * @param <E> the {@link KapuaEntity} for which this {@link AbstractKapuaEntityCreator} is for
+ * @since 1.0.0
  */
-@SuppressWarnings("serial")
 public abstract class AbstractKapuaUpdatableEntityCreator<E extends KapuaEntity> extends AbstractKapuaEntityCreator<E> implements KapuaUpdatableEntityCreator<E> {
 
-    protected String name;
     protected Properties entityAttributes;
 
     /**
      * Constructor
-     * 
-     * @param scopeId
-     * @param name
+     *
+     * @param scopeId the scope {@link KapuaId}
+     * @since 1.0.0
      */
-    protected AbstractKapuaUpdatableEntityCreator(KapuaId scopeId,
-            String name) {
-        super(scopeId);
-        this.name = name;
-        entityAttributes = new Properties();
-    }
-
     public AbstractKapuaUpdatableEntityCreator(KapuaId scopeId) {
         super(scopeId);
         entityAttributes = new Properties();

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityCreator.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,10 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model.misc;
 
-import java.math.BigInteger;
-
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
+
+import java.math.BigInteger;
 
 public class CollisionEntityCreator extends AbstractKapuaNamedEntityCreator<CollisionEntity> {
 

--- a/commons/src/test/sql/H2/test_collision_entity_test_create.sql
+++ b/commons/src/test/sql/H2/test_collision_entity_test_create.sql
@@ -14,14 +14,15 @@ CREATE TABLE collision_entity_test (
   scope_id             		BIGINT(21) 	  UNSIGNED NOT NULL,
   id                     	BIGINT(21) 	  UNSIGNED NOT NULL,
   name               	    VARCHAR(255)  NOT NULL,
+  description        	    TEXT,
   created_on             	TIMESTAMP(3)  NOT NULL,
   created_by             	BIGINT(21)    UNSIGNED NOT NULL,
   modified_on            	TIMESTAMP(3),
   modified_by            	BIGINT(21)    UNSIGNED,
-  optlock                   INT UNSIGNED,
+  optlock                 INT UNSIGNED,
   test_field             	VARCHAR(255) NOT NULL UNIQUE,
-  attributes				TEXT,
-  properties                TEXT,
+  attributes				      TEXT,
+  properties              TEXT,
 
   PRIMARY KEY (id),
 

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -468,6 +468,7 @@ connectionStatus=Connection Status
 #
 accessGroupInfo=Access Group 
 accessGroupName=Access Group Name
+accessGroupDescription=Access Group Description
 entityInfo=Entity
 accessGroupModifiedOn=Modified On
 accessGroupModifiedBy=Modified By
@@ -493,6 +494,7 @@ endpointCreatedBy=Created By
 #
 tagInfo=Tag
 tagName=Tag Name
+tagDescription=Description
 tagModifiedOn=Modified On
 tagModifiedBy=Modified By
 tagCreatedOn=Created On
@@ -518,6 +520,7 @@ userExpirationDate=Expiration Date
 #
 roleInfo=Role
 roleName=Name
+roleDescription=Description
 roleModifiedOn=Modified On
 roleModifiedBy=Modified By
 roleCreatedOn=Created On

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
@@ -39,6 +39,7 @@ public class GroupAddDialog extends EntityAddEditDialog {
     private static final GwtGroupServiceAsync GWT_GROUP_SERVICE = GWT.create(GwtGroupService.class);
 
     protected KapuaTextField<String> groupNameField;
+    protected KapuaTextField<String> groupDescriptionField;
 
     public GroupAddDialog(GwtSession currentSession) {
         super(currentSession);
@@ -56,6 +57,14 @@ public class GroupAddDialog extends EntityAddEditDialog {
         groupNameField.setValidator(new TextFieldValidator(groupNameField, FieldType.NAME));
         groupNameField.setToolTip(MSGS.dialogAddFieldNameTooltip());
         groupFormPanel.add(groupNameField);
+
+        groupDescriptionField = new KapuaTextField<String>();
+        groupDescriptionField.setAllowBlank(true);
+        groupDescriptionField.setMaxLength(255);
+        groupDescriptionField.setName("description");
+        groupDescriptionField.setFieldLabel(MSGS.dialogAddFieldDescription());
+        groupNameField.setToolTip(MSGS.dialogAddFieldDescriptionTooltip());
+        groupFormPanel.add(groupDescriptionField);
         bodyPanel.add(groupFormPanel);
     }
 
@@ -77,6 +86,7 @@ public class GroupAddDialog extends EntityAddEditDialog {
         GwtGroupCreator gwtGroupCreator = new GwtGroupCreator();
         gwtGroupCreator.setScopeId(currentSession.getSelectedAccountId());
         gwtGroupCreator.setName(groupNameField.getValue());
+        gwtGroupCreator.setDescription(groupDescriptionField.getValue());
         GWT_GROUP_SERVICE.create(gwtGroupCreator, new AsyncCallback<GwtGroup>() {
 
             @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsoleGroupMessages;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
@@ -45,6 +46,7 @@ public class GroupEditDialog extends GroupAddDialog {
     @Override
     public void submit() {
         selectedGroup.setGroupName(groupNameField.getValue());
+        selectedGroup.setGroupDescription(KapuaSafeHtmlUtils.htmlUnescape(groupDescriptionField.getValue()));
         GWT_GROUP_SERVICE.update(selectedGroup, new AsyncCallback<GwtGroup>() {
 
             @Override
@@ -84,6 +86,7 @@ public class GroupEditDialog extends GroupAddDialog {
 
     private void populateEditDialog(GwtGroup gwtGroup) {
         groupNameField.setValue(gwtGroup.getGroupName());
+        groupDescriptionField.setValue(gwtGroup.getUnescapedDescription());
         formPanel.clearDirtyFields();
     }
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupFilterPanel.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,6 +30,7 @@ public class GroupFilterPanel extends EntityFilterPanel<GwtGroup> {
     private final EntityGrid<GwtGroup> entityGrid;
     private final GwtSession currentSession;
     private final KapuaTextField<String> nameField;
+    private final KapuaTextField<String> descriptionField;
     private static final ConsoleGroupMessages MSGS = GWT.create(ConsoleGroupMessages.class);
 
     public GroupFilterPanel(AbstractEntityView<GwtGroup> entityView, GwtSession currentSession) {
@@ -53,11 +54,26 @@ public class GroupFilterPanel extends EntityFilterPanel<GwtGroup> {
         nameField.setStyleAttribute("margin-bottom", "10px");
         verticalPanel.add(nameField);
 
+        Label descriptionLabel = new Label(MSGS.filterFieldGroupDescriptionLabel());
+        descriptionLabel.setWidth(WIDTH);
+        descriptionLabel.setStyleAttribute("margin", "5px");
+        verticalPanel.add(descriptionLabel);
+        descriptionField = new KapuaTextField<String>();
+        descriptionField.setName("name");
+        descriptionField.setWidth(WIDTH);
+        descriptionField.setMaxLength(MAX_LEN);
+        descriptionField.setStyleAttribute("margin-top", "0px");
+        descriptionField.setStyleAttribute("margin-left", "5px");
+        descriptionField.setStyleAttribute("margin-right", "5px");
+        descriptionField.setStyleAttribute("margin-bottom", "10px");
+        verticalPanel.add(descriptionField);
+
     }
 
     @Override
     public void resetFields() {
         nameField.setValue(null);
+        descriptionField.setValue(null);
         GwtGroupQuery query = new GwtGroupQuery();
         query.setScopeId(currentSession.getSelectedAccountId());
         entityGrid.refresh(query);
@@ -68,6 +84,7 @@ public class GroupFilterPanel extends EntityFilterPanel<GwtGroup> {
     public void doFilter() {
         GwtGroupQuery query = new GwtGroupQuery();
         query.setName(nameField.getValue());
+        query.setDescription(descriptionField.getValue());
         query.setScopeId(currentSession.getSelectedAccountId());
         entityGrid.refresh(query);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -84,6 +84,9 @@ public class GroupGrid extends EntityGrid<GwtGroup> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("groupName", MSGS.gridGroupColumnHeaderGroupName(), 200);
+        columnConfigs.add(columnConfig);
+
+        columnConfig = new ColumnConfig("description", MSGS.gridGroupColumnHeaderDescription(), 200);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("createdOnFormatted", MSGS.gridGroupColumnHeaderCreatedOn(), 200);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +33,7 @@ public class RoleFilterPanel extends EntityFilterPanel<GwtRole> {
     private final GwtSession currentSession;
 
     private final KapuaTextField<String> nameField;
+    private final KapuaTextField<String> descriptionField;
 
     public RoleFilterPanel(AbstractEntityView<GwtRole> entityView, GwtSession currentSession) {
         super(entityView, currentSession);
@@ -59,11 +60,29 @@ public class RoleFilterPanel extends EntityFilterPanel<GwtRole> {
         nameField.setStyleAttribute("margin-right", "5px");
         nameField.setStyleAttribute("margin-bottom", "10px");
         fieldsPanel.add(nameField);
+
+        Label roleDescriptionLabel = new Label(ROLE_MSGS.filterFieldRoleDescriptionLabel());
+        roleDescriptionLabel.setWidth(WIDTH);
+        roleDescriptionLabel.setStyleAttribute("margin", "5px");
+
+        fieldsPanel.add(roleDescriptionLabel);
+
+        descriptionField = new KapuaTextField<String>();
+        descriptionField.setName("name");
+        descriptionField.setWidth(WIDTH);
+        descriptionField.setMaxLength(MAX_LEN);
+        descriptionField.setStyleAttribute("margin-top", "0px");
+        descriptionField.setStyleAttribute("margin-left", "5px");
+        descriptionField.setStyleAttribute("margin-right", "5px");
+        descriptionField.setStyleAttribute("margin-bottom", "10px");
+        fieldsPanel.add(descriptionField);
+
     }
 
     @Override
     public void resetFields() {
         nameField.setValue(null);
+        descriptionField.setValue(null);
         GwtRoleQuery query = new GwtRoleQuery();
         query.setScopeId(currentSession.getSelectedAccountId());
         entityGrid.refresh(query);
@@ -73,6 +92,7 @@ public class RoleFilterPanel extends EntityFilterPanel<GwtRole> {
     public void doFilter() {
         GwtRoleQuery query = new GwtRoleQuery();
         query.setName(nameField.getValue());
+        query.setDescription(descriptionField.getValue());
         query.setScopeId(currentSession.getSelectedAccountId());
         entityGrid.refresh(query);
     }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -86,6 +86,9 @@ public class RoleGrid extends EntityGrid<GwtRole> {
         List<ColumnConfig> columnConfigs = new ArrayList<ColumnConfig>();
 
         ColumnConfig columnConfig = new ColumnConfig("name", ROLE_MSGS.gridRoleColumnHeaderName(), 400);
+        columnConfigs.add(columnConfig);
+
+        columnConfig = new ColumnConfig("description", ROLE_MSGS.gridRoleColumnHeaderDescription(), 400);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("modifiedOnFormatted", ROLE_MSGS.gridRoleColumnHeaderModifiedOn(), 200);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
@@ -39,11 +39,12 @@ public class RoleAddDialog extends EntityAddEditDialog {
     private static final GwtRoleServiceAsync GWT_ROLE_SERVICE = GWT.create(GwtRoleService.class);
 
     protected KapuaTextField<String> roleNameField;
+    protected KapuaTextField<String> roleDescriptionField;
 
     public RoleAddDialog(GwtSession currentSession) {
         super(currentSession);
 
-        DialogUtils.resizeDialog(this, 400, 150);
+        DialogUtils.resizeDialog(this, 400, 200);
     }
 
     public void validateRoles() {
@@ -64,6 +65,7 @@ public class RoleAddDialog extends EntityAddEditDialog {
 
         gwtRoleCreator.setScopeId(currentSession.getSelectedAccountId());
         gwtRoleCreator.setName(roleNameField.getValue());
+        gwtRoleCreator.setDescription(roleDescriptionField.getValue());
 
         GWT_ROLE_SERVICE.create(xsrfToken, gwtRoleCreator, new AsyncCallback<GwtRole>() {
 
@@ -117,6 +119,14 @@ public class RoleAddDialog extends EntityAddEditDialog {
         roleNameField.setValidator(new TextFieldValidator(roleNameField, FieldType.NAME));
         roleNameField.setToolTip(MSGS.dialogAddFieldNameTooltip());
         roleFormPanel.add(roleNameField);
+
+        roleDescriptionField = new KapuaTextField<String>();
+        roleDescriptionField.setAllowBlank(true);
+        roleDescriptionField.setMaxLength(255);
+        roleDescriptionField.setName("description");
+        roleDescriptionField.setFieldLabel(MSGS.dialogAddFieldDescription());
+        roleNameField.setToolTip(MSGS.dialogAddFieldDescriptionTooltip());
+        roleFormPanel.add(roleDescriptionField);
 
         bodyPanel.add(roleFormPanel);
     }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,7 @@ import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsoleRoleMessages;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
@@ -35,7 +36,7 @@ public class RoleEditDialog extends RoleAddDialog {
         super(currentSession);
         this.selectedRole = selectedRole;
 
-        DialogUtils.resizeDialog(this, 400, 150);
+        DialogUtils.resizeDialog(this, 400, 200);
     }
 
     @Override
@@ -71,11 +72,13 @@ public class RoleEditDialog extends RoleAddDialog {
     private void populateEditDialog(GwtRole gwtRole) {
         roleNameField.setValue(gwtRole.getName());
         roleNameField.setOriginalValue(roleNameField.getValue());
+        roleDescriptionField.setValue(gwtRole.getUnescapedDescription());
     }
 
     @Override
     public void submit() {
         selectedRole.setName(roleNameField.getValue());
+        selectedRole.setDescription(KapuaSafeHtmlUtils.htmlUnescape(roleDescriptionField.getValue()));
 
         GWT_ROLE_SERVICE.update(xsrfToken, selectedRole, new AsyncCallback<GwtRole>() {
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
@@ -90,6 +90,10 @@ public class UserTabAccessRoleGrid extends EntityGrid<GwtAccessRole> {
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
+        columnConfig = new ColumnConfig("roleDescription", MSGS.gridRoleColumnHeaderDescription(), 400);
+        columnConfig.setSortable(false);
+        columnConfigs.add(columnConfig);
+
         columnConfig = new ColumnConfig("createdOnFormatted", MSGS.gridRoleColumnHeaderCreatedOn(), 200);
         columnConfigs.add(columnConfig);
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -68,6 +68,7 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
             KapuaId scopeId = KapuaEid.parseCompactId(gwtGroupCreator.getScopeId());
 
             GroupCreator groupCreator = GROUP_FACTORY.newCreator(scopeId, gwtGroupCreator.getName());
+            groupCreator.setDescription(gwtGroupCreator.getDescription());
             Group group = GROUP_SERVICE.create(groupCreator);
 
             gwtGroup = KapuaGwtAuthorizationModelConverter.convertGroup(group);
@@ -88,6 +89,7 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
 
             if (group != null) {
                 group.setName(gwtGroup.getGroupName());
+                group.setDescription(gwtGroup.getUnescapedDescription());
                 GROUP_SERVICE.update(group);
                 gwtGroupUpdated = KapuaGwtAuthorizationModelConverter.convertGroup(GROUP_SERVICE.find(group.getScopeId(), group.getId()));
             }
@@ -196,6 +198,7 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
                 // gwtGroupDescription.add(new GwtGroupedNVPair("Entity", "Scope
                 // Id", KapuaGwtAuthenticationModelConverter.convertKapuaId(group.getScopeId())));
                 gwtGroupDescription.add(new GwtGroupedNVPair("accessGroupInfo", "accessGroupName", group.getName()));
+                gwtGroupDescription.add(new GwtGroupedNVPair("accessGroupInfo", "accessGroupDescription", group.getDescription()));
                 gwtGroupDescription.add(new GwtGroupedNVPair("entityInfo", "accessGroupModifiedOn", group.getModifiedOn()));
                 gwtGroupDescription.add(new GwtGroupedNVPair("entityInfo", "accessGroupModifiedBy", modifiedUser != null ? modifiedUser.getName() : null));
                 gwtGroupDescription.add(new GwtGroupedNVPair("entityInfo", "accessGroupCreatedOn", group.getCreatedOn()));

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -244,6 +244,7 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
             // If there are results
             if (role != null) {
                 gwtRoleDescription.add(new GwtGroupedNVPair("roleInfo", "roleName", role.getName()));
+                gwtRoleDescription.add(new GwtGroupedNVPair("roleInfo", "roleDescription", role.getDescription()));
                 gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleModifiedOn", role.getModifiedOn()));
                 gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleModifiedBy", modifiedUser != null ? modifiedUser.getName() : null));
                 gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleCreatedOn", role.getCreatedOn()));

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessRole.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,6 +39,14 @@ public class GwtAccessRole extends GwtUpdatableEntityModel {
 
     public void setRoleName(String roleName) {
         set("roleName", roleName);
+    }
+
+    public String getRoleDescription() {
+        return get("roleDescription");
+    }
+
+    public void setRoleDescription(String roleDescription) {
+        set("roleDescription", roleDescription);
     }
 
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroup.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,6 +24,19 @@ public class GwtGroup extends GwtUpdatableEntityModel {
     public void setGroupName(String name) {
         set("groupName", name);
         set("value", name);
+    }
+
+    public String getGroupDescription() {
+        return get("description");
+    }
+
+    public String getUnescapedDescription() {
+        return (String) getUnescaped("description");
+    }
+
+    public void setGroupDescription(String description) {
+        set("description", description);
+        set("value", description);
     }
 
     @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroupCreator.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroupCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,6 +21,7 @@ public class GwtGroupCreator extends GwtEntityCreator {
     private static final long serialVersionUID = -2831647463538674359L;
 
     private String name;
+    private String description;
 
     public GwtGroupCreator() {
         super();
@@ -32,5 +33,13 @@ public class GwtGroupCreator extends GwtEntityCreator {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroupQuery.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroupQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,6 +21,7 @@ public class GwtGroupQuery extends GwtQuery {
     private static final long serialVersionUID = 416159571099764329L;
 
     private String name;
+    private String description;
 
     public String getName() {
         return name;
@@ -28,6 +29,14 @@ public class GwtGroupQuery extends GwtQuery {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRole.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,6 +31,18 @@ public class GwtRole extends GwtUpdatableEntityModel {
 
     public void setName(String name) {
         set("name", name);
+    }
+
+    public String getDescription() {
+        return get("description");
+    }
+
+    public String getUnescapedDescription() {
+        return (String) getUnescaped("description");
+    }
+
+    public void setDescription(String description) {
+        set("description", description);
     }
 
     public Set<GwtRolePermission> getPermissions() {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRoleCreator.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRoleCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,7 @@ public class GwtRoleCreator extends GwtEntityCreator {
     private static final long serialVersionUID = -1333808048669893906L;
 
     private String name;
+    private String description;
 
     private List<GwtPermission> permissions;
 
@@ -33,6 +34,14 @@ public class GwtRoleCreator extends GwtEntityCreator {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public List<GwtPermission> getPermissions() {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRoleQuery.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRoleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ public class GwtRoleQuery extends GwtQuery {
     private static final long serialVersionUID = -5198696327167110220L;
 
     private String name;
+    private String description;
 
     public String getName() {
         return name;
@@ -25,5 +26,13 @@ public class GwtRoleQuery extends GwtQuery {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/GwtKapuaAuthorizationModelConverter.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/GwtKapuaAuthorizationModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -87,8 +87,10 @@ public class GwtKapuaAuthorizationModelConverter {
         GroupFactory groupFactory = locator.getFactory(GroupFactory.class);
         GroupQuery groupQuery = groupFactory.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtGroupQuery.getScopeId()));
         if (gwtGroupQuery.getName() != null && !gwtGroupQuery.getName().isEmpty()) {
-            groupQuery
-                    .setPredicate(new AttributePredicateImpl<String>(GroupAttributes.NAME, gwtGroupQuery.getName(), Operator.LIKE));
+            groupQuery.setPredicate(new AttributePredicateImpl<String>(GroupAttributes.NAME, gwtGroupQuery.getName(), Operator.LIKE));
+        }
+        if (gwtGroupQuery.getDescription() != null && !gwtGroupQuery.getDescription().isEmpty()) {
+            groupQuery.setPredicate(new AttributePredicateImpl<String>(GroupAttributes.DESCRIPTION, gwtGroupQuery.getDescription(), Operator.LIKE));
         }
         String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? GroupAttributes.NAME : loadConfig.getSortField();
         if (sortField.equals("groupName")) {
@@ -122,6 +124,9 @@ public class GwtKapuaAuthorizationModelConverter {
         RoleQuery roleQuery = roleFactory.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtRoleQuery.getScopeId()));
         if (gwtRoleQuery.getName() != null && !gwtRoleQuery.getName().trim().isEmpty()) {
             roleQuery.setPredicate(new AttributePredicateImpl<String>(RoleAttributes.NAME, gwtRoleQuery.getName(), Operator.LIKE));
+        }
+        if (gwtRoleQuery.getDescription() != null && !gwtRoleQuery.getDescription().trim().isEmpty()) {
+            roleQuery.setPredicate(new AttributePredicateImpl<String>(RoleAttributes.DESCRIPTION, gwtRoleQuery.getDescription(), Operator.LIKE));
         }
         String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? RoleAttributes.NAME : loadConfig.getSortField();
         if (sortField.equals("modifiedOnFormatted")) {
@@ -176,6 +181,7 @@ public class GwtKapuaAuthorizationModelConverter {
 
         // Convert name
         role.setName(gwtRole.getName());
+        role.setDescription(gwtRole.getUnescapedDescription());
 
         if (gwtRole.getPermissions() != null) {
             // Convert permission associated with role
@@ -221,6 +227,7 @@ public class GwtKapuaAuthorizationModelConverter {
 
         // Convert name
         roleCreator.setName(gwtRoleCreator.getName());
+        roleCreator.setDescription(gwtRoleCreator.getDescription());
 
         // Convert permission associated with role
         Set<Permission> permissions = new HashSet<Permission>();

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/KapuaGwtAuthorizationModelConverter.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/KapuaGwtAuthorizationModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -53,6 +53,7 @@ public class KapuaGwtAuthorizationModelConverter {
         //
         // Convert other attributes
         gwtGroup.setGroupName(group.getName());
+        gwtGroup.setGroupDescription(group.getDescription());
 
         return gwtGroup;
     }
@@ -74,6 +75,7 @@ public class KapuaGwtAuthorizationModelConverter {
         //
         // Convert other attributes
         gwtRole.setName(role.getName());
+        gwtRole.setDescription(role.getDescription());
 
         //
         // Return converted entity
@@ -98,6 +100,7 @@ public class KapuaGwtAuthorizationModelConverter {
         //
         // Convert other attributes
         gwtAccessRole.setRoleName(role.getName());
+        gwtAccessRole.setRoleDescription(role.getDescription());
         gwtAccessRole.setRoleId(role.getId().toCompactId());
         gwtAccessRole.setAccessInfoId(accessRole.getAccessInfoId().toCompactId());
         //

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ groups=Access Groups
 # Group Grid
 gridGroupColumnHeaderId=Id
 gridGroupColumnHeaderGroupName=Access Group Name
+gridGroupColumnHeaderDescription=Description
 gridGroupColumnHeaderCreatedBy=Created By
 gridGroupColumnHeaderCreatedOn=Created On
 
@@ -30,6 +31,8 @@ dialogAddConfirmation=Access Group successfully created.
 dialogAddError=Access Group creation failed: {0}
 dialogAddFieldName=Name
 dialogAddFieldNameTooltip=Access group name must be at least 3 characters long and can contain alphanumeric characters combined with dash and/or underscore.
+dialogAddFieldDescription=Description
+dialogAddFieldDescriptionTooltip=Enter a group description for detailed information about the group.
 #
 # Edit dialog
 dialogEditHeader=Edit Access Group: {0}
@@ -47,6 +50,7 @@ dialogDeleteError=Access Group delete failed: {0}
 # Group Filter
 filterHeader=Access Group Filter
 filterFieldGroupNameLabel=Name
+filterFieldGroupDescriptionLabel=Description
 
 #
 # Access Groups - Assigned Devices tab

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ mainMenuRoles=Roles
 # Role Grid
 gridRoleColumnHeaderId=Id
 gridRoleColumnHeaderName=Name
+gridRoleColumnHeaderDescription=Description
 gridRoleColumnHeaderCreatedBy=Created By
 gridRoleColumnHeaderModifiedBy=Modified By
 gridRoleColumnHeaderGrantedBy=Granted By
@@ -51,6 +52,8 @@ dialogAddError=Role creation failed: {0}
 
 dialogAddFieldName=Name
 dialogAddFieldNameTooltip=Role name should be at least 3 characters long and can contain alphanumeric characters combined with dash and/or underscore.
+dialogAddFieldDescription=Description
+dialogAddFieldDescriptionTooltip=Enter a role description for detailed information about the role.
 dialogAddFieldRolePermissions=Role permissions
 dialogAddFieldRolePermissionsTooltip=The permissions associated with the new role.
 
@@ -104,3 +107,4 @@ permissionDeleteDialogConfirmation=Permission successfully deleted.
 # Role Filter
 filterHeader=Role Filter
 filterFieldRoleNameLabel=Name
+filterFieldRoleDescriptionLabel=Description

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobFilterPanel.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +33,7 @@ public class JobFilterPanel extends EntityFilterPanel<GwtJob> {
     private final GwtSession currentSession;
 
     private final KapuaTextField<String> jobNameField;
+    private final KapuaTextField<String> jobDescriptionField;
 
     public JobFilterPanel(AbstractEntityView<GwtJob> entityView, GwtSession currentSession) {
         super(entityView, currentSession);
@@ -59,11 +60,28 @@ public class JobFilterPanel extends EntityFilterPanel<GwtJob> {
         jobNameField.setStyleAttribute("margin-right", "5px");
         jobNameField.setStyleAttribute("margin-bottom", "10px");
         fieldsPanel.add(jobNameField);
+
+        Label jobDescriptionLabel = new Label("Description");
+        jobDescriptionLabel.setWidth(WIDTH);
+        jobDescriptionLabel.setStyleAttribute("margin", "5px");
+
+        fieldsPanel.add(jobDescriptionLabel);
+
+        jobDescriptionField = new KapuaTextField<String>();
+        jobDescriptionField.setName("name");
+        jobDescriptionField.setWidth(WIDTH);
+        jobDescriptionField.setMaxLength(MAX_LEN);
+        jobDescriptionField.setStyleAttribute("margin-top", "0px");
+        jobDescriptionField.setStyleAttribute("margin-left", "5px");
+        jobDescriptionField.setStyleAttribute("margin-right", "5px");
+        jobDescriptionField.setStyleAttribute("margin-bottom", "10px");
+        fieldsPanel.add(jobDescriptionField);
     }
 
     @Override
     public void resetFields() {
         jobNameField.setValue(null);
+        jobDescriptionField.setValue(null);
         GwtJobQuery query = new GwtJobQuery();
         query.setScopeId(currentSession.getSelectedAccountId());
         entityGrid.refresh(query);
@@ -73,6 +91,7 @@ public class JobFilterPanel extends EntityFilterPanel<GwtJob> {
     public void doFilter() {
         GwtJobQuery query = new GwtJobQuery();
         query.setName(jobNameField.getValue());
+        query.setDescription(jobDescriptionField.getValue());
         query.setScopeId(currentSession.getSelectedAccountId());
         entityGrid.refresh(query);
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
 public class GwtJobQuery extends GwtQuery {
 
     private String name;
+    private String description;
 
     public String getName() {
         return name;
@@ -23,5 +24,13 @@ public class GwtJobQuery extends GwtQuery {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -37,25 +37,25 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.job.Job;
-import org.eclipse.kapua.service.job.JobFactory;
 import org.eclipse.kapua.service.job.JobAttributes;
+import org.eclipse.kapua.service.job.JobFactory;
 import org.eclipse.kapua.service.job.JobQuery;
-import org.eclipse.kapua.service.job.execution.JobExecutionFactory;
 import org.eclipse.kapua.service.job.execution.JobExecutionAttributes;
+import org.eclipse.kapua.service.job.execution.JobExecutionFactory;
 import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
 import org.eclipse.kapua.service.job.step.JobStep;
+import org.eclipse.kapua.service.job.step.JobStepAttributes;
 import org.eclipse.kapua.service.job.step.JobStepCreator;
 import org.eclipse.kapua.service.job.step.JobStepFactory;
-import org.eclipse.kapua.service.job.step.JobStepAttributes;
 import org.eclipse.kapua.service.job.step.JobStepQuery;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionFactory;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionQuery;
 import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
-import org.eclipse.kapua.service.job.targets.JobTargetFactory;
 import org.eclipse.kapua.service.job.targets.JobTargetAttributes;
+import org.eclipse.kapua.service.job.targets.JobTargetFactory;
 import org.eclipse.kapua.service.job.targets.JobTargetQuery;
-import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerAttributes;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerProperty;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
 
@@ -130,7 +130,7 @@ public class GwtKapuaJobModelConverter {
         if (gwtJobQuery.getName() != null && !gwtJobQuery.getName().isEmpty()) {
             predicate.and(new AttributePredicateImpl<String>(JobAttributes.NAME, gwtJobQuery.getName(), Operator.LIKE));
         }
-        if(gwtJobQuery.getDescription() != null && !gwtJobQuery.getDescription().isEmpty()) {
+        if (gwtJobQuery.getDescription() != null && !gwtJobQuery.getDescription().isEmpty()) {
             predicate.and(new AttributePredicateImpl<String>(JobAttributes.DESCRIPTION, gwtJobQuery.getDescription(), Operator.LIKE));
         }
         jobQuery.setLimit(loadConfig.getLimit());
@@ -206,8 +206,8 @@ public class GwtKapuaJobModelConverter {
         } else {
             String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? JobStepAttributes.STEP_INDEX : loadConfig.getSortField();
             if (sortField.equals("jobStepName")) {
-                sortField = JobStepAttributes.JOB_STEP_NAME;
-            } else if (sortField.equals("jobStepDefinitionName")) {
+                sortField = JobStepAttributes.NAME;
+            } else if (sortField.equals("jobStepDefinitionId")) {
                 sortField = JobStepAttributes.JOB_STEP_DEFINITION_ID;
             }
             SortOrder sortOrder = loadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
@@ -261,7 +261,7 @@ public class GwtKapuaJobModelConverter {
 
         String sortField = StringUtils.isEmpty(loadConfig.getSortField()) ? TriggerAttributes.ENTITY_ID : loadConfig.getSortField();
         if (sortField.equals("triggerName")) {
-            sortField = TriggerAttributes.TRIGGER_NAME;
+            sortField = TriggerAttributes.NAME;
         } else if (sortField.equals("startsOnFormatted")) {
             sortField = TriggerAttributes.STARTS_ON;
         } else if (sortField.equals("endsOnFormatted")) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -129,6 +129,9 @@ public class GwtKapuaJobModelConverter {
         JobQuery jobQuery = JOB_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobQuery.getScopeId()));
         if (gwtJobQuery.getName() != null && !gwtJobQuery.getName().isEmpty()) {
             predicate.and(new AttributePredicateImpl<String>(JobAttributes.NAME, gwtJobQuery.getName(), Operator.LIKE));
+        }
+        if(gwtJobQuery.getDescription() != null && !gwtJobQuery.getDescription().isEmpty()) {
+            predicate.and(new AttributePredicateImpl<String>(JobAttributes.DESCRIPTION, gwtJobQuery.getDescription(), Operator.LIKE));
         }
         jobQuery.setLimit(loadConfig.getLimit());
         jobQuery.setOffset(loadConfig.getOffset());

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -193,3 +193,4 @@ gridJobExecutionsColumnHeaderEndedOnFormatted=Ended on
 # Job Filter
 filterHeader=Job Filter
 filterFieldJobNameLabel=Name
+filterFieldJobDescriptionLabel=Description

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
@@ -39,6 +39,7 @@ public class TagAddDialog extends EntityAddEditDialog {
     private static final GwtTagServiceAsync GWT_TAG_SERVICE = GWT.create(GwtTagService.class);
 
     protected KapuaTextField<String> tagNameField;
+    protected KapuaTextField<String> tagDescriptionField;
 
     public TagAddDialog(GwtSession currentSession) {
         super(currentSession);
@@ -55,6 +56,14 @@ public class TagAddDialog extends EntityAddEditDialog {
         tagNameField.setValidator(new TextFieldValidator(tagNameField, FieldType.NAME));
         tagNameField.setMaxLength(255);
         tagFormPanel.add(tagNameField);
+
+        tagDescriptionField = new KapuaTextField<String>();
+        tagDescriptionField.setAllowBlank(true);
+        tagDescriptionField.setFieldLabel(MSGS.dialogAddFieldTagDescription());
+        tagDescriptionField.setToolTip(MSGS.dialogAddFieldTagDescriptionTooltip());
+        tagDescriptionField.setName("description");
+        tagDescriptionField.setMaxLength(255);
+        tagFormPanel.add(tagDescriptionField);
         bodyPanel.add(tagFormPanel);
     }
 
@@ -75,6 +84,7 @@ public class TagAddDialog extends EntityAddEditDialog {
         GwtTagCreator gwtTagCreator = new GwtTagCreator();
         gwtTagCreator.setScopeId(currentSession.getSelectedAccountId());
         gwtTagCreator.setName(tagNameField.getValue());
+        gwtTagCreator.setDescription(tagDescriptionField.getValue());
         GWT_TAG_SERVICE.create(gwtTagCreator, new AsyncCallback<GwtTag>() {
 
             @Override

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagEditDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.tag.client.messages.ConsoleTagMessages;
 import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
@@ -43,6 +44,7 @@ public class TagEditDialog extends TagAddDialog {
     @Override
     public void submit() {
         selectedTag.setTagName(tagNameField.getValue());
+        selectedTag.setTagDescription(KapuaSafeHtmlUtils.htmlUnescape(tagDescriptionField.getValue()));
         GWT_TAG_SERVICE.update(selectedTag, new AsyncCallback<GwtTag>() {
 
             @Override
@@ -83,6 +85,7 @@ public class TagEditDialog extends TagAddDialog {
 
     private void populateEditDialog(GwtTag gwtTag) {
         tagNameField.setValue(gwtTag.getTagName());
+        tagDescriptionField.setValue(gwtTag.getUnescapedDescription());
 
     }
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagFilterPanel.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,6 +30,7 @@ public class TagFilterPanel extends EntityFilterPanel<GwtTag> {
     private final EntityGrid<GwtTag> entityGrid;
     private final GwtSession currentSession;
     private final KapuaTextField<String> nameField;
+    private final KapuaTextField<String> descriptionField;
     private static final ConsoleTagMessages MSGS = GWT.create(ConsoleTagMessages.class);
 
     public TagFilterPanel(AbstractEntityView<GwtTag> entityView, GwtSession currentSession) {
@@ -53,11 +54,25 @@ public class TagFilterPanel extends EntityFilterPanel<GwtTag> {
         nameField.setStyleAttribute("margin-bottom", "10px");
         verticalPanel.add(nameField);
 
+        Label descriptionLabel = new Label(MSGS.filterFieldTagDescriptionLabel());
+        descriptionLabel.setWidth(WIDTH);
+        descriptionLabel.setStyleAttribute("margin", "5px");
+        verticalPanel.add(descriptionLabel);
+        descriptionField = new KapuaTextField<String>();
+        descriptionField.setName("name");
+        descriptionField.setWidth(WIDTH);
+        descriptionField.setMaxLength(MAX_LEN);
+        descriptionField.setStyleAttribute("margin-top", "0px");
+        descriptionField.setStyleAttribute("margin-left", "5px");
+        descriptionField.setStyleAttribute("margin-right", "5px");
+        descriptionField.setStyleAttribute("margin-bottom", "10px");
+        verticalPanel.add(descriptionField);
     }
 
     @Override
     public void resetFields() {
         nameField.setValue(null);
+        descriptionField.setValue(null);
         GwtTagQuery query = new GwtTagQuery();
         query.setScopeId(currentSession.getSelectedAccountId());
         entityGrid.refresh(query);
@@ -68,6 +83,7 @@ public class TagFilterPanel extends EntityFilterPanel<GwtTag> {
     public void doFilter() {
         GwtTagQuery query = new GwtTagQuery();
         query.setName(nameField.getValue());
+        query.setDescription(descriptionField.getValue());
         query.setScopeId(currentSession.getSelectedAccountId());
         entityGrid.refresh(query);
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -91,6 +91,9 @@ public class TagGrid extends EntityGrid<GwtTag> {
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("tagName", MSGS.gridTagColumnHeaderTagName(), 200);
+        columnConfigs.add(columnConfig);
+
+        columnConfig = new ColumnConfig("description", MSGS.gridTagColumnHeaderTagDescription(), 200);
         columnConfigs.add(columnConfig);
 
         columnConfig = new ColumnConfig("createdOnFormatted", MSGS.gridTagColumnHeaderCreatedOn(), 200);

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -72,6 +72,7 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
         try {
             KapuaId scopeId = KapuaEid.parseCompactId(gwtTagCreator.getScopeId());
             TagCreator tagCreator = tagFactory.newCreator(scopeId, gwtTagCreator.getName());
+            tagCreator.setDescription(gwtTagCreator.getDescription());
 
             Tag tag = tagService.create(tagCreator);
 
@@ -94,6 +95,7 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
 
             if (tag != null) {
                 tag.setName(gwtTag.getTagName());
+                tag.setDescription(gwtTag.getUnescapedDescription());
                 tagService.update(tag);
                 gwtTagUpdated = KapuaGwtTagModelConverter.convertTag(tagService.find(tag.getScopeId(), tag.getId()));
             }
@@ -199,6 +201,7 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
                 // gwtTagDescription.add(new GwtGroupedNVPair("Entity", "Scope
                 // Id", KapuaGwtCommonsModelConverter.convertKapuaId(tag.getScopeId())));
                 gwtTagDescription.add(new GwtGroupedNVPair("tagInfo", "tagName", tag.getName()));
+                gwtTagDescription.add(new GwtGroupedNVPair("tagInfo", "tagDescription", tag.getDescription()));
                 gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagModifiedOn", tag.getModifiedOn()));
                 gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagModifiedBy", modifiedUser != null ? modifiedUser.getName() : null));
                 gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagCreatedOn", tag.getCreatedOn()));

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTag.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTag.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,6 +24,19 @@ public class GwtTag extends GwtUpdatableEntityModel {
     public void setTagName(String name) {
         set("tagName", name);
         set("value", name);
+    }
+
+    public String getTagDescription() {
+        return get("description");
+    }
+
+    public String getUnescapedDescription() {
+        return (String) getUnescaped("description");
+    }
+
+    public void setTagDescription(String description) {
+        set("description", description);
+        set("value", description);
     }
 
     @Override

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTagCreator.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTagCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ public class GwtTagCreator extends GwtEntityCreator {
     private static final long serialVersionUID = -7059294623937906017L;
 
     private String name;
+    private String description;
 
     public GwtTagCreator() {
         super();
@@ -29,5 +30,13 @@ public class GwtTagCreator extends GwtEntityCreator {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTagQuery.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTagQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,6 +21,7 @@ public class GwtTagQuery extends GwtQuery {
     private static final long serialVersionUID = -4379272962842143514L;
 
     private String name;
+    private String description;
     private List<String> ids;
 
     public String getName() {
@@ -29,6 +30,14 @@ public class GwtTagQuery extends GwtQuery {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public List<String> getIds() {

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/GwtKapuaTagModelConverter.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/GwtKapuaTagModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -48,6 +48,9 @@ public class GwtKapuaTagModelConverter {
         AndPredicateImpl andPredicate = new AndPredicateImpl();
         if (gwtTagQuery.getName() != null && !gwtTagQuery.getName().isEmpty()) {
             andPredicate.and(new AttributePredicateImpl<String>(TagAttributes.NAME, gwtTagQuery.getName(), Operator.LIKE));
+        }
+        if (gwtTagQuery.getDescription() != null && !gwtTagQuery.getDescription().isEmpty()) {
+            andPredicate.and(new AttributePredicateImpl<String>(TagAttributes.DESCRIPTION, gwtTagQuery.getDescription(), Operator.LIKE));
         }
         if (!gwtTagQuery.getIds().isEmpty()) {
             int i = 0;

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/KapuaGwtTagModelConverter.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/KapuaGwtTagModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -36,6 +36,7 @@ public class KapuaGwtTagModelConverter {
         //
         // Convert other attributes
         gwtTag.setTagName(tag.getName());
+        gwtTag.setTagDescription(tag.getDescription());
 
         return gwtTag;
     }

--- a/console/module/tag/src/main/resources/org/eclipse/kapua/app/console/module/tag/client/messages/ConsoleTagMessages.properties
+++ b/console/module/tag/src/main/resources/org/eclipse/kapua/app/console/module/tag/client/messages/ConsoleTagMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,7 @@ tags=Tags
 # Tag Grid
 gridTagColumnHeaderId=Id
 gridTagColumnHeaderTagName=Tag Name
+gridTagColumnHeaderTagDescription=Description
 gridTagColumnHeaderCreatedBy=Created By
 gridTagColumnHeaderCreatedOn=Created On
 
@@ -29,6 +30,8 @@ dialogAddConfirmation=Tag successfully created.
 dialogAddError=Tag creation failed: {0}
 dialogAddFieldName=Name
 dialogAddFieldNameTooltip=The name of the new tag. It must be unique.
+dialogAddFieldTagDescription=Description
+dialogAddFieldTagDescriptionTooltip=Enter a tag description for detailed information about the tag.
 #
 # Edit dialog
 dialogEditHeader=Edit Tag: {0}
@@ -46,6 +49,7 @@ dialogDeleteError=Tag delete failed: {0}
 # Tag Filter
 filterHeader=Tag Filter
 filterFieldTagNameLabel=Name
+filterFieldTagDescriptionLabel=Description
 #
 # Tags - Assigned Devices tab
 tagsTabSubjectGridTitle=Assigned Devices

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/step/definition/AbstractGenericJobStepDefinition.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/step/definition/AbstractGenericJobStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,24 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.job.engine.commons.step.definition;
 
-import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
 import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 import org.eclipse.kapua.service.job.step.definition.JobStepType;
 
 import java.util.List;
 
-public abstract class AbstractGenericJobStepDefinition extends AbstractKapuaUpdatableEntity implements JobStepDefinition {
+public abstract class AbstractGenericJobStepDefinition extends AbstractKapuaNamedEntity implements JobStepDefinition {
 
     private static final long serialVersionUID = 474195961081702478L;
-
-    @Override
-    public void setName(String name) {
-    }
-
-    @Override
-    public void setDescription(String description) {
-    }
 
     @Override
     public JobStepType getStepType() {

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/step/definition/AbstractTargetJobStepDefinition.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/step/definition/AbstractTargetJobStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.job.engine.commons.step.definition;
 
-import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
 import org.eclipse.kapua.job.engine.commons.operation.DefaultTargetReader;
 import org.eclipse.kapua.job.engine.commons.operation.DefaultTargetWriter;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
@@ -20,17 +20,9 @@ import org.eclipse.kapua.service.job.step.definition.JobStepType;
 
 import java.util.List;
 
-public abstract class AbstractTargetJobStepDefinition extends AbstractKapuaUpdatableEntity implements JobStepDefinition {
+public abstract class AbstractTargetJobStepDefinition extends AbstractKapuaNamedEntity implements JobStepDefinition {
 
     private static final long serialVersionUID = 474195961081702478L;
-
-    @Override
-    public void setName(String name) {
-    }
-
-    @Override
-    public void setDescription(String description) {
-    }
 
     @Override
     public JobStepType getStepType() {

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,9 +24,9 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * {@link Account} {@link org.eclipse.kapua.model.KapuaEntity}.
+ * {@link Account} {@link org.eclipse.kapua.model.KapuaEntity} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "account")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -41,53 +41,70 @@ public interface Account extends KapuaNamedEntity {
     }
 
     /**
-     * Get the account's organization
+     * Gets the account's {@link Organization}
      *
-     * @return
+     * @return the account's {@link Organization}
+     * @since 1.0.0
      */
     @XmlElement(name = "organization")
     Organization getOrganization();
 
     /**
-     * Set the account's organization
+     * Sets the account's {@link Organization}
      *
-     * @param organization
+     * @param organization the account's {@link Organization}
+     * @since 1.0.0
      */
     void setOrganization(Organization organization);
 
     /**
-     * Return the parent account path.<br>
-     * The account path is a '/' separated list of the parents account identifiers in reverse order (so it should be read from right to left).<br>
-     * e.g. The parent account path 7/14/15 mens that the current account has 15 as parent, then 15 has 14 as parent and 14 has 7 as parent.
+     * Return the parent account path
+     * <p>
+     * The account path is a '/' separated list of the parents {@link Account} identifiers in reverse order (so it should be read from right to left).<br>
+     * e.g. The parent account path 7/14/15 means that the current account has 15 as parent, then 15 has 14 as parent and 14 has 7 as parent.
      *
-     * @return
+     * @return the parent account path
+     * @since 1.0.0
      */
     @XmlElement(name = "parentAccountPath")
     String getParentAccountPath();
 
     /**
-     * Set the parent account path.
+     * Set the parent account path
+     * <p>
+     * The account path is a '/' separated list of the parents {@link Account} identifiers in reverse order (so it should be read from right to left).<br>
+     * e.g. The parent account path 7/14/15 means that the current account has 15 as parent, then 15 has 14 as parent and 14 has 7 as parent.
      *
-     * @param parentAccountPath
+     * @param parentAccountPath the parent account path
+     * @since 1.0.0
      */
     void setParentAccountPath(String parentAccountPath);
 
-    List<Account> getChildAccounts();
 
     /**
-     * Gets the current Account expiration date
+     * Gets the expiration date
      *
-     * @return the current Account expiration date
+     * @return the expiration date
+     * @since 1.0.0
      */
     @XmlElement(name = "expirationDate")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
     Date getExpirationDate();
 
     /**
-     * Sets the current Account expiration date
+     * Sets the expiration date
      *
-     * @param expirationDate the current Account expiration date
+     * @param expirationDate the expiration date
+     * @since 1.0.0
      */
     void setExpirationDate(Date expirationDate);
+
+    /**
+     * Gets the {@link List} of {@link Account} that are children of this {@link Account}
+     *
+     * @return the {@link List} of {@link Account} that are children of this {@link Account}
+     * @since 1.0.0
+     */
+    List<Account> getChildAccounts();
 
 }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountAttributes.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,12 @@ package org.eclipse.kapua.service.account;
 
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
+/**
+ * {@link AccountAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
+ */
 public class AccountAttributes extends KapuaNamedEntityAttributes {
 
     public static final String PARENT_ACCOUNT_PATH = "parentAccountPath";

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,14 +23,13 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 
 /**
- * AccountCreator encapsulates all the information needed to create a new Account in the system.<br>
- * The data provided will be used to seed the new Account and its related information such as the associated organization and users.
+ * {@link AccountCreator} {@link org.eclipse.kapua.model.KapuaEntityCreator} definition
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "accountCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "organizationName",
+@XmlType(propOrder = {"organizationName",
         "organizationPersonName",
         "organizationEmail",
         "organizationPhoneNumber",
@@ -40,7 +39,7 @@ import java.util.Date;
         "organizationZipPostCode",
         "organizationStateProvinceCounty",
         "organizationCountry",
-        "expirationDate" }, factoryClass = AccountXmlRegistry.class, factoryMethod = "newAccountCreator")
+        "expirationDate"}, factoryClass = AccountXmlRegistry.class, factoryMethod = "newAccountCreator")
 public interface AccountCreator extends KapuaNamedEntityCreator<Account> {
 
     /**

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountCreatorImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,74 +11,44 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account.internal;
 
-import java.util.Date;
-
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountCreator;
 
+import java.util.Date;
+
 /**
- * Account creator service implementation.
- * 
- * @since 1.0
- * 
+ * {@link AccountCreator} implementation.
+ *
+ * @since 1.0.0
  */
 public class AccountCreatorImpl extends AbstractKapuaNamedEntityCreator<Account> implements AccountCreator {
 
     private static final long serialVersionUID = -2460883485294616032L;
 
-    private String accountName;
-
     private String organizationName;
-
     private String organizationPersonName;
-
     private String organizationEmail;
-
     private String organizationPhoneNumber;
-
     private String organizationAddressLine1;
-
     private String organizationAddressLine2;
-
     private String organizationCity;
-
     private String organizationZipPostCode;
-
     private String organizationStateProvinceCounty;
-
     private String organizationCountry;
 
     private Date expirationDate;
 
     /**
      * Constructor
-     * 
-     * @param scopeId
-     * @param name
-     *            account name
+     *
+     * @param scopeId the scope {@link KapuaId}
+     * @param name    the name
+     * @since 1.0.0
      */
     public AccountCreatorImpl(KapuaId scopeId, String name) {
         super(scopeId, name);
-    }
-
-    /**
-     * Get the account name
-     * 
-     * @return
-     */
-    public String getAccountName() {
-        return accountName;
-    }
-
-    /**
-     * Set the account name
-     * 
-     * @param accountName
-     */
-    public void setAccountName(String accountName) {
-        this.accountName = accountName;
     }
 
     @Override

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -68,7 +68,7 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
     private OrganizationImpl organization;
 
     @Basic
-    @Column(name = "parent_account_path", nullable = false)
+    @Column(name = "parent_account_path", nullable = false, updatable = true)
     private String parentAccountPath;
 
     @OneToMany(fetch = FetchType.LAZY)
@@ -77,7 +77,7 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
     private List<AccountImpl> childAccounts;
 
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(name = "expiration_date")
+    @Column(name = "expiration_date", nullable = false, updatable = true)
     protected Date expirationDate;
 
     /**
@@ -130,9 +130,11 @@ public class AccountImpl extends AbstractKapuaNamedEntity implements Account {
 
     @Override
     public List<Account> getChildAccounts() {
-        List<Account> list = new ArrayList<>();
-        list.addAll(childAccounts);
-        return list;
+        if (childAccounts == null) {
+            childAccounts = new ArrayList<>();
+        }
+
+        return new ArrayList<>(childAccounts);
     }
 
     @Override

--- a/service/account/internal/src/main/resources/liquibase/1.1.0/account-description.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.1.0/account-description.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-account-1.1.0.xml">
+
+    <changeSet id="changelog-account-description-1.1.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <tableExists tableName="act_account"/>
+        </preConditions>
+
+        <addColumn tableName="act_account">
+            <column name="description" type="text"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/1.1.0/changelog-account-1.1.0.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.1.0/changelog-account-1.1.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-account-1.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="./account-description.xml"/>
+
+</databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/changelog-account-master.xml
+++ b/service/account/internal/src/main/resources/liquibase/changelog-account-master.xml
@@ -10,13 +10,14 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./0.2.0/changelog-account-0.2.0.xml" />
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-account-0.3.0.xml" />
-    <include relativeToChangelogFile="true" file="./1.0.0/changelog-account-1.0.0.xml" />
+    <include relativeToChangelogFile="true" file="./0.2.0/changelog-account-0.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./0.3.0/changelog-account-0.3.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.0.0/changelog-account-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.1.0/changelog-account-1.1.0.xml"/>
 
 </databaseChangeLog>

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,25 +24,26 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 
 /**
- * Kapua base entity definition.<br>
- * All the Kapua entities will be an extension of this entity.
+ * {@link KapuaEntity} definition.
+ * <p>
+ * All the {@link KapuaEntity}s will be an extension of this entity.
  *
  * @since 1.0.0
  */
-@XmlType(propOrder = { //
-        "id", //
-        "scopeId", //
-        "createdOn", //
-        "createdBy" })
+@XmlType(propOrder = {
+        "id",
+        "scopeId",
+        "createdOn",
+        "createdBy"})
 public interface KapuaEntity extends KapuaSerializable {
 
     @XmlTransient
     String getType();
 
     /**
-     * Get the Kapua identifier for the entity
+     * Gets the unique {@link KapuaId}
      *
-     * @return
+     * @return the unique {@link KapuaId}
      * @since 1.0.0
      */
     @XmlElement(name = "id")
@@ -51,17 +52,17 @@ public interface KapuaEntity extends KapuaSerializable {
     KapuaId getId();
 
     /**
-     * Set the Kapua identifier for the entity
+     * Sets the unique {@link KapuaId}
      *
-     * @param id
+     * @param id the unique {@link KapuaId}
      * @since 1.0.0
      */
     void setId(KapuaId id);
 
     /**
-     * Get the Kapua scope identifier for the entity
+     * Gets the scope {@link KapuaId}
      *
-     * @return
+     * @return the scope {@link KapuaId}
      * @since 1.0.0
      */
     @XmlElement(name = "scopeId")
@@ -70,17 +71,17 @@ public interface KapuaEntity extends KapuaSerializable {
     KapuaId getScopeId();
 
     /**
-     * Set the Kapua scope identifier for the entity.
+     * Sets the scope {@link KapuaId}
      *
-     * @param scopeId The Kapua scope identifier to set.
+     * @param scopeId the scope {@link KapuaId}
      * @since 1.0.0
      */
     void setScopeId(KapuaId scopeId);
 
     /**
-     * Get the created on date
+     * Gets the creation date.
      *
-     * @return
+     * @return the creation date.
      * @since 1.0.0
      */
     @XmlElement(name = "createdOn")
@@ -88,9 +89,9 @@ public interface KapuaEntity extends KapuaSerializable {
     Date getCreatedOn();
 
     /**
-     * Set the created by Kapua identifier
+     * Gets the identity {@link KapuaId} who has created this {@link KapuaEntity}
      *
-     * @return
+     * @return the identity {@link KapuaId} who has created this {@link KapuaEntity}
      * @since 1.0.0
      */
     @XmlElement(name = "createdBy")

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityAttributes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityAttributes.java
@@ -11,14 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.model;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 /**
- * {@link KapuaEntity} query predicates.
+ * {@link KapuaEntity} attributes.
+ * <p>
+ * These attributes can be used in the {@link org.eclipse.kapua.model.query.predicate.AttributePredicate} to specify which property
+ * to filter {@link org.eclipse.kapua.service.KapuaEntityService#query(KapuaQuery)} and {@link org.eclipse.kapua.service.KapuaEntityService#count(KapuaQuery)} results
  *
  * @since 1.0.0
  */
 public class KapuaEntityAttributes {
 
-    protected KapuaEntityAttributes() { }
+    protected KapuaEntityAttributes() {
+    }
 
     /**
      * Predicate for field {@link KapuaEntity#getScopeId()}

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,23 +16,23 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
- * Kapua entity base creator service definition.<br>
- * All the Kapua entities base creator service will be an extension of this entity.
+ * {@link KapuaEntityCreator} definition
+ * <p>
+ * All the {@link KapuaEntityCreator} will be an extension of this.
  *
  * @param <E> entity type
  * @since 1.0.0
  */
-@XmlType(propOrder = { "scopeId" })
 public interface KapuaEntityCreator<E extends KapuaEntity> {
 
     /**
-     * Get the Kapua scope identifier
+     * Gets the scope {@link KapuaId}
      *
-     * @return
+     * @return the scope {@link KapuaId}
+     * @since 1.0.0
      */
     @XmlElement(name = "scopeId")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -40,9 +40,10 @@ public interface KapuaEntityCreator<E extends KapuaEntity> {
     KapuaId getScopeId();
 
     /**
-     * Set the Kapua scope identifier
+     * Sets the scope {@link KapuaId}
      *
-     * @param scopeId
+     * @param scopeId the scope {@link KapuaId}
+     * @since 1.0.0
      */
     void setScopeId(KapuaId scopeId);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,6 +15,15 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaListResult;
 import org.eclipse.kapua.model.query.KapuaQuery;
 
+/**
+ * {@link KapuaEntityFactory} definition
+ *
+ * @param <E> The {@link KapuaEntity} for which this {@link KapuaEntityFactory} is for.
+ * @param <C> The {@link KapuaEntityCreator} for which this {@link KapuaEntityFactory} is for.
+ * @param <Q> The {@link KapuaQuery} for which this {@link KapuaEntityFactory} is for.
+ * @param <L> The {@link KapuaListResult} for which this {@link KapuaEntityFactory} is for.
+ * @since 1.0.0
+ */
 public interface KapuaEntityFactory<E extends KapuaEntity, C extends KapuaEntityCreator<E>, Q extends KapuaQuery<E>, L extends KapuaListResult<E>> extends KapuaObjectFactory {
 
     E newEntity(KapuaId scopeId);

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,25 +15,69 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * Kapua named entity definition.
+ * {@link KapuaNamedEntity} definition.
+ * <p>
+ * The {@link KapuaNamedEntity} adds on top of the {@link KapuaUpdatableEntity} the following properties:
  *
- * @since 1.0
+ * <ul>
+ * <li>name</li>
+ * <li>description</li>
+ * </ul>
+ *
+ * </p>
+ *
+ * <div>
+ *
+ * <p>
+ * <b>Name</b>
+ * </p>
+ * <p>
+ * The <i>Name</i> property is the unique name of the {@link KapuaEntity} in the scope.
+ * </p>
+ *
+ * <p>
+ * <b>Description</b>
+ * </p>
+ * <p>
+ * The <i>Description</i> property is the optional description of the {@link KapuaEntity}.
+ * </p>
+ * </div>
+ *
+ * @since 1.0.0
  */
-@XmlType(propOrder = { "name" })
+@XmlType(propOrder = {"name", "description"})
 public interface KapuaNamedEntity extends KapuaUpdatableEntity {
 
     /**
-     * Get the entity name
+     * Gets the name of the {@link KapuaEntity}
      *
-     * @return
+     * @return the name of the {@link KapuaEntity}
+     * @since 1.0.0
      */
     @XmlElement(name = "name")
     String getName();
 
     /**
-     * Set the entity name
+     * Sets the name of the {@link KapuaEntity}
      *
-     * @param name
+     * @param name the name of the {@link KapuaEntity}
+     * @since 1.0.0
      */
     void setName(String name);
+
+    /**
+     * Gets the description for the {@link KapuaEntity}
+     *
+     * @return the description of this {@link KapuaEntity}
+     * @since 1.1.0
+     */
+    String getDescription();
+
+    /**
+     * Sets the description for the {@link KapuaEntity}
+     *
+     * @param description the description for the {@link KapuaEntity}
+     * @since 1.1.0
+     */
+    void setDescription(String description);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityAttributes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.model;
 
+/**
+ * {@link KapuaNamedEntityAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
+ */
 public class KapuaNamedEntityAttributes extends KapuaUpdatableEntityAttributes {
 
     public static final String NAME = "name";
+
+    public static final String DESCRIPTION = "description";
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,26 +15,69 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * Kapua named entity creator service definition.
+ * {@link KapuaNamedEntityCreator} definition.
+ * <p>
+ * The {@link KapuaNamedEntityCreator} adds on top of the {@link KapuaUpdatableEntityCreator} the following properties:
+ * <ul>
+ * <li>name</li>
+ * <li>description</li>
+ * </ul>
  *
- * @param <E> entity type
- * @since 1.0
+ * </p>
+ *
+ * <div>
+ *
+ * <p>
+ * <b>Name</b>
+ * </p>
+ * <p>
+ * The <i>Name</i> property is the unique name of the {@link KapuaEntity} in the scope.
+ * </p>
+ *
+ * <p>
+ * <b>Description</b>
+ * </p>
+ * <p>
+ * The <i>Description</i> property is the optional description of the {@link KapuaEntity}.
+ * </p>
+ * </div>
+ *
+ * @param <E> {@link KapuaEntity} which this {@link KapuaEntityCreator} is for
+ * @since 1.0.0
  */
-@XmlType(propOrder = { "name" })
+@XmlType(propOrder = {"name", "description"})
 public interface KapuaNamedEntityCreator<E extends KapuaEntity> extends KapuaUpdatableEntityCreator<E> {
 
     /**
-     * Get the entity name
+     * Gets the name
      *
-     * @return
+     * @return the name
+     * @since 1.0.0
      */
     @XmlElement(name = "name")
     String getName();
 
     /**
-     * Set the entity name
+     * Sets the name
      *
-     * @param name
+     * @param name the name
+     * @since 1.0.0
      */
     void setName(String name);
+
+    /**
+     * Gets the description
+     *
+     * @return the description
+     * @since 1.0.0
+     */
+    String getDescription();
+
+    /**
+     * Sets the description
+     *
+     * @param description the description
+     * @since 1.0.0
+     */
+    void setDescription(String description);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,30 +25,32 @@ import java.util.Date;
 import java.util.Properties;
 
 /**
- * Kapua updatable entity definition.
+ * {@link KapuaUpdatableEntity} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
-@XmlType(propOrder = { //
-        "modifiedOn", //
-        "modifiedBy", //
-        "optlock" //
+@XmlType(propOrder = {
+        "modifiedOn",
+        "modifiedBy",
+        "optlock"
 })
 public interface KapuaUpdatableEntity extends KapuaEntity {
 
     /**
-     * Get modified on date
+     * Gets the last date that this {@link KapuaEntity} has been updated.
      *
-     * @return
+     * @return the last date that this {@link KapuaEntity} has been updated.
+     * @since 1.0.0
      */
     @XmlElement(name = "modifiedOn")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
     Date getModifiedOn();
 
     /**
-     * Get modified by kapua identifier
+     * Get the last identity {@link KapuaId} that has updated this {@link KapuaEntity}
      *
-     * @return
+     * @return the last identity {@link KapuaId} that has updated this {@link KapuaEntity}
+     * @since 1.0.0
      */
     @XmlElement(name = "modifiedBy")
     @XmlJavaTypeAdapter(KapuaIdAdapter.class)
@@ -56,24 +58,26 @@ public interface KapuaUpdatableEntity extends KapuaEntity {
     KapuaId getModifiedBy();
 
     /**
-     * Get optlock
+     * Gets the optlock
      *
-     * @return
+     * @return the optlock
+     * @since 1.0.0
      */
     @XmlElement(name = "optlock")
     int getOptlock();
 
     /**
-     * Set optlock
+     * Sets the optlock
      *
-     * @param optlock
+     * @param optlock the optlock
+     * @since 1.0.0
      */
     void setOptlock(int optlock);
 
     /**
-     * Get entity attributes
+     * Gets the attributes
      *
-     * @return
+     * @return the attributes
      * @throws KapuaException
      */
     @XmlTransient
@@ -81,29 +85,32 @@ public interface KapuaUpdatableEntity extends KapuaEntity {
             throws KapuaException;
 
     /**
-     * Set entity attributes
+     * Sets the attributes
      *
-     * @param props
+     * @param props the attributes
      * @throws KapuaException
+     * @since 1.0.0
      */
     void setEntityAttributes(Properties props)
             throws KapuaException;
 
     /**
-     * Get the property entities
+     * Gets the property entities
      *
-     * @return
+     * @return the property entities
      * @throws KapuaException
+     * @since 1.0.0
      */
     @XmlTransient
     Properties getEntityProperties()
             throws KapuaException;
 
     /**
-     * Set the property entities
+     * Sets the property entities
      *
-     * @param props
+     * @param props the property entities
      * @throws KapuaException
+     * @since 1.0.0
      */
     void setEntityProperties(Properties props)
             throws KapuaException;

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityAttributes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityAttributes.java
@@ -12,8 +12,9 @@
 package org.eclipse.kapua.model;
 
 /**
- * {@link KapuaUpdatableEntity} query predicates.
+ * {@link KapuaUpdatableEntity} attributes.
  *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
  * @since 1.0.0
  */
 public class KapuaUpdatableEntityAttributes extends KapuaEntityAttributes {

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,18 +13,19 @@ package org.eclipse.kapua.model;
 
 import org.eclipse.kapua.KapuaException;
 
+import javax.xml.bind.annotation.XmlTransient;
 import java.util.Properties;
 
 /**
- * Kapua updateable entity creator service definition.
+ * {@link KapuaUpdatableEntityCreator} definition.
  *
  * @param <E> entity type
- * @since 1.0
+ * @since 1.0.0
  */
 public interface KapuaUpdatableEntityCreator<E extends KapuaEntity> extends KapuaEntityCreator<E> {
 
+    @XmlTransient
     Properties getEntityAttributes() throws KapuaException;
 
     void setEntityAttributes(Properties entityAttributes) throws KapuaException;
-
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/Job.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/Job.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,7 +21,7 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
- * {@link Job} entity.
+ * {@link Job} {@link org.eclipse.kapua.model.KapuaEntity} definition.
  *
  * @since 1.0.0
  */
@@ -36,10 +36,6 @@ public interface Job extends KapuaNamedEntity {
     default String getType() {
         return TYPE;
     }
-
-    String getDescription();
-
-    void setDescription(String description);
 
     List<JobStep> getJobSteps();
 

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobAttributes.java
@@ -13,9 +13,14 @@ package org.eclipse.kapua.service.job;
 
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
+/**
+ * {@link JobAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
+ */
 public class JobAttributes extends KapuaNamedEntityAttributes {
 
     public static final String ENDED_ON = "endedOn";
     public static final String STARTED_ON = "startedOn";
-    public static final String DESCRIPTION = "description";
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,4 +17,5 @@ public class JobAttributes extends KapuaNamedEntityAttributes {
 
     public static final String ENDED_ON = "endedOn";
     public static final String STARTED_ON = "startedOn";
+    public static final String DESCRIPTION = "description";
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,8 +21,7 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
- * {@link JobCreator} encapsulates all the information needed to create a new JobStepDefinition in the system.<br>
- * The data provided will be used to seed the new JobStepDefinition.
+ * {@link JobCreator} {@link org.eclipse.kapua.model.KapuaEntityCreator} definition.
  *
  * @since 1.0.0
  */
@@ -30,10 +29,6 @@ import java.util.List;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobXmlRegistry.class, factoryMethod = "newJobCreator")
 public interface JobCreator extends KapuaNamedEntityCreator<Job> {
-
-    String getDescription();
-
-    void setDescription(String description);
 
     List<JobStep> getJobSteps();
 

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStep.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStep.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,9 +22,9 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
- * {@link JobStep} entity.
+ * {@link JobStep} {@link org.eclipse.kapua.model.KapuaEntity} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "jobStep")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -37,10 +37,6 @@ public interface JobStep extends KapuaNamedEntity {
     default String getType() {
         return TYPE;
     }
-
-    String getDescription();
-
-    void setDescription(String description);
 
     KapuaId getJobId();
 

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,11 +13,16 @@ package org.eclipse.kapua.service.job.step;
 
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
+/**
+ * {@link JobStepAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
+ */
 public class JobStepAttributes extends KapuaNamedEntityAttributes {
 
     public static final String JOB_ID = "jobId";
     public static final String STEP_INDEX = "stepIndex";
     public static final String JOB_STEP_DEFINITION_ID = "jobStepDefinitionId";
-    public static final String JOB_STEP_NAME = "name";
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,8 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
- * {@link JobStepCreator} encapsulates all the information needed to create a new JobStep in the system.<br>
- * The data provided will be used to seed the new JobStep.
+ * {@link JobStepCreator} {@link org.eclipse.kapua.model.KapuaEntityCreator} definition
  *
  * @since 1.0.0
  */
@@ -31,10 +30,6 @@ import java.util.List;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobStepXmlRegistry.class, factoryMethod = "newJobStepCreator")
 public interface JobStepCreator extends KapuaNamedEntityCreator<JobStep> {
-
-    String getDescription();
-
-    void setDescription(String description);
 
     KapuaId getJobId();
 

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinition.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,9 +20,9 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
- * {@link JobStepDefinition} entity.
+ * {@link JobStepDefinition} {@link org.eclipse.kapua.model.KapuaEntity} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "jobStepDefinition")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -35,10 +35,6 @@ public interface JobStepDefinition extends KapuaNamedEntity {
     default String getType() {
         return TYPE;
     }
-
-    String getDescription();
-
-    void setDescription(String description);
 
     JobStepType getStepType();
 

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,11 @@ package org.eclipse.kapua.service.job.step.definition;
 
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
+/**
+ * {@link JobStepDefinitionAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
+ */
 public class JobStepDefinitionAttributes extends KapuaNamedEntityAttributes {
-
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,8 +20,7 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
- * {@link JobStepDefinitionCreator} encapsulates all the information needed to create a new JobStepDefinition in the system.<br>
- * The data provided will be used to seed the new JobStepDefinition.
+ * {@link JobStepDefinitionCreator} {@link org.eclipse.kapua.model.KapuaEntityCreator} definition
  *
  * @since 1.0.0
  */
@@ -29,10 +28,6 @@ import java.util.List;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobStepDefinitionXmlRegistry.class, factoryMethod = "newJobStepDefinitionCreator")
 public interface JobStepDefinitionCreator extends KapuaNamedEntityCreator<JobStepDefinition> {
-
-    String getDescription();
-
-    void setDescription(String description);
 
     JobStepType getStepType();
 

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,45 +11,31 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.internal;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.Job;
 import org.eclipse.kapua.service.job.JobCreator;
 import org.eclipse.kapua.service.job.step.JobStep;
-import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionCreator;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * {@link JobStepDefinitionCreator} encapsulates all the information needed to create a new JobStepDefinition in the system.<br>
- * The data provided will be used to seed the new JobStepDefinition.
- * 
- * @since 1.0.0
+ * {@link JobCreator} implementation
  *
+ * @since 1.0.0
  */
 @KapuaProvider
 public class JobCreatorImpl extends AbstractKapuaNamedEntityCreator<Job> implements JobCreator {
 
     private static final long serialVersionUID = 3119071638220738358L;
 
-    private String description;
     private List<JobStep> jobSteps;
     private String jobXmlDefinition;
 
     public JobCreatorImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
     }
 
     @Override

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,36 +11,29 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.internal;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.step.JobStep;
 
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-
-import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.job.Job;
-import org.eclipse.kapua.service.job.step.JobStep;
-import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * {@link JobStepDefinition} entity.
- * 
- * @since 1.0
+ * {@link Job} {@link org.eclipse.kapua.model.KapuaEntity} definition.
  *
+ * @since 1.0.0
  */
 @Entity(name = "Job")
 @Table(name = "job_job")
 public class JobImpl extends AbstractKapuaNamedEntity implements Job {
 
     private static final long serialVersionUID = -5686107367635300337L;
-
-    @Basic
-    @Column(name = "description", nullable = true, updatable = true)
-    private String description;
 
     @Transient
     private List<JobStep> jobSteps;
@@ -57,15 +50,6 @@ public class JobImpl extends AbstractKapuaNamedEntity implements Job {
     }
 
     @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
     public List<JobStep> getJobSteps() {
         if (jobSteps == null) {
             jobSteps = new ArrayList<>();
@@ -79,10 +63,12 @@ public class JobImpl extends AbstractKapuaNamedEntity implements Job {
         this.jobSteps = jobSteps;
     }
 
+    @Override
     public String getJobXmlDefinition() {
         return jobXmlDefinition;
     }
 
+    @Override
     public void setJobXmlDefinition(String jobXmlDefinition) {
         this.jobXmlDefinition = jobXmlDefinition;
     }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,9 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition.internal;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
@@ -21,18 +18,18 @@ import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionCreator;
 import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 import org.eclipse.kapua.service.job.step.definition.JobStepType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * {@link JobStepDefinitionCreator} encapsulates all the information needed to create a new JobStepDefinition in the system.<br>
- * The data provided will be used to seed the new JobStepDefinition.
- * 
- * @since 1.0.0
+ * {@link JobStepDefinitionCreator} implementation
  *
+ * @since 1.0.0
  */
 public class JobStepDefinitionCreatorImpl extends AbstractKapuaNamedEntityCreator<JobStepDefinition> implements JobStepDefinitionCreator {
 
     private static final long serialVersionUID = 4602067255120049746L;
 
-    private String description;
     private JobStepType jobStepType;
     private String readerName;
     private String processorName;
@@ -41,16 +38,6 @@ public class JobStepDefinitionCreatorImpl extends AbstractKapuaNamedEntityCreato
 
     public JobStepDefinitionCreatorImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
     }
 
     @Override

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,8 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition.internal;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
+import org.eclipse.kapua.service.job.step.definition.JobStepType;
 
 import javax.persistence.Basic;
 import javax.persistence.CollectionTable;
@@ -23,28 +26,19 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
-
-import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
-import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
-import org.eclipse.kapua.service.job.step.definition.JobStepType;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * {@link JobStepDefinition} entity.
- * 
- * @since 1.0
+ * {@link JobStepDefinition} implementation.
  *
+ * @since 1.0.0
  */
 @Entity(name = "JobStepDefinition")
 @Table(name = "job_job_step_definition")
 public class JobStepDefinitionImpl extends AbstractKapuaNamedEntity implements JobStepDefinition {
 
     private static final long serialVersionUID = 3747451706859757246L;
-
-    @Basic
-    @Column(name = "description", nullable = true, updatable = true)
-    private String description;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "job_step_type", nullable = false, updatable = false)
@@ -71,16 +65,6 @@ public class JobStepDefinitionImpl extends AbstractKapuaNamedEntity implements J
 
     public JobStepDefinitionImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
     }
 
     @Override
@@ -125,7 +109,6 @@ public class JobStepDefinitionImpl extends AbstractKapuaNamedEntity implements J
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public List<JobStepPropertyImpl> getStepProperties() {
         if (jobStepProperties == null) {
             jobStepProperties = new ArrayList<>();
@@ -143,5 +126,4 @@ public class JobStepDefinitionImpl extends AbstractKapuaNamedEntity implements J
         }
 
     }
-
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepCreatorImpl.java
@@ -16,15 +16,13 @@ import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.step.JobStep;
 import org.eclipse.kapua.service.job.step.JobStepCreator;
-import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionCreator;
 import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * {@link JobStepDefinitionCreator} encapsulates all the information needed to create a new JobStepDefinition in the system.<br>
- * The data provided will be used to seed the new JobStepDefinition.
+ * {@link JobStepCreator} implementation
  *
  * @since 1.0.0
  */
@@ -33,24 +31,13 @@ public class JobStepCreatorImpl extends AbstractKapuaNamedEntityCreator<JobStep>
 
     private static final long serialVersionUID = 3119071638220738358L;
 
-    public JobStepCreatorImpl(KapuaId scopeId) {
-        super(scopeId);
-    }
-
-    private String description;
     private KapuaId jobId;
     private Integer stepIndex;
     private KapuaId jobStepDefinitionId;
     private List<JobStepProperty> jobStepProperty;
 
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
+    public JobStepCreatorImpl(KapuaId scopeId) {
+        super(scopeId);
     }
 
     @Override

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,8 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.internal;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.step.JobStep;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
+import org.eclipse.kapua.service.job.step.definition.internal.JobStepPropertyImpl;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
@@ -24,30 +28,19 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.Table;
-
-import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
-import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.job.step.JobStep;
-import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
-import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
-import org.eclipse.kapua.service.job.step.definition.internal.JobStepPropertyImpl;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * {@link JobStepDefinition} entity.
- * 
- * @since 1.0
+ * {@link JobStep} implementation.
  *
+ * @since 1.0.0
  */
 @Entity(name = "JobStep")
 @Table(name = "job_job_step")
 public class JobStepImpl extends AbstractKapuaNamedEntity implements JobStep {
 
     private static final long serialVersionUID = -5686107367635300337L;
-
-    @Basic
-    @Column(name = "description", nullable = true, updatable = true)
-    private String description;
 
     @Embedded
     @AttributeOverrides({
@@ -74,16 +67,6 @@ public class JobStepImpl extends AbstractKapuaNamedEntity implements JobStep {
 
     public JobStepImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public String getDescription() {
-        return description;
-    }
-
-    @Override
-    public void setDescription(String description) {
-        this.description = description;
     }
 
     @Override
@@ -117,7 +100,6 @@ public class JobStepImpl extends AbstractKapuaNamedEntity implements JobStep {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public List<JobStepPropertyImpl> getStepProperties() {
         if (stepProperties == null) {
             stepProperties = new ArrayList<>();
@@ -135,5 +117,4 @@ public class JobStepImpl extends AbstractKapuaNamedEntity implements JobStep {
             this.stepProperties.add(JobStepPropertyImpl.parse(sp));
         }
     }
-
 }

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/Trigger.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/Trigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,16 +21,16 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * User schedule entity.
+ * {@link Trigger} {@link org.eclipse.kapua.model.KapuaEntity} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "schedule")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = TriggerXmlRegistry.class, factoryMethod = "newTrigger")
 public interface Trigger extends KapuaNamedEntity {
 
-    String TYPE = "schedule";
+    String TYPE = "trigger";
 
     @Override
     default String getType() {

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerAttributes.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,12 @@ package org.eclipse.kapua.service.scheduler.trigger;
 
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
+/**
+ * {@link TriggerAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
+ */
 public class TriggerAttributes extends KapuaNamedEntityAttributes {
 
     public static final String TRIGGER_PROPERTIES = "triggerProperties";
@@ -22,8 +28,6 @@ public class TriggerAttributes extends KapuaNamedEntityAttributes {
     public static final String TRIGGER_PROPERTIES_VALUE = TRIGGER_PROPERTIES + ".propertyValue";
 
     public static final String TRIGGER_PROPERTIES_TYPE = TRIGGER_PROPERTIES + ".propertyType";
-
-    public static final String TRIGGER_NAME = "name";
 
     public static final String STARTS_ON = "startsOn";
 

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerCreator.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,12 +21,11 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * TriggerCreator encapsulates all the information needed to create a new Trigger in the system.<br>
- * The data provided will be used to seed the new Trigger and its related information such as the associated organization and users.
+ * {@link TriggerCreator} {@link org.eclipse.kapua.model.KapuaEntityCreator} definition
  *
- * @since 1.0
+ * @since 1.0.0
  */
-@XmlRootElement(name = "accountCreator")
+@XmlRootElement(name = "triggerCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = TriggerXmlRegistry.class, factoryMethod = "newTriggerCreator")
 public interface TriggerCreator extends KapuaNamedEntityCreator<Trigger> {

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerCreatorImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,21 +11,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.quartz;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.scheduler.trigger.Trigger;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerCreator;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerProperty;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 /**
- * Trigger creator service implementation.
- * 
- * @since 1.0
- * 
+ * {@link TriggerCreator} implementation.
+ *
+ * @since 1.0.0
  */
 public class TriggerCreatorImpl extends AbstractKapuaNamedEntityCreator<Trigger> implements TriggerCreator {
 
@@ -39,43 +38,50 @@ public class TriggerCreatorImpl extends AbstractKapuaNamedEntityCreator<Trigger>
 
     /**
      * Constructor
-     * 
+     *
      * @param scopeId
-     * @param name
-     *            trigger name
+     * @param name    trigger name
      */
     public TriggerCreatorImpl(KapuaId scopeId, String name) {
         super(scopeId, name);
     }
 
+    @Override
     public Date getStartsOn() {
         return startsOn;
     }
 
+    @Override
     public void setStartsOn(Date startsOn) {
         this.startsOn = startsOn;
     }
 
+    @Override
     public Date getEndsOn() {
         return endsOn;
     }
 
+    @Override
     public void setEndsOn(Date endsOn) {
         this.endsOn = endsOn;
     }
 
+    @Override
     public String getCronScheduling() {
         return cronScheduling;
     }
 
+    @Override
     public void setCronScheduling(String cronScheduling) {
         this.cronScheduling = cronScheduling;
     }
 
+    @Override
     public Long getRetryInterval() {
         return retryInterval;
     }
 
+    @Override
     public void setRetryInterval(Long retryInterval) {
         this.retryInterval = retryInterval;
     }

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerImpl.java
@@ -11,9 +11,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.quartz;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.scheduler.trigger.Trigger;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerProperty;
 
 import javax.persistence.Basic;
 import javax.persistence.CollectionTable;
@@ -24,16 +25,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-
-import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.scheduler.trigger.Trigger;
-import org.eclipse.kapua.service.scheduler.trigger.TriggerProperty;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
- * Trigger entity implementation.
+ * {@link Trigger} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @Entity(name = "Trigger")
 @Table(name = "schdl_trigger")
@@ -77,40 +76,47 @@ public class TriggerImpl extends AbstractKapuaNamedEntity implements Trigger {
         super(scopeId);
     }
 
+    @Override
     public Date getStartsOn() {
         return startsOn;
     }
 
+    @Override
     public void setStartsOn(Date startsOn) {
         this.startsOn = startsOn;
     }
 
+    @Override
     public Date getEndsOn() {
         return endsOn;
     }
 
+    @Override
     public void setEndsOn(Date endsOn) {
         this.endsOn = endsOn;
     }
 
+    @Override
     public String getCronScheduling() {
         return cronScheduling;
     }
 
+    @Override
     public void setCronScheduling(String cronScheduling) {
         this.cronScheduling = cronScheduling;
     }
 
+    @Override
     public Long getRetryInterval() {
         return retryInterval;
     }
 
+    @Override
     public void setRetryInterval(Long retryInterval) {
         this.retryInterval = retryInterval;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public List<TriggerPropertyImpl> getTriggerProperties() {
         if (triggerProperties == null) {
             triggerProperties = new ArrayList<>();

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerPropertyImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerPropertyImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.quartz;
 
+import org.eclipse.kapua.service.scheduler.trigger.TriggerProperty;
+
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-
-import org.eclipse.kapua.service.scheduler.trigger.TriggerProperty;
 
 @Embeddable
 public class TriggerPropertyImpl implements TriggerProperty {
@@ -47,26 +47,32 @@ public class TriggerPropertyImpl implements TriggerProperty {
         setPropertyValue(propertyValue);
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public String getPropertyType() {
         return propertyType;
     }
 
+    @Override
     public void setPropertyType(String propertyType) {
         this.propertyType = propertyType;
     }
 
+    @Override
     public String getPropertyValue() {
         return propertyValue;
     }
 
+    @Override
     public void setPropertyValue(String propertyValue) {
         this.propertyValue = propertyValue;
     }

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/changelog-scheduler-1.1.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/changelog-scheduler-1.1.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-scheduler-1.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="./trigger-description.xml"/>
+
+</databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger-description.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger-description.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-scheduler-1.1.0.xml">
+
+    <changeSet id="changelog-trigger-description-1.1.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <tableExists tableName="schdl_trigger"/>
+        </preConditions>
+
+        <addColumn tableName="schdl_trigger">
+            <column name="description" type="text"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.xml
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-scheduler-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-scheduler-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.1.0/changelog-scheduler-1.1.0.xml"/>
 
 </databaseChangeLog>

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,18 +27,18 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.Set;
 
 /**
- * {@link Domain} entity definition.<br>
- * {@link Domain} contains the information about the available {@link Actions} for a entity {@link Domain}<br>
+ * {@link Domain} {@link KapuaEntity} definition
+ * <p>
+ * {@link Domain} contains the information about the available {@link Actions} for a {@link KapuaEntity} {@link Domain}<br>
  * Services needs to register their own specific {@link Domain}.
- * {@link Domain#getName()} must be unique.
  *
  * @since 1.0.0
  */
 @XmlRootElement(name = "domain")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name",
+@XmlType(propOrder = {"name",
         "actions",
-        "groupable" })
+        "groupable"})
 public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.Domain {
 
     String TYPE = "domain";

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,21 +21,21 @@ import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Set;
 
 /**
- * {@link Domain} creator definition.<br>
+ * {@link DomainCreator} definition.<br>
+ * <p>
  * It is used to create a new {@link Domain} with {@link Actions} associated
  *
  * @since 1.0.0
  */
 @XmlRootElement(name = "domainCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-//public interface DomainCreator extends KapuaEntityCreator<Domain>, org.eclipse.kapua.model.domain.Domain {
-public interface DomainCreator extends KapuaEntityCreator<Domain> {
+public interface DomainCreator extends KapuaEntityCreator<Domain> { // org.eclipse.kapua.model.domain.Domain {
 
-    public String getName();
+    String getName();
 
-    public Set<Actions> getActions();
+    Set<Actions> getActions();
 
-    public boolean getGroupable();
+    boolean getGroupable();
 
     /**
      * Sets the {@link Domain} name.

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Group.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Group.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,7 @@
 package org.eclipse.kapua.service.authorization.group;
 
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.KapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdFactory;
 import org.eclipse.kapua.service.authorization.access.AccessPermission;
@@ -20,25 +20,23 @@ import org.eclipse.kapua.service.authorization.role.RolePermission;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import java.math.BigInteger;
 
 /**
- * Group entity definition.<br>
- * Groups serve as tag for entities marked as {@link Groupable}.
- * It is possible to assign a group to an entity.
+ * {@link Group} {@link org.eclipse.kapua.model.KapuaEntity} definition.<br>
+ * {@link Group}s serve as tag for entities marked as {@link Groupable}.
+ * It is possible to assign a {@link Group} to a {@link org.eclipse.kapua.model.KapuaEntity}.
  * It is possible to assign {@link AccessPermission} and {@link RolePermission} based on the {@link Group#getId()}.
- * {@link Group#getName()} must be unique within the scope.
  *
  * @since 1.0.0
  */
 @XmlRootElement(name = "group")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = GroupXmlRegistry.class, factoryMethod = "newGroup")
-public interface Group extends KapuaUpdatableEntity {
+public interface Group extends KapuaNamedEntity {
 
     @XmlTransient
     KapuaId ANY = KapuaLocator.getInstance().getFactory(KapuaIdFactory.class).newKapuaId(BigInteger.ONE.negate());
@@ -49,23 +47,4 @@ public interface Group extends KapuaUpdatableEntity {
     default String getType() {
         return TYPE;
     }
-
-    /**
-     * Sets the {@link Group} name.<br>
-     * It must be unique within the scope.
-     *
-     * @param name The name of the {@link Group}
-     * @since 1.0.0
-     */
-    void setName(String name);
-
-    /**
-     * Gets the {@link Group} name.
-     *
-     * @return The {@link Group} name.
-     * @since 1.0.0
-     */
-    @XmlElement(name = "name")
-    String getName();
-
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupAttributes.java
@@ -12,14 +12,12 @@
 package org.eclipse.kapua.service.authorization.group;
 
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
-import org.eclipse.kapua.model.query.KapuaQuery;
-import org.eclipse.kapua.model.query.predicate.QueryPredicate;
 
 /**
- * {@link KapuaQuery} {@link QueryPredicate} name for {@link Group} entity.
+ * {@link GroupAttributes} attributes.
  *
- * @since 1.0
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
  */
 public class GroupAttributes extends KapuaNamedEntityAttributes {
-    public static final String DESCRIPTION = "description";
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,5 +21,5 @@ import org.eclipse.kapua.model.query.predicate.QueryPredicate;
  * @since 1.0
  */
 public class GroupAttributes extends KapuaNamedEntityAttributes {
-
+    public static final String DESCRIPTION = "description";
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,41 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group;
 
-import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link Group} creator definition.<br>
+ * {@link GroupCreator} definition.
+ * <p>
  * It is used to create a new {@link Group}.
  *
  * @since 1.0.0
  */
 @XmlRootElement(name = "groupCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name" }, //
-        factoryClass = GroupXmlRegistry.class, //
-        factoryMethod = "newGroupCreator")
-public interface GroupCreator extends KapuaEntityCreator<Group> {
-
-    /**
-     * Sets the {@link Group} name.
-     *
-     * @param name The {@link Group} name.
-     * @since 1.0.0
-     */
-    void setName(String name);
-
-    /**
-     * Gets the {@link Group} name.
-     *
-     * @return The {@link Group} name.
-     * @since 1.0.0
-     */
-    @XmlElement(name = "name")
-    String getName();
+@XmlType(factoryClass = GroupXmlRegistry.class, factoryMethod = "newGroupCreator")
+public interface GroupCreator extends KapuaNamedEntityCreator<Group> {
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/Role.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/Role.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,27 +11,25 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.KapuaNamedEntity;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * Role entity definition.<br>
- * Role is a collection of {@link RolePermission}s that can be assigned to one or more {@link org.eclipse.kapua.service.user.User}s (using {@link AccessInfo}).<br>
- * {@link Role#getName()} must be unique within the scope.
+ * {@link Role} {@link org.eclipse.kapua.model.KapuaEntity} definition.
+ * <p>
+ * {@link Role} is a collection of {@link RolePermission}s that can be assigned to one or more {@link org.eclipse.kapua.service.user.User}s (using {@link AccessInfo}).
  *
  * @since 1.0.0
  */
 @XmlRootElement(name = "role")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name" }, //
-        factoryClass = RoleXmlRegistry.class, factoryMethod = "newRole")
-public interface Role extends KapuaUpdatableEntity {
+@XmlType(factoryClass = RoleXmlRegistry.class, factoryMethod = "newRole")
+public interface Role extends KapuaNamedEntity {
 
     String TYPE = "role";
 
@@ -39,22 +37,4 @@ public interface Role extends KapuaUpdatableEntity {
     default String getType() {
         return TYPE;
     }
-
-    /**
-     * Sets the {@link Role} name.<br>
-     * It must be unique within the scope.
-     *
-     * @param name The name of the {@link Role}
-     * @since 1.0.0
-     */
-    void setName(String name);
-
-    /**
-     * Gets the {@link Role} name.
-     *
-     * @return The {@link Role} name.
-     * @since 1.0.0
-     */
-    @XmlElement(name = "name")
-    String getName();
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleAttributes.java
@@ -14,11 +14,10 @@ package org.eclipse.kapua.service.authorization.role;
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
 /**
- * Query predicate attribute name for role entity.
- * 
- * @since 1.0
- * 
+ * {@link RoleAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
  */
 public class RoleAttributes extends KapuaNamedEntityAttributes {
-    public static final String DESCRIPTION = "description";
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,5 +20,5 @@ import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
  * 
  */
 public class RoleAttributes extends KapuaNamedEntityAttributes {
-
+    public static final String DESCRIPTION = "description";
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
-import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -24,36 +24,16 @@ import java.security.Permissions;
 import java.util.Set;
 
 /**
- * {@link Role} creator definition.<br>
+ * {@link RoleCreator} definition.
+ * <p>
  * It is used to create a new {@link Role} with {@link Permission}s associated
  *
  * @since 1.0.0
  */
 @XmlRootElement(name = "roleCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name",
-        "permissions"
-},
-        factoryClass = RoleXmlRegistry.class,
-        factoryMethod = "newRoleCreator")
-public interface RoleCreator extends KapuaEntityCreator<Role> {
-
-    /**
-     * Sets the {@link Role} name.
-     *
-     * @param name The {@link Role} name.
-     * @since 1.0.0
-     */
-    void setName(String name);
-
-    /**
-     * Gets the {@link Role} name.
-     *
-     * @return The {@link Role} name.
-     * @since 1.0.0
-     */
-    @XmlElement(name = "name")
-    String getName();
+@XmlType(factoryClass = RoleXmlRegistry.class, factoryMethod = "newRoleCreator")
+public interface RoleCreator extends KapuaNamedEntityCreator<Role> {
 
     /**
      * Sets the set of {@link Permissions} to assign to the {@link Role} created entity.

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,6 +30,11 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 import java.util.Set;
 
+/**
+ * {@link Certificate} {@link org.eclipse.kapua.model.KapuaEntity} definition
+ *
+ * @since 1.0.0
+ */
 @XmlRootElement(name = "certificate")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = CertificateXmlRegistry.class, factoryMethod = "newCertificate")

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateAttributes.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,12 @@ package org.eclipse.kapua.service.certificate;
 
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
+/**
+ * {@link CertificateAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
+ */
 public class CertificateAttributes extends KapuaNamedEntityAttributes {
 
     public static final String CA_ID = "caId";

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,9 +27,9 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Set;
 
 /**
- * CertificateCreator encapsulates all the information needed to create a new Certificate in the system.
+ * {@link CertificateCreator} {@link org.eclipse.kapua.model.KapuaEntityCreator} definition
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "certificateCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.internal;
 
-import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.certificate.Certificate;
 import org.eclipse.kapua.service.certificate.CertificateStatus;
@@ -22,7 +22,12 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
-public class CertificateImpl extends AbstractKapuaUpdatableEntity implements Certificate {
+/**
+ * {@link Certificate} implementation
+ *
+ * @since 1.0.0
+ */
+public class CertificateImpl extends AbstractKapuaNamedEntity implements Certificate {
 
     private String certificate;
     private String privateKey;
@@ -32,16 +37,6 @@ public class CertificateImpl extends AbstractKapuaUpdatableEntity implements Cer
 
     public CertificateImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public String getName() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setName(String name) {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -46,12 +46,11 @@ import org.eclipse.kapua.service.certificate.util.CertificateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.xml.namespace.QName;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.xml.namespace.QName;
 
 @KapuaProvider
 public class CertificateServiceImpl implements CertificateService {
@@ -182,28 +181,43 @@ public class CertificateServiceImpl implements CertificateService {
 
         private static final EmptyTocd INSTANCE = new EmptyTocd();
 
-        private EmptyTocd() {}
+        private EmptyTocd() {
+        }
 
         @Override
-        public void setOtherAttributes(Map<QName, String> otherAttributes) {}
+        public void setOtherAttributes(Map<QName, String> otherAttributes) {
+            // This is a Empty TOCD implementation
+        }
 
         @Override
-        public void setName(String value) {}
+        public void setName(String value) {
+            // This is a Empty TOCD implementation
+        }
 
         @Override
-        public void setId(String value) {}
+        public void setId(String value) {
+            // This is a Empty TOCD implementation
+        }
 
         @Override
-        public void setIcon(List<? extends KapuaTicon> icon) {}
+        public void setIcon(List<? extends KapuaTicon> icon) {
+            // This is a Empty TOCD implementation
+        }
 
         @Override
-        public void setDescription(String value) {}
+        public void setDescription(String value) {
+            // This is a Empty TOCD implementation
+        }
 
         @Override
-        public void setAny(List<Object> any) {}
+        public void setAny(List<Object> any) {
+            // This is a Empty TOCD implementation
+        }
 
         @Override
-        public void setAD(List<? extends KapuaTad> icon) {}
+        public void setAD(List<? extends KapuaTad> icon) {
+            // This is a Empty TOCD implementation
+        }
 
         @Override
         public Map<QName, String> getOtherAttributes() {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainAttributes.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,9 +14,10 @@ package org.eclipse.kapua.service.authorization.domain.shiro;
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
 /**
- * Query predicate attribute name for role entity.
+ * {@link DomainAttributes} attributes.
  *
- * @since 1.0
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
  */
 public class DomainAttributes extends KapuaNamedEntityAttributes {
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,23 +20,22 @@ import org.eclipse.kapua.service.authorization.domain.DomainCreator;
 import java.util.Set;
 
 /**
- * Role creator service implementation.
+ * {@link DomainCreator} implementation
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class DomainCreatorImpl extends AbstractKapuaEntityCreator<Domain> implements DomainCreator {
 
     private static final long serialVersionUID = -4676187845961673421L;
 
     private String name;
-    private String serviceName;
     private Set<Actions> actions;
     private boolean groupable;
 
     /**
      * Constructor
      *
-     * @param name        The name to set for this {@link DomainCreator}.
+     * @param name The name to set for this {@link DomainCreator}.
      * @since 1.0.0
      */
     public DomainCreatorImpl(String name) {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -31,7 +31,7 @@ import java.util.Set;
 /**
  * {@link Domain} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @Entity(name = "Domain")
 @Table(name = "athz_domain")
@@ -55,11 +55,19 @@ public class DomainImpl extends AbstractKapuaEntity implements Domain {
 
     /**
      * Constructor
+     *
+     * @since 1.0.0
      */
     public DomainImpl() {
         super();
     }
 
+    /**
+     * Constructor
+     *
+     * @param scopeId the scope KapuaId
+     * @since 1.0.0
+     */
     public DomainImpl(KapuaId scopeId) {
         super(scopeId);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group.shiro;
 
-import org.eclipse.kapua.commons.model.AbstractKapuaEntityCreator;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.domain.DomainCreator;
 import org.eclipse.kapua.service.authorization.group.Group;
@@ -19,23 +19,18 @@ import org.eclipse.kapua.service.authorization.group.GroupCreator;
 
 /**
  * {@link GroupCreator} implementation.
- * 
- * @since 1.0
- * 
+ *
+ * @since 1.0.0
  */
-public class GroupCreatorImpl extends AbstractKapuaEntityCreator<Group> implements GroupCreator {
+public class GroupCreatorImpl extends AbstractKapuaNamedEntityCreator<Group> implements GroupCreator {
 
     private static final long serialVersionUID = -4676187845961673421L;
 
-    private String name;
-
     /**
      * Constructor
-     * 
-     * @param scopeId
-     *            The scope id to set.
-     * @param name
-     *            The name to set for this {@link DomainCreator}.
+     *
+     * @param scopeId The scope id to set.
+     * @param name    The name to set for this {@link DomainCreator}.
      * @since 1.0.0
      */
     public GroupCreatorImpl(KapuaId scopeId, String name) {
@@ -45,15 +40,5 @@ public class GroupCreatorImpl extends AbstractKapuaEntityCreator<Group> implemen
 
     public GroupCreatorImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public String getName() {
-        return name;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -44,6 +44,7 @@ public class GroupDAO extends ServiceDAO {
             throws KapuaException {
         Group group = new GroupImpl(creator.getScopeId());
         group.setName(creator.getName());
+        group.setDescription(creator.getDescription());
 
         return ServiceDAO.create(em, group);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,64 +11,56 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group.shiro;
 
-import javax.persistence.Basic;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.group.Group;
 
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
 /**
  * {@link Group} implementation.
- * 
- * @since 1.0
+ *
+ * @since 1.0.0
  */
 @Entity(name = "Group")
 @Table(name = "athz_group")
-public class GroupImpl extends AbstractKapuaUpdatableEntity implements Group {
+public class GroupImpl extends AbstractKapuaNamedEntity implements Group {
 
     private static final long serialVersionUID = -3760818776351242930L;
 
-    @Basic
-    @Column(name = "name")
-    private String name;
-
-    protected GroupImpl() {
+    /**
+     * Constructor.
+     * <p>
+     * Required by JPA.
+     *
+     * @since 1.1.0
+     */
+    public GroupImpl() {
         super();
     }
 
     /**
-     * Constructor.<br>
-     * Creates a soft clone.
-     * 
-     * @param group
-     * @throws KapuaException
-     */
-    public GroupImpl(Group group) throws KapuaException {
-        super((AbstractKapuaUpdatableEntity) group);
-
-        setName(group.getName());
-    }
-
-    /**
-     * Constructor
-     * 
-     * @param scopeId
+     * Constructor.
+     *
+     * @param scopeId the scope {@link KapuaId}
+     * @since 1.0.0
      */
     public GroupImpl(KapuaId scopeId) {
         super(scopeId);
     }
 
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public String getName() {
-        return name;
+    /**
+     * Constructor.
+     * <p>
+     * It can be used to clone the {@link Group}.
+     *
+     * @param group the {@link Group} to clone.
+     * @throws KapuaException
+     * @since 1.0.0
+     */
+    public GroupImpl(Group group) throws KapuaException {
+        super(group);
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,45 +11,34 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role.shiro;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import org.eclipse.kapua.commons.model.AbstractKapuaEntityCreator;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.role.Role;
 import org.eclipse.kapua.service.authorization.role.RoleCreator;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
- * Role creator service implementation.
- * 
- * @since 1.0
- * 
+ * {@link RoleCreator} implementation.
+ *
+ * @since 1.0.0
  */
-public class RoleCreatorImpl extends AbstractKapuaEntityCreator<Role> implements RoleCreator {
+public class RoleCreatorImpl extends AbstractKapuaNamedEntityCreator<Role> implements RoleCreator {
 
     private static final long serialVersionUID = 972154225756734130L;
 
-    private String name;
     private Set<Permission> permissions;
 
     /**
-     * Costructor
-     * 
-     * @param scopeId
+     * Constructor
+     *
+     * @param scopeId The scope {@link KapuaId}
+     * @since 1.0.0
      */
     public RoleCreatorImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public String getName() {
-        return name;
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -42,6 +42,7 @@ public class RoleDAO extends ServiceDAO {
         Role role = new RoleImpl(creator.getScopeId());
 
         role.setName(creator.getName());
+        role.setDescription(creator.getDescription());
 
         return ServiceDAO.create(em, role);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,65 +11,49 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role.shiro;
 
-import javax.persistence.Basic;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.role.Role;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
 
 /**
  * {@link Role} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @Entity(name = "Role")
 @Table(name = "athz_role")
-public class RoleImpl extends AbstractKapuaUpdatableEntity implements Role {
+public class RoleImpl extends AbstractKapuaNamedEntity implements Role {
 
     private static final long serialVersionUID = -3760818776351242930L;
-
-    @Basic
-    @Column(name = "name")
-    private String name;
 
     protected RoleImpl() {
         super();
     }
 
     /**
-     * Constructor.<br>
-     * Creates a soft clone.
-     *
-     * @param role
-     * @throws KapuaException
-     */
-    public RoleImpl(Role role) throws KapuaException {
-        super(role);
-
-        setName(role.getName());
-    }
-
-    /**
      * Constructor
      *
-     * @param scopeId
+     * @param scopeId The scope {@link KapuaId}
+     * @since 1.0.0
      */
     public RoleImpl(KapuaId scopeId) {
         super(scopeId);
     }
 
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public String getName() {
-        return name;
+    /**
+     * Constructor.
+     * <p>
+     * Creates a soft clone.
+     *
+     * @param role The {@link Role} to clone
+     * @throws KapuaException
+     */
+    public RoleImpl(Role role) throws KapuaException {
+        super(role);
     }
 
     @Override
@@ -101,5 +85,4 @@ public class RoleImpl extends AbstractKapuaUpdatableEntity implements Role {
         }
         return true;
     }
-
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -72,7 +72,6 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         ArgumentValidator.notNull(roleCreator.getScopeId(), "roleCreator.scopeId");
         ArgumentValidator.notEmptyOrNull(roleCreator.getName(), "roleCreator.name");
         ArgumentValidator.notNull(roleCreator.getPermissions(), "roleCreator.permissions");
-
         //
         // Check Access
         AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(AuthorizationDomains.ROLE_DOMAIN, Actions.write, roleCreator.getScopeId()));

--- a/service/security/shiro/src/main/resources/liquibase/1.1.0/changelog-authorization-1.1.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.1.0/changelog-authorization-1.1.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authorization-1.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="./role-description.xml"/>
+    <include relativeToChangelogFile="true" file="./group-description.xml"/>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.1.0/group-description.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.1.0/group-description.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authorization-1.1.0.xml">
+
+    <changeSet id="changelog-group-description-1.1.0" author="eurotech">
+
+        <addColumn tableName="athz_group">
+            <column name="description" type="text"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.1.0/role-description.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.1.0/role-description.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authorization-1.1.0.xml">
+
+    <changeSet id="changelog-role-description-1.1.0" author="eurotech">
+
+        <addColumn tableName="athz_role">
+            <column name="description" type="text"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -18,5 +18,6 @@
     <include relativeToChangelogFile="true" file="./0.2.0/changelog-authorization-0.2.0.xml"/>
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-authorization-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-authorization-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.1.0/changelog-authorization-1.1.0.xml"/>
 
 </databaseChangeLog>

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Tag.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Tag.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,31 +12,29 @@
 package org.eclipse.kapua.service.tag;
 
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.KapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdFactory;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import java.math.BigInteger;
 
 /**
- * Tag entity definition.<br>
- * Tags serve as tag for entities marked as {@link Taggable}.
- * It is possible to assign a tag to an entity.
- * {@link Tag#getName()} must be unique within the scope.
+ * {@link Tag} {@link org.eclipse.kapua.model.KapuaEntity} definition
+ * <p>
+ * {@link Tag}s serve as tag for entities marked as {@link Taggable}.
+ * It is possible to assign a {@link Tag} to a {@link org.eclipse.kapua.model.KapuaEntity}.
  *
  * @since 1.0.0
  */
 @XmlRootElement(name = "tag")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name" }, //
-        factoryClass = TagXmlRegistry.class, factoryMethod = "newTag")
-public interface Tag extends KapuaUpdatableEntity {
+@XmlType(factoryClass = TagXmlRegistry.class, factoryMethod = "newTag")
+public interface Tag extends KapuaNamedEntity {
 
     @XmlTransient
     KapuaId ANY = KapuaLocator.getInstance().getFactory(KapuaIdFactory.class).newKapuaId(BigInteger.ONE.negate());
@@ -47,23 +45,4 @@ public interface Tag extends KapuaUpdatableEntity {
     default String getType() {
         return TYPE;
     }
-
-    /**
-     * Sets the {@link Tag} name.<br>
-     * It must be unique within the scope.
-     *
-     * @param name The name of the {@link Tag}
-     * @since 1.0.0
-     */
-    void setName(String name);
-
-    /**
-     * Gets the {@link Tag} name.
-     *
-     * @return The {@link Tag} name.
-     * @since 1.0.0
-     */
-    @XmlElement(name = "name")
-    String getName();
-
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagAttributes.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,5 +21,5 @@ import org.eclipse.kapua.model.query.predicate.QueryPredicate;
  * @since 1.0.0
  */
 public class TagAttributes extends KapuaNamedEntityAttributes {
-
+    public static final String DESCRIPTION = "description";
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagCreator.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,41 +11,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag;
 
-import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link Tag} creator definition.<br>
+ * {@link TagCreator} definition
+ * <p>
  * It is used to create a new {@link Tag}.
  *
  * @since 1.0.0
  */
 @XmlRootElement(name = "tagCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name" }, //
-        factoryClass = TagXmlRegistry.class, //
-        factoryMethod = "newTagCreator")
-public interface TagCreator extends KapuaEntityCreator<Tag> {
-
-    /**
-     * Sets the {@link Tag} name.
-     *
-     * @param name The {@link Tag} name.
-     * @since 1.0.0
-     */
-    void setName(String name);
-
-    /**
-     * Gets the {@link Tag} name.
-     *
-     * @return The {@link Tag} name.
-     * @since 1.0.0
-     */
-    @XmlElement(name = "name")
-    String getName();
+@XmlType(factoryClass = TagXmlRegistry.class, factoryMethod = "newTagCreator")
+public interface TagCreator extends KapuaNamedEntityCreator<Tag> {
 }

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagCreatorImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag.internal;
 
-import org.eclipse.kapua.commons.model.AbstractKapuaEntityCreator;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntityCreator;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.domain.DomainCreator;
 import org.eclipse.kapua.service.tag.Tag;
@@ -19,40 +19,32 @@ import org.eclipse.kapua.service.tag.TagCreator;
 
 /**
  * {@link TagCreator} implementation.
- * 
+ *
  * @since 1.0.0
  */
-public class TagCreatorImpl extends AbstractKapuaEntityCreator<Tag> implements TagCreator {
+public class TagCreatorImpl extends AbstractKapuaNamedEntityCreator<Tag> implements TagCreator {
 
     private static final long serialVersionUID = -4676187845961673421L;
 
-    private String name;
-
     /**
-     * Constructor
-     * 
-     * @param scopeId
-     *            The scope id to set.
-     * @param name
-     *            The name to set for this {@link DomainCreator}.
+     * Constructor.
+     *
+     * @param scopeId The scope id to set.
+     * @param name    The name to set for this {@link DomainCreator}.
      * @since 1.0.0
      */
     public TagCreatorImpl(KapuaId scopeId, String name) {
         super(scopeId);
+
         setName(name);
     }
 
+    /**
+     * Constructor
+     *
+     * @param scopeId The scopeId {@link KapuaId}
+     */
     public TagCreatorImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public String getName() {
-        return name;
     }
 }

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagDAO.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -45,6 +45,7 @@ public class TagDAO extends ServiceDAO {
             throws KapuaException {
         Tag tag = new TagImpl(creator.getScopeId());
         tag.setName(creator.getName());
+        tag.setDescription(creator.getDescription());
 
         return ServiceDAO.create(em, tag);
     }

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagImpl.java
@@ -11,65 +11,47 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag.internal;
 
-import javax.persistence.Basic;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.tag.Tag;
 
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
 /**
  * {@link Tag} implementation.
- * 
+ *
  * @since 1.0.0
  */
 @Entity(name = "Tag")
 @Table(name = "tag_tag")
-public class TagImpl extends AbstractKapuaUpdatableEntity implements Tag {
+public class TagImpl extends AbstractKapuaNamedEntity implements Tag {
 
     private static final long serialVersionUID = -3760818776351242930L;
-
-    @Basic
-    @Column(name = "name")
-    private String name;
 
     protected TagImpl() {
         super();
     }
 
     /**
-     * Constructor.<br>
+     * Constructor.
+     * <p>
      * Creates a soft clone.
-     * 
-     * @param tag
-     *            The {@link Tag} from which to create the new {@link Tag}.
+     *
+     * @param tag The {@link Tag} from which to create the new {@link Tag}.
      * @throws KapuaException
      */
     public TagImpl(Tag tag) throws KapuaException {
-        super((AbstractKapuaUpdatableEntity) tag);
-
-        setName(tag.getName());
+        super(tag);
     }
 
     /**
-     * Constructor
-     * 
-     * @param scopeId
+     * Constructor.
+     *
+     * @param scopeId The scope {@link KapuaId}
      */
     public TagImpl(KapuaId scopeId) {
         super(scopeId);
-    }
-
-    @Override
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    public String getName() {
-        return name;
     }
 }

--- a/service/tag/internal/src/main/resources/liquibase/1.1.0/changelog-tag-1.1.0.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.1.0/changelog-tag-1.1.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-tag-1.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="./tag-description.xml"/>
+
+</databaseChangeLog>

--- a/service/tag/internal/src/main/resources/liquibase/1.1.0/tag-description.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.1.0/tag-description.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-tag-1.1.0.xml">
+
+    <changeSet id="changelog-tag-description-1.1.0" author="eurotech">
+
+        <addColumn tableName="tag_tag">
+            <column name="description" type="text"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/tag/internal/src/main/resources/liquibase/changelog-tag-master.xml
+++ b/service/tag/internal/src/main/resources/liquibase/changelog-tag-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-tag-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-tag-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.1.0/changelog-tag-1.1.0.xml"/>
 
 </databaseChangeLog>

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/User.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/User.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,22 +23,13 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 
 /**
- * User entity
+ * {@link User} {@link org.eclipse.kapua.model.KapuaEntity} definition
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "user")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "status",
-        "displayName",
-        "email",
-        "phoneNumber",
-        "userType",
-        "externalId",
-        "expirationDate"
-}, //
-        factoryClass = UserXmlRegistry.class, //
-        factoryMethod = "newUser")
+@XmlType(factoryClass = UserXmlRegistry.class, factoryMethod = "newUser")
 public interface User extends KapuaNamedEntity {
 
     String TYPE = "user";
@@ -49,96 +40,126 @@ public interface User extends KapuaNamedEntity {
     }
 
     /**
-     * Return the user status
+     * Gets the {@link UserStatus}
      *
-     * @return
+     * @return the {@link UserStatus}
+     * @since 1.0.0
      */
     @XmlElement(name = "status")
     UserStatus getStatus();
 
     /**
-     * Get the user status
+     * Sets the {@link UserStatus}
      *
-     * @param status
+     * @param status the {@link UserStatus}
+     * @since 1.0.0
      */
     void setStatus(UserStatus status);
 
     /**
-     * Return the display name (may be a friendly username to show in the UI)
+     * Gets the display name (may be a friendlier name)
      *
-     * @return
+     * @return the display name (may be a friendlier name)
+     * @since 1.0.0
      */
     @XmlElement(name = "displayName")
     String getDisplayName();
 
     /**
-     * Set the display name
+     * Sets the display name (may be a friendlier name)
      *
-     * @param displayName
+     * @param displayName the display name (may be a friendlier name)
+     * @since 1.0.0
      */
     void setDisplayName(String displayName);
 
     /**
-     * Get the user email
+     * Gets the email
      *
-     * @return
+     * @return the email
+     * @since 1.0.0
      */
     @XmlElement(name = "email")
     String getEmail();
 
     /**
-     * Set the user email
+     * Sets the user email
      *
-     * @param email
+     * @param email the user email
+     * @since 1.0.0
      */
     void setEmail(String email);
 
     /**
-     * Get the phone number
+     * Gets the phone number
      *
-     * @return
+     * @return the phone number
+     * @since 1.0.0
      */
     @XmlElement(name = "phoneNumber")
     String getPhoneNumber();
 
     /**
-     * Set the phone number
+     * Sets the phone number
      *
-     * @param phoneNumber
+     * @param phoneNumber the phone number
+     * @since 1.0.0
      */
     void setPhoneNumber(String phoneNumber);
 
     /**
-     * Get the user type
+     * Gets the {@link UserType}
      *
-     * @return
+     * @return the {@link UserType}
+     * @since 1.0.0
      */
     @XmlElement(name = "userType")
     UserType getUserType();
 
     /**
-     * Set the user type
+     * Sets the user type
+     *
+     * @param userType the {@link UserType}
+     * @since 1.0.0
      */
     void setUserType(UserType userType);
 
     /**
-     * Get the external ID
+     * Gets the external id.
+     * <p>
+     * This field is used to store external SSO identity bound to this {@link User}
      *
-     * @return
+     * @return the external id.
+     * @since 1.0.0
      */
     @XmlElement(name = "externalId")
     String getExternalId();
 
     /**
-     * Set the external ID
+     * Sets the external id.
+     * <p>
+     * This field is used to store external SSO identity bound to this {@link User}
      *
-     * @param externalId
+     * @param externalId the external id.
+     * @since 1.0.0
      */
     void setExternalId(String externalId);
 
+    /**
+     * Gets the expiration date
+     *
+     * @return the expiration date
+     * @since 1.0.0
+     */
     @XmlElement(name = "expirationDate")
     @XmlJavaTypeAdapter(DateXmlAdapter.class)
     Date getExpirationDate();
 
+    /**
+     * Sets the expiration date
+     *
+     * @param expirationDate the expiration date
+     * @since 1.0.0
+     */
     void setExpirationDate(Date expirationDate);
 }

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserAttributes.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,11 +13,17 @@ package org.eclipse.kapua.service.user;
 
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
+/**
+ * {@link UserAttributes} attributes.
+ *
+ * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @since 1.0.0
+ */
 public class UserAttributes extends KapuaNamedEntityAttributes {
 
     public static final String STATUS = "status";
     public static final String EXPIRATION_DATE = "expirationDate";
     public static final String PHONE_NUMBER = "phoneNumber";
     public static final String EMAIL = "email";
-    public static final String DISPLAY_NAME= "displayName";
+    public static final String DISPLAY_NAME = "displayName";
 }

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,21 +23,13 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 
 /**
- * UserCreator encapsulates all the information needed to create a new User in the system.
+ * {@link UserCreator} {@link org.eclipse.kapua.model.KapuaEntityCreator} definition
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "userCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "displayName",
-        "email",
-        "phoneNumber",
-        "userType",
-        "externalId",
-        "expirationDate",
-        "userStatus" },
-        factoryClass = UserXmlRegistry.class,
-        factoryMethod = "newUserCreator")
+@XmlType(factoryClass = UserXmlRegistry.class, factoryMethod = "newUserCreator")
 public interface UserCreator extends KapuaNamedEntityCreator<User> {
 
     /**

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCreatorImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -21,9 +21,9 @@ import org.eclipse.kapua.service.user.UserType;
 import java.util.Date;
 
 /**
- * User creator service implementation.
+ * {@link UserCreator} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class UserCreatorImpl extends AbstractKapuaNamedEntityCreator<User> implements UserCreator {
 
@@ -82,18 +82,22 @@ public class UserCreatorImpl extends AbstractKapuaNamedEntityCreator<User> imple
         this.phoneNumber = phoneNumber;
     }
 
+    @Override
     public UserType getUserType() {
         return userType;
     }
 
+    @Override
     public void setUserType(UserType userType) {
         this.userType = userType;
     }
 
+    @Override
     public String getExternalId() {
         return externalId;
     }
 
+    @Override
     public void setExternalId(String externalId) {
         this.externalId = externalId;
     }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,6 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.internal;
 
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserStatus;
+import org.eclipse.kapua.service.user.UserType;
+
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -19,20 +25,12 @@ import javax.persistence.Enumerated;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-
-import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.service.user.UserStatus;
-import org.eclipse.kapua.service.user.UserType;
-
 import java.util.Date;
 
 /**
- * User entity implementation.
- * 
- * @since 1.0
+ * {@link User} implementation.
  *
+ * @since 1.0.0
  */
 @Entity(name = "User")
 @Table(name = "usr_user")
@@ -69,21 +67,26 @@ public class UserImpl extends AbstractKapuaNamedEntity implements User {
     private Date expirationDate;
 
     /**
-     * Constructor
+     * Constructor.
+     * <p>
+     * Required by JPA.
+     *
+     * @since 1.0.0
      */
     public UserImpl() {
         super();
     }
 
     /**
-     * Constructor
-     * 
-     * @param scopeId
-     * @param name
+     * Constructor.
+     *
+     * @param scopeId the scope {@link KapuaId}
+     * @param name    the name
+     * @since 1.0.0
      */
-    public UserImpl(KapuaId scopeId,
-            String name) {
+    public UserImpl(KapuaId scopeId, String name) {
         super(scopeId, name);
+
         this.status = UserStatus.ENABLED;
     }
 
@@ -139,7 +142,6 @@ public class UserImpl extends AbstractKapuaNamedEntity implements User {
     @Override
     public void setUserType(UserType userType) {
         this.userType = userType;
-
     }
 
     @Override

--- a/service/user/internal/src/main/resources/liquibase/1.1.0/changelog-user-1.1.0.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.1.0/changelog-user-1.1.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-user-1.1.0.xml">
+
+    <include relativeToChangelogFile="true" file="./user-description.xml"/>
+
+</databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/1.1.0/user-description.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.1.0/user-description.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-user-1.1.0.xml">
+
+    <changeSet id="changelog-user-description-1.1.0" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <tableExists tableName="usr_user"/>
+        </preConditions>
+
+        <addColumn tableName="usr_user">
+            <column name="description" type="text"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/changelog-user-master.xml
+++ b/service/user/internal/src/main/resources/liquibase/changelog-user-master.xml
@@ -11,12 +11,13 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./0.2.0/changelog-user-0.2.0.xml" />
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-user-0.3.0.xml" />
-    <include relativeToChangelogFile="true" file="./1.0.0/changelog-user-1.0.0.xml" />
+    <include relativeToChangelogFile="true" file="./0.2.0/changelog-user-0.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./0.3.0/changelog-user-0.3.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.0.0/changelog-user-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.1.0/changelog-user-1.1.0.xml"/>
 
 </databaseChangeLog>

--- a/test/src/main/java/org/eclipse/kapua/test/account/AccountCreatorMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/account/AccountCreatorMock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,17 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.test.account;
 
-import java.util.Date;
-import java.util.Properties;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.AccountCreator;
+
+import java.util.Date;
+import java.util.Properties;
 
 public class AccountCreatorMock implements AccountCreator {
 
     private KapuaId scopeId;
     private String name;
+    private String description;
     private String organizationName;
     private String organizationEmail;
 
@@ -36,10 +37,21 @@ public class AccountCreatorMock implements AccountCreator {
     }
 
     @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
     public KapuaId getScopeId() {
         return this.scopeId;
     }
 
+    @Override
     public void setScopeId(KapuaId scopeId) {
         this.scopeId = scopeId;
     }
@@ -56,14 +68,12 @@ public class AccountCreatorMock implements AccountCreator {
 
     @Override
     public String getOrganizationPersonName() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganizationPersonName(String organizationPersonName) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
@@ -78,108 +88,91 @@ public class AccountCreatorMock implements AccountCreator {
 
     @Override
     public String getOrganizationPhoneNumber() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganizationPhoneNumber(String organizationPhoneNumber) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getOrganizationAddressLine1() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganizationAddressLine1(String organizationAddressLine1) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getOrganizationAddressLine2() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganizationAddressLine2(String organizationAddressLine2) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getOrganizationCity() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganizationCity(String organizationCity) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getOrganizationZipPostCode() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganizationZipPostCode(String organizationZipPostCode) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getOrganizationStateProvinceCounty() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganizationStateProvinceCounty(String organizationStateProvinceCounty) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getOrganizationCountry() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganizationCountry(String organizationCountry) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public Properties getEntityAttributes() throws KapuaException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setEntityAttributes(Properties entityAttributes) throws KapuaException {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public Date getExpirationDate() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setExpirationDate(Date expirationDate) {
-        // TODO Auto-generated method stub
+        // Not used
     }
 }

--- a/test/src/main/java/org/eclipse/kapua/test/account/AccountMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/account/AccountMock.java
@@ -11,16 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.test.account;
 
-import java.math.BigInteger;
-import java.util.Date;
-import java.util.List;
-import java.util.Properties;
-
-import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.Organization;
+
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
 
 public class AccountMock implements Account {
 
@@ -54,60 +53,63 @@ public class AccountMock implements Account {
     }
 
     @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        // Not used
+    }
+
+    @Override
     public Date getModifiedOn() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public KapuaId getModifiedBy() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public int getOptlock() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
     @Override
     public void setOptlock(int optlock) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
-    public Properties getEntityAttributes()
-            throws KapuaException {
-        // TODO Auto-generated method stub
+    public Properties getEntityAttributes() {
         return null;
     }
 
     @Override
-    public void setEntityAttributes(Properties props)
-            throws KapuaException {
-        // TODO Auto-generated method stub
-
+    public void setEntityAttributes(Properties props) {
+        // Not used
     }
 
     @Override
-    public Properties getEntityProperties()
-            throws KapuaException {
-        // TODO Auto-generated method stub
+    public Properties getEntityProperties() {
         return null;
     }
 
     @Override
-    public void setEntityProperties(Properties props)
-            throws KapuaException {
-        // TODO Auto-generated method stub
-
+    public void setEntityProperties(Properties props) {
+        // Not used
     }
 
     @Override
     public KapuaId getId() {
         return this.id;
+    }
+
+    @Override
+    public void setId(KapuaId id) {
+        // Not used
     }
 
     @Override
@@ -117,38 +119,32 @@ public class AccountMock implements Account {
 
     @Override
     public Date getCreatedOn() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public KapuaId getCreatedBy() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public Organization getOrganization() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setOrganization(Organization organization) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getParentAccountPath() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setParentAccountPath(String parentAccountPath) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
@@ -157,19 +153,12 @@ public class AccountMock implements Account {
     }
 
     @Override
-    public void setId(KapuaId id) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
     public Date getExpirationDate() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setExpirationDate(Date expirationDate) {
-        // TODO Auto-generated method stub
+        // Not used
     }
 }

--- a/test/src/main/java/org/eclipse/kapua/test/user/UserCreatorMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/user/UserCreatorMock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and others.
+ * Copyright (c) 2017, 2019 Eurotech and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,33 +22,47 @@ import java.util.Properties;
 
 public class UserCreatorMock implements UserCreator {
 
-    private String name;
     private KapuaId scopeId;
+    private String name;
+    private String description;
     private String displayName;
     private String email;
     private String phoneNumber;
     private UserType userType;
     private Date expiarionDate;
-
     private UserStatus userStatus;
+    private String externalId;
 
+
+    @Override
     public UserType getUserType() {
         return userType;
     }
 
+    @Override
     public void setUserType(UserType userType) {
         this.userType = userType;
     }
 
+    @Override
     public String getExternalId() {
         return externalId;
     }
 
+    @Override
     public void setExternalId(String externalId) {
         this.externalId = externalId;
     }
 
-    private String externalId;
+    @Override
+    public KapuaId getScopeId() {
+        return scopeId;
+    }
+
+    @Override
+    public void setScopeId(KapuaId scopeId) {
+        this.scopeId = scopeId;
+    }
 
     @Override
     public String getName() {
@@ -61,13 +75,13 @@ public class UserCreatorMock implements UserCreator {
     }
 
     @Override
-    public KapuaId getScopeId() {
-        return scopeId;
+    public String getDescription() {
+        return description;
     }
 
     @Override
-    public void setScopeId(KapuaId scopeId) {
-        this.scopeId = scopeId;
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     @Override
@@ -122,13 +136,11 @@ public class UserCreatorMock implements UserCreator {
 
     @Override
     public Properties getEntityAttributes() throws KapuaException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setEntityAttributes(Properties entityAttributes) throws KapuaException {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 }

--- a/test/src/main/java/org/eclipse/kapua/test/user/UserMock.java
+++ b/test/src/main/java/org/eclipse/kapua/test/user/UserMock.java
@@ -11,16 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.test.user;
 
-import java.math.BigInteger;
-import java.util.Date;
-import java.util.Properties;
-
-import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserStatus;
 import org.eclipse.kapua.service.user.UserType;
+
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.Properties;
 
 public class UserMock implements User {
 
@@ -42,8 +41,7 @@ public class UserMock implements User {
 
     @Override
     public void setScopeId(KapuaId scopeId) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
@@ -57,60 +55,63 @@ public class UserMock implements User {
     }
 
     @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        // Not used
+    }
+
+    @Override
     public Date getModifiedOn() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public KapuaId getModifiedBy() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public int getOptlock() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
     @Override
     public void setOptlock(int optlock) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
-    public Properties getEntityAttributes()
-            throws KapuaException {
-        // TODO Auto-generated method stub
+    public Properties getEntityAttributes() {
         return null;
     }
 
     @Override
-    public void setEntityAttributes(Properties props)
-            throws KapuaException {
-        // TODO Auto-generated method stub
-
+    public void setEntityAttributes(Properties props) {
+        // Not used
     }
 
     @Override
-    public Properties getEntityProperties()
-            throws KapuaException {
-        // TODO Auto-generated method stub
+    public Properties getEntityProperties() {
         return null;
     }
 
     @Override
-    public void setEntityProperties(Properties props)
-            throws KapuaException {
-        // TODO Auto-generated method stub
-
+    public void setEntityProperties(Properties props) {
+        // Not used
     }
 
     @Override
     public KapuaId getId() {
         return this.id;
+    }
+
+    @Override
+    public void setId(KapuaId id) {
+        // Not used
     }
 
     @Override
@@ -120,68 +121,52 @@ public class UserMock implements User {
 
     @Override
     public Date getCreatedOn() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public KapuaId getCreatedBy() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public UserStatus getStatus() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setStatus(UserStatus status) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getDisplayName() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setDisplayName(String displayName) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getEmail() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setEmail(String email) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override
     public String getPhoneNumber() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public void setPhoneNumber(String phoneNumber) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public void setId(KapuaId id) {
-        // TODO Auto-generated method stub
-
+        // Not used
     }
 
     @Override


### PR DESCRIPTION
This PR adds `description` attribute to `KapuaNamedEntity` definition. 

**Related Issue**
This PR also fixes #2387 
Instead of adding `description` to only some instances, now all `KapuaNamedEntity` have both `name` and `description`

**Description of the solution adopted**
Added new `description` attribute to `KapuaNamedEntity` definition. 

Some entities that had `name` but were only `KapuaUpdatableEntity`es have been promoted to `KapuaNamedEntity`.

**Screenshots**
_None_

**Any side note on the changes made**
A lot of javadoc improvement!