### PR TITLE
wrongly marked start and end date

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -362,8 +362,6 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
                         } else if (gwtCause.getCode().equals(GwtKapuaErrorCode.TRIGGER_NEVER_FIRE)) {
                             startsOn.markInvalid(gwtCause.getMessage());
                             startsOnTime.markInvalid(gwtCause.getMessage());
-                            endsOn.markInvalid(gwtCause.getMessage());
-                            endsOnTime.markInvalid(gwtCause.getMessage());
                             cronExpression.markInvalid(gwtCause.getMessage());
                         }
                     }


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
When trigger can not be fired end date and time are not marked anymore.

**Related Issue**
This PR fixes issue #2575 

**Description of the solution adopted**
Removed lines which make end date and end time marked when trigger can not be fired.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
