### PR TITLE
Upgraded jackson-databind version from 2.9.9 to 2.9.9.1 - CVE-2019-12814 - CWE-200; CVE-2019-12384 - CWE-502

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <elasticsearch-netty-3.version>3.10.6.Final</elasticsearch-netty-3.version>
         <elasticsearch-netty-4.version>4.1.15.Final</elasticsearch-netty-4.version>
         <jackson.version>2.9.9</jackson.version> <!-- Elastic Search uses 2.8.6 -->
+        <jackson-databind.version>2.9.9.1</jackson-databind.version> <!-- Elastic Search uses 2.8.6 -->
         <log4j-api.version>2.8.2</log4j-api.version> <!-- same version used by elasticsearch -->
         <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version> <!-- same version used by elasticsearch -->
         <log4j2-mock.version>0.0.1</log4j2-mock.version>
@@ -1435,7 +1436,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR bumps `jackson-databind` to 2.9.9.1 due to CVE-2019-12384 and CVE-2019-12814