### PR TITLE
Removed a meaningless account service test.

### DIFF
--- a/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
+++ b/service/account/internal/src/test/java/org/eclipse/kapua/service/account/internal/AccountServiceTestSteps.java
@@ -49,7 +49,6 @@ import org.eclipse.kapua.service.account.AccountFactory;
 import org.eclipse.kapua.service.account.AccountQuery;
 import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.account.Organization;
-import org.eclipse.kapua.service.account.internal.setting.KapuaAccountSetting;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
@@ -690,11 +689,6 @@ public class AccountServiceTestSteps extends AbstractKapuaSteps {
     @Then("^The returned value is (\\d+)$")
     public void checkIntegerReturnValue(int val) {
         assertEquals(Integer.valueOf(val), intVal);
-    }
-
-    @Then("^Account service metadata is available$")
-    public void checkAccountServiceMetadataExistance() {
-        assertNotNull("Account settings not configured.", KapuaAccountSetting.getInstance());
     }
 
     // *******************

--- a/service/account/internal/src/test/resources/features/AccountService.feature
+++ b/service/account/internal/src/test/resources/features/AccountService.feature
@@ -192,12 +192,6 @@ Scenario: Test account query
     When I query for all accounts that have the system account as parent
     Then The returned value is 9
 
-Scenario: Account service metadata
-    The Account service must have some associated configuration metadata. Check that the
-    metadata exists. No content checks will be performed.
-
-    Then Account service metadata is available
-
 Scenario: Account name must not be mutable
     It must be impossible to change an existing account name. When tried, an exception must
     be thrown and the original account must be unchanged.


### PR DESCRIPTION
## Minor Account service test suite cleanup
A meaningless test was removed from the Account service test suite. 

**Related Issue**
This PR fixes _{#2499}_

**Description of the solution adopted**
The test scenario was removed from the AccountService.feature file. The Test step implementation was also removed from AccountServiceTestSteps.java.

Signed-off-by: Andrej Nussdorfer <andrej.nussdorfer@comtrade.com>