### PR TITLE
Upgraded Guava version from 19.0 to 27.1-jre - CVE-2018-10237 - CWE-119

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceManagementNotificationMessageProcessor.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceManagementNotificationMessageProcessor.java
@@ -15,6 +15,7 @@ import com.codahale.metrics.Counter;
 import com.google.common.base.MoreObjects;
 import org.apache.camel.Exchange;
 import org.apache.camel.spi.UriEndpoint;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.broker.core.message.CamelKapuaMessage;
 import org.eclipse.kapua.commons.metric.MetricServiceFactory;
@@ -24,6 +25,7 @@ import org.eclipse.kapua.service.device.management.job.manager.JobDeviceManageme
 import org.eclipse.kapua.service.device.management.message.notification.KapuaNotifyMessage;
 import org.eclipse.kapua.service.device.management.message.notification.KapuaNotifyPayload;
 import org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,13 +71,13 @@ public class DeviceManagementNotificationMessageProcessor extends AbstractProces
         KapuaNotifyPayload notifyPayload = notifyMessage.getPayload();
 
         try {
-        DEVICE_MANAGEMENT_REGISTRY_MANAGER_SERVICE.processOperationNotification(
-                notifyMessage.getScopeId(),
-                notifyPayload.getOperationId(),
-                MoreObjects.firstNonNull(notifyMessage.getSentOn(), notifyMessage.getReceivedOn()),
-                notifyPayload.getResource(),
-                notifyPayload.getStatus(),
-                notifyPayload.getProgress());
+            DEVICE_MANAGEMENT_REGISTRY_MANAGER_SERVICE.processOperationNotification(
+                    notifyMessage.getScopeId(),
+                    notifyPayload.getOperationId(),
+                    MoreObjects.firstNonNull(notifyMessage.getSentOn(), notifyMessage.getReceivedOn()),
+                    notifyPayload.getResource(),
+                    notifyPayload.getStatus(),
+                    notifyPayload.getProgress());
 
             JOB_DEVICE_MANAGEMENT_OPERATION_MANAGER_SERVICE.processJobTargetOnNotification(
                     notifyMessage.getScopeId(),

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceManagementNotificationMessageProcessor.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceManagementNotificationMessageProcessor.java
@@ -69,13 +69,13 @@ public class DeviceManagementNotificationMessageProcessor extends AbstractProces
         KapuaNotifyPayload notifyPayload = notifyMessage.getPayload();
 
         try {
-            DEVICE_MANAGEMENT_REGISTRY_MANAGER_SERVICE.processOperationNotification(
-                    notifyMessage.getScopeId(),
-                    notifyPayload.getOperationId(),
-                    MoreObjects.firstNonNull(notifyMessage.getSentOn(), notifyMessage.getReceivedOn()),
-                    notifyPayload.getResource(),
-                    notifyPayload.getStatus(),
-                    notifyPayload.getProgress());
+        DEVICE_MANAGEMENT_REGISTRY_MANAGER_SERVICE.processOperationNotification(
+                notifyMessage.getScopeId(),
+                notifyPayload.getOperationId(),
+                MoreObjects.firstNonNull(notifyMessage.getSentOn(), notifyMessage.getReceivedOn()),
+                notifyPayload.getResource(),
+                notifyPayload.getStatus(),
+                notifyPayload.getProgress());
 
             JOB_DEVICE_MANAGEMENT_OPERATION_MANAGER_SERVICE.processJobTargetOnNotification(
                     notifyMessage.getScopeId(),

--- a/broker-core/src/main/readme.txt
+++ b/broker-core/src/main/readme.txt
@@ -40,7 +40,7 @@ replacing the ******* in the original file (this is an extract)
 copy all the jars needed by the application to the lib/kapua directory (this is the current list):
 
   358048  4 Ago 16:02 commons-configuration-1.9.jar
- 2308517  4 Ago 11:58 guava-19.0.jar
+ 2308517  4 Ago 11:58 guava-27.1.jar
   162116  4 Ago 16:04 javax.persistence-2.1.1.jar
    17750  4 Ago 16:26 jbcrypt-0.3m.jar
     6583  4 Ago 12:29 metrics-annotation-3.1.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <elasticsearch.version>2.3.4</elasticsearch.version>
         <findbugs.version>2.0.1</findbugs.version>
         <gson.version>2.7</gson.version>
-        <guava.version>19.0</guava.version>
+        <guava.version>27.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <h2.version>1.4.192</h2.version>
         <httpcomponents.version>4.5.2</httpcomponents.version>


### PR DESCRIPTION
This PR bumps the version of Guava Library to 27.1-jre

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version that has currently a CQ already approved on which we can piggy back our CQ.

CQ to piggy back: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19822
Kapua CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20138

**Screenshots**
_None_

**Any side note on the changes made**
_None_