### PR TITLE
Removed device unique constraint on modem IMEI, IMSI, ICCID

### DIFF
--- a/service/device/registry/internal/src/main/resources/liquibase/1.1.0/changelog-device-1.1.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.1.0/changelog-device-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -18,5 +18,6 @@
         logicalFilePath="KapuaDB/changelog-device-1.1.0.xml">
 
     <include relativeToChangelogFile="true" file="./device-add-model-name.xml"/>
+    <include relativeToChangelogFile="true" file="./device-remove-modem-constraint.xml"/>
 
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device-remove-modem-constraint.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device-remove-modem-constraint.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/device-remove-modem-constraint.xml">
+
+    <changeSet id="device-remove-modem-constraint-imei" author="eurotech" failOnError="false">
+        <comment>
+            This changeSet is marked as failOnError='false' because
+            Liquibase (3.0.5) does not currently support preConditions on uniqueConstraint.
+        </comment>
+        <dropUniqueConstraint tableName="dvc_device" constraintName="uc_imei"/>
+    </changeSet>
+
+    <changeSet id="device-remove-modem-constraint-imsi" author="eurotech" failOnError="false">
+        <comment>
+            This changeSet is marked as failOnError='false' because
+            Liquibase (3.0.5) does not currently support preConditions on uniqueConstraint.
+        </comment>
+        <dropUniqueConstraint tableName="dvc_device" constraintName="uc_imsi"/>
+    </changeSet>
+
+    <changeSet id="device-remove-modem-constraint-iccid" author="eurotech" failOnError="false">
+        <comment>
+            This changeSet is marked as failOnError='false' because
+            Liquibase (3.0.5) does not currently support preConditions on uniqueConstraint.
+        </comment>
+        <dropUniqueConstraint tableName="dvc_device" constraintName="uc_iccid"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This PR removes the constraint of uniqueness within the account of some modem info on the Device. 

**Related Issue**
_None_

**Description of the solution adopted**
Removed those constrains because it can happen that someone moves a SIM between multiple devices and it does not have to delete the old device to change the SIM.

Field constraint removed:

- Uniqueness of IMEI within the account
- Uniqueness of IMSI within the account
- Uniqueness of ICCIDI within the account

**Screenshots**
_None_

**Any side note on the changes made**
_None_