### PR TITLE
Fix for Error/Info boxes stacking

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -354,7 +354,8 @@ public class AccountAddDialog extends EntityAddEditDialog {
 
                     @Override
                     public void onSuccess(GwtAccount account) {
-                        ConsoleInfo.display(MSGS.info(), MSGS.accountCreatedConfirmation());
+                        exitStatus = true;
+                        exitMessage = MSGS.accountCreatedConfirmation();
                         hide();
                     }
                 });


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for Error/Info boxes stacking.

**Related Issue**
This PR fixes/closes #1739

**Description of the solution adopted**
`ConsoleInfo` class is now a singleton class. Created `getInstance()` method for accessing the mentioned singleton class. Updated/overridden the affected methods from the extended `Info` class for correct display of Info/Error messages. After these changes only one last message is shown and there is no more stacking.

**Screenshots**
_None_

**Any side note on the changes made**
Set exitStatus to true for the onSuccess() method after AccountAddDialog submit.