### PR TITLE
Removed error message when update of user is sucessfull

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -16,6 +16,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
@@ -63,6 +64,22 @@ public class UserEditDialog extends UserAddDialog {
             }
         });
 
+    }
+
+    @Override
+    public void validateUser() {
+        if (!email.isValid()) {
+            ConsoleInfo.display("Error", email.getErrorMessage());
+        } else if (!phoneNumber.isValid()) {
+            ConsoleInfo.display("Error", phoneNumber.getErrorMessage());
+        } else if (!expirationDate.isValid()) {
+            ConsoleInfo.display("Error", KapuaSafeHtmlUtils.htmlUnescape(expirationDate.getErrorMessage()));
+        }
+    }
+
+    @Override
+    protected void preSubmit() {
+        super.preSubmit();
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Removed error message if update of user is successfull.

**Related Issue**
This PR fixes issue #2476. 

**Description of the solution adopted**
If update of user is successfull, and all mandatory fields are filled, error message in bottom right corrner is removed.

**Screenshots**
/

**Any side note on the changes made**
/
