### PR TITLE
Upgraded protobuf-java version from 2.6.1 to 3.8.0 - CVE-2015-5237 - CWE-119

### DIFF
--- a/client/gateway/features/karaf/src/main/feature/feature.xml
+++ b/client/gateway/features/karaf/src/main/feature/feature.xml
@@ -27,7 +27,7 @@
         <feature version="${project.version}">kapua-client-gateway</feature>
         <bundle>mvn:${project.groupId}/kapua-client-gateway-profile-kura/${project.version}</bundle>
 
-        <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/2.6.1</bundle>
+        <bundle dependency="true">mvn:com.google.protobuf/protobuf-java/${protobuf.version}</bundle>
     </feature>
 
     <feature name="kapua-client-gateway-provider-mqtt" hidden="true"

--- a/client/gateway/profile/kura/src/main/protobuf/kurapayload.proto
+++ b/client/gateway/profile/kura/src/main/protobuf/kurapayload.proto
@@ -6,6 +6,8 @@
 // To compile:
 // protoc --proto_path=src/main/protobuf --java_out=src/main/java src/main/protobuf/kurapayload.proto
 //
+syntax = "proto2";
+
 package kuradatatypes;
 
 option java_package         = "org.eclipse.kapua.gateway.client.kura.payload";

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <mockito.version>1.10.19</mockito.version>
         <opencsv.version>3.7</opencsv.version>
         <paho.version>1.2.1</paho.version>
-        <protobuf.version>2.6.1</protobuf.version>
+        <protobuf.version>3.8.0</protobuf.version>
         <reflections.version>0.9.10</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.3.2</shiro.version>
@@ -127,7 +127,7 @@
         <karaf-maven-plugin.version>4.1.1</karaf-maven-plugin.version>
         <license-maven-plugin.version>1.9</license-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.5</nexus-staging-maven-plugin.version>
-        <protoc-jar-maven-plugin.version>3.1.0.5</protoc-jar-maven-plugin.version>
+        <protoc-jar-maven-plugin.version>3.8.0</protoc-jar-maven-plugin.version>
         <sql-maven-plugin.version>1.5</sql-maven-plugin.version>
         <surefire.version>2.20</surefire.version>
 

--- a/qa/integration/src/test/protobuf/kurapayload.proto
+++ b/qa/integration/src/test/protobuf/kurapayload.proto
@@ -21,6 +21,8 @@
 //
 // or use maven plugin
 //
+syntax = "proto2";
+
 package kuradatatypes;
 
 option java_package         = "org.eclipse.kura.core.message.protobuf";

--- a/service/device/call/kura/pom.xml
+++ b/service/device/call/kura/pom.xml
@@ -87,7 +87,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>2.6.1</protocVersion>
+                            <protocVersion>${protobuf.version}</protocVersion>
                             <includeStdTypes>true</includeStdTypes>
                             <inputDirectories>
                                 <include>src/main/protobuf</include>

--- a/service/device/call/kura/src/main/protobuf/kurapayload.proto
+++ b/service/device/call/kura/src/main/protobuf/kurapayload.proto
@@ -6,6 +6,8 @@
 // To compile:
 // protoc --proto_path=src/main/protobuf --java_out=src/main/java src/main/protobuf/kurapayload.proto
 //
+syntax = "proto2";
+
 package kuradatatypes;
 
 option java_package         = "org.eclipse.kapua.service.device.call.message.kura.proto";

--- a/simulator-kura/pom.xml
+++ b/simulator-kura/pom.xml
@@ -124,7 +124,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>2.6.1</protocVersion>
+                            <protocVersion>${protobuf.version}</protocVersion>
                             <includeStdTypes>true</includeStdTypes>
                             <inputDirectories>
                                 <include>src/main/protobuf</include>

--- a/simulator-kura/src/main/protobuf/kurapayload.proto
+++ b/simulator-kura/src/main/protobuf/kurapayload.proto
@@ -6,6 +6,8 @@
 // To compile:
 // protoc --proto_path=src/main/protobuf --java_out=src/main/java src/main/protobuf/kurapayload.proto
 //
+syntax = "proto2";
+
 package kuradatatypes;
 
 option java_package         = "org.eclipse.kura.core.message.protobuf";


### PR DESCRIPTION
This PR bumps `protobuf-java` and `protoc-jar-maven-plugin` to 3.8.0 to address CVE-2015-5237