### PR TITLE
Fixing maven build defaults

### DIFF
--- a/RunTests.md
+++ b/RunTests.md
@@ -1,33 +1,72 @@
 # How to execute Kapua tests
 
-This is document in preparation. It contains instructions how to prepare environment for testing
-and how to execute unit, integration and functional tests. Test environment is either based on embedded servers or external setup based on Docker Compose.
+There are couple of ways to run tests, either pure unit tests, component tests or integration tests.
+Integration tests can be run:
+
+- using embedded servers
+- using dockerized servers
 
 ## With dockerized Kapua
-Start dockerized Kapua
+With fabric8 plugin usage tests can now be run without explicitly running dockerized environment.
+Docker containers providing Kapua infrastructure are started with maven itself.
+But tu run these integration tests, you have to switch to qa folder and run following command
+
+    mvn test -PI9nTests
     
-      mvn -Dcucumber.options="--tags @integration" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcommons.settings.hotswap=true -Dorg.eclipse.kapua.qa.noEmbeddedServers=true -Dcommons.db.jdbcConnectionUrlResolver=DEFAULT -Dcommons.db.schema.update=true -Dcommons.db.connection.host=localhost -Dcommons.db.connection.port=3306 -Dcommons.db.schema=kapuadb -Dcommons.db.connection.scheme=jdbc:h2:tcp -Dbroker.host=localhost verify  
+This will run integration tests only, those are tests written in gherkin and being annotated with
+``@integration``
+
+If tests fail and dockers are still running use this command:
+
+    mvn docker:stop -I9nTests
 
 Example response with time:
 
     [INFO] ------------------------------------------------------------------------
     [INFO] BUILD SUCCESS
     [INFO] ------------------------------------------------------------------------
-    [INFO] Total time: 22:06 min
-    [INFO] Finished at: 2018-12-06T10:43:19+01:00
-    [INFO] Final Memory: 187M/1726M
-    [INFO] ------------------------------------------------------------------------
+    [INFO] Total time: 18:11 min
+    [INFO] Finished at: 2019-03-04T14:16:32+01:00
+    [INFO] Final Memory: 48M/728M
+    [INFO] ------------------------------------------------------------------------    
 
 ##Without dockerized Kapua
+By default tests are run with embedded servers providing kapua infrastructure services, such as
+database, event-broker, message broker, elaticsearch.
 
-    mvn -fae -Dcucumber.options="--tags ~@rest" -Dgroups='!org.eclipse.kapua.test.junit.JUnitTests' -Dcommons.settings.hotswap=true -Dcommons.db.schema.update=true -Dcommons.db.schema=kapuadb -Dbroker.host=localhost verify
+So to run those use default profile and run:
 
+    mvn clean install
+    or
+    mvn test
+
+Those two commands will use following defaults:
+
+    cucumber.options="--tags ~@rest"
+    groups='!org.eclipse.kapua.test.junit.JUnitTests'
+    commons.settings.hotswap=true
+    commons.db.schema.update=true
+    commons.db.schema=kapuadb
+    broker.host=localhost
 
 Example response with time:
 
     [INFO] BUILD SUCCESS
     [INFO] ------------------------------------------------------------------------
-    [INFO] Total time: 34:53 min
-    [INFO] Finished at: 2018-12-04T11:41:10+01:00
-    [INFO] Final Memory: 187M/1827M
+    [INFO] Total time: 31:14 min
+    [INFO] Finished at: 2019-03-04T14:51:24+01:00
+    [INFO] Final Memory: 244M/1761M
+    [INFO] ------------------------------------------------------------------------
+
+## Run pure junit tests
+
+    mvn test mvn test -Dgroups='org.eclipse.kapua.test.junit.JUnitTests'
+
+Example response with time:
+
+    [INFO] BUILD SUCCESS
+    [INFO] ------------------------------------------------------------------------
+    [INFO] Total time: 05:26 min
+    [INFO] Finished at: 2019-03-04T15:01:04+01:00
+    [INFO] Final Memory: 133M/1250M
     [INFO] ------------------------------------------------------------------------

--- a/RunTests.md
+++ b/RunTests.md
@@ -9,7 +9,7 @@ Integration tests can be run:
 ## With dockerized Kapua
 With fabric8 plugin usage tests can now be run without explicitly running dockerized environment.
 Docker containers providing Kapua infrastructure are started with maven itself.
-But tu run these integration tests, you have to switch to qa folder and run following command
+But to run these integration tests, you have to switch to qa folder and run following command
 
     mvn test -PI9nTests
     
@@ -18,7 +18,7 @@ This will run integration tests only, those are tests written in gherkin and bei
 
 If tests fail and dockers are still running use this command:
 
-    mvn docker:stop -I9nTests
+    mvn docker:stop -PI9nTests
 
 Example response with time:
 
@@ -60,7 +60,7 @@ Example response with time:
 
 ## Run pure junit tests
 
-    mvn test mvn test -Dgroups='org.eclipse.kapua.test.junit.JUnitTests'
+    mvn test -Dgroups='org.eclipse.kapua.test.junit.JUnitTests'
 
 Example response with time:
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -427,9 +427,10 @@
                     <!-- Travis has an overall 3GB limit -->
                     <argLine>@{argLine} -Xmx1024m</argLine>
                     <systemPropertyVariables>
-                        <cucumber.options>${cucumber.options}</cucumber.options>
+                        <cucumber.options>--tags ~@rest</cucumber.options>
                         <commons.db.schema>kapuadb</commons.db.schema>
                         <commons.settings.hotswap>true</commons.settings.hotswap>
+                        <broker.host>localhost</broker.host>
                         <jetty.war.file>target/war/api.war</jetty.war.file>
                     </systemPropertyVariables>
                 </configuration>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -312,35 +312,189 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
+    <profiles>
+        <!-- Profile for running integration tests with Kapua infrastructure started
+             inside dockerized environment. -->
+        <profile>
+            <id>I9nTests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.eclipse.kapua</groupId>
-                                    <artifactId>kapua-rest-api-web</artifactId>
-                                    <type>war</type>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/war</outputDirectory>
-                                    <destFileName>api.war</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                            <overWriteReleases>true</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <images>
+                                <image>
+                                    <alias>db</alias>
+                                    <name>kapua/kapua-sql:1.1.0-SNAPSHOT</name>
+                                    <run>
+                                        <ports>
+                                            <port>8181:8181</port>
+                                            <port>3306:3306</port>
+                                        </ports>
+                                        <wait>
+                                            <log>TCP server running at</log>
+                                            <time>20000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                                <image>
+                                    <alias>es</alias>
+                                    <name>elasticsearch:5.4.0</name>
+                                    <run>
+                                        <ports>
+                                            <port>9200:9200</port>
+                                            <port>9300:9300</port>
+                                        </ports>
+                                        <env>
+                                            <cluster.name>kapua-datastore</cluster.name>
+                                            <discovery.type>single-node</discovery.type>
+                                            <transport.host>_site_</transport.host>
+                                            <transport.ping_schedule>-1</transport.ping_schedule>
+                                            <transport.tcp.connect_timeout>30s</transport.tcp.connect_timeout>
+                                        </env>
+                                        <wait>
+                                            <log>started</log>
+                                            <time>20000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                                <image>
+                                    <alias>events-broker</alias>
+                                    <name>kapua/kapua-events-broker:1.1.0-SNAPSHOT</name>
+                                    <run>
+                                        <ports>
+                                            <port>5672:5672</port>
+                                        </ports>
+                                        <wait>
+                                            <log>HTTP Server started at</log>
+                                            <time>20000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                                <image>
+                                    <alias>broker</alias>
+                                    <name>kapua/kapua-broker:1.1.0-SNAPSHOT</name>
+                                    <run>
+                                        <ports>
+                                            <port>1883:1883</port>
+                                            <port>8883:8883</port>
+                                            <port>61614:61614</port>
+                                        </ports>
+                                        <dependsOn>
+                                            <container>db</container>
+                                            <container>es</container>
+                                            <container>events-broker</container>
+                                        </dependsOn>
+                                        <links>
+                                            <link>db:db</link>
+                                            <link>es:es</link>
+                                            <link>events-broker:events-broker</link>
+                                        </links>
+                                        <wait>
+                                            <log>started</log>
+                                            <time>20000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                                <image>
+                                    <alias>kapua-console</alias>
+                                    <name>kapua/kapua-console:1.1.0-SNAPSHOT</name>
+                                    <run>
+                                        <ports>
+                                            <port>8080:8080</port>
+                                            <port>8443:8443</port>
+                                        </ports>
+                                        <dependsOn>
+                                            <container>broker</container>
+                                            <container>db</container>
+                                            <container>es</container>
+                                            <container>events-broker</container>
+                                        </dependsOn>
+                                        <links>
+                                            <link>broker:broker</link>
+                                            <link>db:db</link>
+                                            <link>es:es</link>
+                                            <link>events-broker:events-broker</link>
+                                        </links>
+                                        <wait>
+                                            <log>org.eclipse.jetty.server.Server - Started</log>
+                                            <time>60000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                                <image>
+                                    <alias>kapua-api</alias>
+                                    <name>kapua/kapua-api:1.1.0-SNAPSHOT</name>
+                                    <run>
+                                        <ports>
+                                            <port>8081:8080</port>
+                                            <port>8444:8443</port>
+                                        </ports>
+                                        <dependsOn>
+                                            <container>broker</container>
+                                            <container>db</container>
+                                            <container>es</container>
+                                            <container>events-broker</container>
+                                        </dependsOn>
+                                        <links>
+                                            <link>broker:broker</link>
+                                            <link>db:db</link>
+                                            <link>es:es</link>
+                                            <link>events-broker:events-broker</link>
+                                        </links>
+                                        <wait>
+                                            <log>Starting service modules...DONE</log>
+                                            <time>60000</time>
+                                        </wait>
+                                    </run>
+                                </image>
+                            </images>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+
+                        <executions>
+                            <execution>
+                                <id>start</id>
+                                <!--<phase>pre-integration-test</phase>-->
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop</id>
+                                <!--<phase>post-integration-test</phase>-->
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>@{argLine} -Xmx1024m</argLine>
+                            <systemPropertyVariables>
+                                <cucumber.options>--tags @integration</cucumber.options>
+                                <groups>'!org.eclipse.kapua.test.junit.JUnitTests'</groups>
+                                <commons.settings.hotswap>true</commons.settings.hotswap>
+                                <org.eclipse.kapua.qa.noEmbeddedServers>true</org.eclipse.kapua.qa.noEmbeddedServers>
+                                <commons.db.jdbcConnectionUrlResolver>DEFAULT</commons.db.jdbcConnectionUrlResolver>
+                                <commons.db.schema.update>true</commons.db.schema.update>
+                                <commons.db.connection.host>localhost</commons.db.connection.host>
+                                <commons.db.connection.port>3306</commons.db.connection.port>
+                                <commons.db.schema>kapuadb</commons.db.schema>
+                                <commons.db.connection.scheme>jdbc:h2:tcp</commons.db.connection.scheme>
+                                <broker.host>localhost</broker.host>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/qa/src/test/resources/features/rest/user/RestUser.feature
+++ b/qa/src/test/resources/features/rest/user/RestUser.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -10,7 +10,6 @@
 #     Eurotech - initial API and implementation
 ###############################################################################
 @rest
-@integration
 Feature: REST API tests for User
   REST API test of Kapua User API.
 


### PR DESCRIPTION
Made maven test run more intuitive, by supporting basic `clean install` as well as separate profile for
full integration tests.

**Description of the solution adopted**
Fixed maven build with "mvn clean install" to run tests with embedded servers.

Also added profile I9nTests that runs integration tests, but before running
those tests, docker containers are started with fabric8 plugin. Those
tests can now be run with command "mvn test -PI9nTests". This command shall be
executed in qa module, as integration tests are only available there.

Read RunTest.md for further details of running those tests.

**Related Issue**
No issue assigned.

**Screenshots**
Not applicable.

**Any side note on the changes made**
This changes only affect test phase of the build.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>