### PR TITLE
Feature job delete forced

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteForcedDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteForcedDialog.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.client;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityDeleteDialog;
+import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobService;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobServiceAsync;
+
+public class JobDeleteForcedDialog extends EntityDeleteDialog {
+
+    private final GwtJob selectedJob;
+
+    private static final ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
+    private static final GwtJobServiceAsync GWT_JOB_SERVICE = GWT.create(GwtJobService.class);
+
+    public JobDeleteForcedDialog(GwtJob selectedJob) {
+        this.selectedJob = selectedJob;
+        DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
+    }
+
+    @Override
+    public void submit() {
+        GWT_JOB_SERVICE.deleteForced(xsrfToken, selectedJob.getScopeId(), selectedJob.getId(), new AsyncCallback<Void>() {
+
+            @Override
+            public void onSuccess(Void arg0) {
+                exitStatus = true;
+                exitMessage = JOB_MSGS.dialogDeleteForcedStoppedMessage();
+                hide();
+            }
+
+            @Override
+            public void onFailure(Throwable cause) {
+                exitStatus = false;
+                if (!isPermissionErrorMessage(cause)) {
+                    exitMessage = JOB_MSGS.dialogDeleteForcedErrorMessage();
+                }
+                hide();
+            }
+        });
+    }
+
+    @Override
+    public String getHeaderMessage() {
+        return JOB_MSGS.dialogDeleteForcedDialogHeader(selectedJob.getJobName());
+    }
+
+    @Override
+    public String getInfoMessage() {
+        return JOB_MSGS.dialogDeleteForcedDialogInfo();
+    }
+
+    @Override
+    public KapuaIcon getInfoIcon() {
+        return new KapuaIcon(IconSet.EXCLAMATION_TRIANGLE);
+    }
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
@@ -17,7 +17,6 @@ import com.extjs.gxt.ui.client.data.RpcProxy;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
@@ -75,6 +74,7 @@ public class JobGrid extends EntityGrid<GwtJob> {
         getToolbar().getEditEntityButton().setEnabled(selectedItem != null && currentSession.hasPermission(JobSessionPermission.write()));
         getToolbar().getDeleteEntityButton().setEnabled(selectedItem != null && currentSession.hasPermission(JobSessionPermission.delete()));
 
+        ((JobGridToolbar) getToolbar()).getDeleteForcedJobButton().setEnabled(selectedItem != null && currentSession.hasPermission(JobSessionPermission.deleteAll()));
         ((JobGridToolbar) getToolbar()).getStartJobButton().setEnabled(selectedItem != null && currentSession.hasPermission(JobSessionPermission.execute()));
         ((JobGridToolbar) getToolbar()).getStopJobButton().setEnabled(selectedItem != null && currentSession.hasPermission(JobSessionPermission.execute()));
         ((JobGridToolbar) getToolbar()).getRestartJobButton().setEnabled(selectedItem != null && currentSession.hasPermission(JobSessionPermission.execute()));

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
@@ -33,6 +33,7 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
     private Button startJobButton;
     private Button stopJobButton;
     private Button restartJobButton;
+    private Button deleteForcedJobButton;
 
     public JobGridToolbar(GwtSession currentSession) {
         super(currentSession);
@@ -48,6 +49,10 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
 
     public Button getRestartJobButton() {
         return restartJobButton;
+    }
+
+    public Button getDeleteForcedJobButton() {
+        return deleteForcedJobButton;
     }
 
     @Override
@@ -88,6 +93,20 @@ public class JobGridToolbar extends EntityCRUDToolbar<GwtJob> {
         });
         restartJobButton.disable();
         addExtraButton(restartJobButton);
+
+        deleteForcedJobButton = new Button(JOB_MSGS.jobDeleteForcedButton(), new KapuaIcon(IconSet.EXCLAMATION_TRIANGLE), new SelectionListener<ButtonEvent>() {
+
+            @Override
+            public void componentSelected(ButtonEvent buttonEvent) {
+                JobDeleteForcedDialog dialog = new JobDeleteForcedDialog(gridSelectionModel.getSelectedItem());
+                dialog.addListener(Events.Hide, getHideDialogListener());
+                dialog.show();
+            }
+        });
+        deleteForcedJobButton.disable();
+        if (currentSession.hasPermission(JobSessionPermission.deleteAll())) {
+            addExtraButton(deleteForcedJobButton);
+        }
 
         super.onRender(target, index);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -60,7 +60,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
     private static final UserFactory USER_FACTORY = LOCATOR.getFactory(UserFactory.class);
 
     @Override
-    public PagingLoadResult<GwtJob> query(PagingLoadConfig loadConfig, final GwtJobQuery gwtJobQuery) throws GwtKapuaException {
+    public PagingLoadResult<GwtJob> query(PagingLoadConfig loadConfig, GwtJobQuery gwtJobQuery) throws GwtKapuaException {
         //
         // Do query
         int totalLength = 0;
@@ -194,13 +194,13 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
 
     @Override
     public ListLoadResult<GwtGroupedNVPair> findJobDescription(String gwtScopeId,
-            String gwtJobId) throws GwtKapuaException {
+                                                               String gwtJobId) throws GwtKapuaException {
         List<GwtGroupedNVPair> gwtJobDescription = new ArrayList<GwtGroupedNVPair>();
         try {
-            final KapuaId scopeId = KapuaEid.parseCompactId(gwtScopeId);
+            KapuaId scopeId = KapuaEid.parseCompactId(gwtScopeId);
             KapuaId jobId = KapuaEid.parseCompactId(gwtJobId);
 
-            final Job job = JOB_SERVICE.find(scopeId, jobId);
+            Job job = JOB_SERVICE.find(scopeId, jobId);
 
             UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -193,6 +193,20 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
     }
 
     @Override
+    public void deleteForced(GwtXSRFToken xsrfToken, String gwtScopeId, String gwtJobId) throws GwtKapuaException {
+        checkXSRFToken(xsrfToken);
+
+        try {
+            KapuaId scopeId = GwtKapuaCommonsModelConverter.convertKapuaId(gwtScopeId);
+            KapuaId jobId = GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobId);
+
+            JOB_SERVICE.deleteForced(scopeId, jobId);
+        } catch (Throwable t) {
+            KapuaExceptionHandler.handle(t);
+        }
+    }
+
+    @Override
     public ListLoadResult<GwtGroupedNVPair> findJobDescription(String gwtScopeId,
                                                                String gwtJobId) throws GwtKapuaException {
         List<GwtGroupedNVPair> gwtJobDescription = new ArrayList<GwtGroupedNVPair>();

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/permission/JobSessionPermission.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/permission/JobSessionPermission.java
@@ -22,7 +22,11 @@ public class JobSessionPermission extends GwtSessionPermission {
     }
 
     private JobSessionPermission(GwtSessionPermissionAction action) {
-        super("job", action, GwtSessionPermissionScope.SELF);
+        this(action, GwtSessionPermissionScope.SELF);
+    }
+
+    private JobSessionPermission(GwtSessionPermissionAction action, GwtSessionPermissionScope scope) {
+        super("job", action, scope);
     }
 
     public static JobSessionPermission read() {
@@ -35,6 +39,10 @@ public class JobSessionPermission extends GwtSessionPermission {
 
     public static JobSessionPermission delete() {
         return new JobSessionPermission(GwtSessionPermissionAction.delete);
+    }
+
+    public static JobSessionPermission deleteAll() {
+        return new JobSessionPermission(GwtSessionPermissionAction.delete, GwtSessionPermissionScope.ALL);
     }
 
     public static JobSessionPermission execute() {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobService.java
@@ -36,8 +36,7 @@ public interface GwtJobService extends RemoteService {
      * @return
      * @throws GwtKapuaException
      */
-    GwtJob create(GwtXSRFToken xsrfToken, GwtJobCreator gwtJobCreator)
-            throws GwtKapuaException;
+    GwtJob create(GwtXSRFToken xsrfToken, GwtJobCreator gwtJobCreator) throws GwtKapuaException;
 
     /**
      * Returns a Job by its Id or null if a job with such Id does not exist.
@@ -46,8 +45,7 @@ public interface GwtJobService extends RemoteService {
      * @return
      * @throws GwtKapuaException
      */
-    GwtJob find(String accountId, String jobId)
-            throws GwtKapuaException;
+    GwtJob find(String accountId, String jobId) throws GwtKapuaException;
 
     /**
      * Updates a Job in the database and returns the refreshed/reloaded entity instance.
@@ -56,8 +54,7 @@ public interface GwtJobService extends RemoteService {
      * @return
      * @throws GwtKapuaException
      */
-    GwtJob update(GwtXSRFToken xsrfToken, GwtJob gwtJob)
-            throws GwtKapuaException;
+    GwtJob update(GwtXSRFToken xsrfToken, GwtJob gwtJob) throws GwtKapuaException;
 
     /**
      * Delete the supplied Job.
@@ -65,9 +62,16 @@ public interface GwtJobService extends RemoteService {
      * @param gwtJobId
      * @throws GwtKapuaException
      */
-    void delete(GwtXSRFToken xsfrToken, String accountId, String gwtJobId)
-            throws GwtKapuaException;
+    void delete(GwtXSRFToken xsfrToken, String accountId, String gwtJobId) throws GwtKapuaException;
 
-    ListLoadResult<GwtGroupedNVPair> findJobDescription(String gwtScopeId, String gwtJobId)
-            throws GwtKapuaException;
+    /**
+     * Delete the supplied Job forcibly.
+     *
+     * @param gwtJobId
+     * @throws GwtKapuaException
+     */
+    void deleteForced(GwtXSRFToken xsfrToken, String accountId, String gwtJobId) throws GwtKapuaException;
+
+
+    ListLoadResult<GwtGroupedNVPair> findJobDescription(String gwtScopeId, String gwtJobId) throws GwtKapuaException;
 }

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -37,6 +37,12 @@ gridJobSchedulesColumnHeaderEndsOnFormatted=Ends on
 gridJobSchedulesColumnHeaderTriggerDefinitionName=Schedule Type
 gridJobSchedulesColumnHeaderValue=Value
 
+jobDeleteForcedButton=Force Delete
+dialogDeleteForcedDialogHeader=Delete Job: {0}
+dialogDeleteForcedDialogInfo=Delete the selected job forcibly? This can lead to errors in the Job Engine and related components. Use only on critical situations.
+dialogDeleteForcedStoppedMessage=Job successfully deleted.
+dialogDeleteForcedErrorMessage=Selected job could not be deleted! Please check console log for errors.
+
 jobStartButton=Start
 jobStartDialogHeader=Start Job: {0}
 jobStartDialogInfo=Start the selected job?

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
@@ -297,6 +297,7 @@ public class JobEngineServiceJbatch implements JobEngineService {
         if (JbatchDriver.isRunningJob(scopeId, jobId)) {
             throw new JobRunningException(scopeId, jobId);
         }
+
         try {
             JbatchDriver.cleanJobData(scopeId, jobId);
         } catch (Exception ex) {

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.service.job;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
@@ -37,6 +38,16 @@ public interface JobService extends KapuaEntityService<Job, JobCreator>,
      * @since 1.0.0
      */
     @Override
-    JobListResult query(KapuaQuery<Job> query)
-            throws KapuaException;
+    JobListResult query(KapuaQuery<Job> query) throws KapuaException;
+
+    /**
+     * Forcibly deletes a {@link Job} and all of its related data without checking for {@link org.eclipse.kapua.service.job.execution.JobExecution}s.
+     *
+     * @param scopeId The {@link KapuaId} scopeId of the {@link Job}.
+     * @param jobId   The {@link KapuaId} of the {@link Job}.
+     * @throws KapuaException
+     * @since 1.1.0
+     */
+    void deleteForced(KapuaId scopeId, KapuaId jobId) throws KapuaException;
+
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
@@ -42,6 +42,8 @@ import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerListResult;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link JobService} implementation
@@ -51,12 +53,15 @@ import org.eclipse.kapua.service.scheduler.trigger.TriggerService;
 @KapuaProvider
 public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Job, JobCreator, JobService, JobListResult, JobQuery, JobFactory> implements JobService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(JobServiceImpl.class);
+
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
-    private final static AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
-    private final static PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
+    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
+    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     private final JobEngineService jobEngineService = LOCATOR.getService(JobEngineService.class);
+
     private final TriggerService triggerService = LOCATOR.getService(TriggerService.class);
     private final TriggerFactory triggerFactory = LOCATOR.getFactory(TriggerFactory.class);
 
@@ -182,6 +187,32 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
     @Override
     public void delete(KapuaId scopeId, KapuaId jobId) throws KapuaException {
+        deleteInternal(scopeId, jobId, false);
+    }
+
+    @Override
+    public void deleteForced(KapuaId scopeId, KapuaId jobId) throws KapuaException {
+        deleteInternal(scopeId, jobId, true);
+    }
+
+    //
+    // Private methods
+        //
+
+    /**
+     * Deletes the {@link Job} like {@link #delete(KapuaId, KapuaId)}.
+     * <p>
+     * If {@code forced} is {@code true} {@link org.eclipse.kapua.service.authorization.permission.Permission} checked will be {@code job:delete:null},
+     * and when invoking {@link JobEngineService#cleanJobData(KapuaId, KapuaId)} any exception is logged and ignored.
+     *
+     * @param scopeId The {@link KapuaId} scopeId of the {@link Job}.
+     * @param jobId   The {@link KapuaId} of the {@link Job}.
+     * @param forced  Whether or not the {@link Job} must be forcibly deleted.
+     * @throws KapuaException In case something bad happens.
+     * @since 1.1.0
+     */
+    private void deleteInternal(KapuaId scopeId, KapuaId jobId, boolean forced) throws KapuaException {
+
         //
         // Argument Validation
         ArgumentValidator.notNull(scopeId, "scopeId");
@@ -189,7 +220,7 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(JobDomains.JOB_DOMAIN, Actions.delete, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(JobDomains.JOB_DOMAIN, Actions.delete, forced ? null : scopeId));
 
         //
         // Check existence
@@ -219,8 +250,17 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
         //
         // Do delete
+        try {
         KapuaSecurityUtils.doPrivileged(() -> jobEngineService.cleanJobData(scopeId, jobId));
+        } catch (Exception e) {
+            if (forced) {
+                LOG.warn("Error while cleaning Job data. Ignoring exception since delete is forced! Error: {}", e.getMessage());
+                LOG.debug("Error while cleaning Job data. Ignoring exception since delete is forced!", e);
+            } else {
+                throw e;
+            }
+        }
+
         entityManagerSession.onTransactedAction(em -> JobDAO.delete(em, scopeId, jobId));
     }
-
 }


### PR DESCRIPTION
This PR add the feature to delete a job forcing the check on the job status.

**Related Issue**
_None_

**Description of the solution adopted**
Added a new methods that ignores exceptions when requesting the JobEngineService to clean up data. This can be used when for some reasons the job gets stuck and a regular delete is failing because the Job is running on the JobEngine.

This feature is only available to the sys administrator.

**Screenshots**
_None_

**Any side note on the changes made**
_None_