### PR TITLE
Removed errors when editing Device

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -71,6 +71,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
     protected ComboBox<GwtGroup> groupCombo;
     protected KapuaTextField<String> displayNameField;
     protected SimpleComboBox<GwtDeviceStatus> statusCombo;
+    protected FieldSet fieldSet;
 
     // Security Options fields
     // protected SimpleComboBox<String> credentialsTightCombo;
@@ -141,7 +142,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         };
 
         // Device general info fieldset
-        FieldSet fieldSet = new FieldSet();
+        fieldSet = new FieldSet();
         FormLayout layout = new FormLayout();
         layout.setLabelWidth(Constants.LABEL_WIDTH_DEVICE_FORM);
         fieldSet.setLayout(layout);
@@ -305,7 +306,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
     }
 
     public void validateDeviceInput() {
-        if (clientIdField.getValue() == null || displayNameField.getValue() == null || statusCombo.getValue() == null || groupCombo.getValue() == null) {
+        if (clientIdField.isVisible() && clientIdField.getValue() == null || displayNameField.getValue() == null || statusCombo.getValue() == null || groupCombo.getValue() == null) {
             ConsoleInfo.display("Error", MSGS.allFieldsRequired());
         }
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -38,8 +38,8 @@ public class DeviceEditDialog extends DeviceAddDialog {
         generateBody();
         submitButton.disable();
 
-        // hide fields used for add
-        clientIdField.hide();
+        // remove field used only on Add dialog
+        fieldSet.remove(clientIdField);
         // this protects against odd issue https://github.com/eclipse/kapua/issues/1631
         groupCombo.setAllowBlank(true);
 


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Removed errors when editing Device.

**Related Issue**
This PR fixes/closes #2574

**Description of the solution adopted**
Updated the field validation method on the `DeviceAddDialog` - added a check for `clientIdField` field visibility. This prevents validation errors on `clientIdField` after submit of the `DeviceEditDialog` where this field not visible. 
Also made a change on the `DeviceEditDialog` - removed the previously hidden and unneeded `clientIdField` from the `fieldSet` as it caused the `formPanel.isValid()` check failure in the dialog's preSubmit() method.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
