### PR TITLE
Changed error message if account name is changed in Kura

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -215,8 +215,11 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
 
                     String errorMessage = htmlResult.substring(errorMessageStartIndex, errorMessageEndIndex);
 
-                    if (!errorMessage.isEmpty()) {
+                    if (errorMessage.isEmpty()) {
                         ConsoleInfo.display(MSGS.error(), DEVICE_MSGS.deviceCommandCommunicationError());
+                    }
+                    else {
+                        ConsoleInfo.display(MSGS.error(), errorMessage);
                     }
                     commandInput.unmask();
                 } else {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -134,7 +134,7 @@ public class KuraDeviceCallImpl implements DeviceCall<KuraRequestMessage, KuraRe
                 throw new KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes.CLIENT_SEND_ERROR, e);
             }
         } catch (KapuaException ke) {
-            throw new KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes.CALL_ERROR, ke);
+            throw new KuraMqttDeviceCallException(KuraMqttDeviceCallErrorCodes.CALL_DEVICE_ERROR, ke);
         } finally {
             if (transportFacade != null) {
                 transportFacade.clean();

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/exception/KuraMqttDeviceCallErrorCodes.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/exception/KuraMqttDeviceCallErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -40,5 +40,6 @@ public enum KuraMqttDeviceCallErrorCodes implements KapuaErrorCode {
      * Send call error
      */
     CLIENT_SEND_ERROR,
+    CALL_DEVICE_ERROR,
     ;
 }

--- a/service/device/call/kura/src/main/resources/device-call-service-error-messages.properties
+++ b/service/device/call/kura/src/main/resources/device-call-service-error-messages.properties
@@ -9,4 +9,4 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
- CALL_DEVICE_ERROR=The "Account-Name" parameter is not properly set on the device. Please check the parameter and reconnect the device.
+ CALL_DEVICE_ERROR=Operation has timed out. Please check the parameters and/or reconnect the device.

--- a/service/device/call/kura/src/main/resources/device-call-service-error-messages.properties
+++ b/service/device/call/kura/src/main/resources/device-call-service-error-messages.properties
@@ -1,0 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+ CALL_DEVICE_ERROR=The "Account-Name" parameter is not properly set on the device. Please check the parameter and reconnect the device.


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Changed error message in device grids if parameter in Kura is changed.

**Related Issue**
This PR fixes issue #2193 

**Description of the solution adopted**
If account name is changed on Kura side from _kapua-sys_ to some other, then error message is changed on right bottom corner.

**Screenshots**
/

**Any side note on the changes made**
/
