### PR TITLE
Changed visibility of write boolean assets

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
@@ -369,6 +369,12 @@ public class DeviceAssetsPanel extends LayoutContainer {
             radioFalse.setValue(true);
             radioGroup.setOriginalValue(radioFalse);
         }
+        if(channel.getModeEnum().equals(GwtDeviceAssetChannelMode.WRITE)) {
+            radioTrue.setValue(null);
+            radioGroup.setOriginalValue(radioTrue);
+            radioFalse.setValue(null);
+            radioGroup.setOriginalValue(radioFalse);
+        }
 
         return radioGroup;
     }


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Visibility of write Boolean assets are changed.

**Related Issue**
This PR fixes issue #2340.

**Description of the solution adopted**
Value of assets is not visible if assets are Boolean and if they only have `write` permission. It looks like on screenshot bellow.

**Screenshots**
![image](https://user-images.githubusercontent.com/45655642/55956376-1e849080-5c64-11e9-9dca-d806681150c6.png)

**Any side note on the changes made**
/
