### PR TITLE
Shiro.ini in broker-core

### DIFF
--- a/broker-core/src/main/resources/shiro.ini
+++ b/broker-core/src/main/resources/shiro.ini
@@ -1,0 +1,60 @@
+# =======================
+# Shiro INI configuration
+# =======================
+
+[main]
+# Objects and their properties are defined here,
+# Such as the securityManager, Realms and anything
+# else needed to build the SecurityManager
+
+#authenticator
+authenticator = org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticator
+securityManager.authenticator = $authenticator
+
+#
+# Auth filters
+# kapuaAuthcAccessToken = org.eclipse.kapua.app.api.auth.KapuaTokenAuthenticationFilter
+
+
+##########
+# Realms #
+##########
+# Login
+kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
+kapuaApiKeyAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.ApiKeyAuthenticatingRealm
+kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+
+# Session
+kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
+
+# Authorization
+kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
+
+securityManager.realms = $kapuaAuthorizingRealm, $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
+
+
+#edcCacheManager = com.eurotech.cloud.commons.service.security.KapuaCacheManager
+#securityManager.cacheManager = $edcCacheManager
+
+# SessionListeners only works with in the native SessionMode
+# This is not the mode we use when running in Tomcat.
+#securityManager.sessionMode = native
+securityManager.sessionManager.globalSessionTimeout = -1
+securityManager.sessionManager.sessionValidationSchedulerEnabled = false
+
+securityManager.subjectDAO.sessionStorageEvaluator.sessionStorageEnabled = false
+
+[users]
+# The 'users' section is for simple deployments
+# when you only need a small number of statically-defined
+# set of User accounts.
+
+[roles]
+# The 'roles' section is for simple deployments
+# when you only need a small number of statically-defined
+# roles.
+
+[urls]
+# The 'urls' section is used for url-based security
+# in web applications.  We'll discuss this section in the
+# Web documentation


### PR DESCRIPTION
After merging #2644, `broker-core` module lost the `shiro.ini` file that came as a dependency from `kapua-secutity-authentication-api`. This PR adds a new `shiro.ini` in `broker-core`.