### PR TITLE
Removed error state from fields after they are not empty

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -291,6 +291,12 @@ public class LoginDialog extends Dialog {
         login.setEnabled(true);
         reset.setEnabled(hasValue(username) &&
                 hasValue(password));
+        if(hasValue(username)) {
+            username.clearInvalid();
+        }
+        if(hasValue(password)) {
+            password.clearInvalid();
+        }
     }
 
     public void reset() {


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Removed error state from password and username fields.

**Related Issue**
This PR fixes issue #2544 

**Description of the solution adopted**
If username or password fields are not filled, they are in error state. But if user fills this fields, they are not in error state anymore, which means that this fields has auto validation. 

**Screenshots**
/

**Any side note on the changes made**
/
