### PR TITLE
Added shift of step index when deleting a jobStep

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepImpl.java
@@ -56,8 +56,8 @@ public class JobStepImpl extends AbstractKapuaNamedEntity implements JobStep {
     private KapuaEid jobStepDefinitionId;
 
     @Basic
-    @Column(name = "step_index", nullable = false, updatable = false)
-    private int stepIndex;
+    @Column(name = "step_index", nullable = false, updatable = true)
+    private Integer stepIndex;
 
     @ElementCollection
     @CollectionTable(name = "job_job_step_properties", joinColumns = @JoinColumn(name = "step_id", referencedColumnName = "id"))

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -264,6 +264,29 @@ public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do delete
-        entityManagerSession.onTransactedAction(em -> JobStepDAO.delete(em, scopeId, jobStepId));
+        entityManagerSession.onTransactedAction(em -> {
+            JobStep deletedJobStep = JobStepDAO.find(em, scopeId, jobStepId);
+
+            JobStepDAO.delete(em, scopeId, jobStepId);
+
+            //
+            // Shift following steps of one position in the step index
+            JobStepQuery query = new JobStepQueryImpl(scopeId);
+
+            query.setPredicate(
+                    query.andPredicate(
+                            query.attributePredicate(JobStepAttributes.JOB_ID, deletedJobStep.getJobId()),
+                            query.attributePredicate(JobStepAttributes.STEP_INDEX, deletedJobStep.getStepIndex(), Operator.GREATER_THAN)
+                    )
+            );
+
+            JobStepListResult followingJobStep = JobStepDAO.query(em, query);
+
+            for (JobStep js : followingJobStep.getItems()) {
+                js.setStepIndex(js.getStepIndex() - 1);
+
+                JobStepDAO.update(em, js);
+            }
+        });
     }
 }


### PR DESCRIPTION
Implemented the shift of the other JobSteps when deleting a JobStep of a Job

**Related Issue**
This PR fixes #2425 

**Description of the solution adopted**
When deleting a JobStep, now we check if there are other JobStep defined after the one that is being deleted and we are decreasing the JobStep.stepIndex property of 1 

**Screenshots**
_None_

**Any side note on the changes made**
_None_