### PR TITLE
Upgraded Paho version from 1.1.0 to 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <liquibase.version>3.0.5</liquibase.version>
         <mockito.version>1.10.19</mockito.version>
         <opencsv.version>3.7</opencsv.version>
-        <paho.version>1.1.0</paho.version>
+        <paho.version>1.2.1</paho.version>
         <protobuf.version>2.6.1</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
         <shiro.version>1.3.2</shiro.version>


### PR DESCRIPTION
This PR bumps the version of Paho client version from 1.1.0 to 1.2.1.

**Related Issue**
This PR closes #2521 

**Description of the solution adopted**
Just changed the version. of the dependency.
This requires only declaration of the changed dependency since Paho is an Eclipse Project.

**Screenshots**
_None_

**Any side note on the changes made**
In module `kapua-client-gateway-provider-paho` the version is forcibly set to `1.0.2` for reasons explained in the comments