### PR TITLE
Added permissions checks for Add button in Schedules

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedules.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedules.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+import org.eclipse.kapua.app.console.module.job.shared.model.permission.SchedulerSessionPermission;
 
 public class JobTabSchedules extends KapuaTabItem<GwtJob> {
 
@@ -43,7 +44,8 @@ public class JobTabSchedules extends KapuaTabItem<GwtJob> {
     @Override
     protected void doRefresh() {
         schedulesGrid.refresh();
-        schedulesGrid.getToolbar().getAddEntityButton().setEnabled(selectedEntity != null);
+        schedulesGrid.getToolbar().getAddEntityButton()
+                .setEnabled(selectedEntity != null && currentSession.hasPermission(SchedulerSessionPermission.write()));
         schedulesGrid.getToolbar().getRefreshEntityButton().setEnabled(selectedEntity != null);
     }
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesToolbar.java
@@ -38,7 +38,7 @@ public class JobTabSchedulesToolbar extends EntityCRUDToolbar<GwtTrigger> {
     protected void onRender(Element target, int index) {
         super.onRender(target, index);
         if (jobId != null) {
-            addEntityButton.setEnabled(true);
+            addEntityButton.setEnabled(currentSession.hasPermission(SchedulerSessionPermission.write()));
             refreshEntityButton.setEnabled(true);
         } else {
             addEntityButton.setEnabled(false);
@@ -64,7 +64,7 @@ public class JobTabSchedulesToolbar extends EntityCRUDToolbar<GwtTrigger> {
     @Override
     protected void updateButtonEnablement() {
         super.updateButtonEnablement();
-        addEntityButton.setEnabled(jobId != null);
+        addEntityButton.setEnabled(jobId != null && currentSession.hasPermission(SchedulerSessionPermission.write()));
         deleteEntityButton.setEnabled(
                 selectedEntity != null && currentSession.hasPermission(SchedulerSessionPermission.delete()));
     }


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Added permissions checks for Add button in Schedules.

**Related Issue**
This PR fixes/closes #2412 

**Description of the solution adopted**
The `SchedulerSessionPermission.write()` is now needed for enabling the Add button in Schedules.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
