### PR TITLE
Disabled reset button if fields are empty

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -162,6 +162,7 @@ public class LoginDialog extends Dialog {
         getButtonBar().add(new FillToolItem());
 
         reset = new Button(CORE_MSGS.loginReset());
+        reset.disable();
 
         reset.addSelectionListener(new SelectionListener<ButtonEvent>() {
 
@@ -288,6 +289,8 @@ public class LoginDialog extends Dialog {
 
     protected void validate() {
         login.setEnabled(true);
+        reset.setEnabled(hasValue(username) &&
+                hasValue(password));
     }
 
     public void reset() {
@@ -295,10 +298,10 @@ public class LoginDialog extends Dialog {
         username.enable();
         password.reset();
         password.enable();
-
         username.focus();
         status.hide();
         getButtonBar().enable();
+        reset.disable();
         password.clearInvalid();
     }
 


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Disabled reset button on login dialog if fields are not filled.

**Related Issue**
This PR fixes issue #1964.

**Description of the solution adopted**
If username and password fields are empty on login dialog, reset button is disabled. Only if user enters some characters in both of these fields, reset button will be enabled.

**Screenshots**
/

**Any side note on the changes made**
/
