### PR TITLE
Changed height of dialogs and length of user name

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -25,6 +25,7 @@ import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
 import com.extjs.gxt.ui.client.widget.layout.FormData;
 import com.extjs.gxt.ui.client.widget.layout.FormLayout;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
@@ -107,7 +108,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
     public DeviceAddDialog(GwtSession currentSession) {
         super(currentSession);
 
-        DialogUtils.resizeDialog(this, 550, 450);
+        DialogUtils.resizeDialog(this, 550, 500);
     }
 
     @Override
@@ -119,6 +120,13 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         clientIdLabel.hide();
     }
 
+    @Override
+    protected void onRender(Element parent, int pos) {
+        super.onRender(parent, pos);
+        bodyPanel.setAutoHeight(true);
+        setAutoHeight(true);
+    }
+
     protected void generateBody() {
 
         FormData formData = new FormData("-20");
@@ -127,10 +135,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         formPanel.setFrame(false);
         formPanel.setBodyBorder(false);
         formPanel.setHeaderVisible(false);
-        // formPanel.setWidth(310);
         formPanel.setScrollMode(Scroll.AUTOY);
-        // formPanel.setStyleAttribute("padding-bottom", "0px");
-        // formPanel.setLayout(new FlowLayout());
 
         Listener<BaseEvent> comboBoxListener = new Listener<BaseEvent>() {
 
@@ -237,10 +242,27 @@ public class DeviceAddDialog extends EntityAddEditDialog {
 
         // Device Custom attributes fieldset
         FieldSet fieldSetCustomAttributes = new FieldSet();
-        FormLayout layoutCustomAttributes = new FormLayout();
-        layoutCustomAttributes.setLabelWidth(Constants.LABEL_WIDTH_DEVICE_FORM);
-        fieldSetCustomAttributes.setLayout(layoutCustomAttributes);
+        Listener<BaseEvent> fieldSetListener = new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                sync(true);
+            }
+        };
+        fieldSetCustomAttributes.addListener(Events.Collapse, fieldSetListener);
+        fieldSetCustomAttributes.addListener(Events.Expand, fieldSetListener);
+
         fieldSetCustomAttributes.setHeading(DEVICE_MSGS.deviceFormFieldsetCustomAttributes());
+        fieldSetCustomAttributes.setBorders(true);
+        fieldSetCustomAttributes.setWidth(540);
+        fieldSetCustomAttributes.setCollapsible(true);
+        fieldSetCustomAttributes.setAutoHeight(true);
+
+        FormLayout fieldSetLayout = new FormLayout();
+        fieldSetLayout.setLabelWidth(Constants.LABEL_WIDTH_DEVICE_FORM - 11);
+        fieldSetCustomAttributes.setLayout(fieldSetLayout);
+
+        FormData subFieldsetFormData = new FormData("-15");
 
         // Custom Attribute #1
         customAttribute1Field = new KapuaTextField<String>();
@@ -249,7 +271,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         customAttribute1Field.setToolTip(DEVICE_MSGS.deviceFormCustomAttributesTooltip());
         customAttribute1Field.setWidth(225);
         customAttribute1Field.setMaxLength(255);
-        fieldSetCustomAttributes.add(customAttribute1Field, formData);
+        fieldSetCustomAttributes.add(customAttribute1Field, subFieldsetFormData);
 
         // Custom Attribute #2
         customAttribute2Field = new KapuaTextField<String>();
@@ -258,7 +280,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         customAttribute2Field.setToolTip(DEVICE_MSGS.deviceFormCustomAttributesTooltip());
         customAttribute2Field.setWidth(225);
         customAttribute2Field.setMaxLength(255);
-        fieldSetCustomAttributes.add(customAttribute2Field, formData);
+        fieldSetCustomAttributes.add(customAttribute2Field, subFieldsetFormData);
 
         // Custom Attribute #3
         customAttribute3Field = new KapuaTextField<String>();
@@ -267,7 +289,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         customAttribute3Field.setToolTip(DEVICE_MSGS.deviceFormCustomAttributesTooltip());
         customAttribute3Field.setWidth(225);
         customAttribute3Field.setMaxLength(255);
-        fieldSetCustomAttributes.add(customAttribute3Field, formData);
+        fieldSetCustomAttributes.add(customAttribute3Field, subFieldsetFormData);
 
         // Custom Attribute #4
         customAttribute4Field = new KapuaTextField<String>();
@@ -276,7 +298,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         customAttribute4Field.setToolTip(DEVICE_MSGS.deviceFormCustomAttributesTooltip());
         customAttribute4Field.setWidth(225);
         customAttribute4Field.setMaxLength(255);
-        fieldSetCustomAttributes.add(customAttribute4Field, formData);
+        fieldSetCustomAttributes.add(customAttribute4Field, subFieldsetFormData);
 
         // Custom Attribute #5
         customAttribute5Field = new KapuaTextField<String>();
@@ -285,7 +307,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         customAttribute5Field.setToolTip(DEVICE_MSGS.deviceFormCustomAttributesTooltip());
         customAttribute5Field.setWidth(225);
         customAttribute5Field.setMaxLength(255);
-        fieldSetCustomAttributes.add(customAttribute5Field, formData);
+        fieldSetCustomAttributes.add(customAttribute5Field, subFieldsetFormData);
 
         // Optlock
         optlock = new NumberField();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -117,6 +117,7 @@ public class DeviceEditDialog extends DeviceAddDialog {
             // General info data
             clientIdField.setValue(device.getClientId());
             clientIdLabel.setText(device.getClientId());
+            clientIdLabel.setStyleAttribute("word-wrap", "break-word");
             clientIdLabel.setToolTip(DEVICE_MSGS.deviceFormClientIDEditDialogTooltip());
             displayNameField.setValue(device.getUnescapedDisplayName());
             statusCombo.setSimpleValue(GwtDeviceQueryPredicates.GwtDeviceStatus.valueOf(device.getGwtDeviceStatus()));

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -34,7 +34,6 @@ import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser.GwtUserSta
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUserCreator;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserService;
 import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserServiceAsync;
-
 import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.Listener;
@@ -84,7 +83,6 @@ public class UserAddDialog extends EntityAddEditDialog {
 
     @Override
     public void createBody() {
-
         submitButton.disable();
         FormPanel userFormPanel = new FormPanel(FORM_LABEL_WIDTH);
         userFormPanel.setFrame(false);
@@ -106,7 +104,7 @@ public class UserAddDialog extends EntityAddEditDialog {
 
         FieldSet statusFieldSet = new FieldSet();
         statusFieldSet.setBorders(true);
-        statusFieldSet.setStyleAttribute("margin", "5px 10px 0px 10px");
+        statusFieldSet.setStyleAttribute("margin", "5px 10px 15px 10px");
         statusFieldSet.setHeading(USER_MSGS.dialogAddStatus());
 
         FormLayout userLayout = new FormLayout();
@@ -126,7 +124,7 @@ public class UserAddDialog extends EntityAddEditDialog {
 
         username = new KapuaTextField<String>();
         username.setAllowBlank(false);
-        username.setMaxLength(255);
+        username.setMaxLength(50);
         username.setName("userName");
         username.setFieldLabel("* " + USER_MSGS.dialogAddFieldUsername());
         username.setValidator(new TextFieldValidator(username, FieldType.NAME));
@@ -312,5 +310,4 @@ public class UserAddDialog extends EntityAddEditDialog {
     public String getInfoMessage() {
         return USER_MSGS.dialogAddInfo();
     }
-
 }

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,7 +17,6 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
-import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
@@ -35,7 +34,6 @@ public class UserEditDialog extends UserAddDialog {
     public UserEditDialog(GwtSession currentSession, GwtUser selectedUser) {
         super(currentSession);
         this.selectedUser = selectedUser;
-        DialogUtils.resizeDialog(this, 400, 390);
     }
 
     @Override
@@ -146,6 +144,7 @@ public class UserEditDialog extends UserAddDialog {
         usernameLabel.setVisible(true);
         username.setVisible(false);
         usernameLabel.setValue(gwtUser.getUsername());
+        usernameLabel.setStyleAttribute("word-wrap", "break-word");
         usernameLabel.setToolTip(USER_MSGS.dialogAddFieldNameEditDialogTooltip());
         if (password != null) {
             password.setVisible(false);


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed height of device dialogs and set user name length.

**Related Issue**
This PR fixes issue #2477 

**Description of the solution adopted**
User name is limited to 50 characters, and device dialogs are optimized to have auto height.

**Screenshots**
/

**Any side note on the changes made**
/
