### PR TITLE
changed size of Tooltips in device and user dialogues

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -26,7 +26,7 @@ public class DeviceEditDialog extends DeviceAddDialog {
 
     private GwtDevice selectedDevice;
     public static final int MAX_LINE_LENGTH = 40;
-    public static final int MAX_TOOLTIP_WIDTH = 300;
+    public static final int MAX_TOOLTIP_WIDTH = 400;
 
     public DeviceEditDialog(GwtSession currentSession, GwtDevice selectedDevice) {
         super(currentSession);

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -36,7 +36,7 @@ public class UserEditDialog extends UserAddDialog {
     private boolean isChanged;
 
     private GwtUserServiceAsync gwtUserService = GWT.create(GwtUserService.class);
-    public static final int MAX_LINE_LENGTH = 40;
+    public static final int MAX_LINE_LENGTH = 30;
     public static final int MAX_TOOLTIP_WIDTH = 300;
 
     public UserEditDialog(GwtSession currentSession, GwtUser selectedUser) {


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed `tooltip` width in user edit dialog and device edit dialog.

**Related Issue**
This PR is additional fix for PR #2553.

**Description of the solution adopted**
`Tooltip` width is change in user edit and device edit dialogues, if username or client id are too long and.

**Screenshots**
/

**Any side note on the changes made**
/
