### PR TITLE
Changed info message on delete tag dialog

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagDeleteDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagDeleteDialog.java
@@ -44,7 +44,7 @@ public class DeviceTagDeleteDialog extends EntityDeleteDialog {
 
     @Override
     public String getInfoMessage() {
-        return MSGS.dialogDeviceTagDeleteInfo(selectedTag.getTagName(), selectedDevice.getClientId());
+        return MSGS.dialogDeviceTagDeleteInfo();
     }
 
     @Override

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -383,7 +383,7 @@ dialogDeviceTagAddError=Error when applying tag: {0}
 
 
 dialogDeviceTagDeleteHeader=Remove Associated Tag: {0}
-dialogDeviceTagDeleteInfo=Are you sure you want to remove {0} tag from the device {1}?
+dialogDeviceTagDeleteInfo=Are you sure you want to remove the selected tag?
 dialogDeviceTagDeleteConfirmation=Tag successfully removed.
 dialogDeviceTagDeleteError=Error while removing tag: {0}
 dialogDeviceDeleteError=Error when deleting device: {0}


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed info message on delete tag dialog.

**Related Issue**
This PR fixes issue #2510 

**Description of the solution adopted**
If user enter device name or tag name which is to long, info mesage in dialog is not shown correctly, so message is changed to be more adaptive.

**Screenshots**
/

**Any side note on the changes made**
/
