### PR TITLE
Default sorting for Datastore REST API simple queries

### DIFF
--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
@@ -157,8 +157,6 @@ public class DatastoreMediator implements MessageStoreMediator,
         channelInfo.setFirstMessageId(message.getDatastoreId());
         channelInfo.setFirstMessageOn(message.getTimestamp());
         channelInfo.setId(new StorableIdImpl(ChannelInfoField.getOrDeriveId(null, channelInfo)));
-        clientInfo.setFirstMessageId(message.getDatastoreId());
-        clientInfo.setFirstMessageOn(message.getTimestamp());
         channelInfoStoreFacade.upstore(channelInfo);
 
         KapuaPayload payload = message.getPayload();

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelInfoQueryImpl.java
@@ -11,11 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.model.query;
 
+import java.util.Collections;
+
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.internal.AbstractStorableQuery;
 import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
+import org.eclipse.kapua.service.datastore.internal.schema.ChannelInfoSchema;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
+import org.eclipse.kapua.service.datastore.model.query.SortField;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
 
 /**
@@ -35,6 +39,7 @@ public class ChannelInfoQueryImpl extends AbstractStorableQuery<ChannelInfo> imp
      */
     public ChannelInfoQueryImpl(KapuaId scopeId) {
         super(scopeId);
+        setSortFields(Collections.singletonList(SortField.ascending(ChannelInfoSchema.CHANNEL_NAME)));
     }
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ClientInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ClientInfoQueryImpl.java
@@ -11,11 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.model.query;
 
+import java.util.Collections;
+
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.internal.AbstractStorableQuery;
 import org.eclipse.kapua.service.datastore.internal.mediator.ClientInfoField;
+import org.eclipse.kapua.service.datastore.internal.schema.ClientInfoSchema;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
+import org.eclipse.kapua.service.datastore.model.query.SortField;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
 
 /**
@@ -34,6 +38,7 @@ public class ClientInfoQueryImpl extends AbstractStorableQuery<ClientInfo> imple
      */
     public ClientInfoQueryImpl(KapuaId scopeId) {
         super(scopeId);
+        setSortFields(Collections.singletonList(SortField.ascending(ClientInfoSchema.CLIENT_ID)));
     }
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MessageQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MessageQueryImpl.java
@@ -11,12 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.model.query;
 
+import java.util.Collections;
+
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.internal.AbstractStorableQuery;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.internal.schema.MessageSchema;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
+import org.eclipse.kapua.service.datastore.model.query.SortField;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
 
 /**
@@ -36,6 +39,7 @@ public class MessageQueryImpl extends AbstractStorableQuery<DatastoreMessage> im
      */
     public MessageQueryImpl(KapuaId scopeId) {
         super(scopeId);
+        setSortFields(Collections.singletonList(SortField.descending(MessageSchema.MESSAGE_TIMESTAMP)));
     }
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricInfoQueryImpl.java
@@ -11,11 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.model.query;
 
+import java.util.Collections;
+
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.internal.AbstractStorableQuery;
 import org.eclipse.kapua.service.datastore.internal.mediator.MetricInfoField;
+import org.eclipse.kapua.service.datastore.internal.schema.MetricInfoSchema;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
 import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
+import org.eclipse.kapua.service.datastore.model.query.SortField;
 import org.eclipse.kapua.service.datastore.model.query.StorableFetchStyle;
 
 /**
@@ -34,6 +38,7 @@ public class MetricInfoQueryImpl extends AbstractStorableQuery<MetricInfo> imple
      */
     public MetricInfoQueryImpl(KapuaId scopeId) {
         super(scopeId);
+        setSortFields(Collections.singletonList(SortField.ascending(MetricInfoSchema.METRIC_MTR_NAME_FULL)));
     }
 
     @Override


### PR DESCRIPTION
This PR adds default sorting for the Datastore queries:

- `MessageQueryImpl`: sort by `timestamp DESC`
- `MetricInfoQueryImpl`: sort by `name ASC`
- `ChannelInfoQueryImpl`: sort by `channel ASC`
- `ClientInfoQueryImpl`: sort by `client_id ASC`

**Related Issue**
This PR closes #2665 

