### PR TITLE
Fix for String Channel values not displayed correctly

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/KapuaSafeHtmlUtils.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/KapuaSafeHtmlUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,6 +30,12 @@ public class KapuaSafeHtmlUtils {
             return null;
         }
 
+        if (safeHtml.indexOf("&amp;") != -1) {
+            safeHtml = safeHtml.replace("&amp;", "&");
+        }
+        if (safeHtml.indexOf("amp;") != -1) {
+            safeHtml = safeHtml.replace("amp;","");
+        }
         if (safeHtml.indexOf("&lt;") != -1) {
             safeHtml = safeHtml.replace("&lt;", "<");
         }
@@ -41,9 +47,6 @@ public class KapuaSafeHtmlUtils {
         }
         if (safeHtml.indexOf("&#39;") != -1) {
             safeHtml = safeHtml.replace("&#39;", "'");
-        }
-        if (safeHtml.indexOf("&amp;") != -1) {
-            safeHtml = safeHtml.replace("&amp;", "&");
         }
         return safeHtml;
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
@@ -18,6 +18,7 @@ import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
 import org.eclipse.kapua.app.console.module.api.client.util.Constants;
 import org.eclipse.kapua.app.console.module.api.client.util.FormUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.UserAgentUtils;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.device.shared.model.device.management.assets.GwtDeviceAsset;
@@ -282,15 +283,14 @@ public class DeviceAssetsPanel extends LayoutContainer {
 
         TextField<String> field = new TextField<String>();
         field.setName(channel.getName());
-        field.setValue((String) channel.getValue());
         field.setAllowBlank(true);
         field.setFieldLabel(channel.getName() + " (" + channel.getType() + " - " + channel.getMode() + ")");
         field.setLabelStyle("word-break:break-all");
         field.addPlugin(dirtyPlugin);
 
         if (channel.getValue() != null) {
-            field.setValue((String) channel.getValue());
-            field.setOriginalValue((String) channel.getValue());
+            field.setValue(KapuaSafeHtmlUtils.htmlUnescape((String) channel.getValue()));
+            field.setOriginalValue(KapuaSafeHtmlUtils.htmlUnescape((String) channel.getValue()));
         }
         return field;
     }


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Fix for String Channel values not displayed correctly.

**Related Issue**
This PR fixes/closes #2597 

**Description of the solution adopted**
Solved problems when displaying special characters in the Assets -> Channel fields. 
The string value is unescaped using the `KapuaSafeHtmlUtils.htmlUnescape(String)` method. 
Also the `htmlUnescape()` method was updated:
- the if check for `&amp;` string and its replacement with `&` was moved to first place (more efficient as all other cases look for the `&` and not `&amp;` at the beginning of the string)
- added new _if case to_ check for `amp;` which is sometimes unnecessarily added and should be removed (like `amp;amp;amp;amp;amp;` after the first ` &amp;` in `&amp;amp;amp;amp;amp;amp;quot;string&amp;` )

**Screenshots**
_None_

**Any side note on the changes made**
_None_
