### PR TITLE
Removed unneeded dialog listeners

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -57,7 +57,6 @@ public class AccountGridToolbar extends EntityCRUDToolbar<GwtAccount> {
         AccountDeleteDialog dialog = null;
         if (selectedAccount != null) {
             dialog = new AccountDeleteDialog(selectedAccount);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
@@ -69,9 +69,7 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
     @Override
     protected KapuaDialog getAddDialog() {
         if (selectedUserId != null) {
-            CredentialAddDialog dialog = new CredentialAddDialog(currentSession, selectedUserId, selectedUserName);
-            dialog.addListener(Events.Hide, getHideDialogListener());
-            return dialog;
+            return new CredentialAddDialog(currentSession, selectedUserId, selectedUserName);
         }
         return null;
     }
@@ -82,7 +80,6 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
         CredentialEditDialog dialog = null;
         if (selectedUserId != null && selectedCredential != null) {
             dialog = new CredentialEditDialog(currentSession, selectedCredential, selectedUserId, selectedUserName);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -93,7 +90,6 @@ public class CredentialToolbar extends EntityCRUDToolbar<GwtCredential> {
         CredentialDeleteDialog dialog = null;
         if (selectedCredential != null) {
             dialog = new CredentialDeleteDialog(selectedCredential);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,7 +20,6 @@ import org.eclipse.kapua.app.console.module.authorization.client.role.dialog.Rol
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtRole;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.RoleSessionPermission;
 
-import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.user.client.Element;
 
 public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
@@ -31,9 +30,7 @@ public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        RoleAddDialog dialog = new RoleAddDialog(currentSession);
-        dialog.addListener(Events.Hide, getHideDialogListener());
-        return dialog;
+        return new RoleAddDialog(currentSession);
     }
 
     @Override
@@ -42,7 +39,6 @@ public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
         RoleEditDialog dialog = null;
         if (selectedRole != null) {
             dialog = new RoleEditDialog(currentSession, selectedRole);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -59,7 +55,6 @@ public class RoleToolbarGrid extends EntityCRUDToolbar<GwtRole> {
         RoleDeleteDialog dialog = null;
         if (selectedRole != null) {
             dialog = new RoleDeleteDialog(selectedRole);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.client.connection.toolbar;
 
-import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.user.client.Element;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
@@ -44,7 +43,6 @@ public class ConnectionGridToolbar extends EntityCRUDToolbar<GwtDeviceConnection
         ConnectionEditDialog dialog = null;
         if (selectedConnection != null) {
             dialog = new ConnectionEditDialog(currentSession, selectedConnection);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
@@ -24,7 +24,6 @@ import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQueryPr
 import org.eclipse.kapua.app.console.module.device.shared.model.permission.DeviceSessionPermission;
 
 import com.extjs.gxt.ui.client.event.ButtonEvent;
-import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.SelectionListener;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.URL;
@@ -43,9 +42,7 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        DeviceAddDialog dialog = new DeviceAddDialog(currentSession);
-        dialog.addListener(Events.Hide, getHideDialogListener());
-        return dialog;
+        return new DeviceAddDialog(currentSession);
     }
 
     @Override
@@ -69,7 +66,6 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
         DeviceEditDialog dialog = null;
         if (selectedEntity != null) {
             dialog = new DeviceEditDialog(currentSession, selectedEntity);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -79,7 +75,6 @@ public class DeviceGridToolbar extends EntityCRUDToolbar<GwtDevice> {
         DeviceDeleteDialog dialog = null;
         if (selectedEntity != null) {
             dialog = new DeviceDeleteDialog(selectedEntity);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.client.device.tag;
 
-import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaDialog;
@@ -42,7 +41,6 @@ public class DeviceTagToolbar extends TagToolbarGrid {
         DeviceTagAddDialog dialog = null;
         if (selectedDevice != null) {
             dialog = new DeviceTagAddDialog(currentSession, selectedDevice);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -52,7 +50,6 @@ public class DeviceTagToolbar extends TagToolbarGrid {
         DeviceTagDeleteDialog dialog = null;
         if (selectedEntity != null) {
             dialog = new DeviceTagDeleteDialog(selectedDevice, selectedEntity);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointToolbarGrid.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointToolbarGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,6 @@ import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolb
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.permission.EndpointSessionPermission;
-import com.extjs.gxt.ui.client.event.Events;
 
 public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
 
@@ -30,9 +29,7 @@ public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        EndpointAddDialog dialog = new EndpointAddDialog(currentSession);
-        dialog.addListener(Events.Hide, getHideDialogListener());
-        return dialog;
+        return new EndpointAddDialog(currentSession);
     }
 
     @Override
@@ -41,7 +38,6 @@ public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
         EndpointEditDialog dialog = null;
         if (selectedEndpoint != null) {
             dialog = new EndpointEditDialog(currentSession, selectedEndpoint);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -52,7 +48,6 @@ public class EndpointToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
         EndpointDeleteDialog dialog = null;
         if (selectedEndpoint != null) {
             dialog = new EndpointDeleteDialog(selectedEndpoint);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.steps;
 
-import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -44,9 +43,7 @@ public class JobTabStepsToolbar extends EntityCRUDToolbar<GwtJobStep> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        JobStepAddDialog dialog = new JobStepAddDialog(currentSession, jobId);
-        dialog.addListener(Events.Hide, getHideDialogListener());
-        return dialog;
+        return new JobStepAddDialog(currentSession, jobId);
     }
 
     @Override
@@ -55,7 +52,6 @@ public class JobTabStepsToolbar extends EntityCRUDToolbar<GwtJobStep> {
         JobStepEditDialog dialog = null;
         if (selectedJobStep != null) {
             dialog = new JobStepEditDialog(currentSession, selectedJobStep);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -66,7 +62,6 @@ public class JobTabStepsToolbar extends EntityCRUDToolbar<GwtJobStep> {
         JobStepDeleteDialog dialog = null;
         if (selectedJobStep != null) {
             dialog = new JobStepDeleteDialog(selectedJobStep);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagToolbarGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagToolbarGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,7 +17,6 @@ import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.tag.shared.model.GwtTag;
 import org.eclipse.kapua.app.console.module.tag.shared.model.permission.TagSessionPermission;
 
-import com.extjs.gxt.ui.client.event.Events;
 import com.google.gwt.user.client.Element;
 
 public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
@@ -32,9 +31,7 @@ public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
 
     @Override
     protected KapuaDialog getAddDialog() {
-        TagAddDialog dialog = new TagAddDialog(currentSession);
-        dialog.addListener(Events.Hide, getHideDialogListener());
-        return dialog;
+        return new TagAddDialog(currentSession);
     }
 
     @Override
@@ -49,7 +46,6 @@ public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
         TagEditDialog dialog = null;
         if (selectedTag != null) {
             dialog = new TagEditDialog(currentSession, selectedTag);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }
@@ -60,7 +56,6 @@ public class TagToolbarGrid extends EntityCRUDToolbar<GwtTag> {
         TagDeleteDialog dialog = null;
         if (selectedTag != null) {
             dialog = new TagDeleteDialog(selectedTag);
-            dialog.addListener(Events.Hide, getHideDialogListener());
         }
         return dialog;
     }


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Removed unneeded dialog listeners.

**Related Issue**
This PR fixes/closes #2541 

**Description of the solution adopted**
Removed unneeded `getHideDialogListener()`  listener from problematic toolbars that caused double error messages after closing some of the dialogues. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_