### PR TITLE
Disabled row deselect on Data tab

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,16 +12,19 @@
 package org.eclipse.kapua.app.console.module.data.client;
 
 import com.extjs.gxt.ui.client.Style.Scroll;
+import com.extjs.gxt.ui.client.Style.SelectionMode;
 import com.extjs.gxt.ui.client.data.BaseListLoader;
 import com.extjs.gxt.ui.client.data.ListLoadResult;
 import com.extjs.gxt.ui.client.data.LoadConfig;
 import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.event.Events;
 import com.extjs.gxt.ui.client.event.SelectionChangedListener;
 import com.extjs.gxt.ui.client.widget.ContentPanel;
 import com.extjs.gxt.ui.client.widget.LayoutContainer;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.extjs.gxt.ui.client.widget.grid.ColumnModel;
 import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridSelectionModel;
 import com.extjs.gxt.ui.client.widget.layout.FitLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
@@ -114,9 +117,15 @@ public class AssetTable extends LayoutContainer {
         assetGrid.getView().setForceFit(true);
         assetGrid.getView().setEmptyText(MSGS.assetTableEmptyText());
         assetGrid.disableTextSelection(false);
+        assetGrid.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         for (SelectionChangedListener<GwtDatastoreAsset> listener : listeners) {
             assetGrid.getSelectionModel().addSelectionChangedListener(listener);
         }
+
+        final GridSelectionModel<GwtDatastoreAsset> gridSelectionModel = assetGrid.getSelectionModel();
+        GridSelectionChangedListener<GwtDatastoreAsset> gridSelectionChangedListener = new GridSelectionChangedListener<GwtDatastoreAsset>();
+        gridSelectionChangedListener.setSelectionModel(gridSelectionModel);
+        gridSelectionModel.addListener(Events.SelectionChange, gridSelectionChangedListener);
     }
 
     public void clearTable() {

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTable.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.app.console.module.data.client;
 
 import com.extjs.gxt.ui.client.Style.Scroll;
+import com.extjs.gxt.ui.client.Style.SelectionMode;
 import com.extjs.gxt.ui.client.Style.SortDir;
 import com.extjs.gxt.ui.client.data.BasePagingLoader;
 import com.extjs.gxt.ui.client.data.LoadEvent;
@@ -31,6 +32,7 @@ import com.extjs.gxt.ui.client.widget.LayoutContainer;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.extjs.gxt.ui.client.widget.grid.ColumnModel;
 import com.extjs.gxt.ui.client.widget.grid.Grid;
+import com.extjs.gxt.ui.client.widget.grid.GridSelectionModel;
 import com.extjs.gxt.ui.client.widget.layout.FitLayout;
 import com.extjs.gxt.ui.client.widget.toolbar.ToolBar;
 import com.google.gwt.core.client.GWT;
@@ -168,6 +170,7 @@ public class DeviceTable extends LayoutContainer {
         deviceGrid.getView().setForceFit(true);
         deviceGrid.getView().setEmptyText(DATA_MSGS.deviceTableEmptyText());
         deviceGrid.disableTextSelection(false);
+        deviceGrid.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         for (SelectionChangedListener<GwtDatastoreDevice> listener : listeners) {
             deviceGrid.getSelectionModel().addSelectionChangedListener(listener);
         }
@@ -178,6 +181,11 @@ public class DeviceTable extends LayoutContainer {
                 loader.load();
             }
         });
+
+        final GridSelectionModel<GwtDatastoreDevice> gridSelectionModel = deviceGrid.getSelectionModel();
+        GridSelectionChangedListener<GwtDatastoreDevice> gridSelectionChangedListener = new GridSelectionChangedListener<GwtDatastoreDevice>();
+        gridSelectionChangedListener.setSelectionModel(gridSelectionModel);
+        gridSelectionModel.addListener(Events.SelectionChange, gridSelectionChangedListener);
     }
 
     public void addSelectionChangedListener(SelectionChangedListener<GwtDatastoreDevice> listener) {

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/GridSelectionChangedListener.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/GridSelectionChangedListener.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.data.client;
+
+import com.extjs.gxt.ui.client.data.ModelData;
+import com.extjs.gxt.ui.client.event.Listener;
+import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
+import com.extjs.gxt.ui.client.widget.grid.GridSelectionModel;
+
+/**
+ * Listener for grid selection changes on Data tab.
+ * 
+ * @param <M> the model type being selected
+ */
+public class GridSelectionChangedListener<M extends ModelData> implements Listener<SelectionChangedEvent<M>> {
+
+    private GridSelectionModel<M> selectionModel;
+    protected boolean selectedAgain;
+    private M selectedItem;
+
+    /**
+     * The constructor
+     */
+    public GridSelectionChangedListener() {
+        super();
+    }
+
+    /**
+     * Method for setting the selectionModel
+     * @param selectionModel
+     */
+    public void setSelectionModel(GridSelectionModel<M> selectionModel) {
+        this.selectionModel = selectionModel;
+    }
+
+    /**
+     * Method for handling the SelectionChangedEvent<M> on grid rows. 
+     * This method prevents row deselection using CTRL + Click, by selecting 
+     * the previously chosen value again. In all other cases the row selection 
+     * works as usual.
+     * 
+     * @param se the selection event
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public void handleEvent(SelectionChangedEvent<M> se) {
+        if (selectionModel.getSelectedItem() != null && selectedAgain == false) {
+            selectedItem = selectionModel.getSelectedItem();
+        } else if (selectionModel.getSelectedItem() == null) {
+            selectedAgain = true;
+        } else if (selectedItem != selectionModel.getSelectedItem()) {
+            selectedAgain = false;
+            selectedItem = selectionModel.getSelectedItem();
+        }
+        selectionModel.select(false, selectedItem);
+    }
+}

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
@@ -179,6 +179,11 @@ public class TopicsTable extends LayoutContainer {
                 updateTimestamps(tge.getModel().getChildren());
             }
         });
+
+        final GridSelectionModel<GwtTopic> gridSelectionModel = topicInfoGrid.getSelectionModel();
+        GridSelectionChangedListener<GwtTopic> gridSelectionChangedListener = new GridSelectionChangedListener<GwtTopic>();
+        gridSelectionChangedListener.setSelectionModel(gridSelectionModel);
+        selectionModel.addListener(Events.SelectionChange, gridSelectionChangedListener);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Disabled row deselect on Data tab

**Related Issue**
This PR fixes/closes #2021 

**Description of the solution adopted**
Created new `GridSelectionChangedListener` used for Topics/Devices/Assets grids on the Data tab. This listener prevents row deselection using CTRL + Click on the previously mentioned grids.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
