### PR TITLE
resolved error state for start date in date field in date range selector

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelector.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelector.java
@@ -284,10 +284,8 @@ public class DateRangeSelector extends LayoutContainer {
 
                     @Override
                     public String validate(Field<?> field, String value) {
-                        if (startDateField.getValue().after(endDateField.getValue())) {
+                        if (startDateField.getValue() != null && endDateField.getValue() != null && startDateField.getValue().after(endDateField.getValue())) {
                             return MSGS.dataDateRangeInvalidStartDate();
-                        } else {
-                            endDateField.clearInvalid();
                         }
                         return null;
                     }
@@ -303,10 +301,8 @@ public class DateRangeSelector extends LayoutContainer {
 
                     @Override
                     public String validate(Field<?> field, String value) {
-                        if (endDateField.getValue().before(startDateField.getValue())) {
+                        if (startDateField.getValue() != null && endDateField.getValue() != null && endDateField.getValue().before(startDateField.getValue())) {
                             return MSGS.dataDateRangeInvalidStopDate();
-                        } else {
-                            startDateField.clearInvalid();
                         }
                         return null;
                     }
@@ -318,7 +314,7 @@ public class DateRangeSelector extends LayoutContainer {
 
             @Override
             public String validate(Field<?> field, String value) {
-                if (startDateField.getValue().equals(endDateField.getValue()) &&
+                if (startDateField.getValue() != null && endDateField.getValue() != null && startDateField.getValue().equals(endDateField.getValue()) &&
                         startTimeField.getDateValue().after(endTimeField.getDateValue())) {
                     return MSGS.dataDateRangeInvalidStartTime();
                 } else {
@@ -331,7 +327,7 @@ public class DateRangeSelector extends LayoutContainer {
 
             @Override
             public String validate(Field<?> field, String value) {
-                if (startDateField.getValue().equals(endDateField.getValue()) &&
+                if (startDateField.getValue() != null && endDateField.getValue() != null && startDateField != null && endDateField!= null && startDateField.getValue().equals(endDateField.getValue()) &&
                         endTimeField.getDateValue().before(startTimeField.getDateValue())) {
                     return MSGS.dataDateRangeInvalidStopTime();
                 } else {


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added null  checks for startDateField.getValue() and endDateField.getValue(). Also removed else part in startDateField and endDateField because that else part affects on other cases with validation.

**Related Issue**
This PR fixes issue #2408 

**Description of the solution adopted**
When User clicks on DatePicker in startDateField or endDateField(). date picker closes immediately after some date from picker is selected.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
