### PR TITLE
removed asset error msg when install packages in devices

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssets.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssets.java
@@ -64,7 +64,7 @@ public class DeviceTabAssets extends KapuaTabItem<GwtDevice> {
             return;
         }
 
-        if (tabsPanel.getSelectedItem() == tabValues) {
+        if (tabsPanel.getSelectedItem() == this) {
             assetsValues.refresh();
         }
     }


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Removed error message for assets when package is installed in Devices.

**Related Issue**
This PR fixes issue #2028 

**Description of the solution adopted**
Changed if clause in DeviceTabAssets,, to refresh only if User is on Assets tab, otherwise Assets tab will not be refreshed.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
