### PR TITLE
added message for refreshing application when displayname is changed

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -16,6 +16,8 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog.InfoDialogType;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
@@ -29,6 +31,7 @@ import org.eclipse.kapua.app.console.module.user.shared.service.GwtUserServiceAs
 public class UserEditDialog extends UserAddDialog {
 
     private GwtUser selectedUser;
+    private boolean isChanged;
 
     private GwtUserServiceAsync gwtUserService = GWT.create(GwtUserService.class);
 
@@ -82,6 +85,9 @@ public class UserEditDialog extends UserAddDialog {
     @Override
     protected void preSubmit() {
         super.preSubmit();
+        if (displayName.isDirty()) {
+            isChanged = true;
+        }
     }
 
     @Override
@@ -97,6 +103,10 @@ public class UserEditDialog extends UserAddDialog {
 
             @Override
             public void onSuccess(GwtUser gwtUser) {
+                if (currentSession.getUserName().equals(gwtUser.getUsername()) && isChanged) {
+                    InfoDialog infoDialog = new InfoDialog(InfoDialogType.INFO, USER_MSGS.dialogEditUserName());
+                    infoDialog.show();
+                }
                 exitStatus = true;
                 exitMessage = USER_MSGS.dialogEditConfirmation();
                 hide();

--- a/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
+++ b/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
@@ -67,6 +67,7 @@ dialogEditConfirmation=User successfully updated.
 dialogEditError=User edit failed: {0}
 dialogEditAdminUserStatusError=Admin user cannot be disabled.
 dialogEditAdminExpirationDateError=Admin user cannot have an expiration date.
+dialogEditUserName=After changing Display Name parameter please refresh browser window in order to update it in all views.
 
 dialogEditFieldName=Name
 dialogEditFieldNameTooltip=The name of the User. It must be unique.


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Added new message which Informs current user that if his display name is changed, he should refresh application if he wants to update username in top right corner.

**Related Issue**
This PR fixes issue  #1600

**Description of the solution adopted**
Due to inability to trigger refreshing display name when user change display name, @LeoNerdoG  and I have discussed about solution with this message.

**Screenshots**
![kapua](https://user-images.githubusercontent.com/30318334/56195540-7ab92d00-6035-11e9-9c15-67339c791745.png)


**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
