### PR TITLE
set min width for available devices table

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -83,6 +83,7 @@ public class AssetTabItem extends TabItem {
         deviceTable = new DeviceTable(currentSession);
         deviceLayout.setMargins(new Margins(0, 5, 0, 0));
         deviceLayout.setSplit(true);
+        deviceLayout.setMinSize(235);
         deviceTable.addSelectionChangedListener(new SelectionChangedListener<GwtDatastoreDevice>() {
 
             @Override

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -82,6 +82,7 @@ public class DeviceTabItem extends TabItem {
         deviceTable.setBorders(false);
         deviceLayout.setMargins(new Margins(0, 5, 0, 0));
         deviceLayout.setSplit(true);
+        deviceLayout.setMinSize(235);
         deviceTable.addSelectionChangedListener(new SelectionChangedListener<GwtDatastoreDevice>() {
 
             @Override


### PR DESCRIPTION
Signed-off-by: CT\pgoran <goran.palibrk@comtrade.com>

Brief description of the PR.
Set min width for Available Devices tables in byAsset and byDevice tabs in Data view.

**Related Issue**
This PR fixes issue #2594 

**Description of the solution adopted**
A more detailed description of the changes made to solve/close one or more issues.
If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
