### PR TITLE
Changed header name on edit dialog in devices

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -104,7 +104,7 @@ public class DeviceEditDialog extends DeviceAddDialog {
 
     @Override
     public String getHeaderMessage() {
-        return DEVICE_MSGS.deviceFormHeadingEdit(this.selectedDevice.getDisplayName() != null ? this.selectedDevice.getDisplayName() : this.selectedDevice.getClientId());
+        return DEVICE_MSGS.deviceFormHeadingEdit(this.selectedDevice.getDisplayName() != null ? this.selectedDevice.getClientId() : this.selectedDevice.getClientId());
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Header name is changed on device edit dialog.

**Related Issue**
This PR fixes issue #2470. 

**Description of the solution adopted**
Changed header name on edit dialog in devices.

**Screenshots**
/

**Any side note on the changes made**
/
