### PR TITLE
Fixed wrong error messages when the user does not have needed permissions

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
@@ -49,7 +49,9 @@ public class AccountDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable t) {
                 exitStatus = false;
-                exitMessage = MSGS.accountDeleteErrorMessage();
+                if (!isPermissionErrorMessage(t)) {
+                    exitMessage = MSGS.accountDeleteErrorMessage();
+                }
                 hide();
             }
         });

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
@@ -31,6 +31,8 @@ import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
@@ -240,5 +242,21 @@ public abstract class ActionDialog extends KapuaDialog {
 
     public void setDisabledFormPanelEvents(Boolean disabledFormPanelEvents) {
         this.disabledFormPanelEvents = disabledFormPanelEvents;
+    }
+
+    /**
+     * Method for checking the thrown exception for the SUBJECT_UNAUTHORIZED error code.
+     * @param caught The exception thrown
+     * @return In case of the SUBJECT_UNAUTHORIZED error code the returned value is true 
+     * and the exitMessage is set. For every other case the returned value is false.
+     */
+    public boolean isPermissionErrorMessage(Throwable caught) {
+        if ((caught instanceof GwtKapuaException)
+                && GwtKapuaErrorCode.SUBJECT_UNAUTHORIZED.equals(((GwtKapuaException) caught).getCode())) {
+            exitMessage = caught.getLocalizedMessage();
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialDeleteDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -76,12 +76,13 @@ public class CredentialDeleteDialog extends EntityDeleteDialog {
             public void onFailure(Throwable cause) {
                 exitStatus = false;
 
-                if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.API_KEY) {
-                    exitMessage = MSGS.dialogDeleteErrorAPI(cause.getLocalizedMessage());
-                } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
-                    exitMessage = MSGS.dialogDeleteErrorPassword(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.API_KEY) {
+                        exitMessage = MSGS.dialogDeleteErrorAPI(cause.getLocalizedMessage());
+                    } else if (selectedCredential.getCredentialTypeEnum() == GwtCredentialType.PASSWORD) {
+                        exitMessage = MSGS.dialogDeleteErrorPassword(cause.getLocalizedMessage());
+                    }
                 }
-
                 hide();
             }
         });

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
@@ -59,8 +59,9 @@ public class CredentialEditDialog extends CredentialAddDialog {
                 status.hide();
 
                 exitStatus = false;
-                exitMessage = MSGS.dialogEditError(caught.getLocalizedMessage());
-
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = MSGS.dialogEditError(caught.getLocalizedMessage());
+                }
                 hide();
             }
 

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialUnlockDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialUnlockDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -56,7 +56,9 @@ public class CredentialUnlockDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogUnlockError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = MSGS.dialogUnlockError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupDeleteDialog.java
@@ -15,7 +15,6 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityDeleteDialog;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
-import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.authorization.client.messages.ConsoleGroupMessages;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
 import org.eclipse.kapua.app.console.module.authorization.shared.service.GwtGroupService;
@@ -41,9 +40,10 @@ public class GroupDeleteDialog extends EntityDeleteDialog {
 
             @Override
             public void onFailure(Throwable arg0) {
-                FailureHandler.handle(arg0);
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeleteError(arg0.getLocalizedMessage());
+                if (!isPermissionErrorMessage(arg0)) {
+                    exitMessage = MSGS.dialogDeleteError(arg0.getLocalizedMessage());
+                }
                 hide();
 
             }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleDeleteDialog.java
@@ -60,7 +60,9 @@ public class RoleDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -103,8 +103,10 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onFailure(Throwable caught) {
-                exitMessage = MSGS.dialogAddError(caught.getLocalizedMessage());
                 exitStatus = false;
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = MSGS.dialogAddError(caught.getLocalizedMessage());
+                }
                 hide();
             }
 
@@ -127,8 +129,10 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
 
                     @Override
                     public void onFailure(Throwable caught) {
-                        exitMessage = MSGS.dialogAddError(caught.getLocalizedMessage());
                         exitStatus = false;
+                        if (!isPermissionErrorMessage(caught)) {
+                            exitMessage = MSGS.dialogAddError(caught.getLocalizedMessage());
+                        }
                         hide();
                     }
 
@@ -201,8 +205,10 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
 
                 @Override
                 public void onFailure(Throwable caught) {
-                    exitMessage = MSGS.dialogAddError(caught.getLocalizedMessage());
                     exitStatus = false;
+                    if (!isPermissionErrorMessage(caught)) {
+                        exitMessage = MSGS.dialogAddError(caught.getLocalizedMessage());
+                    }
                     hide();
                 }
 
@@ -281,12 +287,14 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
                 status.hide();
 
                 exitStatus = false;
-                if ((cause instanceof GwtKapuaException) && (GwtKapuaErrorCode.ENTITY_UNIQUENESS.equals(((GwtKapuaException) cause).getCode()))) {
-                    exitMessage = MSGS.dialogAddPermissionAlreadyExists();
-                } else {
-                    exitMessage = MSGS.dialogAddError(MSGS.dialogAddPermissionError(cause.getLocalizedMessage()));
-                }
+                if (!isPermissionErrorMessage(cause)) {
+                    if ((cause instanceof GwtKapuaException) && (GwtKapuaErrorCode.ENTITY_UNIQUENESS.equals(((GwtKapuaException) cause).getCode()))) {
+                        exitMessage = MSGS.dialogAddPermissionAlreadyExists();
+                    } else {
+                        exitMessage = MSGS.dialogAddError(MSGS.dialogAddPermissionError(cause.getLocalizedMessage()));
+                    }
 
+                }
                 domainsCombo.markInvalid(exitMessage);
                 actionsCombo.markInvalid(exitMessage);
                 if (groupsCombo.isEnabled()){

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -53,7 +53,9 @@ public class RolePermissionDeleteDialog extends EntityDeleteDialog {
                 @Override
                 public void onFailure(Throwable cause) {
                     exitStatus = false;
-                    exitMessage = MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                    if (!isPermissionErrorMessage(cause)) {
+                        exitMessage = MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                    }
                     hide();
                 }
             });

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -90,8 +90,10 @@ public class PermissionAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onFailure(Throwable caught) {
-                exitMessage = MSGS.dialogAddPermissionErrorAccessInfo(caught.getLocalizedMessage());
                 exitStatus = false;
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = MSGS.dialogAddPermissionErrorAccessInfo(caught.getLocalizedMessage());
+                }
                 hide();
             }
         });
@@ -126,8 +128,10 @@ public class PermissionAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onFailure(Throwable caught) {
-                exitMessage = MSGS.dialogAddPermissionErrorDomains(caught.getLocalizedMessage());
                 exitStatus = false;
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = MSGS.dialogAddPermissionErrorDomains(caught.getLocalizedMessage());
+                }
                 hide();
             }
 
@@ -150,8 +154,10 @@ public class PermissionAddDialog extends EntityAddEditDialog {
 
                     @Override
                     public void onFailure(Throwable caught) {
-                        exitMessage = MSGS.dialogAddPermissionErrorActions(caught.getLocalizedMessage());
                         exitStatus = false;
+                        if (!isPermissionErrorMessage(caught)) {
+                            exitMessage = MSGS.dialogAddPermissionErrorActions(caught.getLocalizedMessage());
+                        }
                         hide();
                     }
 
@@ -222,8 +228,10 @@ public class PermissionAddDialog extends EntityAddEditDialog {
 
                 @Override
                 public void onFailure(Throwable caught) {
-                    exitMessage = MSGS.dialogAddPermissionErrorGroups(caught.getLocalizedMessage());
                     exitStatus = false;
+                    if (!isPermissionErrorMessage(caught)) {
+                        exitMessage = MSGS.dialogAddPermissionErrorGroups(caught.getLocalizedMessage());
+                    }
                     hide();
                 }
 
@@ -302,13 +310,14 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                 status.hide();
 
                 exitStatus = false;
-                if ((cause instanceof GwtKapuaException) &&
-                        (GwtKapuaErrorCode.ENTITY_UNIQUENESS.equals(((GwtKapuaException) cause).getCode()))) {
-                    exitMessage = MSGS.dialogAddPermissionAlreadyExists();
-                } else {
-                    exitMessage = MSGS.dialogAddError(MSGS.dialogAddPermissionError(cause.getLocalizedMessage()));
+                if (!isPermissionErrorMessage(cause)) {
+                    if ((cause instanceof GwtKapuaException) &&
+                            (GwtKapuaErrorCode.ENTITY_UNIQUENESS.equals(((GwtKapuaException) cause).getCode()))) {
+                        exitMessage = MSGS.dialogAddPermissionAlreadyExists();
+                    } else {
+                        exitMessage = MSGS.dialogAddError(MSGS.dialogAddPermissionError(cause.getLocalizedMessage()));
+                    }
                 }
-
                 domainsCombo.markInvalid(exitMessage);
                 actionsCombo.markInvalid(exitMessage);
                 if (groupsCombo.isEnabled()){

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -59,7 +59,9 @@ public class PermissionDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeletePermissionError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = MSGS.dialogDeletePermissionError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -66,7 +66,9 @@ public class AccessRoleAddDialog extends EntityAddEditDialog {
             @Override
             public void onFailure(Throwable caught) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogAddError(MSGS.dialogAddRoleErrorAccessInfo(caught.getLocalizedMessage()));
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = MSGS.dialogAddError(MSGS.dialogAddRoleErrorAccessInfo(caught.getLocalizedMessage()));
+                }
 
                 hide();
             }
@@ -102,14 +104,15 @@ public class AccessRoleAddDialog extends EntityAddEditDialog {
                 status.hide();
 
                 exitStatus = false;
-                switch (((GwtKapuaException) cause).getCode()) {
+                if (!isPermissionErrorMessage(cause)) {
+                    switch (((GwtKapuaException) cause).getCode()) {
                     case DUPLICATE_NAME:
                         exitMessage = MSGS.dialogAddRoleDuplicateError();
                         break;
                     default:
                         exitMessage = MSGS.dialogAddError(MSGS.dialogAddRoleError(cause.getLocalizedMessage()));
+                    }
                 }
-
                 rolesCombo.markInvalid(exitMessage);
                 ConsoleInfo.display(CMSGS.error(), exitMessage);
             }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -59,7 +59,9 @@ public class AccessRoleDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeleteRoleError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = MSGS.dialogDeleteRoleError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -52,7 +52,7 @@ roleTabSubjectGridTitle=Subject
 dialogAddHeader=Create new role
 dialogAddInfo=Create a new role. 
 dialogAddConfirmation=Permission successfully added.
-dialogAddError=Role assigning failed: {0}
+dialogAddError=Permission granting failed: {0}
 
 dialogAddFieldName=Name
 dialogAddFieldNameTooltip=The name of the new role. It must be unique.

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceDeleteDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceDeleteDialog.java
@@ -58,7 +58,9 @@ public class DeviceDeleteDialog extends EntityDeleteDialog {
 
                     public void onFailure(Throwable caught) {
                         exitStatus = false;
-                        exitMessage = DEVICE_MSGS.dialogDeviceDeleteError(caught.getLocalizedMessage());
+                        if (!isPermissionErrorMessage(caught)) {
+                            exitMessage = DEVICE_MSGS.dialogDeviceDeleteError(caught.getLocalizedMessage());
+                        }
                         hide();
                     }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -55,7 +55,9 @@ public class DeviceEditDialog extends DeviceAddDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = DEVICE_MSGS.dialogFormEditLoadFailed(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = DEVICE_MSGS.dialogFormEditLoadFailed(cause.getLocalizedMessage());
+                }
                 unmaskDialog();
             }
         });
@@ -89,7 +91,9 @@ public class DeviceEditDialog extends DeviceAddDialog {
             @Override
             public void onFailure(Throwable caught) {
                 exitStatus = false;
-                exitMessage = DEVICE_MSGS.deviceFormEditError(caught.getLocalizedMessage());
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = DEVICE_MSGS.deviceFormEditError(caught.getLocalizedMessage());
+                }
                 hide();
             }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagDeleteDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -61,7 +61,9 @@ public class DeviceTagDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeviceTagDeleteError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = MSGS.dialogDeviceTagDeleteError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteDialog.java
@@ -47,7 +47,9 @@ public class JobDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = JOB_MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = JOB_MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.app.console.module.job.client;
 
 import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
@@ -57,6 +58,7 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
             @Override
             public void componentSelected(ButtonEvent buttonEvent) {
                 JobStartDialog dialog = new JobStartDialog(gridSelectionModel.getSelectedItem());
+                dialog.addListener(Events.Hide, getHideDialogListener());
                 dialog.show();
             }
         });
@@ -68,6 +70,7 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
             @Override
             public void componentSelected(ButtonEvent buttonEvent) {
                 JobStopDialog dialog = new JobStopDialog(gridSelectionModel.getSelectedItem());
+                dialog.addListener(Events.Hide, getHideDialogListener());
                 dialog.show();
             }
         });
@@ -79,6 +82,7 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
             @Override
             public void componentSelected(ButtonEvent buttonEvent) {
                 JobRestartDialog dialog = new JobRestartDialog(gridSelectionModel.getSelectedItem());
+                dialog.addListener(Events.Hide, getHideDialogListener());
                 dialog.show();
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobRestartDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobRestartDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,6 @@ package org.eclipse.kapua.app.console.module.job.client;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.SimpleDialog;
-import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
@@ -54,14 +53,18 @@ public class JobRestartDialog extends SimpleDialog {
 
             @Override
             public void onFailure(Throwable caught) {
-                ConsoleInfo.display(MSGS.popupError(), JOB_MSGS.jobRestartErrorMessage(caught.getLocalizedMessage()));
+                exitStatus = false;
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = JOB_MSGS.jobRestartErrorMessage(caught.getLocalizedMessage());
+                }
                 unmask();
                 hide();
             }
 
             @Override
             public void onSuccess(Void result) {
-                ConsoleInfo.display(MSGS.popupInfo(), JOB_MSGS.jobRestartRestartedMessage());
+                exitStatus = true;
+                exitMessage = JOB_MSGS.jobRestartRestartedMessage();
                 unmask();
                 hide();
             }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStartDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStartDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,6 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.SimpleDialog;
-import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
@@ -52,14 +51,18 @@ public class JobStartDialog extends SimpleDialog {
 
             @Override
             public void onFailure(Throwable caught) {
-                ConsoleInfo.display(MSGS.popupError(), JOB_MSGS.jobStartErrorMessage(caught.getLocalizedMessage()));
+                exitStatus = false;
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = JOB_MSGS.jobStartErrorMessage(caught.getLocalizedMessage());
+                }
                 unmask();
                 hide();
             }
 
             @Override
             public void onSuccess(Void result) {
-                ConsoleInfo.display(MSGS.popupInfo(), JOB_MSGS.jobStartStartedMessage());
+                exitStatus = true;
+                exitMessage = JOB_MSGS.jobStartStartedMessage();
                 unmask();
                 hide();
             }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStopDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStopDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,6 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.SimpleDialog;
-import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
@@ -52,14 +51,18 @@ public class JobStopDialog extends SimpleDialog {
 
             @Override
             public void onFailure(Throwable caught) {
-                ConsoleInfo.display(MSGS.popupError(), JOB_MSGS.jobStopErrorMessage());
+                exitStatus = false;
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = JOB_MSGS.jobStopErrorMessage();
+                }
                 unmask();
                 hide();
             }
 
             @Override
             public void onSuccess(Void result) {
-                ConsoleInfo.display(MSGS.popupInfo(), JOB_MSGS.jobStopStoppedMessage());
+                exitStatus = true;
+                exitMessage = JOB_MSGS.jobStopStoppedMessage();
                 unmask();
                 hide();
             }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -45,7 +45,9 @@ public class JobScheduleDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = JOB_MSGS.dialogDeleteScheduleError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = JOB_MSGS.dialogDeleteScheduleError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -45,7 +45,9 @@ public class JobStepDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = JOB_MSGS.dialogDeleteStepError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = JOB_MSGS.dialogDeleteStepError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
@@ -270,8 +270,9 @@ public class JobTargetAddDialog extends EntityAddEditDialog {
                 status.hide();
 
                 exitStatus = false;
-                exitMessage = JOB_MSGS.dialogAddTargetError(cause.getLocalizedMessage());
-
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = JOB_MSGS.dialogAddTargetError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -56,7 +56,9 @@ public class JobTargetDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = JOB_MSGS.dialogDeleteTargetError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = JOB_MSGS.dialogDeleteTargetError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagDeleteDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagDeleteDialog.java
@@ -15,7 +15,6 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityDeleteDialog;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
-import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.tag.client.messages.ConsoleTagMessages;
 import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
 import org.eclipse.kapua.app.console.module.tag.shared.service.GwtTagService;
@@ -41,9 +40,10 @@ public class TagDeleteDialog extends EntityDeleteDialog {
 
             @Override
             public void onFailure(Throwable arg0) {
-                FailureHandler.handle(arg0);
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeleteError(arg0.getLocalizedMessage());
+                if (!isPermissionErrorMessage(arg0)) {
+                    exitMessage = MSGS.dialogDeleteError(arg0.getLocalizedMessage());
+                }
                 hide();
 
             }

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserDeleteDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserDeleteDialog.java
@@ -60,7 +60,9 @@ public class UserDeleteDialog extends EntityDeleteDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                }
                 hide();
             }
         });


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fixed wrong error messages when the user does not have needed permissions.

**Related Issue**
This PR fixes/closes #2490 

**Description of the solution adopted**
Added new boolean util method `isPermissionErrorMessage()` to the `ActionDialog` class. In this method a check of the error code is made and in specific case of `SUBJECT_UNAUTHORIZED` error code `exitMessage` is set and the return value is true. For all other error codes returned value is false, and the `exitMessage` is set specifically in `onFailure()` method of the dialog in question.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
