### PR TITLE
 Upgraded commons-beanutils version from 1.9.2 to 1.9.3 - CVE-2014-0114 - CWE-20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,14 @@
         <artemis.version>2.2.0</artemis.version>
         <assertj.version>3.2.0</assertj.version>
         <camel.version>2.16.3</camel.version>
-        <commons-beanutils.version>1.9.2</commons-beanutils.version>
+        <commons-beanutils.version>1.9.3</commons-beanutils.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-codec.version>1.9</commons-codec.version>
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>3.4</commons-lang.version>
+        <commons-logging.version>1.2</commons-logging.version>
         <commons-pool.version>2.3</commons-pool.version>
         <cucumber.version>1.2.4</cucumber.version>
         <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
@@ -1066,14 +1067,19 @@
                 <version>${commons-io.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-pool2</artifactId>
-                <version>${commons-pool.version}</version>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-pool2</artifactId>
+                <version>${commons-pool.version}</version>
             </dependency>
 
 


### PR DESCRIPTION
This PR bumps the version of `commons-beanutils`dependency to 1.9.3
Transitive dependencies:

- Commons Collections:: from 3.2.1 to 3.2.2
- Commons Logging: 1.1.1 to 1.2

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
On each version we can piggy back on existing CQs.

- Commons Beanutils: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20301
- Commons Collections: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20299
- Commons Logging: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20302

**Screenshots**
_None_

**Any side note on the changes made**
Full list of fixes: https://issues.apache.org/jira/browse/BEANUTILS-496?jql=project%20%3D%20BEANUTILS%20AND%20fixVersion%20%3D%201.9.3
We are not using this dependency directly but is a transient dependency of:
- shiro-core - 1.3.2: https://mvnrepository.com/artifact/org.apache.shiro/shiro-core/1.3.2
- artemis-jms-server - 2.2.0: https://mvnrepository.com/artifact/org.apache.activemq/artemis-jms-server/2.2.0
- apache-activemq - 5.14.5: https://mvnrepository.com/artifact/org.apache.activemq/activemq-broker/5.15.5