### PR TITLE
Upgraded Qpid Jms Client version from 0.24.0 to 0.40.0 - CVE-2018-17187 - CWE-300 

### DIFF
--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -239,12 +239,10 @@
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-jms_2.0_spec</artifactId>
-            <version>1.0-alpha-2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-j</artifactId>
-            <version>${qpid-proton.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version> <!-- same version used by elasticsearch -->
         <log4j2-mock.version>0.0.1</log4j2-mock.version>
         <qpid-jms-client.version>0.40.0</qpid-jms-client.version>
-        <qpid-proton.version>0.20.0</qpid-proton.version>
+        <qpid-proton.version>0.31.0</qpid-proton.version>
         <quartz-scheduler.version>2.2.3</quartz-scheduler.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <log4j-api.version>2.8.2</log4j-api.version> <!-- same version used by elasticsearch -->
         <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version> <!-- same version used by elasticsearch -->
         <log4j2-mock.version>0.0.1</log4j2-mock.version>
-        <qpid-jms-client.version>0.24.0</qpid-jms-client.version>
+        <qpid-jms-client.version>0.40.0</qpid-jms-client.version>
         <qpid-proton.version>0.20.0</qpid-proton.version>
         <quartz-scheduler.version>2.2.3</quartz-scheduler.version>
         <jetty.version>9.4.12.v20180830</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <qpid-jms-client.version>0.40.0</qpid-jms-client.version>
         <qpid-proton.version>0.31.0</qpid-proton.version>
         <qpid-geronimo-jms.version>1.0-alpha-2</qpid-geronimo-jms.version>
+        <netty-all.version>4.1.34.Final</netty-all.version>
         <quartz-scheduler.version>2.2.3</quartz-scheduler.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
 
@@ -1319,6 +1320,8 @@
                 <artifactId>qpid-jms-client</artifactId>
                 <version>${qpid-jms-client.version}</version>
                 <exclusions>
+                    <!-- Excluding io.netty artifacts since we are importing them separately -->
+                    <!-- Do not remove this unless a CQ for those dependencies if files-->
                     <exclusion>
                         <groupId>io.netty</groupId>
                         <artifactId>*</artifactId>
@@ -1339,7 +1342,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>${elasticsearch-netty-4.version}</version>
+                <version>${netty-all.version}</version>
             </dependency>
 
             <!-- -->

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <log4j2-mock.version>0.0.1</log4j2-mock.version>
         <qpid-jms-client.version>0.40.0</qpid-jms-client.version>
         <qpid-proton.version>0.31.0</qpid-proton.version>
+        <qpid-geronimo-jms.version>1.0-alpha-2</qpid-geronimo-jms.version>
         <quartz-scheduler.version>2.2.3</quartz-scheduler.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
 
@@ -1312,6 +1313,7 @@
                 <version>0.5.2</version>
             </dependency>
 
+
             <dependency>
                 <groupId>org.apache.qpid</groupId>
                 <artifactId>qpid-jms-client</artifactId>
@@ -1323,6 +1325,17 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.apache.qpid</groupId>
+                <artifactId>proton-j</artifactId>
+                <version>${qpid-proton.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.geronimo.specs</groupId>
+                <artifactId>geronimo-jms_2.0_spec</artifactId>
+                <version>${qpid-geronimo-jms.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>


### PR DESCRIPTION
This PR bumps the version of Qpid Jms Client library to 0.40.0
Transitive dependencies:

- Proton-J: from 0.20.0 to 0.31.0
- Netty-all: from 4.1.15 to 4.1.34

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
On each version we can piggy back on existing CQs.

Qpid Jms Client: http://dev.eclipse.org/ipzilla/show_bug.cgi?id=20158
Proton-J: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20157
Netty-all: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20156

**Screenshots**
_None_

**Any side note on the changes made**
_None_