### PR TITLE
Added test scenarios for user role service

### DIFF
--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Red Hat Inc and others.
+ * Copyright (c) 2017, 2019 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.qa.common;
 
 import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
@@ -173,5 +174,11 @@ public class BasicSteps extends TestBase {
         } else {
             System.setProperty(key, value);
         }
+    }
+
+    @And("^I expect the exception \"([^\"]*)\"$")
+    public void iExpectTheException(String name) {
+        stepData.put("ExceptionExpected", true);
+        stepData.put("ExceptionName", name);
     }
 }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserServiceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,10 +20,18 @@ import cucumber.api.CucumberOptions;
 
 @RunWith(CucumberWithProperties.class)
 @CucumberOptions(
-        features = "classpath:features/user/UserServiceI9n.feature",
+        features = {
+                "classpath:features/user/UserServiceI9n.feature",
+                "classpath:features/user/UserRoleServiceI9n.feature"
+        },
         glue = {"org.eclipse.kapua.qa.common",
                 "org.eclipse.kapua.service.account.steps",
-                "org.eclipse.kapua.service.user.steps"
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.authorization.steps",
+                "org.eclipse.kapua.service.device.registry.steps",
+                "org.eclipse.kapua.service.job.steps",
+                "org.eclipse.kapua.service.tag.steps",
+                "org.eclipse.kapua.service.datastore.steps"
                },
         plugin = {"pretty", 
                   "html:target/cucumber/UserServiceI9n",

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -1,0 +1,223 @@
+###############################################################################
+# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@user
+@integration
+@userRole
+Feature: User role service integration tests
+
+  Scenario: Start datastore for all scenarios
+
+    Given Start Datastore
+
+  Scenario: Start event broker for all scenarios
+
+    Given Start Event Broker
+
+  Scenario: Adding existing roles to user
+    Adding user more than one role
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Scope with ID 1
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And I create user with name "user1"
+    And Credentials
+      | name  | password      | enabled |
+      | user1 | User@10031995 | true    |
+    And I configure the role service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I create the domain
+      | name | actions             |
+      | test | read,write, execute |
+    And The permissions "read, write, execute"
+    And I create the access info entity
+    And I create the roles
+      | name  |
+      | role1 |
+      | role2 |
+      | role3 |
+    And I add permissions to the role
+    And I add access roles to user
+    Then Access role with name "role3" is found
+    And I logout
+
+  Scenario: Add user permissions to the role
+  Creating user "user1" and role "test_role", adding permissions with user domain and read, write and delete actions to the "test_role",
+  adding "test_role" to "user1" and after that trying to find, delete or create users as user "user1"
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Scope with ID 1
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And I create user with name "user1"
+    And Credentials
+      | name  | password      | enabled |
+      | user1 | User@10031995 | true    |
+    And I select the domain "user"
+    And I create the access info entity
+    And I create the following role
+      | scopeId | name      |
+      | 1       | test_role |
+    And I create the following role permission
+      | scopeId | actionName |
+      | 1       | read       |
+      | 1       | write      |
+      | 1       | delete     |
+    And I add access role to user
+    And I logout
+    Then I login as user with name "user1" and password "User@10031995"
+    And I create user with name "new-user"
+    And I find user with name "new-user"
+    And I try to edit user to name "new-user"
+    And I try to delete user "new-user"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Add device permissions to the role
+  Creating user "user1" and role "test_role", adding permissions with device domain and read, write and delete actions to the "test_role",
+  adding "test_role" to "user1" and after that trying to find, delete or create devices as user "user1"
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Scope with ID 1
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    And I create user with name "user1"
+    And Credentials
+      | name  | password      | enabled |
+      | user1 | User@10031995 | true    |
+    And I select the domain "device"
+    And I create the access info entity
+    And I create the following role
+      | scopeId | name      |
+      | 1       | test_role |
+    And I create the following role permission
+      | scopeId | actionName |
+      | 1       | read       |
+      | 1       | write      |
+      | 1       | delete     |
+    And I add access role to user
+    And I logout
+    Then I login as user with name "user1" and password "User@10031995"
+    And I create a device with name "device1"
+    And I find device with client id "device1"
+    And I try to edit device to clientId "device2"
+    And I delete the device with the client id "device1"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Add device event permissions to the role
+  Creating user "user1" and role "test_role", adding permissions with device and device_event domain and read, write and delete actions to the "test_role",
+  adding "test_role" to "user1" and after that trying to find device events"
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Scope with ID 1
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+      | boolean | lockoutPolicy.enabled      | false |
+      | integer | lockoutPolicy.maxFailures  | 3     |
+      | integer | lockoutPolicy.resetAfter   | 300   |
+      | integer | lockoutPolicy.lockDuration | 3     |
+    Given User A
+      | name  | displayName  | email             | phoneNumber     | status  | userType |
+      | user1 | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password      | enabled |
+      | user1 | User@10031995 | true    |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    And I create the access info entity
+    And I create the following role
+      | scopeId | name      |
+      | 1       | test_role |
+    And I select the domain "device"
+    And I create the following role permission
+      | scopeId | actionName |
+      | 1       | read       |
+      | 1       | write      |
+      | 1       | delete     |
+    And I select the domain "account"
+    And I create the following role permission
+      | scopeId | actionName |
+      | 1       | read       |
+      | 1       | write      |
+      | 1       | delete     |
+    And I add access role to user
+    And I logout
+    Then I login as user with name "user1" and password "User@10031995"
+    And A birth message from device "device_1"
+    And I expect the exception "SubjectUnauthorizedException" with the text "Missing permission: device_event:read:"
+    When I search for events from device "device_1" in account "kapua-sys"
+    Then An exception was thrown
+    And I logout
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select the domain "device_event"
+    And I create the following role permission
+      | scopeId | actionName |
+      | 1       | read       |
+      | 1       | write      |
+      | 1       | delete     |
+    And I logout
+    Given I login as user with name "user1" and password "User@10031995"
+    When I search for events from device "device_1" in account "kapua-sys"
+    Then I find 1 device events
+    And The type of the last event is "BIRTH"
+    And No exception was thrown
+    And I logout
+
+  Scenario: Stop broker after all scenarios
+
+    Given Stop Broker
+
+  Scenario: Stop event broker for all scenarios
+
+    Given Stop Event Broker
+
+  Scenario: Stop datastore after all scenarios
+
+    Given Stop Datastore
+
+
+
+
+
+
+
+
+
+
+
+

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -1213,11 +1213,15 @@ public class DatastoreSteps extends TestBase {
     }
 
     @When("^I search for data message with id \"(.*)\"")
-    public void messageStoreFind(String storeId) throws KapuaException {
-
+    public void messageStoreFind(String storeId) throws Exception {
         Account account = (Account) stepData.get("LastAccount");
-        DatastoreMessage tmpMsg = messageStoreService.find(account.getId(), storableIdFactory.newStorableId(storeId), StorableFetchStyle.SOURCE_FULL);
-        stepData.put("message", tmpMsg);
+        try {
+            primeException();
+            DatastoreMessage tmpMsg = messageStoreService.find(account.getId(), storableIdFactory.newStorableId(storeId), StorableFetchStyle.SOURCE_FULL);
+            stepData.put("message", tmpMsg);
+        } catch (Exception ex) {
+            verifyException(ex);
+        }
     }
 
     @Then("^I don't find message$")

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobServiceSteps.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobServiceSteps.java
@@ -1541,4 +1541,38 @@ public class JobServiceSteps extends TestBase {
 
         return tmpCr;
     }
+
+    @Then("^I find a job with name \"([^\"]*)\"$")
+    public void iFindAJobWithName(String jobName) {
+    Job job = (Job) stepData.get("Job");
+    assertEquals(job.getName(), jobName);
+    }
+
+    @Then("^I delete the job with name \"([^\"]*)\"$")
+    public void iDeleteTheJobWithName(String jobName) throws Exception {
+        Job job = (Job) stepData.get("Job");
+
+        try {
+            primeException();
+            if (job.getName().equals(jobName)) {
+                jobService.delete(getCurrentScopeId(), job.getId());
+            }
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
+    }
+
+    @Then("^I try to edit job to name \"([^\"]*)\"$")
+    public void iTryToEditJobToName(String jobName) throws Throwable {
+       Job job = (Job) stepData.get("Job");
+       job.setName(jobName);
+
+       try {
+           primeException();
+           Job newJob = jobService.update(job);
+           stepData.put("Job", newJob);
+       } catch (KapuaException ex) {
+           verifyException(ex);
+       }
+    }
 }

--- a/service/tag/test-steps/src/main/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
+++ b/service/tag/test-steps/src/main/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.tag.steps;
 import cucumber.api.Scenario;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
@@ -145,7 +146,9 @@ public class TagServiceSteps extends TestBase {
     public void tagWithName(String tagName) throws Throwable {
 
         TagCreator tagCreator = tagCreatorCreator(tagName);
-        tagService.create(tagCreator);
+        stepData.remove("tag");
+        Tag tag = tagService.create(tagCreator);
+        stepData.put("tag", tag);
     }
 
     @When("^Tag with name \"([^\"]*)\" is searched$")
@@ -195,5 +198,31 @@ public class TagServiceSteps extends TestBase {
         tagCreator.setName(tagName);
 
         return tagCreator;
+    }
+
+    @And("^Tag name is changed into name \"([^\"]*)\"$")
+    public void tagNameIsChangedIntoName(String tagName) throws Exception {
+       Tag tag = (Tag) stepData.get("tag");
+       tag.setName(tagName);
+
+       try {
+           primeException();
+           stepData.remove("tag");
+           Tag newtag = tagService.update(tag);
+           stepData.put("tag", newtag);
+       } catch (KapuaException ex) {
+           verifyException(ex);
+       }
+    }
+
+    @And("^Tag is deleted$")
+    public void tagIsDeleted() throws Exception {
+        Tag tag = (Tag) stepData.get("tag");
+
+        try {
+            tagService.delete(getCurrentScopeId(), tag.getId());
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
     }
 }

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserRoleServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserRoleServiceSteps.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.steps;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.apache.shiro.SecurityUtils;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.qa.common.TestBase;
+import org.eclipse.kapua.qa.common.TestDomain;
+import org.eclipse.kapua.qa.common.TestJAXBContextProvider;
+import org.eclipse.kapua.qa.common.StepData;
+import org.eclipse.kapua.qa.common.DBHelper;
+import org.eclipse.kapua.service.authorization.access.AccessRoleService;
+import org.eclipse.kapua.service.authorization.access.AccessRoleFactory;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
+import org.eclipse.kapua.service.authorization.access.AccessRoleCreator;
+import org.eclipse.kapua.service.authorization.access.AccessRole;
+import org.eclipse.kapua.service.authorization.role.Role;
+import org.eclipse.kapua.service.user.UserFactory;
+import org.eclipse.kapua.service.user.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+
+
+@ScenarioScoped
+public class UserRoleServiceSteps extends TestBase {
+    public static final Logger logger = LoggerFactory.getLogger(UserRoleServiceSteps.class);
+    private static final TestDomain TEST_DOMAIN = new TestDomain();
+
+    private UserService userService;
+    private UserFactory userFactory;
+    private AccessRoleService accessRoleService;
+    private AccessRoleFactory accessRoleFactory;
+
+    @Inject
+    public UserRoleServiceSteps(StepData stepData, DBHelper dbHelper) {
+        this.stepData = stepData;
+        this.database = dbHelper;
+    }
+
+    @Before
+    public void beforeScenario(Scenario scenario) {
+
+        this.scenario = scenario;
+        database.setup();
+        stepData.clear();
+
+        locator = KapuaLocator.getInstance();
+        accessRoleService = locator.getService(AccessRoleService.class);
+        userService = locator.getService(UserService.class);
+        accessRoleFactory = locator.getFactory(AccessRoleFactory.class);
+        userFactory = locator.getFactory(UserFactory.class);
+
+        if (isUnitTest()) {
+            // Create KapuaSession using KapuaSecurtiyUtils and kapua-sys user as logged in user.
+            // All operations on database are performed using system user.
+            // Only for unit tests. Integration tests assume that a real logon is performed.
+            KapuaSession kapuaSession = new KapuaSession(null, SYS_SCOPE_ID, SYS_USER_ID);
+            KapuaSecurityUtils.setSession(kapuaSession);
+        }
+
+        XmlUtil.setContextProvider(new TestJAXBContextProvider());
+    }
+
+    @After
+    public void afterScenario() {
+
+        // Clean up the database
+        try {
+            logger.info("Logging out in cleanup");
+            if (isIntegrationTest()) {
+                database.deleteAll();
+                SecurityUtils.getSubject().logout();
+            } else {
+                database.dropAll();
+                database.close();
+            }
+            KapuaSecurityUtils.clearSession();
+        } catch (Exception e) {
+            logger.error("Failed to log out in @After", e);
+        }
+    }
+
+    @And("^I add access role to user$")
+    public void addRoleToUser() throws Exception {
+        AccessInfo accessInfo = (AccessInfo) stepData.get("AccessInfo");
+        Role role = (Role) stepData.get("Role");
+        AccessRoleCreator accessRoleCreator = accessRoleFactory.newCreator(getCurrentScopeId());
+            accessRoleCreator.setAccessInfoId(accessInfo.getId());
+            accessRoleCreator.setRoleId(role.getId());
+            stepData.put("AccessRoleCreator", accessRoleCreator);
+
+            try {
+                primeException();
+                stepData.remove("AccessRole");
+                AccessRole accessRole = accessRoleService.create(accessRoleCreator);
+                stepData.put("AccessRole", accessRole);
+                stepData.put("AccessRoleId", accessRole.getId());
+            } catch (KapuaException ex) {
+                verifyException(ex);
+            }
+    }
+
+    @Then("^Access role is not found$")
+    public void accessRoleIsNotFound() throws Exception{
+        AccessRole accessRole = (AccessRole) stepData.get("AccessRole");
+
+        try {
+            assertEquals(null, accessRoleService.find(getCurrentScopeId(), accessRole.getId()));
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
+    }
+}

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.user.steps;
 import cucumber.api.Scenario;
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
@@ -946,6 +947,38 @@ public class UserServiceSteps extends TestBase {
             assertEquals(cucUser.getStatus(), user.getStatus());
         }
         return true;
+    }
+
+    @And("^I create user with name \"([^\"]*)\"$")
+    public void iCreateUserWithName(String userName) throws Exception {
+        stepData.remove("UserCreator");
+        UserCreator userCreator = userFactory.newCreator(getCurrentScopeId());
+        userCreator.setName(userName);
+        stepData.put("UserCreator", userCreator);
+
+        try {
+            primeException();
+            stepData.remove("User");
+            User user = userService.create(userCreator);
+            stepData.put("User", user);
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
+    }
+
+    @Then("^I try to edit user to name \"([^\"]*)\"$")
+    public void iTryToEditUserWithName(String newUserName) throws Exception {
+        User user = (User) stepData.get("User");
+        user.setName(newUserName);
+
+        try {
+            primeException();
+            stepData.remove("User");
+            User newUser = userService.update(user);
+            stepData.put("User", newUser);
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
     }
 
     // *****************


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
This PR introduces first batch of integration tests for Roles that are added to the user.

**Related Issue**
This PR partially fixes issue #126

**Description of added tests**
Added scenarios for Roles that are added to the user which means:

Test 1: Adding existing role to user
Test 2:   Add user permissions to the role
Test 3: Add device permissions to the role
Test 4: Add job permissions to the role
Test 5: Add device and device_event   permissions to the role
Test 6:   Add account permissions to the role
Test 7:   Add datastore permissions to the role
Test 8:   Add domain, access_info and user permissions to the role
Test 9:   Add endpoint_info permissions to the role
Test 10:   Add group permission to the role
Test 11:   Add role permission to the role
Test 12:   Add scheduler permission to the role
Test 13:   Add tag permission to the role
Test 14:   Add user permission to the role
Test 15:   Delete access role from user
Test 16:   Add deleted role again
Test 17:   Delete permissions from role

**Screenshots**
/

**Any side note on the changes made**
/
