### PR TITLE
Use .tgz files to build Docker Images

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -265,6 +265,8 @@
                                     <build>
                                         <assembly>
                                             <descriptor>${project.basedir}/descriptors/kapua-api-jetty.xml</descriptor>
+                                            <mode>tgz</mode>
+                                            <tarLongFileMode>posix</tarLongFileMode>
                                         </assembly>
                                         <dockerFile>${project.basedir}/docker/Dockerfile</dockerFile>
                                         <filter>@</filter>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -720,6 +720,8 @@
                                     <build>
                                         <assembly>
                                             <descriptor>${project.basedir}/descriptors/kapua-broker.xml</descriptor>
+                                            <mode>tgz</mode>
+                                            <tarLongFileMode>posix</tarLongFileMode>
                                         </assembly>
                                         <dockerFile>${project.basedir}/docker/Dockerfile</dockerFile>
                                         <filter>@</filter>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -266,6 +266,8 @@
                                         <assembly>
                                             <descriptor>${project.basedir}/descriptors/kapua-console-jetty.xml</descriptor>
                                             <basedir>/</basedir>
+                                            <mode>tgz</mode>
+                                            <tarLongFileMode>posix</tarLongFileMode>
                                         </assembly>
                                         <dockerFile>${project.basedir}/docker/Dockerfile</dockerFile>
                                         <filter>@</filter>

--- a/assembly/events-broker/pom.xml
+++ b/assembly/events-broker/pom.xml
@@ -46,6 +46,8 @@
                                         <assembly>
                                             <descriptor>${project.basedir}/descriptors/events-broker.xml</descriptor>
                                             <basedir>/</basedir>
+                                            <mode>tgz</mode>
+                                            <tarLongFileMode>posix</tarLongFileMode>
                                         </assembly>
                                         <dockerFile>${project.basedir}/docker/Dockerfile</dockerFile>
                                     </build>

--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -49,6 +49,8 @@
                                     <build>
                                         <assembly>
                                             <descriptor>${project.basedir}/descriptors/jetty-base.xml</descriptor>
+                                            <mode>tgz</mode>
+                                            <tarLongFileMode>posix</tarLongFileMode>
                                         </assembly>
                                         <dockerFile>${project.basedir}/docker/Dockerfile</dockerFile>
                                         <filter>@</filter>

--- a/assembly/sql/pom.xml
+++ b/assembly/sql/pom.xml
@@ -46,6 +46,8 @@
                                         <filter>@</filter>
                                         <assembly>
                                             <descriptor>${project.basedir}/descriptors/kapua-sql.xml</descriptor>
+                                            <mode>tgz</mode>
+                                            <tarLongFileMode>posix</tarLongFileMode>
                                         </assembly>
                                         <dockerFile>${project.basedir}/docker/Dockerfile</dockerFile>
                                     </build>


### PR DESCRIPTION
This PR configures the `docker-maven-plugin` to extract Maven Assemblies to .tgz files instead of plain directory. 

**Related Issue**
No related issues

**Description of the solution adopted**
When building Docker Images on Windows, `docker-maven-plugin` would lose all the file permissions specified in the Maven Assembly Descriptors, because it would extract such assemblies in plain NTFS or FAT directories, that have no clue of Unix permissions; this would lead to `permission denied` errors when running Docker Images built on Windows. Using a .tgz file instead as an intermediate storage would preserve the permissions and allow the execution of such images.

