### PR TITLE
Changed functionality of check boxes in data and job targets

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridCheckBoxSelectionModel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridCheckBoxSelectionModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,8 +12,12 @@
 package org.eclipse.kapua.app.console.module.api.client.ui.grid;
 
 import com.extjs.gxt.ui.client.data.ModelData;
+import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.GridEvent;
+import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.widget.Component;
 import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.Event;
 
 /**
@@ -38,5 +42,24 @@ public class EntityGridCheckBoxSelectionModel<M extends ModelData> extends Check
       } else {
         super.handleMouseDown(e);
       }
+    }
+
+    @Override
+    public void init(Component component) {
+        Listener<GridEvent<M>> enterEventListener = new Listener<GridEvent<M>>() {
+
+            @Override
+            public void handleEvent(GridEvent<M> be) {
+              if (be.getKeyCode() == KeyCodes.KEY_ENTER) {
+                  if (grid.getSelectionModel().getSelectedItem() == null) {
+                      grid.getSelectionModel().selectAll();
+                  } else {
+                      grid.getSelectionModel().deselectAll();
+                  }
+              }
+            }
+        };
+        grid.addListener(Events.OnKeyUp, enterEventListener);
+        super.init(component);
     }
 }


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed functionality of check boxes in data tab and job targets tab.

**Related Issue**
This PR fixes issue #1991. 

**Description of the solution adopted**
In Data tab -> Metrics grid, and in Jobs -> Targets add dialog, functionality of check boxes is changed. Event _onKeyUp_ was added on this check boxes for _Enter_ keyboard key. Problem in original issue was _Space_ key, but this key has his own function which is defined in GWT class, so in this PR event is added for Enter keyboard key.

**Screenshots**
/

**Any side note on the changes made**
/
