### PR TITLE
Different way of displaying Event message information on Events tab

### DIFF
--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -17,6 +17,7 @@ yes=Yes
 no=No
 info=Confirmation
 information=Information
+showDetails=Show details
 success=Success
 error=Error 
 confirm=Confirm

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
@@ -22,9 +22,13 @@ import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.extjs.gxt.ui.client.data.RpcProxy;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.IconButtonEvent;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.store.ListStore;
 import com.extjs.gxt.ui.client.widget.ContentPanel;
+import com.extjs.gxt.ui.client.widget.HorizontalPanel;
+import com.extjs.gxt.ui.client.widget.Text;
+import com.extjs.gxt.ui.client.widget.button.ToolButton;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.extjs.gxt.ui.client.widget.grid.ColumnData;
 import com.extjs.gxt.ui.client.widget.grid.ColumnModel;
@@ -37,6 +41,10 @@ import com.extjs.gxt.ui.client.widget.toolbar.SeparatorToolItem;
 import com.extjs.gxt.ui.client.widget.toolbar.ToolBar;
 import com.extjs.gxt.ui.client.widget.treegrid.TreeGridCellRenderer;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.MouseOutEvent;
+import com.google.gwt.event.dom.client.MouseOutHandler;
+import com.google.gwt.event.dom.client.MouseOverEvent;
+import com.google.gwt.event.dom.client.MouseOverHandler;
 import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Window;
@@ -194,17 +202,48 @@ public class DeviceTabHistory extends KapuaTabItem<GwtDevice> {
         TreeGridCellRenderer<GwtDeviceEvent> eventMessageRenderer = new TreeGridCellRenderer<GwtDeviceEvent>() {
 
             @Override
-            public Object render(GwtDeviceEvent model, String property, ColumnData config, int rowIndex, int colIndex, ListStore<GwtDeviceEvent> store, Grid<GwtDeviceEvent> grid) {
-                StringBuilder message = new StringBuilder("");
+            public Object render(final GwtDeviceEvent model, String property, ColumnData config, int rowIndex, int colIndex, ListStore<GwtDeviceEvent> store, Grid<GwtDeviceEvent> grid) {
+                final HorizontalPanel horizontalPanel = new HorizontalPanel();
+                final Text cellText = new Text();
+                cellText.setStyleName("x-grid3-cell");
+                cellText.setText(model.getUnescapedEventMessage());
 
-                if (model.getEventMessage() != null) {
-                    message.append("<label title='")
-                            .append(model.getUnescapedEventMessage())
-                            .append("'>")
-                            .append(model.getUnescapedEventMessage())
-                            .append("</label>");
-                }
-                return message.toString();
+                // Search button
+                final ToolButton searchButton = new ToolButton("x-tool-search", new SelectionListener<IconButtonEvent>() {
+
+                    @Override
+                    public void componentSelected(IconButtonEvent ce) {
+                        final EventMessageDetailsDialog dialog = new EventMessageDetailsDialog(model.getReceivedOnFormatted(), model.getEventType(), model.getUnescapedEventMessage());
+                        dialog.show();
+                    }
+                });
+
+                searchButton.setStyleAttribute("margin-right", "5px");
+                searchButton.setToolTip(MSGS.showDetails());
+                horizontalPanel.add(searchButton);
+                horizontalPanel.add(cellText);
+                searchButton.hide();
+
+                // Show search button on mouse over
+                horizontalPanel.addDomHandler(new MouseOverHandler() {
+
+                    @Override
+                    public void onMouseOver(MouseOverEvent arg0) {
+                        if (model.getUnescapedEventMessage() != null && !model.getUnescapedEventMessage().isEmpty()) {
+                            searchButton.show();
+                        }
+                    }
+                }, MouseOverEvent.getType());
+
+                // Hide search button on mouse out
+                horizontalPanel.addDomHandler(new MouseOutHandler() {
+
+                    @Override
+                    public void onMouseOut(MouseOutEvent arg0) {
+                        searchButton.hide();
+                    }
+                }, MouseOutEvent.getType());
+                return horizontalPanel;
             }
         };
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/EventMessageDetailsDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/EventMessageDetailsDialog.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.device.client.device.history;
+
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.SimpleDialog;
+import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
+import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
+import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
+
+import com.extjs.gxt.ui.client.Style.Scroll;
+import com.extjs.gxt.ui.client.widget.LayoutContainer;
+import com.extjs.gxt.ui.client.widget.form.TextArea;
+import com.extjs.gxt.ui.client.widget.layout.FitLayout;
+import com.google.gwt.core.client.GWT;
+
+public class EventMessageDetailsDialog extends SimpleDialog {
+    private String eventReceivedOnFormatted;
+    private String eventType;
+    private String eventMessage;
+    private TextArea eventMessageField;
+    private LayoutContainer eventOutput;
+
+    private static final ConsoleDeviceMessages DEVICES_MSGS = GWT.create(ConsoleDeviceMessages.class);
+
+    public EventMessageDetailsDialog(String eventReceivedOnFormatted, String eventType, String eventMessage) {
+        this.eventReceivedOnFormatted = eventReceivedOnFormatted;
+        this.eventType = eventType;
+        this.eventMessage = eventMessage;
+
+        DialogUtils.resizeDialog(this, 550, 320);
+    }
+
+    @Override
+    public void createBody() {
+
+        FormPanel eventsFormPanel = new FormPanel(0);
+        eventsFormPanel.setHeight(270);
+        eventsFormPanel.setWidth(550);
+        eventsFormPanel.setScrollMode(Scroll.AUTO);
+        eventsFormPanel.setPadding(15);
+        submitButton.hide();
+
+        eventOutput = new LayoutContainer();
+        eventOutput.setBorders(false);
+        eventOutput.setLayout(new FitLayout());
+
+        eventMessageField = new TextArea();
+        eventMessageField.setReadOnly(true);
+        eventMessageField.setHeight(220);
+        eventMessageField.setWidth(515);
+        eventMessageField.setStyleAttribute("white-space", "pre-wrap");
+        eventMessageField.setValue(KapuaSafeHtmlUtils.htmlUnescape(eventMessage));
+        eventOutput.add(eventMessageField);
+        eventsFormPanel.add(eventOutput);
+        bodyPanel.add(eventsFormPanel);
+    }
+
+    @Override
+    protected void addListeners() {
+    }
+
+    @Override
+    public void submit() {
+    }
+
+    @Override
+    public String getHeaderMessage() {
+        return DEVICES_MSGS.deviceEventMessageDialogHeaderMessage(eventType, eventReceivedOnFormatted);
+    }
+
+    @Override
+    public KapuaIcon getInfoIcon() {
+        return null;
+    }
+
+    @Override
+    public String getInfoMessage() {
+        return null;
+    }
+}

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -234,6 +234,7 @@ deviceEventType=Event Type
 deviceEventMessage=Event Message
 deviceEventActionType=Action Type
 deviceEventResponseCode=Response Code
+deviceEventMessageDialogHeaderMessage=Detailed message for {0} event received on {1}:
 deviceHistoryTableNoHistory=No Events Received
 
 deviceBndId=ID


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
This PR proposes a new solution for displaying the event message information on Events tab.

**Related Issue**
This PR fixes/closes #2245 

**Description of the solution adopted**
Added new `EventMessageDetailsDialog` dialog (_Screenshots 2_) on which the Event message details are shown. 
The dialog header contains the event message type and the date on which the event is received on. This dialog is shown after clicking the newly added `searchButton` (_Screenshot 1_) for which `onMouseOver` and `onMouseOut` event listeners, that control when the button will be shown/hidden were added. 
If the event message for specific event is empty, the dialog and the `searchButton` itself will not be shown. 
In case of long event messages the dialog is scrollable (_Screenshot 3_).

**Screenshots**

_Screenshot 1:_
<img width="959" alt="em1" src="https://user-images.githubusercontent.com/35954696/54992054-998c4c80-4fbe-11e9-81e7-7a5513d8680f.png">

_Screenshot 2:_
<img width="956" alt="em2" src="https://user-images.githubusercontent.com/35954696/54992059-9e510080-4fbe-11e9-8947-b01cb8d6a8d1.png">

_Screenshot 3:_
<img width="959" alt="em3" src="https://user-images.githubusercontent.com/35954696/54992780-7a8eba00-4fc0-11e9-82c3-45683c3603c7.png">

**Any side note on the changes made**
_None_
