### PR TITLE
Removed error message after successful login

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -256,6 +256,7 @@ public class LoginDialog extends Dialog {
             public void onSuccess(GwtSession gwtSession) {
                 currentSession = gwtSession;
                 callMainScreen();
+                ConsoleInfo.hideInfo();
             }
         });
     }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/ConsoleInfo.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/ConsoleInfo.java
@@ -83,6 +83,10 @@ public class ConsoleInfo extends Info {
         ConsoleInfo.getInstance().show(config);
     }
 
+    public static void hideInfo() {
+        ConsoleInfo.getInstance().afterHide();
+    }
+
     @Override
     protected void onShowInfo() {
         RootPanel.get().add(this);


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Removed error message after user is logged in successful.

**Related Issue**
This PR fixes issue #2588

**Description of the solution adopted**
After successful log in of user, "Invalid log in" error message is removed from the right bottom corner.

**Screenshots**
/

**Any side note on the changes made**
/
