### PR TITLE
enabled login button when user logs out

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -162,14 +162,6 @@ public class LoginDialog extends Dialog {
         getButtonBar().add(new FillToolItem());
 
         reset = new Button(CORE_MSGS.loginReset());
-        reset.addListener(Events.OnFocus, new Listener<BaseEvent>() {
-
-            @Override
-            public void handleEvent(BaseEvent be) {
-                username.clearInvalid();
-                password.clearInvalid();
-            }
-        });
 
         reset.addSelectionListener(new SelectionListener<ButtonEvent>() {
 
@@ -185,7 +177,6 @@ public class LoginDialog extends Dialog {
         });
 
         login = new Button(CORE_MSGS.loginLogin());
-        login.disable();
         login.addSelectionListener(new SelectionListener<ButtonEvent>() {
 
             @Override
@@ -229,12 +220,20 @@ public class LoginDialog extends Dialog {
      * Login submit
      */
     protected void onSubmit() {
-        status.show();
-        getButtonBar().disable();
-        username.disable();
-        password.disable();
-
-        performLogin();
+        if (username.getValue() == null && password.getValue() == null) {
+            ConsoleInfo.display(MSGS.dialogError(), MSGS.usernameAndPasswordRequired());
+            password.markInvalid(password.getErrorMessage());
+        } else if (username.getValue() == null) {
+            ConsoleInfo.display(MSGS.dialogError(), MSGS.usernameFieldRequired());
+        } else if (password.getValue() == null) {
+            ConsoleInfo.display(MSGS.dialogError(), MSGS.passwordFieldRequired());
+        } else {
+            status.show();
+            getButtonBar().disable();
+            username.disable();
+            password.disable();
+            performLogin();
+        }
     }
 
     // Login
@@ -287,9 +286,7 @@ public class LoginDialog extends Dialog {
     }
 
     protected void validate() {
-        login.setEnabled(hasValue(username) &&
-                username.isValid() &&
-                hasValue(password));
+        login.setEnabled(true);
     }
 
     public void reset() {
@@ -301,7 +298,6 @@ public class LoginDialog extends Dialog {
         username.focus();
         status.hide();
         getButtonBar().enable();
-        login.disable();
         password.clearInvalid();
     }
 

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -97,9 +97,12 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
         try {
             // Get the user
             KapuaLocator locator = KapuaLocator.getInstance();
+            LoginCredentials credentials = null;
             AuthenticationService authenticationService = locator.getService(AuthenticationService.class);
             CredentialsFactory credentialsFactory = locator.getFactory(CredentialsFactory.class);
-            LoginCredentials credentials = credentialsFactory.newUsernamePasswordCredentials(gwtLoginCredentials.getUsername(), gwtLoginCredentials.getPassword());
+            if(gwtLoginCredentials.getUsername() != null && gwtLoginCredentials.getPassword() != null) {
+                credentials = credentialsFactory.newUsernamePasswordCredentials(gwtLoginCredentials.getUsername(), gwtLoginCredentials.getPassword());
+            }
 
             // Login
             authenticationService.login(credentials);

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -45,6 +45,9 @@ browserWindowTooSmall=Browser Window is too small for accurate UI display.
  # Entity Grid labels
  gridEmptyResult=No result found
  allFieldsRequired=Fields with * are mandatory.
+ usernameAndPasswordRequired=Username and password are mandatory fields.
+ usernameFieldRequired=Username field is mandatory.
+ passwordFieldRequired=Password field is mandatory.
  specifyEndTime=Please specify end time.
  specifyEndDate=Please specify end date.
  


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Enabled login button when user logs out.

**Related Issue**
This PR fixes issue #1620.

**Description of the solution adopted**
In this issue, problem is disabled Login button when user logs out, and his credentials are saved in browser which means that fields on login dialog are auto completed. This problem is caused by GWT, and every event, like _TAB_ click on keyboard, activates this button. Because of that, in this PR logic on login page is changed. 
First, Login button is enabled in every case. After that, some validation are added. If username and password fields on dialog are empty, proper error message is shown in the bottom right corner, and fields are marked invalid. Also, `onFocus` event is removed from reset button, because fields have to be in error state always when they are not filled. 
On this way, issue is resolved and button field is not disabled after log out, and, also, functionality is not changed or disturbed.

**Screenshots**
/

**Any side note on the changes made**
/
