### PR TITLE
Changed display of parameter name if name is too long

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
@@ -285,6 +285,7 @@ public class DeviceAssetsPanel extends LayoutContainer {
         field.setValue((String) channel.getValue());
         field.setAllowBlank(true);
         field.setFieldLabel(channel.getName() + " (" + channel.getType() + " - " + channel.getMode() + ")");
+        field.setLabelStyle("word-break:break-all");
         field.addPlugin(dirtyPlugin);
 
         if (channel.getValue() != null) {
@@ -299,6 +300,7 @@ public class DeviceAssetsPanel extends LayoutContainer {
         field.setName(channel.getName());
         field.setAllowBlank(true);
         field.setFieldLabel(channel.getName() + " (" + channel.getType() + " - " + channel.getMode() + ")");
+        field.setLabelStyle("word-break:break-all");
         field.addPlugin(dirtyPlugin);
         field.setMaxValue(MAX_SAFE_INTEGER);
 
@@ -353,6 +355,7 @@ public class DeviceAssetsPanel extends LayoutContainer {
         radioGroup.setName(channel.getName());
         radioGroup.setItemId(channel.getName());
         radioGroup.setFieldLabel(channel.getName() + " (" + channel.getType() + " - " + channel.getMode() + ")");
+        radioGroup.setLabelStyle("word-break:break-all");
         radioGroup.add(radioTrue);
         radioGroup.add(radioFalse);
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -345,7 +345,7 @@ public class DeviceConfigPanel extends LayoutContainer {
             multiField.setReadOnly(true);
             multiField.setEnabled(false);
         }
-
+        multiField.setLabelStyle("word-break:break-all");
         Field<?> field = null;
         String value = null;
         String[] values = param.getValues();
@@ -457,6 +457,7 @@ public class DeviceConfigPanel extends LayoutContainer {
         if (validator instanceof StringValidator) {
             field.setValidator(validator);
         }
+        field.setLabelStyle("word-break:break-all");
         return field;
     }
 
@@ -484,6 +485,7 @@ public class DeviceConfigPanel extends LayoutContainer {
             field.setValue((String) param.getValue());
             field.setOriginalValue((String) param.getValue());
         }
+        field.setLabelStyle("word-break:break-all");
         return field;
     }
 
@@ -553,6 +555,7 @@ public class DeviceConfigPanel extends LayoutContainer {
                 }
                 break;
         }
+        field.setLabelStyle("word-break:break-all");
         return field;
     }
 
@@ -588,6 +591,7 @@ public class DeviceConfigPanel extends LayoutContainer {
         if (param.getValue() != null) {
             field.setSimpleValue(getKeyFromValue(oMap, param.getValue()));
         }
+        field.setLabelStyle("word-break:break-all");
         return field;
     }
 
@@ -635,7 +639,7 @@ public class DeviceConfigPanel extends LayoutContainer {
             radioFalse.setValue(true);
             radioGroup.setOriginalValue(radioFalse);
         }
-
+        radioGroup.setLabelStyle("word-break:break-all");
         return radioGroup;
     }
 


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed display of parameter name in device configuration.

**Related Issue**
This PR fixes issue #2183. 

**Description of the solution adopted**
If name of parameter in device configuration and in asset tab is very long, it is displayed on different way. This is shown on screenshots bellow. 

**Screenshots**
_Screenshot 1_
![image](https://user-images.githubusercontent.com/45655642/55385457-8254de00-552d-11e9-9953-02f059f959e2.png)

_Screenshot 2_
![image](https://user-images.githubusercontent.com/45655642/55385514-a44e6080-552d-11e9-93bf-314d90942ded.png)

**Any side note on the changes made**
/
