### PR TITLE
Rationalized dependency versions in main pom.xml files

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -29,7 +29,6 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-assembly-java-base</artifactId>
-            <version>${project.version}</version>
             <type>pom</type>
         </dependency>
 
@@ -37,7 +36,6 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-rest-api-web</artifactId>
-            <version>${project.version}</version>
             <type>war</type>
         </dependency>
 
@@ -48,7 +46,6 @@
         <dependency>
             <groupId>aopalliance</groupId>
             <artifactId>aopalliance</artifactId>
-            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
@@ -149,8 +146,6 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <!--TODO manage version in central place -->
-            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
@@ -167,7 +162,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>4.1.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
@@ -200,7 +194,7 @@
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-jvm</artifactId>
-            <version>1.3.4</version>
+            <version>${jolokia-jvm.version}</version>
             <classifier>agent</classifier>
         </dependency>
         <dependency>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-assembly-java-base</artifactId>
-            <version>${project.version}</version>
             <type>pom</type>
         </dependency>
 
@@ -194,7 +193,6 @@
         <dependency>
             <groupId>aopalliance</groupId>
             <artifactId>aopalliance</artifactId>
-            <version>1.0</version>
         </dependency>
         <dependency>
             <!-- Google protobuf for message encoding -->
@@ -205,7 +203,6 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>apache-activemq</artifactId>
-            <version>${activemq.version}</version>
             <classifier>bin</classifier>
             <type>tar.gz</type>
             <exclusions>
@@ -248,14 +245,11 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <!-- used both by qpid and elasticsearch -->
-            <version>${elasticsearch-netty-4.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <!--TODO manage version in central place -->
-            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
@@ -296,7 +290,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>4.1.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
@@ -333,7 +326,6 @@
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-jvm</artifactId>
-            <version>1.3.4</version>
             <classifier>agent</classifier>
         </dependency>
         <dependency>
@@ -373,44 +365,24 @@
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty3-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>reindex-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>lang-mustache-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>percolator-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
 
-        <!--
-            Java APIs from Tomcat:
-            We stick to 8.0.38 because they are only APIs and we can
-            piggyback on this version.
-            -->
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-servlet-api</artifactId>
-            <version>8.0.38</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>tomcat-websocket-api</artifactId>
-            <version>8.0.38</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -498,7 +470,7 @@
                                 <artifactItem>
                                     <groupId>javax.inject</groupId>
                                     <artifactId>javax.inject</artifactId>
-                                    <version>1</version>
+                                    <version>${javax-inject.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>target/broker_dependency</outputDirectory>
@@ -622,7 +594,7 @@
                                 <artifactItem>
                                     <groupId>org.apache.commons</groupId>
                                     <artifactId>commons-pool2</artifactId>
-                                    <version>2.3</version>
+                                    <version>${commons-pool.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>target/broker_dependency</outputDirectory>
@@ -630,7 +602,7 @@
                                 <artifactItem>
                                     <groupId>org.bitbucket.b_c</groupId>
                                     <artifactId>jose4j</artifactId>
-                                    <version>0.5.2</version>
+                                    <version>${jose4j.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>target/broker_dependency</outputDirectory>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-assembly-java-base</artifactId>
-            <version>${project.version}</version>
             <type>pom</type>
         </dependency>
 
@@ -36,7 +35,6 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-console-web</artifactId>
-            <version>${project.version}</version>
             <type>war</type>
         </dependency>
 
@@ -47,7 +45,6 @@
         <dependency>
             <groupId>aopalliance</groupId>
             <artifactId>aopalliance</artifactId>
-            <version>1.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
@@ -148,8 +145,6 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <!--TODO manage version in central place -->
-            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
@@ -166,7 +161,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>4.1.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
@@ -199,7 +193,6 @@
         <dependency>
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-jvm</artifactId>
-            <version>1.3.4</version>
             <classifier>agent</classifier>
         </dependency>
         <dependency>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -39,6 +39,25 @@
         <module>api</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-assembly-java-base</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>apache-activemq</artifactId>
+                <classifier>bin</classifier>
+                <type>tar.gz</type>
+                <version>${activemq.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <profiles>
         <!-- Profile used to exclude console module on release process -->
         <profile>

--- a/client/gateway/features/karaf/src/main/feature/feature.xml
+++ b/client/gateway/features/karaf/src/main/feature/feature.xml
@@ -56,7 +56,7 @@
 
         <bundle>mvn:${project.groupId}/kapua-client-gateway-provider-paho/${project.version}</bundle>
 
-        <bundle dependency="true">mvn:org.eclipse.paho/org.eclipse.paho.client.mqttv3/1.1.1</bundle>
+        <bundle dependency="true">mvn:org.eclipse.paho/org.eclipse.paho.client.mqttv3/${paho.version}</bundle>
     </feature>
 
 </features>

--- a/client/gateway/provider/fuse/pom.xml
+++ b/client/gateway/provider/fuse/pom.xml
@@ -28,6 +28,9 @@
     <name>Eclipse Kapua :: Gateway Client :: Provider :: FUSE MQTT</name>
     <description>An MQTT client implementation based on FUSE MQTT</description>
 
+    <properties>
+        <fuse-mqtt-client.version>1.14</fuse-mqtt-client.version>
+    </properties>
     <dependencies>
 
         <dependency>
@@ -53,7 +56,7 @@
         <dependency>
             <groupId>org.fusesource.mqtt-client</groupId>
             <artifactId>mqtt-client</artifactId>
-            <version>1.14</version>
+            <version>${fuse-mqtt-client.version}</version>
         </dependency>
 
         <!-- testing dependencies -->

--- a/client/gateway/provider/paho/pom.xml
+++ b/client/gateway/provider/paho/pom.xml
@@ -53,11 +53,6 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <!--
-              - We only requre Paho 1.0.2 in order to be more compatible
-              - with existing software.
-              -->
-            <version>1.0.2</version><!--$NO-MVN-MAN-VER$-->
         </dependency>
 
         <!-- testing dependencies -->

--- a/console/core/pom.xml
+++ b/console/core/pom.xml
@@ -29,17 +29,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
+
             <plugin>
                 <!-- GWT Maven Plugin -->
                 <groupId>org.codehaus.mojo</groupId>
@@ -143,13 +134,11 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-console-module-endpoint</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-console-module-endpoint</artifactId>
             <classifier>sources</classifier>
-            <version>1.1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -238,7 +227,6 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.2</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -249,13 +237,12 @@
             <!-- Apache shiro security framework web support -->
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-web</artifactId>
-            <version>${shiro.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.eclipse.neoscada.utils</groupId>
             <artifactId>org.eclipse.scada.utils</artifactId>
-            <version>0.4.0</version>
+            <version>${scada-utils.version}</version>
         </dependency>
 
         <!-- use logback only for testing -->

--- a/console/module/about/pom.xml
+++ b/console/module/about/pom.xml
@@ -34,16 +34,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -64,11 +64,8 @@
 
         <!-- External Dependencies -->
         <dependency>
-            <!-- Imaging utils used to handle device component configuration  icons -->
-            <!-- Former commons-imaging changed because the 1.0-FINAL was not contined/supported in maven -->
             <groupId>org.apache.sanselan</groupId>
             <artifactId>sanselan</artifactId>
-            <version>0.97-incubator</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -81,16 +78,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/api/pom.xml
+++ b/console/module/api/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.2</version>
         </dependency>
 
         <!-- Testing dependencies -->
@@ -71,17 +70,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
+
             <plugin>
                 <!-- GWT Maven Plugin -->
                 <groupId>org.codehaus.mojo</groupId>

--- a/console/module/authentication/pom.xml
+++ b/console/module/authentication/pom.xml
@@ -41,16 +41,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/authorization/pom.xml
+++ b/console/module/authorization/pom.xml
@@ -41,16 +41,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/data/pom.xml
+++ b/console/module/data/pom.xml
@@ -56,16 +56,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/device/pom.xml
+++ b/console/module/device/pom.xml
@@ -62,11 +62,8 @@
             <artifactId>opencsv</artifactId>
         </dependency>
         <dependency>
-            <!-- Imaging utils used to handle device component configuration icons -->
-            <!-- former commons-imaging changed because the 1.0-FINAL was not contined/supported in maven -->
             <groupId>org.apache.sanselan</groupId>
             <artifactId>sanselan</artifactId>
-            <version>0.97-incubator</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -79,16 +76,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/endpoint/pom.xml
+++ b/console/module/endpoint/pom.xml
@@ -54,16 +54,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/job/pom.xml
+++ b/console/module/job/pom.xml
@@ -81,16 +81,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/tag/pom.xml
+++ b/console/module/tag/pom.xml
@@ -54,16 +54,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/user/pom.xml
+++ b/console/module/user/pom.xml
@@ -53,16 +53,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/module/welcome/pom.xml
+++ b/console/module/welcome/pom.xml
@@ -35,16 +35,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -34,6 +34,7 @@
         <com.google.gwt.version>2.4.0</com.google.gwt.version>
         <com.extjs.gxt.version>2.2.5</com.extjs.gxt.version>
         <com.allen-sauer.gwt.log.version>3.1.8</com.allen-sauer.gwt.log.version>
+        <sanselan.version>0.97-incubator</sanselan.version>
     </properties>
 
     <repositories>
@@ -46,12 +47,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.eclipse.kapua</groupId>
-                <artifactId>kapua-console-web</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-console-core</artifactId>
@@ -152,6 +147,18 @@
 
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-console-module-endpoint</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-console-module-endpoint</artifactId>
+                <version>${project.version}</version>
+                <classifier>sources</classifier>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-console-module-job</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -222,6 +229,18 @@
                 <artifactId>gwt-log</artifactId>
                 <version>${com.allen-sauer.gwt.log.version}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>${commons-fileupload.versison}</version>
+            </dependency>
+            <dependency>
+                <!-- Imaging utils used to handle device component configuration  icons -->
+                <!-- Former commons-imaging changed because the 1.0-FINAL was not contined/supported in maven -->
+                <groupId>org.apache.sanselan</groupId>
+                <artifactId>sanselan</artifactId>
+                <version>${sanselan.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -260,7 +279,7 @@
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
+                    <version>${eclipse-lifecycle-mapping.version}</version>
                     <configuration>
                         <lifecycleMappingMetadata>
                             <pluginExecutions>

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -159,27 +159,22 @@
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty3-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>reindex-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>lang-mustache-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>percolator-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <!-- log4j2 for ES -->
         <dependency>

--- a/external/swagger-ui/pom.xml
+++ b/external/swagger-ui/pom.xml
@@ -12,7 +12,8 @@
         Eurotech
  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/job-engine/jbatch/pom.xml
+++ b/job-engine/jbatch/pom.xml
@@ -21,6 +21,9 @@
 
     <artifactId>kapua-job-engine-jbatch</artifactId>
 
+    <properties>
+        <jbatch.version>1.0.2</jbatch.version>
+    </properties>
     <dependencies>
         <!-- Implemented dependencies -->
         <dependency>
@@ -67,7 +70,7 @@
         <dependency>
             <groupId>com.ibm.jbatch</groupId>
             <artifactId>com.ibm.jbatch.container</artifactId>
-            <version>1.0.2</version>
+            <version>${jbatch.version}</version>
         </dependency>
 
     </dependencies>

--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -23,6 +23,9 @@
     <artifactId>kapua-message-internal</artifactId>
     <name>${project.artifactId}</name>
 
+    <properties>
+        <jaxb.version>2.2.5</jaxb.version>
+    </properties>
     <dependencies>
         <!-- Internal dependencies -->
         <dependency>
@@ -34,7 +37,7 @@
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <version>2.2.5</version>
+            <version>${jaxb.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 
         <!-- Dependencies versions -->
         <activemq.version>5.14.5</activemq.version>
+        <aopalliance.version>1.0</aopalliance.version>
         <artemis.version>2.2.0</artemis.version>
         <assertj.version>3.2.0</assertj.version>
         <camel.version>2.16.3</camel.version>
@@ -37,10 +38,12 @@
         <commons-codec.version>1.9</commons-codec.version>
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-collections.version>3.2.2</commons-collections.version>
+        <commons-fileupload.versison>1.3.2</commons-fileupload.versison>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>3.4</commons-lang.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-pool.version>2.3</commons-pool.version>
+        <compress-lzf.version>1.0.3</compress-lzf.version>
         <cucumber.version>1.2.4</cucumber.version>
         <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
         <eclipselink.version>2.6.3</eclipselink.version>
@@ -54,8 +57,13 @@
         <h2.version>1.4.199</h2.version>
         <httpcomponents.version>4.5.2</httpcomponents.version>
         <javassist.version>3.19.0-GA</javassist.version>
+        <javax-batch-api.version>1.0.1</javax-batch-api.version>
         <javax-inject.version>1</javax-inject.version>
+        <javax-json.version>1.0.4</javax-json.version>
+        <javax-persistence.version>2.1.1</javax-persistence.version>
         <joda.version>2.9.4</joda.version>
+        <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
+        <jose4j.version>0.5.2</jose4j.version>
         <junit.version>4.11</junit.version>
         <liquibase.version>3.0.5</liquibase.version>
         <mockito.version>1.10.19</mockito.version>
@@ -63,8 +71,11 @@
         <paho.version>1.2.1</paho.version>
         <protobuf.version>2.6.1</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
+        <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.3.2</shiro.version>
         <slf4j.version>1.7.26</slf4j.version>
+        <spring-security.version>4.1.3.RELEASE</spring-security.version>
+
         <logback.version>1.2.3</logback.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <swagger.version>1.5.12</swagger.version>
@@ -89,22 +100,32 @@
         <!-- Plugins versions -->
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
         <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
+        <maven-bundle-plugin.version>3.3.0</maven-bundle-plugin.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.0.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
+        <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
         <maven-source-plugin.version>2.4</maven-source-plugin.version>
+        <maven-war-plugin.version>3.0.0</maven-war-plugin.version>
 
         <checkstyle.version>7.6.1</checkstyle.version>
+        <dependency-check-maven.version>1.4.5</dependency-check-maven.version>
         <docker-maven-plugin.version>0.24.0</docker-maven-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.5</nexus-staging-maven-plugin.version>
+        <eclipse-lifecycle-mapping.version>1.0.0</eclipse-lifecycle-mapping.version>
         <jacoco.version>0.7.9</jacoco.version>
+        <jacoco-extras.version>0.1.1</jacoco-extras.version>
+        <karaf-maven-plugin.version>4.1.1</karaf-maven-plugin.version>
+        <license-maven-plugin.version>1.9</license-maven-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.5</nexus-staging-maven-plugin.version>
+        <protoc-jar-maven-plugin.version>3.1.0.5</protoc-jar-maven-plugin.version>
         <sql-maven-plugin.version>1.5</sql-maven-plugin.version>
         <surefire.version>2.20</surefire.version>
 
@@ -152,7 +173,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>${maven-enforcer-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>enforce-maven</id>
@@ -204,7 +225,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>${maven-shade-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -214,24 +235,24 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>${maven-war-plugin.version}</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>${maven-bundle-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
-                    <version>4.1.1</version>
+                    <version>${karaf-maven-plugin.version}</version>
                 </plugin>
 
                 <plugin>
                     <groupId>com.github.os72</groupId>
                     <artifactId>protoc-jar-maven-plugin</artifactId>
-                    <version>3.1.0.5</version>
+                    <version>${protoc-jar-maven-plugin.version}</version>
                 </plugin>
 
                 <plugin>
@@ -262,7 +283,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>1.9</version>
+                    <version>${license-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>default-cli</id>
@@ -285,7 +306,7 @@
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
+                    <version>${eclipse-lifecycle-mapping.version}</version>
                     <configuration>
                         <lifecycleMappingMetadata>
                             <pluginExecutions>
@@ -299,7 +320,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore/>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -312,7 +333,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore/>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -325,7 +346,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore/>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -338,7 +359,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore/>
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>
@@ -417,7 +438,7 @@
             <plugin>
                 <groupId>de.dentrassi.maven</groupId>
                 <artifactId>jacoco-extras</artifactId>
-                <version>0.1.1</version>
+                <version>${jacoco-extras.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -1026,8 +1047,20 @@
                 <version>${project.version}</version>
             </dependency>
 
-            <!-- -->
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-console-web</artifactId>
+                <version>${project.version}</version>
+                <type>war</type>
+            </dependency>
+
             <!-- External dependencies -->
+
+            <dependency>
+                <groupId>aopalliance</groupId>
+                <artifactId>aopalliance</artifactId>
+                <version>${aopalliance.version}</version>
+            </dependency>
 
             <!-- Apache Commons-->
             <dependency>
@@ -1081,7 +1114,6 @@
                 <artifactId>commons-pool2</artifactId>
                 <version>${commons-pool.version}</version>
             </dependency>
-
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -1154,7 +1186,7 @@
             <dependency>
                 <groupId>com.ning</groupId>
                 <artifactId>compress-lzf</artifactId>
-                <version>1.0.3</version>
+                <version>${compress-lzf.version}</version>
             </dependency>
             <dependency>
                 <groupId>info.cukes</groupId>
@@ -1203,18 +1235,43 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
+                <artifactId>javax.persistence</artifactId>
+                <version>${javax-persistence.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.moxy</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.core</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.asm</artifactId>
+                <version>${eclipselink.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.persistence</groupId>
+                <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
                 <version>${eclipselink.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.json</artifactId>
-                <version>1.0.4</version>
+                <version>${javax-json.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.batch</groupId>
                 <artifactId>javax.batch-api</artifactId>
-                <version>1.0.1</version>
+                <version>${javax-batch-api.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>
@@ -1230,6 +1287,12 @@
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${validation-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.neoscada.utils</groupId>
+                <artifactId>org.eclipse.scada.utils</artifactId>
+                <version>${scada-utils.version}</version>
             </dependency>
 
             <dependency>
@@ -1258,6 +1321,12 @@
                 <version>${joda.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.jolokia</groupId>
+                <artifactId>jolokia-jvm</artifactId>
+                <version>${jolokia-jvm.version}</version>
+                <classifier>agent</classifier>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
@@ -1266,26 +1335,6 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.jpa</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.core</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.asm</artifactId>
-                <version>${eclipselink.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.persistence</groupId>
-                <artifactId>org.eclipse.persistence.jpa.jpql</artifactId>
-                <version>${eclipselink.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -1297,7 +1346,20 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
             </dependency>
+            <dependency>
+                <!-- Apache shiro security framework -->
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-core</artifactId>
+                <version>${shiro.version}</version>
+            </dependency>
+            <dependency>
+                <!-- Apache shiro security framework web support -->
+                <groupId>org.apache.shiro</groupId>
+                <artifactId>shiro-web</artifactId>
+                <version>${shiro.version}</version>
+            </dependency>
 
+            <!-- Elasticsearch -->
             <dependency>
                 <groupId>org.elasticsearch</groupId>
                 <artifactId>elasticsearch</artifactId>
@@ -1306,6 +1368,16 @@
             <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>transport</artifactId>
+                <version>${elasticsearch-client-transport.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>rest</artifactId>
+                <version>${elasticsearch-client-rest.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.plugin</groupId>
+                <artifactId>transport-netty3-client</artifactId>
                 <version>${elasticsearch-client-transport.version}</version>
             </dependency>
             <dependency>
@@ -1320,9 +1392,19 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>org.elasticsearch.client</groupId>
-                <artifactId>rest</artifactId>
-                <version>${elasticsearch-client-rest.version}</version>
+                <groupId>org.elasticsearch.plugin</groupId>
+                <artifactId>reindex-client</artifactId>
+                <version>${elasticsearch-client-transport.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.plugin</groupId>
+                <artifactId>lang-mustache-client</artifactId>
+                <version>${elasticsearch-client-transport.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.plugin</groupId>
+                <artifactId>percolator-client</artifactId>
+                <version>${elasticsearch-client-transport.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.javassist</groupId>
@@ -1359,9 +1441,8 @@
             <dependency>
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>
-                <version>0.5.2</version>
+                <version>${jose4j.version}</version>
             </dependency>
-
 
             <dependency>
                 <groupId>org.apache.qpid</groupId>
@@ -1393,7 +1474,12 @@
                 <version>${netty-all.version}</version>
             </dependency>
 
-            <!-- -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${elasticsearch-netty-4.version}</version>
+            </dependency>
+
             <!-- Logging -->
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -1401,7 +1487,7 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
-            <!-- Implementation -->
+            <!-- Logging - Implementation -->
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
@@ -1413,7 +1499,7 @@
                 <version>${logback.version}</version>
             </dependency>
 
-            <!-- Bridge implementations -->
+            <!-- Logging - Bridge implementations -->
             <dependency>
                 <groupId>de.dentrassi.elasticsearch</groupId>
                 <artifactId>log4j2-mock</artifactId>
@@ -1445,7 +1531,6 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
-            <!-- -->
             <!-- Active MQ-->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
@@ -1463,7 +1548,6 @@
                 <version>${artemis.version}</version>
             </dependency>
 
-            <!--            -->
             <!-- Jetty-->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
@@ -1494,6 +1578,13 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>apache-jstl</artifactId>
                 <version>${jetty.version}</version>
+            </dependency>
+
+            <!-- Spring -->
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>${spring-security.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -1634,7 +1725,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>1.4.5</version>
+                        <version>${dependency-check-maven.version}</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -151,12 +151,10 @@
             <artifactId>h2</artifactId>
         </dependency>
 
-        <!-- -->
         <!-- Activemq -->
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>${activemq.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.geronimo.specs</groupId>
@@ -167,22 +165,18 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-camel</artifactId>
-            <version>${activemq.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-kahadb-store</artifactId>
-            <version>${activemq.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-mqtt</artifactId>
-            <version>${activemq.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-spring</artifactId>
-            <version>${activemq.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.paho</groupId>
@@ -262,7 +256,6 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-server</artifactId>
-            <version>${artemis.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/qa/integration-steps/pom.xml
+++ b/qa/integration-steps/pom.xml
@@ -162,12 +162,10 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>${activemq.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-server</artifactId>
-            <version>${artemis.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.paho</groupId>

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -258,7 +258,6 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>${activemq.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -270,25 +269,21 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-spring</artifactId>
-            <version>${activemq.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-kahadb-store</artifactId>
-            <version>${activemq.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-mqtt</artifactId>
-            <version>${activemq.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-camel</artifactId>
-            <version>${activemq.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -30,6 +30,41 @@
         <module>markers</module>
     </modules>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Activemq -->
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-broker</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-camel</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-kahadb-store</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-mqtt</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-spring</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jms-server</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <profiles>
         <!-- Profile for running integration tests with Kapua infrastructure started
              inside dockerized environment. -->

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -25,27 +25,22 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-moxy</artifactId>
-            <version>2.23.2</version>
         </dependency>
 
         <!-- Apache shiro security framework -->
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-            <version>${shiro.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-web</artifactId>
-            <version>${shiro.version}</version>
         </dependency>
 
-        <!-- Same version of the Servlet APIs supported in Apache Tomcat 8.0.x -->
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -22,6 +22,27 @@
     <artifactId>kapua-rest-api</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <jersey.version>2.23.2</jersey.version>
+        <javax-servlet-api.version>3.1.0</javax-servlet-api.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Moxy for object marshalling unmarshalling -->
+            <dependency>
+                <groupId>org.glassfish.jersey.media</groupId>
+                <artifactId>jersey-media-moxy</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>${javax-servlet-api.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <modules>
         <module>web</module>
         <module>core</module>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -23,8 +23,6 @@
     <packaging>war</packaging>
 
     <properties>
-        <jersey.version>2.23.2</jersey.version>
-        <swagger.version>1.5.12</swagger.version>
         <swagger-ui.version>2.1.4</swagger-ui.version>
     </properties>
 
@@ -134,9 +132,6 @@
             <artifactId>kapua-stream-internal</artifactId>
         </dependency>
 
-        <!-- -->
-        <!-- External Libraries -->
-
         <!-- Jersey -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
@@ -155,27 +150,22 @@
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-moxy</artifactId>
-            <version>2.23.2</version>
         </dependency>
 
         <!-- Apache shiro security framework -->
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-            <version>${shiro.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-web</artifactId>
-            <version>${shiro.version}</version>
         </dependency>
 
-        <!-- Same version of the Servlet APIs supported in Apache Tomcat 8.0.x -->
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -203,27 +193,22 @@
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty3-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>reindex-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>lang-mustache-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>percolator-client</artifactId>
-            <version>${elasticsearch-client-transport.version}</version>
         </dependency>
     </dependencies>
 

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -66,37 +66,15 @@
             <artifactId>kapua-security-certificate-api</artifactId>
         </dependency>
 
-        <!-- -->
         <!-- External dependencies -->
         <dependency>
             <!-- Apache shiro security framework -->
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-            <version>${shiro.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>4.1.3.RELEASE</version>
         </dependency>
-       <!--  <dependency>
-            Json Web Token implementation
-            https://github.com/auth0/java-jwt
-            <groupId>com.auth0</groupId>
-            <artifactId>java-jwt</artifactId>
-            <version>2.2.1</version>
-        </dependency> -->
-        <!-- <dependency>
-            Json Web Token implementation
-            https://github.com/jwtk/jjwt
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt</artifactId>
-            <version>0.7.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.8.2</version>
-        </dependency> -->
     </dependencies>
 </project>

--- a/simulator-kura/pom.xml
+++ b/simulator-kura/pom.xml
@@ -27,6 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.account>kapua</docker.account>
+        <osgi.version>6.0.0</osgi.version>
     </properties>
 
     <dependencies>
@@ -37,7 +38,6 @@
         <dependency>
             <groupId>org.eclipse.neoscada.utils</groupId>
             <artifactId>org.eclipse.scada.utils</artifactId>
-            <version>0.4.0</version>
         </dependency>
 
         <dependency>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
-            <version>6.0.0</version>
+            <version>${osgi.version}</version>
         </dependency>
 
         <dependency>
@@ -137,8 +137,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                    </transformer>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <filters>
                         <filter>


### PR DESCRIPTION
All the dependencies declared in `<dependencyManagement>` with more than one usages have been moved to the root `pom.xml` file or, where appropriate, in a lower level `pom.xml` (e.g. all the dependencies strictly related to the console are declared in `console/pom.xml`; same goes for rest-api and assembly) and their version declared as Maven properties inside the `pom`s.

@ctron, can we also upgrade `org.eclipse.paho:org.eclipse.paho.client.mqttv3` in `kapua-client-gateway-provider-paho` to 1.2.1 as the other paho dependencies we have?
