### PR TITLE
reset filter fields after user input

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -171,6 +171,7 @@ public class EntityCRUDToolbar<M extends GwtEntityModel> extends ToolBar {
 
             @Override
             public void componentSelected(ButtonEvent ce) {
+                filterPanel.resetFields();
                 KapuaDialog dialog = getAddDialog();
                 if (dialog != null) {
                     dialog.addListener(Events.Hide, getHideDialogListener());


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Filter fields reset when 
**Related Issue**
This PR fixes issue #2489 

**Description of the solution adopted**
Just called reset filter fields method in EntityCRUDToolbar after rendering KapuaDialog.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
