### PR TITLE
Display of modified and created by user fields

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -357,7 +357,7 @@ public class ServiceDAO {
         //
         // WHERE
         QueryPredicate kapuaPredicates = kapuaQuery.getPredicate();
-        if (kapuaQuery.getScopeId() != null) {
+        if ((kapuaQuery.getScopeId() != null) && (!kapuaQuery.getScopeId().equals(KapuaId.ANY))) {
 
             AndPredicate scopedAndPredicate = kapuaQuery.andPredicate(
                     kapuaQuery.attributePredicate(KapuaEntityAttributes.SCOPE_ID, kapuaQuery.getScopeId())

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -357,7 +357,7 @@ public class ServiceDAO {
         //
         // WHERE
         QueryPredicate kapuaPredicates = kapuaQuery.getPredicate();
-        if ((kapuaQuery.getScopeId() != null) && (!kapuaQuery.getScopeId().equals(KapuaId.ANY))) {
+        if (kapuaQuery.getScopeId() != null) {
 
             AndPredicate scopedAndPredicate = kapuaQuery.andPredicate(
                     kapuaQuery.attributePredicate(KapuaEntityAttributes.SCOPE_ID, kapuaQuery.getScopeId())

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -215,7 +215,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
 
                 @Override
                 public UserListResult call() throws Exception {
-                    return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                    return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                 }
             });
 
@@ -687,7 +687,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                     }
                 });
 

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -71,7 +71,6 @@ import org.eclipse.kapua.service.endpoint.EndpointInfoService;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserFactory;
 import org.eclipse.kapua.service.user.UserListResult;
-import org.eclipse.kapua.service.user.UserQuery;
 import org.eclipse.kapua.service.user.UserService;
 
 import org.slf4j.Logger;
@@ -212,27 +211,27 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
         try {
             final Account account = ACCOUNT_SERVICE.find(scopeId, accountId);
 
-            User userCreatedBy = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+            UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
                 @Override
-                public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, account.getCreatedBy());
+                public UserListResult call() throws Exception {
+                    return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
                 }
             });
-            User userModifiedBy = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 
-                @Override
-                public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, account.getModifiedBy());
-                }
-            });
+            Map<String, String> usernameMap = new HashMap<String, String>();
+            for (User user : userListResult.getItems()) {
+                usernameMap.put(user.getId().toCompactId(), user.getName());
+            }
 
             final String entityInfo = "entityInfo";
             accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "expirationDate", account.getExpirationDate()));
             accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountCreatedOn", account.getCreatedOn()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountCreatedBy", userCreatedBy != null ? userCreatedBy.getName() : null));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountCreatedBy",
+                    account.getCreatedBy() != null ? usernameMap.get(account.getCreatedBy().toCompactId()) : null));
             accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountModifiedOn", account.getModifiedOn()));
-            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountModifiedBy", userModifiedBy != null ? userModifiedBy.getName() : null));
+            accountPropertiesPairs.add(new GwtGroupedNVPair(entityInfo, "accountModifiedBy",
+                    account.getModifiedBy() != null ? usernameMap.get(account.getModifiedBy().toCompactId()) : null));
 
             if (account.getScopeId() != null) {
                 Account parentAccount = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
@@ -684,12 +683,11 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
             totalLength = (int) ACCOUNT_SERVICE.count(query);
 
             if (!accounts.isEmpty()) {
-                final UserQuery userQuery = USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtAccountQuery.getScopeId()));
                 UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(userQuery);
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
                     }
                 });
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
@@ -133,7 +133,7 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                     }
                 });
 
@@ -183,7 +183,7 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
 
                 @Override
                 public UserListResult call() throws Exception {
-                    return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                    return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                 }
             });
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
@@ -188,7 +188,7 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                     }
                 });
 
@@ -229,7 +229,7 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
                 @Override
                 public UserListResult call() throws Exception {
-                    return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                    return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                 }
             });
 

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
@@ -184,16 +184,16 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
             totalLength = Long.valueOf(ROLE_SERVICE.count(roleQuery)).intValue();
 
             if (!roles.isEmpty()) {
-                UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
+                UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtRoleQuery.getScopeId())));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
                     }
                 });
 
                 Map<String, String> usernameMap = new HashMap<String, String>();
-                for (User user : userListResult.getItems()) {
+                for (User user : usernames.getItems()) {
                     usernameMap.put(user.getId().toCompactId(), user.getName());
                 }
 
@@ -225,29 +225,27 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
             // Find
             final Role role = ROLE_SERVICE.find(scopeId, roleId);
-            User createdUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+            UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
                 @Override
-                public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, role.getCreatedBy());
+                public UserListResult call() throws Exception {
+                    return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
                 }
             });
-            User modifiedUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 
-                @Override
-                public User call() throws Exception {
-                    return USER_SERVICE.find(scopeId, role.getModifiedBy());
-                }
-            });
+            Map<String, String> usernameMap = new HashMap<String, String>();
+            for (User user : userListResult.getItems()) {
+                usernameMap.put(user.getId().toCompactId(), user.getName());
+            }
 
             // If there are results
             if (role != null) {
                 gwtRoleDescription.add(new GwtGroupedNVPair("roleInfo", "roleName", role.getName()));
                 gwtRoleDescription.add(new GwtGroupedNVPair("roleInfo", "roleDescription", role.getDescription()));
                 gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleModifiedOn", role.getModifiedOn()));
-                gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleModifiedBy", modifiedUser != null ? modifiedUser.getName() : null));
+                gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleModifiedBy", role.getModifiedBy() != null ? usernameMap.get(role.getModifiedBy().toCompactId()) : null));
                 gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleCreatedOn", role.getCreatedOn()));
-                gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleCreatedBy", createdUser != null ? createdUser.getName() : null));
+                gwtRoleDescription.add(new GwtGroupedNVPair("entityInfo", "roleCreatedBy", role.getCreatedBy() != null ? usernameMap.get(role.getCreatedBy().toCompactId()) : null));
             }
 
         } catch (Throwable t) {

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
@@ -141,7 +141,7 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                     }
                 });
 
@@ -192,7 +192,7 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                     }
                 });
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -80,7 +80,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                     }
                 });
 
@@ -206,7 +206,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
 
                 @Override
                 public UserListResult call() throws Exception {
-                    return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                    return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                 }
             });
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -137,7 +137,7 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return userService.query(userFactory.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(gwtTagQuery.getScopeId())));
+                        return userService.query(userFactory.newQuery(KapuaId.ANY));
                     }
                 });
 
@@ -183,29 +183,27 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
             final Tag tag = tagService.find(scopeId, tagId);
 
             if (tag != null) {
-                User createdUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+                UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 
                     @Override
-                    public User call() throws Exception {
-                        return userService.find(scopeId, tag.getCreatedBy());
+                    public UserListResult call() throws Exception {
+                        return userService.query(userFactory.newQuery(KapuaId.ANY));
                     }
                 });
-                User modifiedUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
 
-                    @Override
-                    public User call() throws Exception {
-                        return userService.find(scopeId, tag.getModifiedBy());
-                    }
-                });
+                Map<String, String> usernameMap = new HashMap<String, String>();
+                for (User user : userListResult.getItems()) {
+                    usernameMap.put(user.getId().toCompactId(), user.getName());
+                }
 
                 // gwtTagDescription.add(new GwtGroupedNVPair("Entity", "Scope
                 // Id", KapuaGwtCommonsModelConverter.convertKapuaId(tag.getScopeId())));
                 gwtTagDescription.add(new GwtGroupedNVPair("tagInfo", "tagName", tag.getName()));
                 gwtTagDescription.add(new GwtGroupedNVPair("tagInfo", "tagDescription", tag.getDescription()));
                 gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagModifiedOn", tag.getModifiedOn()));
-                gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagModifiedBy", modifiedUser != null ? modifiedUser.getName() : null));
+                gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagModifiedBy", tag.getModifiedBy() != null ? usernameMap.get(tag.getModifiedBy().toCompactId()) : null));
                 gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagCreatedOn", tag.getCreatedOn()));
-                gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagCreatedBy", createdUser != null ? createdUser.getName() : null));
+                gwtTagDescription.add(new GwtGroupedNVPair("entityInfo", "tagCreatedBy", tag.getCreatedBy() != null ? usernameMap.get(tag.getCreatedBy().toCompactId()) : null));
 
             }
         } catch (Exception e) {

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -137,7 +137,7 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return userService.query(userFactory.newQuery(KapuaId.ANY));
+                        return userService.query(userFactory.newQuery(null));
                     }
                 });
 
@@ -187,7 +187,7 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return userService.query(userFactory.newQuery(KapuaId.ANY));
+                        return userService.query(userFactory.newQuery(null));
                     }
                 });
 

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
@@ -259,7 +259,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                     }
                 });
 
@@ -299,7 +299,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
                     @Override
                     public UserListResult call() throws Exception {
-                        return USER_SERVICE.query(USER_FACTORY.newQuery(KapuaId.ANY));
+                        return USER_SERVICE.query(USER_FACTORY.newQuery(null));
                     }
                 });
 

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -245,7 +245,6 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         //
         // Argument Validation
         ArgumentValidator.notNull(query, "query");
-        ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
 
         //
         // Check Access
@@ -262,7 +261,6 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         //
         // Argument Validator
         ArgumentValidator.notNull(query, "query");
-        ArgumentValidator.notNull(query.getScopeId(), "query.scopeId");
 
         //
         // Check Access


### PR DESCRIPTION
This solves issue with display of created by and modified by fields on multiple screens.
Issue is shown when using sub account and not kapua-sys account.

**Related Issue**
This is one way that would be possible to solve issue #2465.
Aleksandra tried with her PR #2534.

This approach is a bit more aggressive on user service, where it uses
KapuaId.ANY in query() methods to find all records.
Of course if permission check is executed before, user has to have permission
ANY to execute such a query.
In case of doPrivileged() this also shouldn't be a problem as it is
privileged after all.

Fixed created by / modified by on all grids and details.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>

**Description of the solution adopted**
Big change was done on DAO query itself. It is now possible to do query on all items by using KapuaId.ANY. **Is this a possible issue**? I think not, but would be glad to discuss.

**Screenshots**
Not applicable.

**Any side note on the changes made**
Review of DAO changes.
