### PR TITLE
Add Gitter chat room references

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://travis-ci.org/eclipse/kapua.svg?branch=develop)](https://travis-ci.org/eclipse/kapua/branches)
 [![Hudson](https://img.shields.io/jenkins/s/https/hudson.eclipse.org/kapua/job/Develop.svg)](https://hudson.eclipse.org/kapua/job/develop)
+[![Gitter](https://badges.gitter.im/eclipse/kapua.svg)](https://gitter.im/eclipse/kapua?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 [Eclipse Kapua&trade;](http://eclipse.org/kapua) is a modular platform providing the services required to manage IoT gateways and smart edge devices. Kapua provides a core integration framework and an initial set of core IoT services including a device registry, device management services, messaging services, data management, and application enablement.
 

--- a/docs/kuraKapuaDocs.md
+++ b/docs/kuraKapuaDocs.md
@@ -1,6 +1,6 @@
 # Kura - Kapua connection
 
-This is a short introduction into how locally connect Kura and Kapua. Although some of the info bellow can already be found on Kapua github project and Kura guides, this document contains everything needed for the connection. If you have any questions post them on [Eclipse Community Forums](https://www.eclipse.org/forums/index.php/f/340/) or join our [mailing list](https://dev.eclipse.org/mailman/listinfo/kapua-dev). In case you find any issues, [report them](https://github.com/eclipse/kapua/issues). Also if you want to contribute, [this is the place to start!](https://github.com/eclipse/kapua).
+This is a short introduction into how locally connect Kura and Kapua. Although some of the info bellow can already be found on Kapua github project and Kura guides, this document contains everything needed for the connection. If you have any questions post them on [Eclipse Community Forums](https://www.eclipse.org/forums/index.php/f/340/), [Gitter chat room](https://gitter.im/eclipse/kapua) or join our [mailing list](https://dev.eclipse.org/mailman/listinfo/kapua-dev). In case you find any issues, [report them](https://github.com/eclipse/kapua/issues). Also if you want to contribute, [this is the place to start!](https://github.com/eclipse/kapua).
 
 ## Usefull links
 

--- a/docs/user-manual/en/community.md
+++ b/docs/user-manual/en/community.md
@@ -4,5 +4,6 @@ Join the the growing community around Eclipse Kapua.
 
 * Join the [mailing list](https://dev.eclipse.org/mailman/listinfo/kapua-dev)
 * Post your questions and comments on [Discussion Forum](https://www.eclipse.org/forums/index.php/f/340/)
+* Join the [Gitter chat room](https://gitter.im/eclipse/kapua)
 * Report an [Issue](https://github.com/eclipse/kapua/issues)
 * Contribute [Code](https://github.com/eclipse/kapua)


### PR DESCRIPTION
Just adding a few references to the new [Gitter chat room](https://gitter.im/eclipse/kapua) that I created for the project