### PR TITLE
Implemented cloud defined DisplayName for Devices

### DIFF
--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.lifecycle.internal;
 
+import com.google.common.base.Strings;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -85,7 +86,12 @@ public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
             device = deviceRegistryService.create(deviceCreator);
         } else {
             device = deviceRegistryService.find(scopeId, deviceId);
-            device.setDisplayName(payload.getDisplayName());
+
+            // If the BirthMessage does not contain a 'Display Name' keep the one registered on the DeviceRegistryService.
+            if (!Strings.isNullOrEmpty(payload.getDisplayName())) {
+                device.setDisplayName(payload.getDisplayName());
+            }
+
             device.setSerialNumber(payload.getSerialNumber());
             device.setModelId(payload.getModelId());
             device.setModelName(payload.getModelName());


### PR DESCRIPTION
This PR implements _Display Name_ defined by Kapua

**Related Issue**
This PR closes #2622 

**Description of the solution adopted**
If the _Display Name_ in the BirthMessage is empty or `null` the Display Name on the registered Device is not updated. So a Device can avoid to publish the _Display Name_ and that can be specified from Kapua until the Device sends a new one.

**Screenshots**
_None_

**Any side note on the changes made**
_None_