### PR TITLE
Removed wire service from configuration panel

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -433,6 +433,15 @@ public class DeviceConfigPanel extends LayoutContainer {
         field.setAllowBlank(true);
         field.setFieldLabel(param.getName());
         field.addPlugin(dirtyPlugin);
+        if (param.getId().equals("WireGraph")) {
+            field.setMaxLength(1000000);
+        }
+        if (param.getId().equals("brokerXml")) {
+            field.setMaxLength(1000000);
+        }
+        if (param.getId().equals("users")) {
+            field.setMaxLength(1000000);
+        }
 
         if (param.isRequired()) {
             field.setAllowBlank(false);
@@ -454,7 +463,7 @@ public class DeviceConfigPanel extends LayoutContainer {
             field.setMaxLength(1);
             field.setValidator(validator);
         }
-        if (validator instanceof StringValidator) {
+        if (validator instanceof StringValidator && !param.getId().equals("WireGraph") && !param.getId().equals("brokerXml") && !param.getId().equals("users")) {
             field.setValidator(validator);
         }
         field.setLabelStyle("word-break:break-all");


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Removed wire service from configuration.

**Related Issue**
This PR fixes issue #1800.

**Description of the solution adopted**
Wire service is removed from configuration panel in devices. This service is removed by service name, and in `if` statement some cases are tested. Also, with `||` operator this statement don't work, but with `&&` works.

**Screenshots**
/

**Any side note on the changes made**
/
