### PR TITLE
Fix for Created by/Modified by properties not shown correctly

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDescriptionTab.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDescriptionTab.java
@@ -45,7 +45,7 @@ public class AccountDescriptionTab extends EntityDescriptionTabItem<GwtAccount> 
 
             @Override
             protected void load(Object loadConfig, AsyncCallback<ListLoadResult<GwtGroupedNVPair>> callback) {
-                GWT_ACCOUNT_SERVICE.getAccountInfo(currentSession.getSelectedAccountId(), selectedEntity.getId(), callback);
+                GWT_ACCOUNT_SERVICE.getAccountInfo(currentSession.getSelectedAccountId(), currentSession.getAccountId(), selectedEntity.getId(), callback);
             }
         };
     }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsTabDescription.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,11 +18,15 @@ import com.extjs.gxt.ui.client.event.ComponentEvent;
 import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.extjs.gxt.ui.client.store.ListStore;
+import com.extjs.gxt.ui.client.widget.grid.ColumnData;
+import com.extjs.gxt.ui.client.widget.grid.Grid;
 import com.extjs.gxt.ui.client.widget.toolbar.SeparatorToolItem;
 import com.extjs.gxt.ui.client.widget.toolbar.ToolBar;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import java.util.Date;
 import org.eclipse.kapua.app.console.module.account.client.toolbar.AccountEditDialog;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.account.shared.model.permission.AccountSessionPermission;
@@ -32,6 +36,7 @@ import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.EditButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.EntityDescriptionTabItem;
+import org.eclipse.kapua.app.console.module.api.client.util.DateUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
@@ -51,7 +56,7 @@ public class AccountDetailsTabDescription extends EntityDescriptionTabItem<GwtAc
 
             @Override
             protected void load(Object loadConfig, AsyncCallback<ListLoadResult<GwtGroupedNVPair>> callback) {
-                gwtAccountService.getAccountInfo(currentSession.getSelectedAccountId(), getSelectedEntity().getId(), callback);
+                gwtAccountService.getAccountInfo(currentSession.getSelectedAccountId(), currentSession.getAccountId(), getSelectedEntity().getId(), callback);
             }
         };
     }
@@ -113,5 +118,19 @@ public class AccountDetailsTabDescription extends EntityDescriptionTabItem<GwtAc
     protected void onRender(Element parent, int index) {
         super.onRender(parent, index);
         setBorders(false);
+    }
+
+    @Override
+    protected Object renderValueCell(GwtGroupedNVPair model, String property, ColumnData config, int rowIndex,
+            int colIndex, ListStore<GwtGroupedNVPair> store, Grid<GwtGroupedNVPair> grid) {
+        Object value = model.getValue();
+        if (model.getName().equals("expirationDate") && model.getValue().equals("N/A")) {
+            return MSGS.never();
+        } else if (value != null && value instanceof Date) {
+            Date dateValue = (Date) value;
+            return DateUtils.formatDateTime(dateValue);
+        } else {
+            return value;
+        }
     }
 }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -203,27 +203,28 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
     }
 
     @Override
-    public ListLoadResult<GwtGroupedNVPair> getAccountInfo(String scopeIdString, String accountIdString)
+    public ListLoadResult<GwtGroupedNVPair> getAccountInfo(String scopeIdString, String accountIdString, String selectedAccountIdString)
             throws GwtKapuaException {
         final KapuaId scopeId = KapuaEid.parseCompactId(scopeIdString);
-        KapuaId accountId = KapuaEid.parseCompactId(accountIdString);
+        final KapuaId accountId = KapuaEid.parseCompactId(accountIdString);
+        final KapuaId selectedAccountId = KapuaEid.parseCompactId(selectedAccountIdString);
 
         List<GwtGroupedNVPair> accountPropertiesPairs = new ArrayList<GwtGroupedNVPair>();
         try {
-            final Account account = ACCOUNT_SERVICE.find(scopeId, accountId);
+            final Account account = ACCOUNT_SERVICE.find(scopeId, selectedAccountId);
 
             User userCreatedBy = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 
                 @Override
                 public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, account.getCreatedBy());
+                    return USER_SERVICE.find(accountId, account.getCreatedBy());
                 }
             });
             User userModifiedBy = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 
                 @Override
                 public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, account.getModifiedBy());
+                    return USER_SERVICE.find(accountId, account.getModifiedBy());
                 }
             });
 

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/service/GwtAccountService.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/service/GwtAccountService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -65,11 +65,13 @@ public interface GwtAccountService extends RemoteService {
     /**
      * Get account info ad name values pairs
      *
+     * @param gwtScopeId
      * @param gwtAccountId
+     * @param gwtSelectedAccountId
      * @return
      * @throws GwtKapuaException
      */
-    public ListLoadResult<GwtGroupedNVPair> getAccountInfo(String gwtScopeId, String gwtAccountId)
+    public ListLoadResult<GwtGroupedNVPair> getAccountInfo(String gwtScopeId, String gwtAccountId, String gwtSelectedAccountId)
             throws GwtKapuaException;
 
     /**

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointGrid.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointGrid.java
@@ -77,7 +77,7 @@ public class EndpointGrid extends EntityGrid<GwtEndpoint> {
             @Override
             protected void load(Object loadConfig,
                     AsyncCallback<PagingLoadResult<GwtEndpoint>> callback) {
-                GWT_ENDPOINT_SERVICE.query((PagingLoadConfig) loadConfig, query, callback);
+                GWT_ENDPOINT_SERVICE.query((PagingLoadConfig) loadConfig, currentSession.getAccountId(), query, callback);
 
             }
         };

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointTabDescription.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointTabDescription.java
@@ -37,7 +37,7 @@ public class EndpointTabDescription extends EntityDescriptionTabItem<GwtEndpoint
 
             @Override
             protected void load(Object loadConfig, AsyncCallback<ListLoadResult<GwtGroupedNVPair>> callback) {
-                GWT_ENDPOINT_SERVICE.getEndpointDescription(selectedEntity.getScopeId(), selectedEntity.getId(), callback);
+                GWT_ENDPOINT_SERVICE.getEndpointDescription(selectedEntity.getScopeId(), currentSession.getAccountId(), selectedEntity.getId(), callback);
 
             }
         };

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -127,10 +127,11 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
     }
 
     @Override
-    public PagingLoadResult<GwtEndpoint> query(PagingLoadConfig loadConfig, final GwtEndpointQuery gwtEndpointQuery) throws GwtKapuaException {
+    public PagingLoadResult<GwtEndpoint> query(PagingLoadConfig loadConfig, String gwtAccountId, final GwtEndpointQuery gwtEndpointQuery) throws GwtKapuaException {
         int totalLength = 0;
         List<GwtEndpoint> gwtEndpointList = new ArrayList<GwtEndpoint>();
         try {
+            final KapuaId accountId = KapuaEid.parseCompactId(gwtAccountId);
             EndpointInfoQuery endpointQuery = GwtKapuaEndpointModelConverter.convertEndpointQuery(loadConfig, gwtEndpointQuery);
 
             EndpointInfoListResult endpoints = ENDPOINT_INFO_SERVICE.query(endpointQuery);
@@ -141,7 +142,7 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtEndpointQuery.getScopeId())));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(accountId));
                     }
                 });
 
@@ -179,10 +180,11 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
     }
 
     @Override
-    public ListLoadResult<GwtGroupedNVPair> getEndpointDescription(String scopeShortId, String endpointShortId) throws GwtKapuaException {
+    public ListLoadResult<GwtGroupedNVPair> getEndpointDescription(String scopeShortId, String accountShortId, String endpointShortId) throws GwtKapuaException {
         List<GwtGroupedNVPair> gwtEndpointDescription = new ArrayList<GwtGroupedNVPair>();
         try {
             final KapuaId scopeId = KapuaEid.parseCompactId(scopeShortId);
+            final KapuaId accountId = KapuaEid.parseCompactId(accountShortId);
             KapuaId endpointId = KapuaEid.parseCompactId(endpointShortId);
 
             final EndpointInfo endpointInfo = ENDPOINT_INFO_SERVICE.find(scopeId, endpointId);
@@ -192,14 +194,14 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
 
                     @Override
                     public User call() throws Exception {
-                        return USER_SERVICE.find(scopeId, endpointInfo.getCreatedBy());
+                        return USER_SERVICE.find(accountId, endpointInfo.getCreatedBy());
                     }
                 });
                 User modifiedUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 
                     @Override
                     public User call() throws Exception {
-                        return USER_SERVICE.find(scopeId, endpointInfo.getModifiedBy());
+                        return USER_SERVICE.find(accountId, endpointInfo.getModifiedBy());
                     }
                 });
 

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/service/GwtEndpointService.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/service/GwtEndpointService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,11 +33,11 @@ public interface GwtEndpointService extends RemoteService {
 
     public GwtEndpoint find(String scopeShortId, String roleShortId) throws GwtKapuaException;
 
-    public PagingLoadResult<GwtEndpoint> query(PagingLoadConfig loadConfig, GwtEndpointQuery gwtEndpointQuery) throws GwtKapuaException;
+    public PagingLoadResult<GwtEndpoint> query(PagingLoadConfig loadConfig, String gwtAccountId, GwtEndpointQuery gwtEndpointQuery) throws GwtKapuaException;
 
     public void delete(String scopeId, String endpointId) throws GwtKapuaException;
 
-    public ListLoadResult<GwtGroupedNVPair> getEndpointDescription(String scopeShortId, String endpointShortId) throws GwtKapuaException;
+    public ListLoadResult<GwtGroupedNVPair> getEndpointDescription(String scopeShortId, String accountShortId, String endpointShortId) throws GwtKapuaException;
 
     public List<GwtEndpoint> findAll(String scopeId) throws GwtKapuaException;
 


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for Created by/Modified by properties not shown correctly.

**Related Issue**
This PR fixes/closes #2465 

**Description of the solution adopted**
Added new parameter `currentSession.getAccountId()` to:
- `GwtAccountService(Impl)` class's `getAccountInfo()` method
- `GwtEndpointService(Impl)` class's `query()`  and `getEndpointDescription()` methods
That additional parameter is used when querying Users for the needed Created By/Modified By properties.

Overridden the `renderValueCell()` method in `AccountDetailsTabDescription` regarding the display of _Expiration Date_ property.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
