### PR TITLE
Fix for Transaction error when editing Users

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -53,6 +53,7 @@ public class UserEditDialog extends UserAddDialog {
             public void onSuccess(GwtUser gwtUser) {
                 unmaskDialog();
                 populateEditDialog(gwtUser);
+                selectedUser = gwtUser;
             }
 
             @Override


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for Transaction error when editing Users.

**Related Issue**
This PR fixes/closes #2560 

**Description of the solution adopted**
Updated the value of `selectedUser` parameter in the loadUser() method in the `UserEditDialog` class. The mentioned `loadUser()` method makes a call to the `GwtUserService`'s find() method and the `selectedUser` is updated with the result.
After the previously mentioned change the correct and updated value of the `selectedUser` property is passed to the `GwtUserService`'s `update()` method and the `javax.persistence.OptimisticLockException`  no longer occurs. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_
