### PR TITLE
Changed display of properties in label if they are too long

### DIFF
--- a/console/module/api/pom.xml
+++ b/console/module/api/pom.xml
@@ -56,7 +56,20 @@
             <artifactId>commons-fileupload</artifactId>
             <version>1.3.2</version>
         </dependency>
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>marker-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/SplitTooltipStringUtil.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/SplitTooltipStringUtil.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.api.client.util;
+
+
+public class SplitTooltipStringUtil {
+
+    private SplitTooltipStringUtil() { }
+
+    /**
+     * Split long string into multiple rows.
+     * Used for correct display of tooltip which contains user name and device client id.
+     *
+     * @param input long string
+     * @param maxLineLength length of single line
+     * @return string with line separators
+     */
+    public static String splitTooltipString(String input, int maxLineLength) {
+        StringBuilder multiRowString = new StringBuilder();
+
+        if(input != null) {
+            for (int start = 0; start <= input.length(); start += maxLineLength) {
+                int end = start;
+
+                if ((end + maxLineLength) <= input.length()) {
+                    end += maxLineLength;
+                } else {
+                    end = input.length();
+                }
+                multiRowString.append(input.substring(start, end));
+                if (end < input.length()) {
+                    multiRowString.append("</br>");
+                }
+            }
+        }
+
+        return multiRowString.toString();
+    }
+}

--- a/console/module/api/src/test/java/org/eclipse/kapua/app/console/module/api/test/SplitTooltipStringTest.java
+++ b/console/module/api/src/test/java/org/eclipse/kapua/app/console/module/api/test/SplitTooltipStringTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.api.test;
+
+import org.eclipse.kapua.app.console.module.api.client.util.SplitTooltipStringUtil;
+import org.eclipse.kapua.test.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class SplitTooltipStringTest {
+
+    @Test
+    public void testStringSplit() {
+        String inputString = "testtesttesttest";
+        String result = SplitTooltipStringUtil.splitTooltipString(inputString, 10);
+        Assert.assertTrue(result.contains("</br>"));
+    }
+}

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -11,9 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.client.device;
 
+import com.extjs.gxt.ui.client.widget.tips.ToolTipConfig;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.SplitTooltipStringUtil;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.GwtGroup;
 import org.eclipse.kapua.app.console.module.authorization.shared.model.permission.GroupSessionPermission;
@@ -23,6 +25,8 @@ import org.eclipse.kapua.app.console.module.device.shared.model.GwtDeviceQueryPr
 public class DeviceEditDialog extends DeviceAddDialog {
 
     private GwtDevice selectedDevice;
+    public static final int MAX_LINE_LENGTH = 40;
+    public static final int MAX_TOOLTIP_WIDTH = 300;
 
     public DeviceEditDialog(GwtSession currentSession, GwtDevice selectedDevice) {
         super(currentSession);
@@ -118,10 +122,17 @@ public class DeviceEditDialog extends DeviceAddDialog {
 
     private void populateDialog(GwtDevice device) {
         if (device != null) {
+            ToolTipConfig toolTipConfig = new ToolTipConfig();
+            toolTipConfig.setMaxWidth(MAX_TOOLTIP_WIDTH);
+            String toolTipText = SplitTooltipStringUtil.splitTooltipString(device.getClientId(), MAX_LINE_LENGTH);
+            toolTipConfig.setText(toolTipText);
             // General info data
-            clientIdField.setValue(device.getClientId());
-            clientIdLabel.setText(device.getClientId());
-            clientIdLabel.setToolTip(DEVICE_MSGS.deviceFormClientIDEditDialogTooltip());
+                clientIdLabel.setValue(device.getClientId());
+                clientIdLabel.setStyleAttribute("white-space", "nowrap");
+                clientIdLabel.setStyleAttribute("text-overflow", "ellipsis");
+                clientIdLabel.setStyleAttribute("overflow", "hidden");
+                clientIdLabel.setToolTip(toolTipConfig);
+
             displayNameField.setValue(device.getUnescapedDisplayName());
             statusCombo.setSimpleValue(GwtDeviceQueryPredicates.GwtDeviceStatus.valueOf(device.getGwtDeviceStatus()));
 

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.user.client.dialog;
 
+import com.extjs.gxt.ui.client.widget.tips.ToolTipConfig;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
@@ -20,6 +21,7 @@ import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.SplitTooltipStringUtil;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser;
 import org.eclipse.kapua.app.console.module.user.shared.model.GwtUser.GwtUserStatus;
@@ -31,6 +33,8 @@ public class UserEditDialog extends UserAddDialog {
     private GwtUser selectedUser;
 
     private GwtUserServiceAsync gwtUserService = GWT.create(GwtUserService.class);
+    public static final int MAX_LINE_LENGTH = 40;
+    public static final int MAX_TOOLTIP_WIDTH = 300;
 
     public UserEditDialog(GwtSession currentSession, GwtUser selectedUser) {
         super(currentSession);
@@ -149,8 +153,17 @@ public class UserEditDialog extends UserAddDialog {
         infoFieldSet.remove(username);
         usernameLabel.setVisible(true);
         username.setVisible(false);
-        usernameLabel.setValue(gwtUser.getUsername());
-        usernameLabel.setToolTip(USER_MSGS.dialogAddFieldNameEditDialogTooltip());
+        ToolTipConfig toolTipConfig = new ToolTipConfig();
+        toolTipConfig.setMaxWidth(MAX_TOOLTIP_WIDTH);
+        String toolTipText = SplitTooltipStringUtil.splitTooltipString(gwtUser.getUsername(), MAX_LINE_LENGTH);
+        toolTipConfig.setText(toolTipText);
+
+            usernameLabel.setValue(gwtUser.getUsername());
+            usernameLabel.setStyleAttribute("white-space", "nowrap");
+            usernameLabel.setStyleAttribute("text-overflow", "ellipsis");
+            usernameLabel.setStyleAttribute("overflow", "hidden");
+            usernameLabel.setToolTip(toolTipConfig);
+
         if (password != null) {
             password.setVisible(false);
             password.setAllowBlank(true);
@@ -173,4 +186,5 @@ public class UserEditDialog extends UserAddDialog {
         expirationDate.setMaxLength(10);
         formPanel.clearDirtyFields();
     }
+
 }


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed display of name parameter on edit dialogues.

**Related Issue**
This PR fixes issue #2477

**Description of the solution adopted**
If user name on User Edit dialogue, and client id on Device Edit dialogue are too long, than names are resized, and tool tip with full name are added over them. It looks like on screenshots bellow.

**Screenshots**
_UserEditDialog_
![image](https://user-images.githubusercontent.com/45655642/55878364-9091a280-5b9c-11e9-8db7-bc6ccf202f26.png)

_DeviceEditDialog_
![image](https://user-images.githubusercontent.com/45655642/55878448-bb7bf680-5b9c-11e9-95a7-c5c88e4ba03d.png)

**Any side note on the changes made**
/
