### PR TITLE
Upgraded Guava version from 19.0 to 27.1-jre - CVE-2018-10237 - CWE-119 - errata corrige

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -159,6 +159,8 @@
                 <include>com.fasterxml.jackson.dataformat:*</include>
                 <include>com.google.code.findbugs:annotations</include>
                 <include>com.google.guava:guava</include>
+                <include>com.google.guava:failureaccess</include>
+                <include>com.google.guava:listenablefuture</include>
                 <include>com.google.inject.extensions:guice-multibindings</include>
                 <include>com.google.inject:guice</include>
                 <include>com.google.protobuf:protobuf-java</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -282,6 +282,14 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>listenablefuture</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
         </dependency>
@@ -462,6 +470,20 @@
                                 <artifactItem>
                                     <groupId>com.google.guava</groupId>
                                     <artifactId>guava</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/broker_dependency</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.google.guava</groupId>
+                                    <artifactId>failureaccess</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/broker_dependency</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.google.guava</groupId>
+                                    <artifactId>listenablefuture</artifactId>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>target/broker_dependency</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
         <findbugs.version>2.0.1</findbugs.version>
         <gson.version>2.7</gson.version>
         <guava.version>27.1-jre</guava.version>
+        <guava-failureaccess.version>1.0.1</guava-failureaccess.version>
+        <guava-listenablefuture.version>9999.0-empty-to-avoid-conflict-with-guava</guava-listenablefuture.version>
         <guice.version>4.1.0</guice.version>
         <h2.version>1.4.199</h2.version>
         <httpcomponents.version>4.5.2</httpcomponents.version>
@@ -1056,6 +1058,38 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>failureaccess</artifactId>
+                <version>${guava-failureaccess.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>listenablefuture</artifactId>
+                <version>${guava-listenablefuture.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>
@@ -1294,7 +1328,7 @@
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations </artifactId>
+                <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Brief description of the PR.
This PR contains some fixes that we missed on PR #2615, mainly to fix the `kapua-broker` Docker image.

**Related Issue**
_None_

**Description of the solution adopted**
Added import of dependencies on the `kapua-broker` Docker image and excluded unnecessary dependencies of Guava which in 19.0 were marked as `optional` dependencies. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_