### PR TITLE
Upgraded Logback version from 1.1.8 to 1.2.3 - CVE-2017-5929 - CWE-502

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <reflections.version>0.9.10</reflections.version>
         <shiro.version>1.3.2</shiro.version>
         <slf4j.version>1.7.24</slf4j.version>
-        <logback.version>1.1.8</logback.version>
+        <logback.version>1.2.3</logback.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <swagger.version>1.5.12</swagger.version>
         <validation-api.version>1.1.0.Final</validation-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <protobuf.version>2.6.1</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
         <shiro.version>1.3.2</shiro.version>
-        <slf4j.version>1.7.24</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <swagger.version>1.5.12</swagger.version>


### PR DESCRIPTION
This PR bumps the version of Logback libraries to 1.2.3
Transitive dependencies:

- Lockback Classic: from 1.1.8 to 1.2.3
- Lockback Core: from 1.1.8 to 1.2.3
- Slf4j API: from 1.7.24 to 1.7.25

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
On each version we can piggy back on existing CQs.

- Lockback Classic: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20180
- Lockback Core: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20181
- Slf4j API: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20182

**Screenshots**
_None_

**Any side note on the changes made**
_None_