### PR TITLE
Changed password field on login dialog to be in error state

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -227,6 +227,7 @@ public class LoginDialog extends Dialog {
             ConsoleInfo.display(MSGS.dialogError(), MSGS.usernameFieldRequired());
         } else if (password.getValue() == null) {
             ConsoleInfo.display(MSGS.dialogError(), MSGS.passwordFieldRequired());
+            password.markInvalid(password.getErrorMessage());
         } else {
             status.show();
             getButtonBar().disable();


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed password field on login dialog to be invalid if is empty.

**Related Issue**
This PR is continuation of PR 2533.

**Description of the solution adopted**
After invalid username or password input on login dialog, if user enters something only in username field and password field is empty, password field is changed to bi in error state.

**Screenshots**
/

**Any side note on the changes made**
/
