### PR TITLE
Changed input condition in package version field in devices

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -69,7 +69,8 @@ public class TextFieldValidator implements Validator {
                 "^\\+? ?[0-9_]+( [0-9_]+)*$"),
         ALPHABET("alphabet", "^[a-zA-Z_]+$"),
         ALPHANUMERIC("alphanumeric", "^[a-zA-Z0-9_]+$"),
-        NUMERIC("numeric", "^[+0-9.]+$");
+        NUMERIC("numeric", "^[+0-9.]+$"),
+        PACKAGE_VERSION("package_version", "^[a-zA-Z0-9.\\-\\_]*$");
 
         private String name;
         private String regex;

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -10,6 +10,8 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
+package_versionRegexMsg=Package version can contain alphanumeric characters combined with point and dash.
+
 simple_nameRegexMsg=Name must be at least 3 characters and can contain alphanumeric characters combined with dash.
 simple_nameToolTipMsg=Must be at least 3 characters and can contain alphanumeric characters combined with dash.
 simple_nameRequiredMsg=Name is required.

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,8 @@ import org.eclipse.kapua.app.console.module.api.client.ui.dialog.TabbedDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaNumberField;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldValidator;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldValidator.FieldType;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.device.shared.model.device.management.packages.GwtPackageInstallRequest;
 import org.eclipse.kapua.app.console.module.device.shared.service.GwtDeviceManagementService;
@@ -110,6 +112,7 @@ public class PackageInstallDialog extends TabbedDialog {
             dpVersionField = new KapuaTextField<String>();
             dpVersionField.setMaxLength(125);
             dpVersionField.setName("dpVersion");
+            dpVersionField.setValidator(new TextFieldValidator(dpVersionField, FieldType.PACKAGE_VERSION));
             dpVersionField.setAllowBlank(false);
             dpVersionField.setFieldLabel("* " + DEVICE_MSGS.packageInstallDpTabVersion());
             dpVersionField.setToolTip(DEVICE_MSGS.devicePackageVersionTooltip());


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed input condition in package version field in device packages.

**Related Issue**
This PR fixes issue #2115 

**Description of the solution adopted**
In device packages, on install dialog, some symobls are not permitted on field package version.

**Screenshots**
/

**Any side note on the changes made**
/
