### PR TITLE
Fixed KapuaSession data management in REST API

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,11 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.core.auth;
 
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.web.filter.authc.AuthenticatingFilter;
@@ -24,6 +19,11 @@ import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
 import org.eclipse.kapua.service.authentication.CredentialsFactory;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public class KapuaTokenAuthenticationFilter extends AuthenticatingFilter {
 
@@ -58,6 +58,7 @@ public class KapuaTokenAuthenticationFilter extends AuthenticatingFilter {
         if (authorizationHeader != null) {
             tokenId = httpRequest.getHeader(AUTHORIZATION_HEADER).replace(BEARER + " ", "");
         }
+
         //
         // Build AccessToken for Shiro Auth
         KapuaLocator locator = KapuaLocator.getInstance();

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/filter/KapuaSessionCleanupFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/filter/KapuaSessionCleanupFilter.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.filter;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.subject.Subject;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+
+/**
+ * This {@link Filter} cleans up the {@link Subject#getSession()} state and the {@link KapuaSecurityUtils#getSession()} after a request.
+ * <p>
+ * The processing of the request can leave some information on the Shiro {@link Subject} or the {@link org.eclipse.kapua.commons.security.KapuaSession} and we must clean it to avoid that
+ * a subsequent request uses a {@link Thread} with dirty data inside.
+ * <p>
+ * Apache Shiro it is possible to define {@code noSessionCreation} on the urls mappings in the shiro.ini.
+ * Unfortunately using the {@code noSessionCreation} does not have any effect because our {@link org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthenticationFilter} is invoked before the {@link org.apache.shiro.web.filter.session.NoSessionCreationFilter}
+ * so it has no effect (see {@link org.apache.shiro.web.filter.session.NoSessionCreationFilter javadoc}.
+ *
+ * @since 1.1.0
+ */
+public class KapuaSessionCleanupFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // No init required
+    }
+
+    @Override
+    public void destroy() {
+        // No destroy required
+    }
+
+    /**
+     * After the invokation of {@link FilterChain#doFilter(ServletRequest, ServletResponse)} the {@link Subject} and the {@link org.eclipse.kapua.commons.security.KapuaSession}
+     * are checked and cleaned accordingly.
+     * <p>
+     * See also {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)} javadoc.
+     *
+     * @param request  See {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)} javadoc.
+     * @param response See {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)} javadoc.
+     * @param chain    See {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)} javadoc.
+     * @throws IOException      See {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)} javadoc.
+     * @throws ServletException See {@link Filter#doFilter(ServletRequest, ServletResponse, FilterChain)} javadoc.
+     * @since 1.1.0
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            Subject subject = SecurityUtils.getSubject();
+            if (subject.isAuthenticated()) {
+                subject.logout();
+            }
+
+            if (KapuaSecurityUtils.getSession() != null) {
+                KapuaSecurityUtils.clearSession();
+            }
+        }
+    }
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Accounts.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Accounts.java
@@ -74,6 +74,7 @@ public class Accounts extends AbstractKapuaResource {
                                           @ApiParam(value = "The account name to filter results.") @QueryParam("name") String name, //
                                           @ApiParam(value = "The result set offset.", defaultValue = "0") @QueryParam("offset") @DefaultValue("0") int offset, //
                                           @ApiParam(value = "The result set limit.", defaultValue = "50") @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
+
         AccountQuery query = accountFactory.newQuery(scopeId);
 
         AndPredicate andPredicate = query.andPredicate();

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Authentication.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Authentication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,25 +11,25 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
+import org.eclipse.kapua.service.authentication.AuthenticationService;
+import org.eclipse.kapua.service.authentication.JwtCredentials;
+import org.eclipse.kapua.service.authentication.LoginCredentials;
+import org.eclipse.kapua.service.authentication.RefreshTokenCredentials;
+import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.service.KapuaService;
-import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
-import org.eclipse.kapua.service.authentication.AuthenticationService;
-import org.eclipse.kapua.service.authentication.JwtCredentials;
-import org.eclipse.kapua.service.authentication.RefreshTokenCredentials;
-import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
-import org.eclipse.kapua.service.authentication.token.AccessToken;
-
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 
 @Api("Authentication")
 @Path("/authentication")
@@ -42,82 +42,73 @@ public class Authentication extends AbstractKapuaResource {
      * Authenticates an user with username and password and returns
      * the authentication token to be used in subsequent REST API calls.
      *
-     * @param authenticationCredentials
-     *            The username and password authentication credential of a user.
+     * @param authenticationCredentials The username and password authentication credential of a user.
      * @return The authentication token
-     * @throws Exception
-     *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @ApiOperation(nickname = "authenticationUser", value = "Authenticate an user", notes = "Authenticates an user with username and password and returns " +
             "the authentication token to be used in subsequent REST API calls.", response = AccessToken.class)
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Path("user")
-    public AccessToken loginUsernamePassword(
-            @ApiParam(value = "The username and password authentication credential of a user.", required = true) UsernamePasswordCredentials authenticationCredentials) throws Exception {
-        return authenticationService.login(authenticationCredentials);
+    public AccessToken loginUsernamePassword(@ApiParam(value = "The username and password authentication credential of a user.", required = true) UsernamePasswordCredentials authenticationCredentials) throws Exception {
+        return login(authenticationCredentials);
     }
 
     /**
      * Authenticates an user with a api key and returns
      * the authentication token to be used in subsequent REST API calls.
      *
-     * @param authenticationCredentials
-     *            The API KEY authentication credential of a user.
+     * @param authenticationCredentials The API KEY authentication credential of a user.
      * @return The authentication token
-     * @throws Exception
-     *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @ApiOperation(nickname = "authenticationApiKey", value = "Authenticate an user", notes = "Authenticates an user with API KEY and returns " +
             "the authentication token to be used in subsequent REST API calls.", response = AccessToken.class)
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Path("apikey")
-    public AccessToken loginApiKey(
-            @ApiParam(value = "The API KEY authentication credential of a user.", required = true) ApiKeyCredentials authenticationCredentials) throws Exception {
-        return authenticationService.login(authenticationCredentials);
+    public AccessToken loginApiKey(@ApiParam(value = "The API KEY authentication credential of a user.", required = true) ApiKeyCredentials authenticationCredentials) throws Exception {
+        return login(authenticationCredentials);
     }
 
     /**
      * Authenticates an user with JWT and returns
      * the authentication token to be used in subsequent REST API calls.
      *
-     * @param authenticationCredentials
-     *            The JWT authentication credential of a user.
+     * @param authenticationCredentials The JWT authentication credential of a user.
      * @return The authentication token
-     * @throws Exception
-     *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @ApiOperation(nickname = "authenticationJwt", value = "Authenticate an user", notes = "Authenticates an user with a JWT and returns " +
             "the authentication token to be used in subsequent REST API calls.", response = AccessToken.class)
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Path("jwt")
-    public AccessToken loginJwt(
-            @ApiParam(value = "The JWT authentication credential of a user.", required = true) JwtCredentials authenticationCredentials) throws Exception {
-        return authenticationService.login(authenticationCredentials);
+    public AccessToken loginJwt(@ApiParam(value = "The JWT authentication credential of a user.", required = true) JwtCredentials authenticationCredentials) throws Exception {
+        return login(authenticationCredentials);
     }
 
     /**
      * Invalidates the AccessToken related to this session.
      * All subsequent calls will end up with a HTTP 401.
      * A new login is required after this call to make other requests.
-     * 
-     * @throws Exception
-     *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     *
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @ApiOperation(nickname = "authenticationLogout", value = "Logs out an user", notes = "Terminates the current session and invalidates the access token")
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Path("logout")
+
     public Response logout() throws Exception {
         authenticationService.logout();
 
@@ -127,18 +118,29 @@ public class Authentication extends AbstractKapuaResource {
     /**
      * Refreshes an expired {@link AccessToken}. Both the current AccessToken and the Refresh token will be invalidated.
      * If also the Refresh token is expired, the user will have to restart with a new login.
-     * 
-     * @throws Exception
-     *             Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     *
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @ApiOperation(nickname = "authenticationRefresh", value = "Refreshes an AccessToken", notes = "Both the current AccessToken and the Refresh token will be invalidated. "
             + "If also the Refresh token is expired, the user will have to restart with a new login.")
     @POST
-    @Consumes({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
-    @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML })
+    @Consumes({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     @Path("refresh")
     public AccessToken refresh(@ApiParam(value = "The current AccessToken's tokenId and refreshToken", required = true) RefreshTokenCredentials refreshTokenCredentials) throws Exception {
         return authenticationService.refreshAccessToken(refreshTokenCredentials.getTokenId(), refreshTokenCredentials.getRefreshToken());
+    }
+
+    /**
+     * Authenticates the given {@link LoginCredentials}.
+     *
+     * @param loginCredentials The {@link LoginCredentials} to validate.
+     * @return The Authentication token
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.1.0
+     */
+    private AccessToken login(LoginCredentials loginCredentials) throws Exception {
+        return authenticationService.login(loginCredentials);
     }
 }

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -49,69 +49,69 @@ securityManager.rememberMeManager.cookie.maxAge = 0
 # The 'urls' section is used for url-based security
 # in web applications.  We'll discuss this section in the
 # Web documentation
-/v1/test                        = kapuaAuthcAccessToken, noSessionCreation
+/v1/test                        = kapuaAuthcAccessToken
 
 # Authentication
-/v1/authentication/logout       = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/credentials.json          = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/credentials.xml           = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/credentials/**            = kapuaAuthcAccessToken, noSessionCreation
+/v1/authentication/logout       = kapuaAuthcAccessToken
+/v1/*/credentials.json          = kapuaAuthcAccessToken
+/v1/*/credentials.xml           = kapuaAuthcAccessToken
+/v1/*/credentials/**            = kapuaAuthcAccessToken
 
 # Authorization
-/v1/*/accessinfos.xml           = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/accessinfos.json          = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/accessinfos/**            = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/domains.xml               = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/domains.json              = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/domains/**                = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/groups.xml                = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/groups.json               = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/groups/**                 = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/roles.xml                 = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/roles.json                = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/roles/**                  = kapuaAuthcAccessToken, noSessionCreation
+/v1/*/accessinfos.xml           = kapuaAuthcAccessToken
+/v1/*/accessinfos.json          = kapuaAuthcAccessToken
+/v1/*/accessinfos/**            = kapuaAuthcAccessToken
+/v1/*/domains.xml               = kapuaAuthcAccessToken
+/v1/*/domains.json              = kapuaAuthcAccessToken
+/v1/*/domains/**                = kapuaAuthcAccessToken
+/v1/*/groups.xml                = kapuaAuthcAccessToken
+/v1/*/groups.json               = kapuaAuthcAccessToken
+/v1/*/groups/**                 = kapuaAuthcAccessToken
+/v1/*/roles.xml                 = kapuaAuthcAccessToken
+/v1/*/roles.json                = kapuaAuthcAccessToken
+/v1/*/roles/**                  = kapuaAuthcAccessToken
 
 # Account
-/v1/*/accounts.xml              = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/accounts.json             = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/accounts/**               = kapuaAuthcAccessToken, noSessionCreation
+/v1/*/accounts.xml              = kapuaAuthcAccessToken
+/v1/*/accounts.json             = kapuaAuthcAccessToken
+/v1/*/accounts/**               = kapuaAuthcAccessToken
 
 # Datastore
-/v1/*/data/clients.xml          = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/clients.json         = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/clients/**           = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/channels.xml         = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/channels.json        = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/channels/**          = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/messages.xml         = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/messages.json        = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/messages/**          = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/metrics.xml          = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/metrics.json         = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/data/metrics/**           = kapuaAuthcAccessToken, noSessionCreation
+/v1/*/data/clients.xml          = kapuaAuthcAccessToken
+/v1/*/data/clients.json         = kapuaAuthcAccessToken
+/v1/*/data/clients/**           = kapuaAuthcAccessToken
+/v1/*/data/channels.xml         = kapuaAuthcAccessToken
+/v1/*/data/channels.json        = kapuaAuthcAccessToken
+/v1/*/data/channels/**          = kapuaAuthcAccessToken
+/v1/*/data/messages.xml         = kapuaAuthcAccessToken
+/v1/*/data/messages.json        = kapuaAuthcAccessToken
+/v1/*/data/messages/**          = kapuaAuthcAccessToken
+/v1/*/data/metrics.xml          = kapuaAuthcAccessToken
+/v1/*/data/metrics.json         = kapuaAuthcAccessToken
+/v1/*/data/metrics/**           = kapuaAuthcAccessToken
 
 # Device and Device Management
-/v1/*/devices.json              = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/devices.xml               = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/devices/**                = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/deviceconnections.json    = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/deviceconnections.xml     = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/deviceconnections/**      = kapuaAuthcAccessToken, noSessionCreation
-                                
+/v1/*/devices.json              = kapuaAuthcAccessToken
+/v1/*/devices.xml               = kapuaAuthcAccessToken
+/v1/*/devices/**                = kapuaAuthcAccessToken
+/v1/*/deviceconnections.json    = kapuaAuthcAccessToken
+/v1/*/deviceconnections.xml     = kapuaAuthcAccessToken
+/v1/*/deviceconnections/**      = kapuaAuthcAccessToken
+
 # Endpoint
-/v1/*/endpointInfos.json        = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/endpointInfos.xml         = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/endpointInfos/**          = kapuaAuthcAccessToken, noSessionCreation
+/v1/*/endpointInfos.json        = kapuaAuthcAccessToken
+/v1/*/endpointInfos.xml         = kapuaAuthcAccessToken
+/v1/*/endpointInfos/**          = kapuaAuthcAccessToken
 
 # Streams
-/v1/*/streams/**                = kapuaAuthcAccessToken, noSessionCreation
+/v1/*/streams/**                = kapuaAuthcAccessToken
 
 # Tag
-/v1/*/tags.json                 = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/tags.xml                  = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/tags/**                   = kapuaAuthcAccessToken, noSessionCreation
+/v1/*/tags.json                 = kapuaAuthcAccessToken
+/v1/*/tags.xml                  = kapuaAuthcAccessToken
+/v1/*/tags/**                   = kapuaAuthcAccessToken
 
 # User
-/v1/*/users.json                = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/users.xml                 = kapuaAuthcAccessToken, noSessionCreation
-/v1/*/users/**                  = kapuaAuthcAccessToken, noSessionCreation
+/v1/*/users.json                = kapuaAuthcAccessToken
+/v1/*/users.xml                 = kapuaAuthcAccessToken
+/v1/*/users/**                  = kapuaAuthcAccessToken

--- a/rest-api/web/src/main/webapp/WEB-INF/web.xml
+++ b/rest-api/web/src/main/webapp/WEB-INF/web.xml
@@ -14,9 +14,9 @@
 <!-- This web.xml file is not required when using Servlet 3.0 container, 
     see implementation details http://jersey.java.net/nonav/documentation/latest/jax-rs.html -->
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-    id="WebApp_ID" version="3.0">
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         id="WebApp_ID" version="3.0">
 
     <display-name>Kapua REST API</display-name>
 
@@ -24,7 +24,7 @@
     <!-- Listeners -->
     <listener>
         <listener-class>org.apache.shiro.web.env.EnvironmentLoaderListener</listener-class>
-    </listener>    
+    </listener>
 
     <listener>
         <listener-class>org.eclipse.kapua.app.api.web.RestApiListener</listener-class>
@@ -41,6 +41,14 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 
+    <filter>
+        <filter-name>KapuaSessionCleanUpFilter</filter-name>
+        <filter-class>org.eclipse.kapua.app.api.core.filter.KapuaSessionCleanupFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>KapuaSessionCleanUpFilter</filter-name>
+        <url-pattern>/v1/*</url-pattern>
+    </filter-mapping>
 
     <!-- -->
     <!-- Servlets -->


### PR DESCRIPTION
REST API resources under `authentication/*` (except `authentication/logout`) are not marked as `noSessionCreation` in the `shiro.ini` file. 
This was causing some of the session information to be left on the Thread. When retrieving the access token to match the refreshed access token, some thread had information stored from another thread and this was causing an InternalError, which then was reported as `401 Unauthorized` to the requester.
 
**Related Issue**
This PR fixes #2579 

**Description of the solution adopted**
On all REST API login resources added a clean up phase

**Screenshots**
_None_

**Any side note on the changes made**
_None_