### PR TITLE
Changed message on asset confirmation and device configuration dialog

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
@@ -411,7 +411,7 @@ public class AccountConfigComponents extends LayoutContainer {
 
         // ask for confirmation
         String componentName = devConfPanel.getConfiguration().getComponentName();
-        String message = DEVICES_MSGS.deviceConfigConfirmation(componentName);
+        String message = DEVICES_MSGS.deviceConfigConfirmation();
 
         KapuaMessageBox.confirm(MSGS.confirm(),
                 message,

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -399,7 +399,7 @@ public class DeviceAssetsValues extends LayoutContainer {
 
         // ask for confirmation
         String assetName = assetValuesPanel.getAsset().getName();
-        String message = DEVICE_MSGS.deviceAssetConfirmation(assetName);
+        String message = DEVICE_MSGS.deviceAssetConfirmation();
 
         KapuaMessageBox.confirm(MSGS.confirm(),
                 message,

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -467,7 +467,7 @@ public class DeviceConfigComponents extends LayoutContainer {
 
         // ask for confirmation
         String componentName = devConfPanel.getConfiguration().getComponentName();
-        String message = DEVICE_MSGS.deviceConfigConfirmation(componentName);
+        String message = DEVICE_MSGS.deviceConfigConfirmation();
         final boolean isCloudUpdate = "CloudService".equals(componentName);
         if (isCloudUpdate) {
             message = DEVICE_MSGS.deviceCloudConfigConfirmation(componentName);

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -39,7 +39,7 @@ assetNameLabel=Asset Name: {0}
 assetValuesTab=Values
 assetNoAssets=No Available Assets
 assetNoAssetsErrorMessage=The selected device has no available assets.
-deviceAssetConfirmation=Are you sure you want to apply the new channels values to asset {0}?
+deviceAssetConfirmation=Are you sure you want to apply the new channels values to the selected asset?
 
 deviceTableStatus=Connection Status
 deviceTableClientID=Client ID
@@ -266,7 +266,7 @@ deviceConfigComponents=Services
 deviceConfigSnapshots=Snapshots
 deviceSnapshotFileTooltip=Select a snapshot file that should be uploaded and applied to the device.
 
-deviceConfigConfirmation=Are you sure you want to apply the new configuration to {0}?
+deviceConfigConfirmation=Are you sure you want to apply the new configuration to the selected asset?
 deviceCloudConfigConfirmation=Are you sure you want to apply the new configuration to service {0}? During the configuration update, the device will disconnect and reconnect. If a timeout is encountered during the reload of the device configuration, please refresh it manually.
 deviceConfigDirty=There are unsaved changes. Do you want to discard them and continue?
 


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed message on asset and configuration confirm dialog.

**Related Issue**
This PR fixes issue #2546

**Description of the solution adopted**
Info message on asset and configuration confirm dialog is changed to be without asset name, because if asset name is too long it can not be displayed properly on dialog.

**Screenshots**
/

**Any side note on the changes made**
/