### PR TITLE
Fix limitExceeded on MessageQuery

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -118,6 +118,8 @@ public class DataMessagesJson extends AbstractKapuaResource implements JsonSeria
         result.getItems().forEach(m -> jsonDatastoreMessages.add(new JsonDatastoreMessage(m)));
         JsonMessageListResult jsonResult = new JsonMessageListResult();
         jsonResult.addItems(jsonDatastoreMessages);
+        jsonResult.setTotalCount(result.getTotalCount());
+        jsonResult.setLimitExceeded(result.isLimitExceeded());
         return jsonResult;
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -290,7 +290,10 @@ public final class MessageStoreFacade {
 
         String dataIndexName = SchemaUtil.getDataIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(dataIndexName, MessageSchema.MESSAGE_TYPE_NAME);
-        return new MessageListResultImpl(client.query(typeDescriptor, query, DatastoreMessage.class));
+        MessageListResult result = new MessageListResultImpl(client.query(typeDescriptor, query, DatastoreMessage.class));
+        Integer offset = query.getOffset();
+        result.setLimitExceeded((offset == null ? 0 : offset) + result.getSize() < result.getTotalCount());
+        return result;
     }
 
     /**


### PR DESCRIPTION
After merging #2656, `limitExceeded` was still always set to `false`. This PR aims at fixing it.