### PR TITLE
Upgraded Jackson Databind version from 2.8.6 to 2.9.9 - CVE-2018-14718 - CWE-502

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <elasticsearch-client-rest.version>5.3.0</elasticsearch-client-rest.version>
         <elasticsearch-netty-3.version>3.10.6.Final</elasticsearch-netty-3.version>
         <elasticsearch-netty-4.version>4.1.15.Final</elasticsearch-netty-4.version>
-        <jackson.version>2.8.6</jackson.version> <!-- same version used by elasticsearch -->
+        <jackson.version>2.9.9</jackson.version> <!-- Elastic Search uses 2.8.6 -->
         <log4j-api.version>2.8.2</log4j-api.version> <!-- same version used by elasticsearch -->
         <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version> <!-- same version used by elasticsearch -->
         <log4j2-mock.version>0.0.1</log4j2-mock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1292,6 +1292,11 @@
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations </artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${jackson.version}</version>
             </dependency>


### PR DESCRIPTION
This PR bumps the version of Jackson Databind Library to 1.4.199
Transitive dependencies:

- Jackson Core: from 2.8.6 to 2.9.9
- Jackson Annotations: from 2.8.6 to 2.9.9

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
On each version we can piggy back on existing CQs.

Jackson Databind: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20155
Jackson Core: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20153
Jackson Annotations: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20154

**Screenshots**
_None_

**Any side note on the changes made**
_None_