### PR TITLE
Additional permission problems fixes

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -332,20 +332,23 @@ public class AccountAddDialog extends EntityAddEditDialog {
 
                     @Override
                     public void onFailure(Throwable cause) {
-                        FailureHandler.handleFormException(formPanel, cause);
+                        exitStatus = false;
                         status.hide();
                         formPanel.getButtonBar().enable();
                         unmask();
                         submitButton.enable();
                         cancelButton.enable();
-                        if (cause instanceof GwtKapuaException) {
-                            GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                            if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)
-                                    || gwtCause.getCode().equals(GwtKapuaErrorCode.ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT)) {
-                                accountNameField.markInvalid(gwtCause.getMessage());
-                            } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.ILLEGAL_ARGUMENT) && gwtCause.getArguments()[0].equals("expirationDate")) {
-                                expirationDateField.markInvalid(MSGS.conflictingExpirationDate());
+                        if (!isPermissionErrorMessage(cause)) {
+                            if (cause instanceof GwtKapuaException) {
+                                GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                                if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)
+                                        || gwtCause.getCode().equals(GwtKapuaErrorCode.ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT)) {
+                                    accountNameField.markInvalid(gwtCause.getMessage());
+                                } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.ILLEGAL_ARGUMENT) && gwtCause.getArguments()[0].equals("expirationDate")) {
+                                    expirationDateField.markInvalid(MSGS.conflictingExpirationDate());
+                                }
                             }
+                            FailureHandler.handleFormException(formPanel, cause);
                         }
                     }
 

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
@@ -108,30 +108,33 @@ public class AccountEditDialog extends AccountAddDialog {
 
                     @Override
                     public void onFailure(Throwable caught) {
-                        FailureHandler.handleFormException(formPanel, caught);
+                        exitStatus = false;
                         status.hide();
                         formPanel.getButtonBar().enable();
                         unmask();
                         submitButton.enable();
                         cancelButton.enable();
-                        if (caught instanceof GwtKapuaException) {
-                            GwtKapuaException gwtCause = (GwtKapuaException) caught;
-                            switch (gwtCause.getCode()) {
-                            case DUPLICATE_NAME:
-                                accountNameField.markInvalid(gwtCause.getMessage());
-                                break;
-                            case ILLEGAL_ARGUMENT:
-                                if (gwtCause.getArguments()[0].equals("expirationDate")) {
-                                    expirationDateField.markInvalid(MSGS.conflictingExpirationDate());
-                                    ConsoleInfo.display("Error", MSGS.conflictingExpirationDate());
-                                } else if (gwtCause.getArguments()[0].equals("notAllowedExpirationDate")) {
-                                    expirationDateField.markInvalid(MSGS.notAllowedExpirationDate());
-                                    ConsoleInfo.display("Error", MSGS.notAllowedExpirationDate());
+                        if (!isPermissionErrorMessage(caught)) {
+                            if (caught instanceof GwtKapuaException) {
+                                GwtKapuaException gwtCause = (GwtKapuaException) caught;
+                                switch (gwtCause.getCode()) {
+                                case DUPLICATE_NAME:
+                                    accountNameField.markInvalid(gwtCause.getMessage());
+                                    break;
+                                case ILLEGAL_ARGUMENT:
+                                    if (gwtCause.getArguments()[0].equals("expirationDate")) {
+                                        expirationDateField.markInvalid(MSGS.conflictingExpirationDate());
+                                        ConsoleInfo.display("Error", MSGS.conflictingExpirationDate());
+                                    } else if (gwtCause.getArguments()[0].equals("notAllowedExpirationDate")) {
+                                        expirationDateField.markInvalid(MSGS.notAllowedExpirationDate());
+                                        ConsoleInfo.display("Error", MSGS.notAllowedExpirationDate());
+                                    }
+                                    break;
+                                default:
+                                    break;
                                 }
-                                break;
-                            default:
-                                break;
                             }
+                            FailureHandler.handleFormException(formPanel, caught);
                         }
                     }
 

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.account.client.toolbar;
 
+import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.user.client.Element;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.account.shared.model.permission.AccountSessionPermission;
@@ -34,7 +35,9 @@ public class AccountGridToolbar extends EntityCRUDToolbar<GwtAccount> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        return new AccountAddDialog(currentSession);
+        AccountAddDialog dialog = new AccountAddDialog(currentSession);
+        dialog.addListener(Events.Hide, getHideDialogListener());
+        return dialog;
     }
 
     @Override
@@ -43,6 +46,7 @@ public class AccountGridToolbar extends EntityCRUDToolbar<GwtAccount> {
         AccountEditDialog dialog = null;
         if (selectedAccount != null) {
             dialog = new AccountEditDialog(currentSession, selectedAccount);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -53,6 +57,7 @@ public class AccountGridToolbar extends EntityCRUDToolbar<GwtAccount> {
         AccountDeleteDialog dialog = null;
         if (selectedAccount != null) {
             dialog = new AccountDeleteDialog(selectedAccount);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
@@ -11,11 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.api.client.ui.dialog;
 
+import com.extjs.gxt.ui.client.data.LoadEvent;
 import com.extjs.gxt.ui.client.event.BaseEvent;
 import com.extjs.gxt.ui.client.event.ButtonEvent;
 import com.extjs.gxt.ui.client.event.ComponentEvent;
 import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.event.LoadListener;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.util.KeyNav;
 import com.extjs.gxt.ui.client.widget.Status;
@@ -247,16 +249,33 @@ public abstract class ActionDialog extends KapuaDialog {
     /**
      * Method for checking the thrown exception for the SUBJECT_UNAUTHORIZED error code.
      * @param caught The exception thrown
-     * @return In case of the SUBJECT_UNAUTHORIZED error code the returned value is true 
-     * and the exitMessage is set. For every other case the returned value is false.
+     * @return In case of the SUBJECT_UNAUTHORIZED error code the returned value is true, 
+     * the dialog is closed and the exitMessage is set. For every other case the returned 
+     * value is false.
      */
     public boolean isPermissionErrorMessage(Throwable caught) {
         if ((caught instanceof GwtKapuaException)
                 && GwtKapuaErrorCode.SUBJECT_UNAUTHORIZED.equals(((GwtKapuaException) caught).getCode())) {
             exitMessage = caught.getLocalizedMessage();
+            hide();
             return true;
         } else {
             return false;
+        }
+    }
+
+    /**
+     * Dialog specific load listener class that overrides the default loaderLoadException method.  
+     * The exception is handled by FailureHandler class's handle() method and the dialog is closed.
+     */
+    public class DialogLoadListener extends LoadListener {
+        @Override
+        public void loaderLoadException(LoadEvent loadEvent) {
+            super.loaderLoadException(loadEvent);
+            if (loadEvent.exception != null) {
+                FailureHandler.handle(loadEvent.exception);
+                hide();
+            }
         }
     }
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
@@ -22,7 +22,6 @@ import com.extjs.gxt.ui.client.event.FormEvent;
 import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.extjs.gxt.ui.client.widget.Dialog;
-import com.extjs.gxt.ui.client.widget.MessageBox;
 import com.extjs.gxt.ui.client.widget.Status;
 import com.extjs.gxt.ui.client.widget.button.Button;
 import com.extjs.gxt.ui.client.widget.form.FieldSet;
@@ -44,6 +43,7 @@ import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldV
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtXSRFToken;
 import org.eclipse.kapua.app.console.module.api.shared.service.GwtSecurityTokenService;
 import org.eclipse.kapua.app.console.module.api.shared.service.GwtSecurityTokenServiceAsync;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.Constants;
 
 public class FileUploadDialog extends Dialog {
@@ -100,7 +100,7 @@ public class FileUploadDialog extends Dialog {
             public void handleEvent(FormEvent be) {
                 String htmlResponse = be.getResultHtml();
                 if (htmlResponse == null || htmlResponse.isEmpty()) {
-                    MessageBox.info(MSGS.information(), MSGS.fileUploadSuccess(), null);
+                    ConsoleInfo.display(MSGS.information(), MSGS.fileUploadSuccess());
                 } else {
                     String errMsg = htmlResponse;
                     int startIdx = htmlResponse.indexOf("<pre>");
@@ -111,7 +111,7 @@ public class FileUploadDialog extends Dialog {
                             errMsg = MSGS.fileUploadInvalidShapshotFailure();
                         }
                     } 
-                    MessageBox.alert(MSGS.error(), MSGS.fileUploadFailure() + ": " + errMsg, null);
+                    ConsoleInfo.display(MSGS.error(), MSGS.fileUploadFailure() + ": " + errMsg);
                 }
                 hide();
             }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -265,9 +265,10 @@ public class CredentialAddDialog extends EntityAddEditDialog {
                 status.hide();
 
                 exitStatus = false;
-                exitMessage = cause.getLocalizedMessage();
-                credentialType.markInvalid(exitMessage);
-                ConsoleInfo.display(CMSGS.error(), exitMessage);
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = cause.getLocalizedMessage();
+                    credentialType.markInvalid(exitMessage);
+                }
             }
         });
     }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
@@ -62,7 +62,6 @@ public class CredentialEditDialog extends CredentialAddDialog {
                 if (!isPermissionErrorMessage(caught)) {
                     exitMessage = MSGS.dialogEditError(caught.getLocalizedMessage());
                 }
-                hide();
             }
 
             @Override

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
@@ -69,7 +69,9 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
     @Override
     protected KapuaDialog getAddDialog() {
         if (selectedUserId != null) {
-            return new CredentialAddDialog(currentSession, selectedUserId, selectedUserName);
+            CredentialAddDialog dialog = new CredentialAddDialog(currentSession, selectedUserId, selectedUserName);
+            dialog.addListener(Events.Hide, getHideDialogListener());
+            return dialog;
         }
         return null;
     }
@@ -80,6 +82,7 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
         CredentialEditDialog dialog = null;
         if (selectedUserId != null && selectedCredential != null) {
             dialog = new CredentialEditDialog(currentSession, selectedCredential, selectedUserId, selectedUserName);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -90,6 +93,7 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
         CredentialDeleteDialog dialog = null;
         if (selectedCredential != null) {
             dialog = new CredentialDeleteDialog(selectedCredential);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
@@ -90,7 +90,7 @@ public class GroupAddDialog extends EntityAddEditDialog {
         GWT_GROUP_SERVICE.create(gwtGroupCreator, new AsyncCallback<GwtGroup>() {
 
             @Override
-            public void onSuccess(GwtGroup arg0) {
+            public void onSuccess(GwtGroup gwtGroup) {
                 exitStatus = true;
                 exitMessage = MSGS.dialogAddConfirmation();
                 hide();
@@ -98,17 +98,20 @@ public class GroupAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onFailure(Throwable cause) {
-                FailureHandler.handleFormException(formPanel, cause);
+                exitStatus = false;
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        groupNameField.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            groupNameField.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
@@ -51,17 +51,20 @@ public class GroupEditDialog extends GroupAddDialog {
 
             @Override
             public void onFailure(Throwable cause) {
-                FailureHandler.handleFormException(formPanel, cause);
+                exitStatus = false;
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        groupNameField.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            groupNameField.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.app.console.module.authorization.client.role.dialog.Rol
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.RoleSessionPermission;
 
+import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.user.client.Element;
 
 public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
@@ -30,7 +31,9 @@ public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        return new RoleAddDialog(currentSession);
+        RoleAddDialog dialog = new RoleAddDialog(currentSession);
+        dialog.addListener(Events.Hide, getHideDialogListener());
+        return dialog;
     }
 
     @Override
@@ -39,6 +42,7 @@ public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
         RoleEditDialog dialog = null;
         if (selectedRole != null) {
             dialog = new RoleEditDialog(currentSession, selectedRole);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -55,6 +59,7 @@ public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
         RoleDeleteDialog dialog = null;
         if (selectedRole != null) {
             dialog = new RoleDeleteDialog(selectedRole);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
@@ -70,7 +70,7 @@ public class RoleAddDialog extends EntityAddEditDialog {
         GWT_ROLE_SERVICE.create(xsrfToken, gwtRoleCreator, new AsyncCallback<GwtRole>() {
 
             @Override
-            public void onSuccess(GwtRole arg0) {
+            public void onSuccess(GwtRole gwtRole) {
                 exitStatus = true;
                 exitMessage = MSGS.dialogAddConfirmation();
                 hide();
@@ -78,17 +78,20 @@ public class RoleAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onFailure(Throwable cause) {
-                FailureHandler.handleFormException(formPanel, cause);
+                exitStatus = false;
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        roleNameField.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            roleNameField.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
@@ -61,7 +61,9 @@ public class RoleEditDialog extends RoleAddDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogEditLoadFailed(cause.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = MSGS.dialogEditLoadFailed(cause.getLocalizedMessage());
+                }
                 unmaskDialog();
                 hide();
             }
@@ -83,7 +85,7 @@ public class RoleEditDialog extends RoleAddDialog {
         GWT_ROLE_SERVICE.update(xsrfToken, selectedRole, new AsyncCallback<GwtRole>() {
 
             @Override
-            public void onSuccess(GwtRole arg0) {
+            public void onSuccess(GwtRole gwtRole) {
                 exitStatus = true;
                 exitMessage = MSGS.dialogEditConfirmation();
                 hide();
@@ -93,17 +95,19 @@ public class RoleEditDialog extends RoleAddDialog {
             public void onFailure(Throwable cause) {
                 exitStatus = false;
                 exitMessage = MSGS.dialogEditError(cause.getLocalizedMessage());
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        roleNameField.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            roleNameField.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -139,7 +139,11 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
 
                 @Override
                 public void onFailure(Throwable caught) {
-                    FailureHandler.handle(caught);
+                    exitStatus = false;
+                    if (!isPermissionErrorMessage(caught)) {
+                        FailureHandler.handle(caught);
+                        hide();
+                    }
                 }
 
                 @Override
@@ -179,23 +183,25 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
         GWT_CONNECTION_OPTION_SERVICE.update(xsrfToken, selectedDeviceConnectionOption, new AsyncCallback<GwtDeviceConnectionOption>() {
 
             @Override
-            public void onFailure(Throwable arg0) {
+            public void onFailure(Throwable cause) {
                 exitStatus = false;
                 status.hide();
                 unmask();
-                FailureHandler.handle(arg0);
                 submitButton.enable();
                 cancelButton.enable();
-                if (arg0 instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) arg0;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.INTERNAL_ERROR)) {
-                        reservedUserCombo.markInvalid(arg0.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.INTERNAL_ERROR)) {
+                            reservedUserCombo.markInvalid(cause.getMessage());
+                        }
+                    FailureHandler.handle(cause);
                     }
                 }
             }
 
             @Override
-            public void onSuccess(GwtDeviceConnectionOption arg0) {
+            public void onSuccess(GwtDeviceConnectionOption gwtDeviceConnectionOption) {
                 exitStatus = true;
                 exitMessage = MSGS.dialogEditConfirmation();
                 hide();
@@ -219,7 +225,11 @@ public class ConnectionEditDialog extends EntityAddEditDialog {
 
                 @Override
                 public void onFailure(Throwable caught) {
-                    FailureHandler.handle(caught);
+                    exitStatus = false;
+                    if (!isPermissionErrorMessage(caught)) {
+                        FailureHandler.handle(caught);
+                        hide();
+                    }
                 }
 
                 @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.client.connection.toolbar;
 
+import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.user.client.Element;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
@@ -43,6 +44,7 @@ public class ConnectionGridToolbar extends EntityCRUDToolbar<GwtDeviceConnection
         ConnectionEditDialog dialog = null;
         if (selectedConnection != null) {
             dialog = new ConnectionEditDialog(currentSession, selectedConnection);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -210,7 +210,11 @@ public class DeviceAddDialog extends EntityAddEditDialog {
 
                 @Override
                 public void onFailure(Throwable caught) {
-                    FailureHandler.handle(caught);
+                    exitStatus = false;
+                    if (!isPermissionErrorMessage(caught)) {
+                        FailureHandler.handle(caught);
+                        hide();
+                    }
                 }
 
                 @Override
@@ -336,17 +340,19 @@ public class DeviceAddDialog extends EntityAddEditDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        clientIdField.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            clientIdField.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
@@ -24,6 +24,7 @@ import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQueryPr
 import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceSessionPermission;
 
 import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.URL;
@@ -42,7 +43,9 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        return new DeviceAddDialog(currentSession);
+        DeviceAddDialog dialog = new DeviceAddDialog(currentSession);
+        dialog.addListener(Events.Hide, getHideDialogListener());
+        return dialog;
     }
 
     @Override
@@ -66,6 +69,7 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
         DeviceEditDialog dialog = null;
         if (selectedEntity != null) {
             dialog = new DeviceEditDialog(currentSession, selectedEntity);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -75,6 +79,7 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
         DeviceDeleteDialog dialog = null;
         if (selectedEntity != null) {
             dialog = new DeviceDeleteDialog(selectedEntity);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -443,6 +443,7 @@ public class DeviceAssetsValues extends LayoutContainer {
                                                 public void onFailure(Throwable caught) {
                                                     FailureHandler.handle(caught);
                                                     dirty = true;
+                                                    refresh();
                                                 }
 
                                                 @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -44,9 +44,8 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
-import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog;
-import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog.InfoDialogType;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.Constants;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
@@ -217,9 +216,7 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
                     String errorMessage = htmlResult.substring(errorMessageStartIndex, errorMessageEndIndex);
 
                     if (!errorMessage.isEmpty()) {
-                        errorMessage = DEVICE_MSGS.deviceCommandCommunicationError();
-                    InfoDialog exitDialog = new InfoDialog(InfoDialogType.ERROR, MSGS.error() + MSGS.commandExecutionFailure() + ":<br/>" + errorMessage);
-                    exitDialog.show();
+                        ConsoleInfo.display(MSGS.error(), DEVICE_MSGS.deviceCommandCommunicationError());
                     }
                     commandInput.unmask();
                 } else {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -47,6 +47,7 @@ import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
+import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
@@ -511,7 +512,10 @@ public class DeviceConfigComponents extends LayoutContainer {
 
                                                 @Override
                                                 public void onFailure(Throwable caught) {
-                                                    if(!selectedDevice.isOnline()) {
+                                                    if ((caught instanceof GwtKapuaException) && GwtKapuaErrorCode.SUBJECT_UNAUTHORIZED
+                                                            .equals(((GwtKapuaException) caught).getCode())) {
+                                                        ConsoleInfo.display(MSGS.popupError(), caught.getLocalizedMessage());
+                                                    } else if (!selectedDevice.isOnline()) {
                                                         ConsoleInfo.display(MSGS.popupError(), DEVICE_MSGS.deviceConnectionError());
                                                     }
                                                     dirty = true;

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -30,12 +30,14 @@ import com.extjs.gxt.ui.client.widget.toolbar.ToolBar;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Node;
 import com.google.gwt.user.client.Element;
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog.InfoDialogType;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.client.device.DeviceView;
 import org.eclipse.kapua.app.console.module.device.client.device.packages.button.PackageInstallButton;
@@ -49,6 +51,7 @@ import org.eclipse.kapua.app.console.module.device.shared.model.permission.Devic
 public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
 
     private static final ConsoleDeviceMessages MSGS = GWT.create(ConsoleDeviceMessages.class);
+    private static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
 
     private DeviceView deviceTabs;
 
@@ -272,20 +275,8 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
                     return;
                 } else {
 
-                    InfoDialogType exitDialogType;
                     String exitMessage = packageInstallDialog.getExitMessage();
-
-                    if (exitStatus == true) { // Operation Success
-                        exitDialogType = InfoDialogType.INFO;
-                    } else { // Operaton Failed
-                        exitDialogType = InfoDialogType.ERROR;
-                    }
-
-                    //
-                    // Exit dialog
-                    InfoDialog exitDialog = new InfoDialog(exitDialogType, exitMessage);
-
-                    exitDialog.show();
+                    ConsoleInfo.display(exitStatus == true ? CMSGS.information() : CMSGS.error(), exitMessage);
 
                     uninstallButton.disable();
                     deviceTabs.setSelectedEntity(selectedEntity);
@@ -315,20 +306,8 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
                         return;
                     } else {
 
-                        InfoDialogType exitDialogType;
                         String exitMessage = packageUninstallDialog.getExitMessage();
-
-                        if (exitStatus == true) { // Operation Success
-                            exitDialogType = InfoDialogType.INFO;
-                        } else { // Operaton Failed
-                            exitDialogType = InfoDialogType.ERROR;
-                        }
-
-                        //
-                        // Exit dialog
-                        InfoDialog exitDialog = new InfoDialog(exitDialogType, exitMessage);
-
-                        exitDialog.show();
+                        ConsoleInfo.display(exitStatus == true ? CMSGS.information() : CMSGS.error(), exitMessage);
 
                         uninstallButton.disable();
                         deviceTabs.setSelectedEntity(selectedEntity);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/PackageInstallDialog.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.dialog.TabbedDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaNumberField;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldValidator;
 import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldValidator.FieldType;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
@@ -235,8 +236,13 @@ public class PackageInstallDialog extends TabbedDialog {
             @Override
             public void onFailure(Throwable caught) {
                 exitStatus = false;
-                exitMessage = caught.getMessage();
-                hide();
+                status.hide();
+                unmask();
+                submitButton.enable();
+                cancelButton.enable();
+                if (!isPermissionErrorMessage(caught)) {
+                    FailureHandler.handle(caught);
+                }
             }
         });
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -79,15 +79,16 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
                 cancelButton.enable();
                 status.hide();
                 exitStatus = false;
-
-                FailureHandler.handleFormException(formPanel, cause);
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        tagsCombo.markInvalid(gwtCause.getMessage());
-                    } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.ENTITY_NOT_FOUND)) {
-                        tagsCombo.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            tagsCombo.markInvalid(gwtCause.getMessage());
+                        } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.ENTITY_NOT_FOUND)) {
+                            tagsCombo.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });
@@ -136,8 +137,10 @@ public class DeviceTagAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onFailure(Throwable caught) {
-                exitMessage = MSGS.dialogDeviceTagAddFieldTagLoadingError(caught.getLocalizedMessage());
                 exitStatus = false;
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = MSGS.dialogDeviceTagAddFieldTagLoadingError(caught.getLocalizedMessage());
+                }
                 hide();
             }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.client.device.tag;
 
+import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaDialog;
@@ -41,6 +42,7 @@ public class DeviceTagToolbar extends TagToolbarGrid {
         DeviceTagAddDialog dialog = null;
         if (selectedDevice != null) {
             dialog = new DeviceTagAddDialog(currentSession, selectedDevice);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -50,6 +52,7 @@ public class DeviceTagToolbar extends TagToolbarGrid {
         DeviceTagDeleteDialog dialog = null;
         if (selectedEntity != null) {
             dialog = new DeviceTagDeleteDialog(selectedDevice, selectedEntity);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -260,7 +260,7 @@ deviceCommandNoOutput=No Output
 deviceCommandExecuting=Executing Command...
 deviceCommandMaxLengthErrorMessage=The limit for this field is 1024 characters. Longer commands should be put in .sh files, zipped, uploaded and executed using the file field.
 deviceCommandExecutionErrorMessage=The entered command can not be executed. Please check the command and password and try again.
-deviceCommandCommunicationError=There was a problem with device communication. You have entered an invalid/incomplete command, rebooted/powered down the device or the permissions have changed. Please refresh the console..
+deviceCommandCommunicationError=There was a problem with device communication. You have entered an invalid/incomplete command, rebooted/powered down the device or the permissions have changed. Please refresh the console.
 
 deviceConfigComponents=Services
 deviceConfigSnapshots=Snapshots

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
@@ -131,7 +131,7 @@ public class EndpointAddDialog extends EntityAddEditDialog {
         GWT_ENDPOINT_SERVICE.create(gwtEndpointCreator, new AsyncCallback<GwtEndpoint>() {
 
             @Override
-            public void onSuccess(GwtEndpoint arg0) {
+            public void onSuccess(GwtEndpoint gwtEndpoint) {
                 exitStatus = true;
                 exitMessage = MSGS.dialogAddConfirmation();
                 hide();
@@ -139,15 +139,18 @@ public class EndpointAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onFailure(Throwable cause) {
-                FailureHandler.handleFormException(formPanel, cause);
+                exitStatus = false;
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                endpointDnsField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
-                endpointSchemaField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
-                endpointPortField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                if (!isPermissionErrorMessage(cause)) {
+                    FailureHandler.handleFormException(formPanel, cause);
+                    endpointDnsField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                    endpointSchemaField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                    endpointPortField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                }
             }
         });
 

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointDeleteDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointDeleteDialog.java
@@ -40,10 +40,12 @@ public class EndpointDeleteDialog extends EntityDeleteDialog {
         GWT_ENDPOINT_SERVICE.delete(gwtEndpoint.getScopeId(), gwtEndpoint.getId(), new AsyncCallback<Void>() {
 
             @Override
-            public void onFailure(Throwable arg0) {
-                FailureHandler.handle(arg0);
+            public void onFailure(Throwable cause) {
                 exitStatus = false;
-                exitMessage = MSGS.dialogDeleteError(arg0.getLocalizedMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    FailureHandler.handle(cause);
+                    exitMessage = MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                }
                 hide();
 
             }

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointEditDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointEditDialog.java
@@ -53,15 +53,18 @@ public class EndpointEditDialog extends EndpointAddDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                endpointDnsField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
-                endpointSchemaField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
-                endpointPortField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                if (!isPermissionErrorMessage(cause)) {
+                    FailureHandler.handleFormException(formPanel, cause);
+                    endpointDnsField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                    endpointSchemaField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                    endpointPortField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                }
+
             }
 
             @Override

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointToolbarGrid.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointToolbarGrid.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolb
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.permission.EndpointSessionPermission;
+import com.extjs.gxt.ui.client.event.Events;
 
 public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
 
@@ -29,7 +30,9 @@ public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        return new EndpointAddDialog(currentSession);
+        EndpointAddDialog dialog = new EndpointAddDialog(currentSession);
+        dialog.addListener(Events.Hide, getHideDialogListener());
+        return dialog;
     }
 
     @Override
@@ -38,6 +41,7 @@ public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
         EndpointEditDialog dialog = null;
         if (selectedEndpoint != null) {
             dialog = new EndpointEditDialog(currentSession, selectedEndpoint);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -48,6 +52,7 @@ public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
         EndpointDeleteDialog dialog = null;
         if (selectedEndpoint != null) {
             dialog = new EndpointDeleteDialog(selectedEndpoint);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
@@ -95,7 +95,7 @@ public class JobAddDialog extends EntityAddEditDialog {
         GWT_JOB_SERVICE.create(xsrfToken, gwtJobCreator, new AsyncCallback<GwtJob>() {
 
             @Override
-            public void onSuccess(GwtJob arg0) {
+            public void onSuccess(GwtJob gwtJob) {
                 exitStatus = true;
                 exitMessage = JOB_MSGS.dialogAddConfirmation();
                 hide();
@@ -104,17 +104,19 @@ public class JobAddDialog extends EntityAddEditDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        name.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            name.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobEditDialog.java
@@ -48,7 +48,7 @@ public class JobEditDialog extends JobAddDialog {
         gwtJobService.update(xsrfToken, selectedJob, new AsyncCallback<GwtJob>() {
 
             @Override
-            public void onSuccess(GwtJob arg0) {
+            public void onSuccess(GwtJob gwtJob) {
                 exitStatus = true;
                 exitMessage = JOB_MSGS.dialogEditConfirmation();
                 hide();
@@ -57,16 +57,18 @@ public class JobEditDialog extends JobAddDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        name.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            name.markInvalid(gwtCause.getMessage());
+                        }
+                        FailureHandler.handleFormException(formPanel, cause);
                     }
                 }
             }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -323,7 +323,7 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         TRIGGER_SERVICE.create(xsrfToken, gwtTriggerCreator, new AsyncCallback<GwtTrigger>() {
 
             @Override
-            public void onSuccess(GwtTrigger arg0) {
+            public void onSuccess(GwtTrigger gwtTrigger) {
                 exitStatus = true;
                 exitMessage = JOB_MSGS.dialogAddScheduleConfirmation();
                 hide();
@@ -332,31 +332,33 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.SCHEDULE_DUPLICATE_NAME)) {
-                        triggerName.markInvalid(gwtCause.getMessage());
-                    } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.RETRY_AND_CRON_BOTH_SELECTED)) {
-                        cronExpression.markInvalid(gwtCause.getMessage());
-                        retryInterval.markInvalid(gwtCause.getMessage());
-                    } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.SAME_START_AND_DATE)) {
-                        startsOn.markInvalid(gwtCause.getMessage());
-                        startsOnTime.markInvalid(gwtCause.getMessage());
-                        endsOn.markInvalid(gwtCause.getMessage());
-                        endsOnTime.markInvalid(gwtCause.getMessage());
-                    } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.TRIGGER_NEVER_FIRE)) {
-                        startsOn.markInvalid(gwtCause.getMessage());
-                        startsOnTime.markInvalid(gwtCause.getMessage());
-                        endsOn.markInvalid(gwtCause.getMessage());
-                        endsOnTime.markInvalid(gwtCause.getMessage());
-                        cronExpression.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.SCHEDULE_DUPLICATE_NAME)) {
+                            triggerName.markInvalid(gwtCause.getMessage());
+                        } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.RETRY_AND_CRON_BOTH_SELECTED)) {
+                            cronExpression.markInvalid(gwtCause.getMessage());
+                            retryInterval.markInvalid(gwtCause.getMessage());
+                        } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.SAME_START_AND_DATE)) {
+                            startsOn.markInvalid(gwtCause.getMessage());
+                            startsOnTime.markInvalid(gwtCause.getMessage());
+                            endsOn.markInvalid(gwtCause.getMessage());
+                            endsOnTime.markInvalid(gwtCause.getMessage());
+                        } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.TRIGGER_NEVER_FIRE)) {
+                            startsOn.markInvalid(gwtCause.getMessage());
+                            startsOnTime.markInvalid(gwtCause.getMessage());
+                            endsOn.markInvalid(gwtCause.getMessage());
+                            endsOnTime.markInvalid(gwtCause.getMessage());
+                            cronExpression.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -123,6 +123,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
         };
 
         BaseListLoader<ListLoadResult<GwtJobStepDefinition>> jobStepDefinitionLoader = new BaseListLoader<ListLoadResult<GwtJobStepDefinition>>(jobStepDefinitionProxy);
+        jobStepDefinitionLoader.addLoadListener(new DialogLoadListener());
         ListStore<GwtJobStepDefinition> jobStepDefinitionStore = new ListStore<GwtJobStepDefinition>(jobStepDefinitionLoader);
         jobStepDefinitionCombo.setStore(jobStepDefinitionStore);
         jobStepDefinitionCombo.setDisplayField("jobStepDefinitionName");
@@ -185,7 +186,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
         JOB_STEP_SERVICE.create(xsrfToken, gwtJobStepCreator, new AsyncCallback<GwtJobStep>() {
 
             @Override
-            public void onSuccess(GwtJobStep arg0) {
+            public void onSuccess(GwtJobStep gwtJobStep) {
                 exitStatus = true;
                 exitMessage = JOB_MSGS.dialogAddStepConfirmation();
                 hide();
@@ -194,17 +195,19 @@ public class JobStepAddDialog extends EntityAddEditDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        jobStepName.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            jobStepName.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -63,9 +63,10 @@ public class JobStepEditDialog extends JobStepAddDialog {
             @Override
             public void onFailure(Throwable caught) {
                 exitStatus = false;
-                exitMessage = JOB_MSGS.dialogEditError(caught.getLocalizedMessage());
-
-                hide();
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = JOB_MSGS.dialogEditError(caught.getLocalizedMessage());
+                    hide();
+                }
             }
 
             @Override
@@ -105,7 +106,7 @@ public class JobStepEditDialog extends JobStepAddDialog {
         JOB_STEP_SERVICE.update(xsrfToken, selectedJobStep, new AsyncCallback<GwtJobStep>() {
 
             @Override
-            public void onSuccess(GwtJobStep arg0) {
+            public void onSuccess(GwtJobStep gwtJobStep) {
                 exitStatus = true;
                 exitMessage = JOB_MSGS.dialogEditStepConfirmation();
                 hide();
@@ -114,17 +115,19 @@ public class JobStepEditDialog extends JobStepAddDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        jobStepName.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            jobStepName.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsToolbar.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.steps;
 
+import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -43,7 +44,9 @@ public class JobTabStepsToolbar extends EntityCRUDToolbar<GwtJobStep> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        return new JobStepAddDialog(currentSession, jobId);
+        JobStepAddDialog dialog = new JobStepAddDialog(currentSession, jobId);
+        dialog.addListener(Events.Hide, getHideDialogListener());
+        return dialog;
     }
 
     @Override
@@ -52,6 +55,7 @@ public class JobTabStepsToolbar extends EntityCRUDToolbar<GwtJobStep> {
         JobStepEditDialog dialog = null;
         if (selectedJobStep != null) {
             dialog = new JobStepEditDialog(currentSession, selectedJobStep);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -62,6 +66,7 @@ public class JobTabStepsToolbar extends EntityCRUDToolbar<GwtJobStep> {
         JobStepDeleteDialog dialog = null;
         if (selectedJobStep != null) {
             dialog = new JobStepDeleteDialog(selectedJobStep);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
@@ -158,9 +158,10 @@ public class JobTargetAddDialog extends EntityAddEditDialog {
                         status.hide();
 
                         exitStatus = false;
-                        exitMessage = JOB_MSGS.dialogGetTargetError(caught.getLocalizedMessage());
-
-                        hide();
+                        if (!isPermissionErrorMessage(caught)) {
+                            exitMessage = JOB_MSGS.dialogGetTargetError(caught.getLocalizedMessage());
+                            hide();
+                        }
                     }
 
                     @Override
@@ -189,9 +190,10 @@ public class JobTargetAddDialog extends EntityAddEditDialog {
                     status.hide();
 
                     exitStatus = false;
-                    exitMessage = JOB_MSGS.dialogGetTargetError(caught.getLocalizedMessage());
-
-                    hide();
+                    if (!isPermissionErrorMessage(caught)) {
+                        exitMessage = JOB_MSGS.dialogGetTargetError(caught.getLocalizedMessage());
+                        hide();
+                    }
                 }
 
                 @Override
@@ -215,8 +217,10 @@ public class JobTargetAddDialog extends EntityAddEditDialog {
             public void onFailure(Throwable caught) {
 
                 exitStatus = false;
-                exitMessage = JOB_MSGS.dialogGetTargetError(caught.getLocalizedMessage());
-                hide();
+                if (!isPermissionErrorMessage(caught)) {
+                    exitMessage = JOB_MSGS.dialogGetTargetError(caught.getLocalizedMessage());
+                    hide();
+                }
             }
 
             @Override
@@ -273,7 +277,6 @@ public class JobTargetAddDialog extends EntityAddEditDialog {
                 if (!isPermissionErrorMessage(cause)) {
                     exitMessage = JOB_MSGS.dialogAddTargetError(cause.getLocalizedMessage());
                 }
-                hide();
             }
         });
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
@@ -88,7 +88,7 @@ public class TagAddDialog extends EntityAddEditDialog {
         GWT_TAG_SERVICE.create(gwtTagCreator, new AsyncCallback<GwtTag>() {
 
             @Override
-            public void onSuccess(GwtTag arg0) {
+            public void onSuccess(GwtTag gwtTag) {
                 exitStatus = true;
                 exitMessage = MSGS.dialogAddConfirmation();
                 hide();
@@ -96,16 +96,19 @@ public class TagAddDialog extends EntityAddEditDialog {
 
             @Override
             public void onFailure(Throwable cause) {
-                FailureHandler.handleFormException(formPanel, cause);
+                exitStatus = false;
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        tagNameField.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            tagNameField.markInvalid(gwtCause.getMessage());
+                        }
+                        FailureHandler.handleFormException(formPanel, cause);
                     }
                 }
             }

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagEditDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagEditDialog.java
@@ -50,17 +50,19 @@ public class TagEditDialog extends TagAddDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
-                        tagNameField.markInvalid(gwtCause.getMessage());
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        if (gwtCause.getCode().equals(GwtKapuaErrorCode.DUPLICATE_NAME)) {
+                            tagNameField.markInvalid(gwtCause.getMessage());
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagToolbarGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagToolbarGrid.java
@@ -16,6 +16,8 @@ import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolb
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
 import org.eclipse.kapua.app.console.module.tag.shared.model.permission.TagSessionPermission;
+
+import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.user.client.Element;
 
 public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
@@ -30,7 +32,9 @@ public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        return new TagAddDialog(currentSession);
+        TagAddDialog dialog = new TagAddDialog(currentSession);
+        dialog.addListener(Events.Hide, getHideDialogListener());
+        return dialog;
     }
 
     @Override
@@ -45,6 +49,7 @@ public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
         TagEditDialog dialog = null;
         if (selectedTag != null) {
             dialog = new TagEditDialog(currentSession, selectedTag);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -55,6 +60,7 @@ public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
         TagDeleteDialog dialog = null;
         if (selectedTag != null) {
             dialog = new TagDeleteDialog(selectedTag);
+            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -252,8 +252,8 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
             gwtTagQuery.setIds(gwtTagIds);
 
             return query(loadConfig, gwtTagQuery);
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+        } catch (KapuaException e) {
+            KapuaExceptionHandler.handle(e);
             return new BasePagingLoadResult<GwtTag>(new ArrayList<GwtTag>(), 0, 0);
         }
     }

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -273,7 +273,7 @@ public class UserAddDialog extends EntityAddEditDialog {
         gwtUserService.create(xsrfToken, gwtUserCreator, new AsyncCallback<GwtUser>() {
 
             @Override
-            public void onSuccess(GwtUser arg0) {
+            public void onSuccess(GwtUser gwtUser) {
                 exitStatus = true;
                 exitMessage = USER_MSGS.dialogAddConfirmation();
                 hide();
@@ -282,22 +282,24 @@ public class UserAddDialog extends EntityAddEditDialog {
             @Override
             public void onFailure(Throwable cause) {
                 exitStatus = false;
-                FailureHandler.handleFormException(formPanel, cause);
                 status.hide();
                 formPanel.getButtonBar().enable();
                 unmask();
                 submitButton.enable();
                 cancelButton.enable();
-                if (cause instanceof GwtKapuaException) {
-                    GwtKapuaException gwtCause = (GwtKapuaException) cause;
-                    switch (gwtCause.getCode()) {
-                    case DUPLICATE_NAME:
-                    case ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT:
-                        username.markInvalid(gwtCause.getMessage());
-                        break;
-                    default:
-                        break;
+                if (!isPermissionErrorMessage(cause)) {
+                    if (cause instanceof GwtKapuaException) {
+                        GwtKapuaException gwtCause = (GwtKapuaException) cause;
+                        switch (gwtCause.getCode()) {
+                        case DUPLICATE_NAME:
+                        case ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT:
+                            username.markInvalid(gwtCause.getMessage());
+                            break;
+                        default:
+                            break;
+                        }
                     }
+                    FailureHandler.handleFormException(formPanel, cause);
                 }
             }
         });


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Additional permission problems fixes.

**Related Issue**
This PR fixes/closes #2508, #1836 

**Description of the solution adopted**
This PR changes behavior of multiple dialogues in case of permission exceptions. 
In case of permission exception - after submitting the dialog or queries for populating dialog fields, all dialogues will be closed and the needed error message shown. 
Added needed calls for already existing `getHideDialogListener()` on some toolbars for correct displaying of error messages. Created new `DialogLoadListener` to `ActionDialog` class for handling `loaderLoadException()` which is for example added to the `jobStepDefinitionLoader` in the `JobStepAddDialog` class.
Also same inconsistencies were fixed as well: dialogues closing/or not after submit and wrong error messages. Also replaced some `InfoDialogs` (on Command, Packages, Snapshot tab) with `ConsoleInfo.display()` messages shown in lower right corner like on other tabs.
**Screenshots**
_None_

**Any side note on the changes made**
Made a small change to the `GwtTagServiceImpl` class, by casting the caught exception to `KapuaException `instead of the `Throwable`. This solved a problem with a 500 error on the Devices -> Tags grid.
