### PR TITLE
Added first part of jobEngineService integration tests

### DIFF
--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -39,6 +39,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-engine-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-security-authentication-api</artifactId>
         </dependency>
         <dependency>

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestJAXBContextProvider.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,6 +19,7 @@ import org.eclipse.kapua.broker.core.router.ParentEndPoint;
 import org.eclipse.kapua.broker.core.router.SimpleEndPoint;
 import org.eclipse.kapua.commons.configuration.metatype.TscalarImpl;
 import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
+import org.eclipse.kapua.job.engine.commons.model.JobTargetSublist;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTdesignate;
 import org.eclipse.kapua.model.config.metatype.KapuaTicon;
@@ -41,11 +42,17 @@ import org.eclipse.kapua.service.device.call.kura.model.deploy.KuraBundleInfo;
 import org.eclipse.kapua.service.device.call.kura.model.deploy.KuraDeploymentPackage;
 import org.eclipse.kapua.service.device.call.kura.model.deploy.KuraDeploymentPackages;
 import org.eclipse.kapua.service.device.call.kura.model.snapshot.KuraSnapshotIds;
+import org.eclipse.kapua.service.device.management.asset.DeviceAsset;
+import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundle;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundles;
+import org.eclipse.kapua.service.device.management.command.DeviceCommandInput;
 import org.eclipse.kapua.service.device.management.configuration.DeviceComponentConfiguration;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackages;
+import org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest;
+import org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallRequest;
+import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshots;
 import org.eclipse.kapua.service.job.Job;
 import org.eclipse.kapua.service.job.JobListResult;
@@ -93,11 +100,17 @@ public class TestJAXBContextProvider implements JAXBContextProvider {
                         KuraBundle.class,
                         KuraBundles.class,
                         KuraBundleInfo.class,
+                        DeviceAsset.class,
+                        DeviceAssets.class,
                         DevicePackages.class,
                         DeviceBundle.class,
                         DeviceBundles.class,
+                        DeviceCommandInput.class,
                         DeviceConfiguration.class,
                         DeviceComponentConfiguration.class,
+                        DevicePackageInstallRequest.class,
+                        DevicePackageUninstallRequest.class,
+                        DevicePackageDownloadRequest.class,
                         KuraSnapshotIds.class,
                         DeviceSnapshots.class,
                         // Authorization
@@ -122,6 +135,7 @@ public class TestJAXBContextProvider implements JAXBContextProvider {
                         Job.class,
                         JobListResult.class,
                         JobXmlRegistry.class,
+                        JobTargetSublist.class,
                         // Broker core
                         EndPointContainer.class,
                         SimpleEndPoint.class,

--- a/qa/common/src/main/resources/sql/all_delete.sql
+++ b/qa/common/src/main/resources/sql/all_delete.sql
@@ -50,9 +50,9 @@ DELETE FROM job_job_execution;
 
 DELETE FROM job_job_step;
 
-DELETE FROM job_job_step_definition;
+DELETE FROM job_job_step_definition WHERE id NOT IN (1,2,3,4,5,6,7);
 
-DELETE FROM job_job_step_definition_properties;
+DELETE FROM job_job_step_definition_properties WHERE step_definition_id NOT IN (1,2,3,4,5,6,7);
 
 DELETE FROM job_job_step_properties;
 

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -82,6 +82,26 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-registry-test-steps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-management-bundle-job</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-management-asset-job</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-management-packages-job</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-management-command-job</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-device-management-configuration-job</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/job/RunJobEngineServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/job/RunJobEngineServiceI9nTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.service.job;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = "classpath:features/job/JobEngineServiceOfflineDeviceI9n.feature",
+        glue = { "org.eclipse.kapua.service.job.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.qa.common",
+                "org.eclipse.kapua.service.account.steps",
+                "org.eclipse.kapua.service.device.registry.steps",
+        },
+        plugin = { "pretty",
+                "html:target/cucumber",
+                "json:target/cucumber.json" },
+        strict = true,
+        monochrome = true)
+public class RunJobEngineServiceI9nTest {
+}

--- a/qa/integration/src/test/resources/features/job/JobEngineServiceOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobEngineServiceOfflineDeviceI9n.feature
@@ -1,0 +1,387 @@
+###############################################################################
+# Copyright (c) 2019 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+  @integration
+  @jobs
+  @jobEngineService
+
+  Feature: JobEngineService tests with offline device
+
+    Scenario: Set environment variables
+      Given System property "broker.ip" with value "localhost"
+      And System property "commons.db.connection.host" with value "localhost"
+
+    Scenario: Start event broker for all scenarios
+      Given Start Event Broker
+
+    Scenario: Start broker for all scenarios
+      Given Start Broker
+
+    Scenario: Starting a job with Command Execution step
+      Create a new job and set a disconnected KuraMock device as the job target.
+      Add a new Command Execution step to the created job. Start the job.
+      After the executed job is finished, the executed target's step index should
+      be 0 and the status PROCESS_FAILED.
+
+      Given I start the Kura Mock
+      When Device is connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      When I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock device
+      And I configure the job service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      And I configure the job target service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      And I configure the job step service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      Given I create a job with the name "TestJob"
+      And A new job target item
+      And Search for step definition with the name "Command Execution"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name         | type                                                                    | value                                                                                                                                         |
+        | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+        | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting a job with Asset Write step
+      Create a new job and set a disconnected KuraMock device as the job target.
+      Add a new Asset Write step to the created job. Start the job.
+      After the executed job is finished, the executed target's step index should
+      be 0 and the status PROCESS_FAILED.
+
+      Given I start the Kura Mock
+      When Device is connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      When I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock device
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And A new job target item
+      And Search for step definition with the name "Asset Write"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name    | type                                                           | value                                                                                                                                                                                                                                                   |
+        | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
+        | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                                   |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting a job with Bundle Start step
+      Create a new job and set a disconnected KuraMock device as the job target.
+      Add a new Bundle Start step to the created job. Start the job.
+      After the executed job is finished, the executed target's step index should
+      be 0 and the status PROCESS_FAILED
+
+      Given I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      When I start the Kura Mock
+      And Device is connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      And I get the KuraMock device
+      And Bundles are requested
+      Then A bundle named org.eclipse.kura.camel.sun.misc with id 65 and version 1.0.0 is present and RESOLVED
+      When KuraMock is disconnected
+      And I wait 5 seconds
+      Then Device status is "DISCONNECTED"
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And A new job target item
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 136   |
+        | timeout  | java.lang.Long   | 10000 |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      When I start the Kura Mock
+      And Device is connected
+      And Bundles are requested
+      Then A bundle named org.eclipse.kura.camel.sun.misc with id 65 and version 1.0.0 is present and RESOLVED
+      And KuraMock is disconnected
+      And I logout
+
+    Scenario: Starting a job with Bundle Stop step
+      Create a new job and set a disconnected KuraMock device as the job target.
+      Add a new Bundle Stop step to the created job. Start the job.
+      After the executed job is finished, the executed target's step index should
+      be 0 and the status PROCESS_FAILED
+
+      Given I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      When I start the Kura Mock
+      And Device is connected
+      And I wait 5 seconds
+      And I get the KuraMock device
+      And Bundles are requested
+      And A bundle named org.eclipse.kura.linux.bluetooth with id 63 and version 1.0.7 is present and ACTIVE
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      And I wait 5 seconds
+      Then Device status is "DISCONNECTED"
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And A new job target item
+      And Search for step definition with the name "Bundle Stop"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 63    |
+        | timeout  | java.lang.Long   | 10000 |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      When I start the Kura Mock
+      And Device is connected
+      And Bundles are requested
+      Then A bundle named org.eclipse.kura.linux.bluetooth with id 63 and version 1.0.7 is present and ACTIVE
+      And KuraMock is disconnected
+      And I logout
+
+    Scenario: Starting a job with Configuration Put step
+      Create a new job and set a disconnected KuraMock device as the job target.
+      Add a new Configuration Put step to the created job. Start the job.
+      After the executed job is finished, the executed target's step index should
+      be 0 and the status PROCESS_FAILED
+
+      Given I start the Kura Mock
+      When Device is connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock device
+      And I configure the job service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      And I configure the job target service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      And I configure the job step service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      Given I create a job with the name "TestJob"
+      And A new job target item
+      And Search for step definition with the name "Configuration Put"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+        | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations>|
+        | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting a job with Package Install Command step
+      Create a new job and set a disconnected KuraMock device as the job target.
+      Add a new Package Install Command step to the created job. Start the job.
+      After the executed job is finished, the executed target's step index should
+      be 0 and the status PROCESS_FAILED
+
+      Given I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      When I start the Kura Mock
+      And Device is connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      And I get the KuraMock device
+      And Packages are requested
+      And Number of received packages is 1
+      When KuraMock is disconnected
+      And I wait 5 seconds
+      Then Device status is "DISCONNECTED"
+      And I configure the job service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      And I configure the job target service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      And I configure the job step service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      Given I create a job with the name "TestJob"
+      And A new job target item
+      And Search for step definition with the name "Package Download / Install"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name                     | type                                                                                             | value                                                                                                                                                                                                                                           |
+        | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
+        | timeout                  | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      When I start the Kura Mock
+      And Device is connected
+      And Packages are requested
+      Then Number of received packages is 1
+      And KuraMock is disconnected
+      And I logout
+
+    Scenario: Starting a job with Package Uninstall Command step
+      Create a new job and set a disconnected KuraMock device as the job target.
+      Add a new Package Uninstall Command step to the created job. Start the job.
+      After the executed job is finished, the executed target's step index should
+      be 0 and the status PROCESS_FAILED
+
+      Given I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      Then I start the Kura Mock
+      When Device is connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      And I get the KuraMock device
+      And Packages are requested
+      And Number of received packages is 1
+      And Package named org.eclipse.kura.example.ble.tisensortag with version 1.0.0 is received
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I configure the job service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      And I configure the job target service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      And I configure the job step service
+        | type    | name                       | value |
+        | boolean | infiniteChildEntities      | true  |
+        | integer | maxNumberChildEntities     | 5     |
+      Given I create a job with the name "TestJob"
+      And A new job target item
+      And Search for step definition with the name "Package Uninstall"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name                     | type                                                                                               | value                                                                                                                                                                                                         |
+        | packageUninstallRequest  | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.ble.tisensortag</name><version>1.0.0</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
+        | timeout                  | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                         |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      When I start the Kura Mock
+      And Device is connected
+      And Packages are requested
+      Then Number of received packages is 1
+      And KuraMock is disconnected
+      And I logout
+
+    Scenario: Stop broker after all scenarios
+      Given Stop Broker
+
+    Scenario: Stop event broker for all scenarios
+      Given Stop Event Broker

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -89,14 +89,22 @@
         <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
         <api>org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService</api>
         <api>org.eclipse.kapua.service.device.management.command.DeviceCommandFactory</api>
+        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandInput</api>
         <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService</api>
         <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory</api>
         <api>org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService</api>
         <api>org.eclipse.kapua.service.device.management.packages.DevicePackageFactory</api>
+        <api>org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest</api>
+        <api>org.eclipse.kapua.service.device.management.packages.model.install.DevicePackageInstallRequest</api>
+        <api>org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest</api>
         <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService</api>
         <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory</api>
         <api>org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService</api>
         <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
+        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationService</api>
+        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationFactory</api>
+        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
+        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
 
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
@@ -141,6 +149,9 @@
 
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
+
+        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
+        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>

--- a/service/job/test-steps/pom.xml
+++ b/service/job/test-steps/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-engine-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-security-authentication-api</artifactId>
         </dependency>
         <dependency>

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/TestProcessor.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/TestProcessor.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.steps;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.job.engine.commons.operation.AbstractTargetProcessor;
+import org.eclipse.kapua.job.engine.commons.wrappers.JobTargetWrapper;
+import org.eclipse.kapua.service.job.operation.TargetProcessor;
+import org.eclipse.kapua.service.job.targets.JobTarget;
+
+import javax.batch.runtime.context.JobContext;
+import javax.batch.runtime.context.StepContext;
+import javax.inject.Inject;
+
+public class TestProcessor extends AbstractTargetProcessor implements TargetProcessor {
+
+    @Inject
+    JobContext jobContext;
+
+    @Inject
+    StepContext stepContext;
+
+    @Override
+    protected void initProcessing(JobTargetWrapper wrappedJobTarget) {
+        setContext(jobContext, stepContext);
+    }
+
+    @Override
+    public void processTarget(JobTarget jobTarget) throws KapuaException {
+
+        boolean fail = Boolean.parseBoolean(System.getProperty("testJobDefinitionProcessorFail", "false"));
+
+        if (fail) {
+            throw KapuaException.internalError("This processing has been set to fail");
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Aleksandra Jovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Added first part of jobEngineService integration tests

**Related Issue**
This PR fixes/closes part of issue #2662  

**Description of the solution adopted**
This PR represents the first part of `jobEngineService` integration tests. 
New `JobEngineServiceOfflineDeviceI9n.feature` file was added, as well as the new runner class `RunJobEngineServiceI9nTest`. 
The added scenarios cover the cases for starting a job with an offline device and one target. 
The device used in these tests is the already created KuraMock, which is firstly connected, information gathered and than disconnected. 
The needed step definitions were gathered from the database. For this to work correctly some changes were also made to the `all_delete.sql` file in the `qa.common` package.
Additional dependencies were added to the `pom.xml` and `locator.xml` and `TestJAXBContextProvider` when needed.
New methods/steps were added to `BrokerSteps` and `JobServiceTests` classes.

List of created scenarios:

1. Starting a job with Command Execution step
2. Starting a job with Asset Write step
3. Starting a job with Bundle Start step
4. Starting a job with Bundle Stop step
5. Starting a job with Configuration Put step
6. Starting a job with Package Install Command step
7. Starting a job with Package Uninstall Command step

This PR also contains some changes made by @Coduz  - a new `TestProcessor` class and the updated `prepareDefaultJobStepDefinitionCreator` method of the `JobServiceSteps` class.

**Screenshots**
_None_

**Any side note on the changes made**
_None_
