### PR TITLE
Added "Kapua Permissions" into Summary

### DIFF
--- a/docs/user-manual/en/summary.md
+++ b/docs/user-manual/en/summary.md
@@ -4,3 +4,4 @@
 * [Community](community.md)
 * [Simulator](simulator.md)
 * [Setup JWT security](jwt_security.md)
+* [Kapua Permissions](Permissions.md)


### PR DESCRIPTION
Signed-off-by: Leonardo Gaube <leonardo.gaube@comtrade.com>

In the previous PR (#2587) I have added documentation for Kapua's permissions,
but I forgot to add this to "Summary" page, so this was not visible.
I am adding this now, so users can acces this on page https://github.com/eclipse/kapua/tree/develop/docs/user-manual/en.

**Related Issue**
This is related to issue #2586 and PR #2587 - it adds the permission document to "Summary" page (see above).

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
