### PR TITLE
Upgraded Liquibase Core version to 3.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.0</jose4j.version>
         <junit.version>4.11</junit.version>
-        <liquibase.version>3.0.5</liquibase.version>
+        <liquibase.version>3.6.3</liquibase.version>
         <mockito.version>1.10.19</mockito.version>
         <opencsv.version>3.7</opencsv.version>
         <paho.version>1.2.1</paho.version>
@@ -1322,6 +1322,13 @@
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
                 <version>${liquibase.version}</version>
+                <exclusions>
+                    <!-- This is not required. The implementation of SLF4J will be by the application assembly-->
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.neoscada.utils</groupId>


### PR DESCRIPTION
This PR bumps the version of Liquibase Core library to 3.6.3.

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 

Kapua CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20248

**Screenshots**
_None_

**Any side note on the changes made**
If the CQ gets approved, we need to track the build and test dependency of `liquibase-maven-plugin`