### PR TITLE
Upgraded commons-collections version from 3.2.1 to 3.2.2 - CVE-2015-7501 - CWE-502

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <commons-cli.version>1.4</commons-cli.version>
         <commons-codec.version>1.9</commons-codec.version>
         <commons-configuration.version>1.9</commons-configuration.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>3.4</commons-lang.version>
         <commons-pool.version>2.3</commons-pool.version>
@@ -1024,24 +1025,57 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- -->
             <!-- External dependencies -->
+
+            <!-- Apache Commons-->
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
                 <version>${commons-beanutils.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>${commons-cli.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>${commons-codec.version}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-configuration</groupId>
+                <artifactId>commons-configuration</artifactId>
+                <version>${commons-configuration.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>${commons-collections.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>${commons-pool.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -1117,22 +1151,6 @@
                 <version>1.0.3</version>
             </dependency>
             <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
-                <version>${commons-configuration.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons-io.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>info.cukes</groupId>
                 <artifactId>cucumber-core</artifactId>
                 <version>${cucumber.version}</version>
@@ -1161,11 +1179,6 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-jms</artifactId>
                 <version>${camel.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-pool2</artifactId>
-                <version>${commons-pool.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.opencsv</groupId>
@@ -1242,11 +1255,6 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commons-lang.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
This PR bumps the version of `commons-collections` library to 3.2.2

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
We can piggy back on existing CQ.

Kapua CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20299

**Screenshots**
_None_

**Any side note on the changes made**
Grouped `commons-*` dependencies in `pom.xml` file.
Full list of fixes: https://issues.apache.org/jira/browse/COLLECTIONS-652?jql=project%20%3D%20COLLECTIONS%20AND%20fixVersion%20%3D%203.2.2
We are not using this dependency directly but is a transient dependency of:
- shiro-core - 1.3.2: https://mvnrepository.com/artifact/org.apache.shiro/shiro-core/1.3.2
- artemis-jms-server - 2.2.0: https://mvnrepository.com/artifact/org.apache.activemq/artemis-jms-server/2.2.0
- apache-activemq - 5.14.5: https://mvnrepository.com/artifact/org.apache.activemq/activemq-broker/5.15.5
