### PR TITLE
Set kapua-guice dependency scope to test

### DIFF
--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -244,6 +244,11 @@
             <artifactId>kapua-qa-markers</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -63,6 +63,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -57,6 +57,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -42,6 +42,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/service/datastore/internal/pom.xml
+++ b/service/datastore/internal/pom.xml
@@ -54,6 +54,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/service/endpoint/internal/pom.xml
+++ b/service/endpoint/internal/pom.xml
@@ -39,6 +39,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -51,6 +51,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/service/scheduler/quartz/pom.xml
+++ b/service/scheduler/quartz/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -51,6 +51,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/tag/internal/pom.xml
+++ b/service/tag/internal/pom.xml
@@ -36,6 +36,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-guice</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This PR sets the `scope` of the `org.eclipse.kapua:kapua-guice` artifact to `test`, in various implementations, since it's only needed in test. Without the test scope, the `kapua-guice` module would be forced in the application, preventing the use of any other Locator implementation.

**Related Issue**
No related issue
