### PR TITLE
Upgraded H2 version from 1.4.192 to 1.4.199 - CVE-2018-10054 - CWE-94

### DIFF
--- a/commons/src/test/resources/liquibase/liquibase.sql
+++ b/commons/src/test/resources/liquibase/liquibase.sql
@@ -14,7 +14,7 @@
 
 -- changeset hekonsek:1 
 
-CREATE TABLE tst_liquibase (
+CREATE TABLE TST_LIQUIBASE (
   id                         BIGINT(21) 	  UNSIGNED NOT NULL,
 
   PRIMARY KEY (id),

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <gson.version>2.7</gson.version>
         <guava.version>27.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
-        <h2.version>1.4.192</h2.version>
+        <h2.version>1.4.199</h2.version>
         <httpcomponents.version>4.5.2</httpcomponents.version>
         <javassist.version>3.19.0-GA</javassist.version>
         <javax-inject.version>1</javax-inject.version>


### PR DESCRIPTION
This PR bumps the version of H2 Library to 1.4.199

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
This dependency needs a complete CQ.

Kapua CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20144

**Screenshots**
_None_

**Any side note on the changes made**
Improved a bit the implementation of the Liquibase Client