### PR TITLE
Bottom view in grids is not frozen

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesHistory.java
@@ -149,6 +149,7 @@ public class DeviceTabPackagesHistory extends KapuaTabItem<GwtDevice> {
         column.setId("inputProperty_packageName");
         column.setHeader(DEVICES_MSGS.deviceInstallTabHistoryTableName());
         column.setWidth(200);
+        column.setSortable(false);
         column.setRenderer(
                 new GridCellRenderer() {
                     @Override
@@ -171,6 +172,7 @@ public class DeviceTabPackagesHistory extends KapuaTabItem<GwtDevice> {
         column.setId("inputProperty_packageVersion");
         column.setHeader(DEVICES_MSGS.deviceInstallTabHistoryTableVersion());
         column.setWidth(200);
+        column.setSortable(false);
         column.setRenderer(
                 new GridCellRenderer() {
                     @Override
@@ -191,6 +193,7 @@ public class DeviceTabPackagesHistory extends KapuaTabItem<GwtDevice> {
 
         column = new ColumnConfig();
         column.setId("inputProperty_kapuapackagedownloaduri");
+        column.setSortable(false);
         column.setHeader(DEVICES_MSGS.deviceInstallTabHistoryTableURI());
         column.setWidth(200);
         configs.add(column);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
@@ -259,6 +259,9 @@ public class GwtKapuaDeviceModelConverter {
             if (sortField.equals("startedOnFormatted")) {
                 sortField = DeviceManagementOperationAttributes.STARTED_ON;
             }
+            if (sortField.equals("endedOnFormatted")) {
+                sortField = DeviceManagementOperationAttributes.ENDED_ON;
+            }
             query.setSortCriteria(new FieldSortCriteria(sortField, sortOrder));
         } else {
             query.setSortCriteria(new FieldSortCriteria(DeviceManagementOperationAttributes.STARTED_ON, SortOrder.DESCENDING));


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Bottom view is not frozen in grids, and sort options are changed.

**Related Issue**
This PR fixes issue #2577. 

**Description of the solution adopted**
In this issue, some columns in device packages grid can not be sorted and grid is frozen. Ended On column is fixed, and now user can sort items by this column, but other three columns (Name, Version and URI) are created on different way. So on this columns sort option is set to false, and user can not sort items by these columns. On this way, grid is protected from refraction.

**Screenshots**
/

**Any side note on the changes made**
/