### PR TITLE
Updated permission check when enabling Assigned Devices tab in Tags

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DevicesTagsTabItemDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DevicesTagsTabItemDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,7 +13,6 @@ package org.eclipse.kapua.app.console.module.device.client.device.tag;
 
 import org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.AbstractEntityTabDescriptor;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
-import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.AccessInfoSessionPermission;
 import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceSessionPermission;
 import org.eclipse.kapua.app.console.module.tag.client.TagView;
 import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
@@ -37,7 +36,7 @@ public class DevicesTagsTabItemDescriptor extends AbstractEntityTabDescriptor<Gw
 
     @Override
     public Boolean isEnabled(GwtSession currentSession) {
-        return currentSession.hasPermission(DeviceSessionPermission.read()) && currentSession.hasPermission(AccessInfoSessionPermission.read());
+        return currentSession.hasPermission(DeviceSessionPermission.read());
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Updated permission check when enabling Assigned Devices tab in Tags

**Related Issue**
This PR fixes/closes #2447 

**Description of the solution adopted**
Removed unneeded `AccessInfoSessionPermission.read()` check when enabling the Assigned Devices tab in Tags.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
