### PR TITLE
Added QA steps and for running dockers and tests on external docker host

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <snakeyaml.version>1.15</snakeyaml.version>
         <swagger.version>1.5.12</swagger.version>
         <cucumber.version>1.2.4</cucumber.version>
+        <spotify.version>8.15.1</spotify.version>
         <elasticsearch.version>5.3.0</elasticsearch.version>
         <elasticsearch-client-transport.version>5.3.0</elasticsearch-client-transport.version>
         <elasticsearch-client-rest.version>5.3.0</elasticsearch-client-rest.version>
@@ -1226,6 +1227,11 @@
                 <groupId>info.cukes</groupId>
                 <artifactId>cucumber-guice</artifactId>
                 <version>${cucumber.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-client</artifactId>
+                <version>${spotify.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>

--- a/qa/integration-steps/pom.xml
+++ b/qa/integration-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -142,6 +142,10 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-client</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/BrokerClient.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/BrokerClient.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.qa.integration.steps;
+
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BrokerClient implements MqttCallback {
+
+    private static final Logger logger = LoggerFactory.getLogger(BrokerClient.class);
+
+    private MqttClient mqttClient;
+
+    private MemoryPersistence persistence;
+
+    private MqttConnectOptions connOpts = new MqttConnectOptions();
+
+    private String broker;
+
+    private int recivedMsgCnt;
+
+    public BrokerClient(String broker, int port, String clientId, String user, String pass) throws MqttException {
+
+        this.broker = "tcp://" + broker + ":" + port;
+        persistence = new MemoryPersistence();
+        mqttClient = new MqttClient(this.broker, clientId, persistence);
+        connOpts.setCleanSession(true);
+        connOpts.setUserName(user);
+        connOpts.setPassword(pass.toCharArray());
+    }
+
+    public void connect() throws MqttException {
+
+        logger.info("Connecting to broker: " + broker);
+        mqttClient.setCallback(this);
+        mqttClient.connect(connOpts);
+        logger.info("Connected");
+    }
+
+    public void disconnect() throws MqttException {
+
+        mqttClient.disconnect(2000);
+    }
+
+    public void subscribe(String topic, int qos) throws MqttException {
+        logger.info("Subscribing to topic: " + topic);
+        mqttClient.subscribe(topic, qos);
+        logger.info("Subscribed to topic: " + topic);
+    }
+
+    public void publish(String topic, int qos, String content) throws MqttException {
+
+        logger.info("Publishing message: " + content);
+        MqttMessage message = new MqttMessage(content.getBytes());
+        message.setQos(qos);
+        mqttClient.publish(topic, message);
+        logger.info("Message published.");
+    }
+
+    public void resetMsgCnt() {
+        recivedMsgCnt = 0;
+    }
+
+    public int getRecivedMsgCnt() {
+        return recivedMsgCnt;
+    }
+
+    @Override
+    public void connectionLost(Throwable throwable) {
+        logger.info("Mqtt subscription connection lost.");
+    }
+
+    @Override
+    public void messageArrived(String s, MqttMessage mqttMessage) throws Exception {
+        logger.info("Mqtt message arrived.");
+        recivedMsgCnt++;
+    }
+
+    @Override
+    public void deliveryComplete(IMqttDeliveryToken iMqttDeliveryToken) {
+        logger.info("Mqtt delivery complete");
+    }
+
+}

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/BrokerConfigData.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/BrokerConfigData.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.qa.integration.steps;
+
+/**
+ * Data object used in Gherkin to create messaging broker.
+ */
+public class BrokerConfigData {
+
+    private String name;
+
+    private String brokerAddress;
+
+    private String brokerIp;
+
+    private String clusterName;
+
+    private int mqttPort;
+
+    private int mqttHostPort;
+
+    private int mqttsPort;
+
+    private int mqttsHostPort;
+
+    private int webPort;
+
+    private int webHostPort;
+
+    private int debugPort;
+
+    private int debugHostPort;
+
+    private int brokerInternalDebugPort;
+
+    private String dockerImage;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getBrokerAddress() {
+        return brokerAddress;
+    }
+
+    public void setBrokerAddress(String brokerAddress) {
+        this.brokerAddress = brokerAddress;
+    }
+
+    public String getBrokerIp() {
+        return brokerIp;
+    }
+
+    public void setBrokerIp(String brokerIp) {
+        this.brokerIp = brokerIp;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    public int getMqttPort() {
+        return mqttPort;
+    }
+
+    public void setMqttPort(int mqttPort) {
+        this.mqttPort = mqttPort;
+    }
+
+    public int getMqttHostPort() {
+        return mqttHostPort;
+    }
+
+    public void setMqttHostPort(int mqttHostPort) {
+        this.mqttHostPort = mqttHostPort;
+    }
+
+    public int getMqttsPort() {
+        return mqttsPort;
+    }
+
+    public void setMqttsPort(int mqttsPort) {
+        this.mqttsPort = mqttsPort;
+    }
+
+    public int getMqttsHostPort() {
+        return mqttsHostPort;
+    }
+
+    public void setMqttsHostPort(int mqttsHostPort) {
+        this.mqttsHostPort = mqttsHostPort;
+    }
+
+    public int getWebPort() {
+        return webPort;
+    }
+
+    public void setWebPort(int webPort) {
+        this.webPort = webPort;
+    }
+
+    public int getWebHostPort() {
+        return webHostPort;
+    }
+
+    public void setWebHostPort(int webHostPort) {
+        this.webHostPort = webHostPort;
+    }
+
+    public int getDebugPort() {
+        return debugPort;
+    }
+
+    public void setDebugPort(int debugPort) {
+        this.debugPort = debugPort;
+    }
+
+    public int getDebugHostPort() {
+        return debugHostPort;
+    }
+
+    public void setDebugHostPort(int debugHostPort) {
+        this.debugHostPort = debugHostPort;
+    }
+
+    public int getBrokerInternalDebugPort() {
+        return brokerInternalDebugPort;
+    }
+
+    public void setBrokerInternalDebugPort(int brokerInternalDebugPort) {
+        this.brokerInternalDebugPort = brokerInternalDebugPort;
+    }
+
+    public String getDockerImage() {
+        return dockerImage;
+    }
+
+    public void setDockerImage(String dockerImage) {
+        this.dockerImage = dockerImage;
+    }
+}

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -1,0 +1,423 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.qa.integration.steps;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.ContainerCreation;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.Image;
+import com.spotify.docker.client.messages.NetworkConfig;
+import com.spotify.docker.client.messages.NetworkCreation;
+import com.spotify.docker.client.messages.PortBinding;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.apache.activemq.command.BrokerInfo;
+import org.eclipse.kapua.qa.common.StepData;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@ScenarioScoped
+public class DockerSteps {
+
+    private static final Logger logger = LoggerFactory.getLogger(DockerSteps.class);
+
+    private static final String NETWORK_PREFIX = "kapua-net";
+
+    private DockerClient docker;
+
+    private NetworkConfig networkConfig;
+
+    private String networkId;
+
+    private boolean debug;
+
+    private List<String> envVar;
+
+    private Map<String, String> containerMap;
+
+    public Map<String, Integer> portMap;
+
+    public Map<String, BrokerInfo> brokerMap;
+
+    private ContainerConfig dbContainerConfig;
+
+    private StepData stepData;
+
+    @Inject
+    public DockerSteps(StepData stepData) {
+
+        this.stepData = stepData;
+        containerMap = new HashMap<>();
+    }
+
+    @Given("^Enable debug$")
+    public void enableDebug() {
+        this.debug = true;
+    }
+
+    @Given("^Disable debug$")
+    public void disableDebug() {
+        this.debug = false;
+    }
+
+    @Before
+    public void setupDockerClient() {
+        logger.info("Creating docker client.");
+        try {
+            docker = DefaultDockerClient.fromEnv().build();
+        } catch (DockerCertificateException e) {
+            logger.error("Could not connect to docker.");
+            throw new RuntimeException("Cannot initialize docker client!", e);
+        }
+    }
+
+    @Given("^Create mqtt \"(.*)\" client for broker \"(.*)\" on port (\\d+) with user \"(.*)\" and pass \"(.*)\"$")
+    public void createMqttClient(String clientId, String broker, int port, String user, String pass) {
+        try {
+            BrokerClient client = new BrokerClient(broker, port, clientId, user, pass);
+            stepData.put(clientId, client);
+        } catch (MqttException e) {
+            logger.error("Error creating mqtt client with id " + clientId, e);
+        }
+    }
+
+    @Given("^Connect to mqtt client \"(.*)\"$")
+    public void connectMqttClient(String clientId) {
+        BrokerClient client = (BrokerClient) stepData.get(clientId);
+        try {
+            client.connect();
+        } catch (MqttException e) {
+            logger.error("Unable to connect to mqtt broker with client " + clientId, e);
+            e.printStackTrace();
+        }
+    }
+
+    @Given("^Disconnect mqtt client \"(.*)\"$")
+    public void disconnectMqttClient(String clientId) {
+        BrokerClient client = (BrokerClient) stepData.get(clientId);
+        try {
+            client.disconnect();
+        } catch (MqttException e) {
+            logger.error("Unable to disconnect from mqtt broker with client " + clientId, e);
+        }
+    }
+
+    @Given("^Subscribe mqtt client \"(.*)\" to topic \"(.*)\"$")
+    public void subscribeMqttClient(String clientId, String topic) {
+        BrokerClient client = (BrokerClient) stepData.get(clientId);
+        try {
+            client.subscribe(topic, 1);
+        } catch (MqttException e) {
+            logger.error("Can not subscribe with client " + clientId);
+        }
+    }
+
+    @Then("^Client \"(.*)\" has (\\d+) messages?.*$")
+    public void clientCountMsg(String clientId, int numMsgs) {
+        BrokerClient client = (BrokerClient) stepData.get(clientId);
+        int receivedMsgs = client.getRecivedMsgCnt();
+        Assert.assertEquals(numMsgs, receivedMsgs);
+    }
+
+    @Given("^Publish string \"(.*)\" to topic \"(.*)\" as client \"(.*)\"")
+    public void publishMqttClient(String message, String topic, String clientId) {
+        BrokerClient client = (BrokerClient) stepData.get(clientId);
+        try {
+            client.publish(topic, 1, message);
+        } catch (MqttException e) {
+            logger.error("Can not publish to topic " + topic);
+        }
+    }
+
+    @Given("^Create network$")
+    public void createNetwork() throws DockerException, InterruptedException {
+        networkConfig = NetworkConfig.builder().name(NETWORK_PREFIX).build();
+        NetworkCreation networkCreation = docker.createNetwork(networkConfig);
+        networkId = networkCreation.id();
+    }
+
+    @Given("^Remove network$")
+    public void removeNetwork() throws DockerException, InterruptedException {
+        docker.removeNetwork(networkId);
+    }
+
+    @Given("^Pull image \"(.*)\"$")
+    public void pullImage(String image) throws DockerException, InterruptedException {
+        docker.pull(image);
+    }
+
+    @Given("^List images by name \"(.*)\"$")
+    public void listImages(String imageName) throws Exception {
+        List<Image> images = docker.listImages(DockerClient.ListImagesParam.byName(imageName));
+        if ((images != null) && (images.size() > 0)) {
+            for (Image image : images) {
+                logger.info("Image: " + image);
+            }
+        } else {
+            logger.info("No docker images found.");
+        }
+    }
+
+    @And("^Start DB container with name \"(.*)\"$")
+    public void startDBContainer(String name) throws DockerException, InterruptedException {
+        logger.info("Starting DB container...");
+        ContainerConfig dbConfig = getDbContainerConfig();
+        ContainerCreation dbContainerCreation = docker.createContainer(dbConfig, name);
+        String containerId = dbContainerCreation.id();
+
+        docker.startContainer(containerId);
+        docker.connectToNetwork(containerId, networkId);
+        containerMap.put("db", containerId);
+        logger.info("DB container started: {}", containerId);
+    }
+
+    @And("^Start ES container with name \"(.*)\"$")
+    public void startESContainer(String name) throws DockerException, InterruptedException {
+        logger.info("Starting ES container...");
+        ContainerConfig esConfig = getEsContainerConfig();
+        ContainerCreation esContainerCreation = docker.createContainer(esConfig, name);
+        String containerId = esContainerCreation.id();
+
+        docker.startContainer(containerId);
+        docker.connectToNetwork(containerId, networkId);
+        containerMap.put("es", containerId);
+        logger.info("ES container started: {}", containerId);
+    }
+
+    @And("^Start EventBroker container with name \"(.*)\"$")
+    public void startEBContainer(String name) throws DockerException, InterruptedException {
+        logger.info("Starting EventBroker container...");
+        ContainerConfig ebConfig = getEventBrokerContainerConfig();
+        ContainerCreation ebContainerCreation = docker.createContainer(ebConfig, name);
+        String containerId = ebContainerCreation.id();
+
+        docker.startContainer(containerId);
+        docker.connectToNetwork(containerId, networkId);
+        containerMap.put(name, containerId);
+        logger.info("EventBroker container started: {}", containerId);
+    }
+
+    @And("^Start Message Broker container$")
+    public void startEBContainer(List<BrokerConfigData> brokerConfigDataList) throws DockerException, InterruptedException {
+        BrokerConfigData bcData = brokerConfigDataList.get(0);
+        logger.info("Starting Message Broker container {}...", bcData.getName());
+        ContainerConfig mbConfig = getBrokerContainerConfig(
+                bcData.getBrokerAddress(), bcData.getBrokerIp(), bcData.getClusterName(), null,
+                bcData.getMqttPort(), bcData.getMqttHostPort(), bcData.getMqttsPort(), bcData.getMqttsHostPort(),
+                bcData.getWebPort(), bcData.getWebHostPort(), bcData.getDebugPort(), bcData.getDebugHostPort(),
+                bcData.getBrokerInternalDebugPort(), bcData.getDockerImage());
+        ContainerCreation mbContainerCreation = docker.createContainer(mbConfig, bcData.getName());
+        String containerId = mbContainerCreation.id();
+
+        docker.startContainer(containerId);
+        docker.connectToNetwork(containerId, networkId);
+        containerMap.put(bcData.getName(), containerId);
+        logger.info("Message Broker {} container started: {}", bcData.getName(), containerId);
+    }
+
+    @Then("^Stop container with name \"(.*)\"$")
+    public void stopContainer(String name) throws DockerException, InterruptedException {
+        logger.info("Stopping container {}...", name);
+        String containerId = containerMap.get(name);
+        docker.stopContainer(containerId, 3);
+        logger.info("Container {} stopped.", name);
+    }
+
+    @Then("^Remove container with name \"(.*)\"$")
+    public void removeContainer(String name) throws DockerException, InterruptedException {
+        logger.info("Removing container {}...", name);
+        String containerId = containerMap.get(name);
+        docker.removeContainer(containerId);
+        logger.info("Container {} removed.", name);
+    }
+
+    /**
+     * Creation of docker container configuration for broker.
+     *
+     * @param brokerAddr
+     * @param brokerIp
+     * @param clusterName
+     * @param controlMessageForwarding
+     * @param mqttPort                 mqtt port on docker
+     * @param mqttHostPort             mqtt port on docker host
+     * @param mqttsPort                mqtts port on docker
+     * @param mqttsHostPort            mqtts port on docker host
+     * @param webPort                  web port on docker
+     * @param webHostPort              web port on docker host
+     * @param debugPort                debug port on docker
+     * @param debugHostPort            debug port on docker host
+     * @param brokerInternalDebugPort
+     * @param dockerImage              full name of image (e.g. "kapua/kapua-broker:1.1.0-SNAPSHOT")
+     * @return Container configuration for specific boroker instance
+     */
+    private ContainerConfig getBrokerContainerConfig(String brokerAddr, String brokerIp,
+            String clusterName,
+            String controlMessageForwarding,
+            int mqttPort, int mqttHostPort,
+            int mqttsPort, int mqttsHostPort,
+            int webPort, int webHostPort,
+            int debugPort, int debugHostPort,
+            int brokerInternalDebugPort,
+            String dockerImage) {
+
+        final Map<String, List<PortBinding>> portBindings = new HashMap<>();
+        addHostPort("0.0.0.0", portBindings, mqttPort, mqttHostPort);
+        addHostPort("0.0.0.0", portBindings, mqttsPort, mqttsHostPort);
+        addHostPort("0.0.0.0", portBindings, webPort, webHostPort);
+        addHostPort("0.0.0.0", portBindings, debugPort, debugHostPort);
+
+        final HostConfig hostConfig = HostConfig.builder().portBindings(portBindings).build();
+
+        List<String> envVars = Lists.newArrayList("commons.db.schema.update=true",
+                "commons.db.connection.host=db",
+                "commons.db.connection.port=3306",
+                "datastore.elasticsearch.nodes=es",
+                "datastore.elasticsearch.port=9200",
+                "datastore.client.class=org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient",
+                "commons.eventbus.url=failover:(amqp://events-broker:5672)?jms.sendTimeout=1000",
+                "certificate.jwt.private.key=file:///var/opt/activemq/key.pk8",
+                "certificate.jwt.certificate=file:///var/opt/activemq/cert.pem",
+                String.format("broker.ip=%s", brokerIp));
+        if (envVar != null) {
+            envVars.addAll(envVar);
+        }
+
+        if (debug) {
+            envVars.add(String.format("ACTIVEMQ_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%s", brokerInternalDebugPort));
+        }
+
+        if (!Strings.isNullOrEmpty(clusterName)) {
+            envVars.add(String.format("cluster.name=%s", clusterName));
+        }
+
+        if (!Strings.isNullOrEmpty(controlMessageForwarding)) {
+            envVars.add(String.format("cluster.control_message_forwarding=%s", controlMessageForwarding));
+        }
+
+        String[] ports = {
+                String.valueOf(mqttPort),
+                String.valueOf(mqttsPort),
+                String.valueOf(webPort),
+                String.valueOf(debugPort)
+        };
+
+        return ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .exposedPorts(ports)
+                .env(envVars)
+                .image(dockerImage)
+                .build();
+    }
+
+    /**
+     * Creation of docker container configuration for H2 database.
+     *
+     * @return Container configuration for database instance.
+     */
+    private ContainerConfig getDbContainerConfig() {
+        final int dbPort = 3306;
+        final Map<String, List<PortBinding>> portBindings = new HashMap<>();
+        addHostPort("0.0.0.0", portBindings, dbPort, dbPort);
+        final HostConfig hostConfig = HostConfig.builder().portBindings(portBindings).build();
+
+        return ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .exposedPorts(String.valueOf(dbPort))
+                .env(
+                        "DATABASE=kapuadb",
+                        "DB_USER=kapua",
+                        "DB_PASSWORD=kapua",
+                        "DB_PORT_3306_TCP_PORT=3306"
+                )
+                .image("kapua/kapua-sql:1.1.0-SNAPSHOT")
+                .build();
+    }
+
+    /**
+     * Creation of docker container configuration for Elasticsearch.
+     *
+     * @return Container configuration for Elasticsearch instance.
+     */
+    private ContainerConfig getEsContainerConfig() {
+        final int esPortRest = 9200;
+        final int esPortNodes = 9300;
+        final Map<String, List<PortBinding>> portBindings = new HashMap<>();
+        addHostPort("0.0.0.0", portBindings, esPortRest, esPortRest);
+        addHostPort("0.0.0.0", portBindings, esPortNodes, esPortNodes);
+        final HostConfig hostConfig = HostConfig.builder().portBindings(portBindings).build();
+
+        return ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .exposedPorts(String.valueOf(esPortRest), String.valueOf(esPortNodes))
+                .image("elasticsearch:5.4.0")
+                .cmd(
+                        "-Ecluster.name=kapua-datastore",
+                        "-Ediscovery.type=single-node",
+                        "-Etransport.host=0.0.0.0 ",
+                        "-Etransport.ping_schedule=-1 ",
+                        "-Etransport.tcp.connect_timeout=30s"
+                )
+                .build();
+    }
+
+    /**
+     * Creation of docker container configuration for event broker.
+     *
+     * @return Container configuration for event broker instance.
+     */
+    private ContainerConfig getEventBrokerContainerConfig() {
+        final int brokerPort = 5672;
+        final Map<String, List<PortBinding>> portBindings = new HashMap<>();
+        addHostPort("0.0.0.0", portBindings, brokerPort, brokerPort);
+        final HostConfig hostConfig = HostConfig.builder().portBindings(portBindings).build();
+
+        return ContainerConfig.builder()
+                .hostConfig(hostConfig)
+                .exposedPorts(String.valueOf(brokerPort))
+                .image("kapua/kapua-events-broker:1.1.0-SNAPSHOT")
+                .build();
+    }
+
+    /**
+     * Add docker port to host port mapping.
+     *
+     * @param host         ip address of host
+     * @param portBindings list ob bindings that gets updated
+     * @param port         docker port
+     * @param hostPort     port on host
+     */
+    private void addHostPort(String host, Map<String, List<PortBinding>> portBindings,
+            int port, int hostPort) {
+
+        List<PortBinding> hostPorts = new ArrayList<>();
+        hostPorts.add(PortBinding.of(host, hostPort));
+        portBindings.put(String.valueOf(port), hostPorts);
+    }
+
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/docker/RunDockerBrokerTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/docker/RunDockerBrokerTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.kapua.integration.docker;
 
 import cucumber.api.CucumberOptions;
-import org.eclipse.kapua.qa.common.cucumber.CucumberProperty;
 import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
@@ -27,17 +26,17 @@ import org.junit.runner.RunWith;
                 "json:target/DockerBroker_cucumber.json"
         },
         monochrome = true)
-@CucumberProperty(key="DOCKER_HOST", value= "127.0.0.1")
+//@CucumberProperty(key="DOCKER_HOST", value= "127.0.0.1")
 //@CucumberProperty(key="DOCKER_CERT_PATH", value= "...")
-@CucumberProperty(key="commons.db.schema.update", value= "true")
-@CucumberProperty(key="commons.db.connection.host", value= "db")
-@CucumberProperty(key="commons.db.connection.port", value= "3306")
-@CucumberProperty(key="datastore.elasticsearch.nodes", value= "es")
-@CucumberProperty(key="datastore.elasticsearch.port", value= "9200")
-@CucumberProperty(key="datastore.client.class", value= "org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
-@CucumberProperty(key="commons.eventbus.url", value= "failover:(amqp://events-broker:5672)?jms.sendTimeout=1000")
-@CucumberProperty(key="certificate.jwt.private.key", value= "file:///var/opt/activemq/key.pk8")
-@CucumberProperty(key="certificate.jwt.certificate", value= "file:///var/opt/activemq/cert.pem")
-@CucumberProperty(key="broker.ip", value= "broker")
+//@CucumberProperty(key="commons.db.schema.update", value= "true")
+//@CucumberProperty(key="commons.db.connection.host", value= "db")
+//@CucumberProperty(key="commons.db.connection.port", value= "3306")
+//@CucumberProperty(key="datastore.elasticsearch.nodes", value= "es")
+//@CucumberProperty(key="datastore.elasticsearch.port", value= "9200")
+//@CucumberProperty(key="datastore.client.class", value= "org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+//@CucumberProperty(key="commons.eventbus.url", value= "failover:(amqp://events-broker:5672)?jms.sendTimeout=1000")
+//@CucumberProperty(key="certificate.jwt.private.key", value= "file:///var/opt/activemq/key.pk8")
+//@CucumberProperty(key="certificate.jwt.certificate", value= "file:///var/opt/activemq/cert.pem")
+//@CucumberProperty(key="broker.ip", value= "broker")
 public class RunDockerBrokerTest {
 }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/docker/RunDockerBrokerTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/docker/RunDockerBrokerTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kapua.integration.docker;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.qa.common.cucumber.CucumberProperty;
+import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = "classpath:features/docker/broker.feature",
+        glue = {"org.eclipse.kapua.qa.common",
+                "org.eclipse.kapua.qa.integration.steps"
+        },
+        plugin = { "pretty",
+                "html:target/cucumber/DockerBroker",
+                "json:target/DockerBroker_cucumber.json"
+        },
+        monochrome = true)
+@CucumberProperty(key="DOCKER_HOST", value= "127.0.0.1")
+//@CucumberProperty(key="DOCKER_CERT_PATH", value= "...")
+@CucumberProperty(key="commons.db.schema.update", value= "true")
+@CucumberProperty(key="commons.db.connection.host", value= "db")
+@CucumberProperty(key="commons.db.connection.port", value= "3306")
+@CucumberProperty(key="datastore.elasticsearch.nodes", value= "es")
+@CucumberProperty(key="datastore.elasticsearch.port", value= "9200")
+@CucumberProperty(key="datastore.client.class", value= "org.eclipse.kapua.service.datastore.client.rest.RestDatastoreClient")
+@CucumberProperty(key="commons.eventbus.url", value= "failover:(amqp://events-broker:5672)?jms.sendTimeout=1000")
+@CucumberProperty(key="certificate.jwt.private.key", value= "file:///var/opt/activemq/key.pk8")
+@CucumberProperty(key="certificate.jwt.certificate", value= "file:///var/opt/activemq/cert.pem")
+@CucumberProperty(key="broker.ip", value= "broker")
+public class RunDockerBrokerTest {
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/account/RunAccountServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/account/RunAccountServiceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.integration.service.account;
 
 import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.qa.common.cucumber.CucumberProperty;
 import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
 import org.junit.runner.RunWith;
 
@@ -30,4 +31,16 @@ import org.junit.runner.RunWith;
                  },
         strict = true,
         monochrome = true)
+@CucumberProperty(key="DOCKER_HOST", value= "")
+@CucumberProperty(key="DOCKER_CERT_PATH", value= "")
+@CucumberProperty(key="commons.db.schema.update", value= "")
+@CucumberProperty(key="commons.db.connection.host", value= "")
+@CucumberProperty(key="commons.db.connection.port", value= "")
+@CucumberProperty(key="datastore.elasticsearch.nodes", value= "")
+@CucumberProperty(key="datastore.elasticsearch.port", value= "")
+@CucumberProperty(key="datastore.client.class", value= "")
+@CucumberProperty(key="commons.eventbus.url", value= "")
+@CucumberProperty(key="certificate.jwt.private.key", value= "")
+@CucumberProperty(key="certificate.jwt.certificate", value= "")
+@CucumberProperty(key="broker.ip", value= "")
 public class RunAccountServiceI9nTest {}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLDeviceManageI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLDeviceManageI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,8 +32,19 @@ import org.junit.runner.RunWith;
         },
         strict = true,
         monochrome = true )
+@CucumberProperty(key="kapua.config.url", value="")
+@CucumberProperty(key="DOCKER_HOST", value= "")
+@CucumberProperty(key="DOCKER_CERT_PATH", value= "")
+@CucumberProperty(key="commons.db.schema.update", value= "")
+@CucumberProperty(key="commons.db.connection.host", value= "")
+@CucumberProperty(key="commons.db.connection.port", value= "")
+@CucumberProperty(key="datastore.elasticsearch.nodes", value= "")
+@CucumberProperty(key="datastore.elasticsearch.port", value= "")
+@CucumberProperty(key="datastore.client.class", value= "")
+@CucumberProperty(key="commons.eventbus.url", value= "")
+@CucumberProperty(key="certificate.jwt.private.key", value= "")
+@CucumberProperty(key="certificate.jwt.certificate", value= "")
 @CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="3")
 @CucumberProperty(key="broker.ip", value="192.168.33.10")
-@CucumberProperty(key="kapua.config.url", value="")
 public class RunBrokerACLDeviceManageI9nTest {
 }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,21 +19,32 @@ import org.junit.runner.RunWith;
 @RunWith(CucumberWithProperties.class)
 @CucumberOptions(
         features = {"classpath:features/broker/acl/BrokerACLI9n.feature"
-                   },
+        },
         glue = {"org.eclipse.kapua.qa.common",
                 "org.eclipse.kapua.service.account.steps",
                 "org.eclipse.kapua.service.user.steps",
                 "org.eclipse.kapua.service.tag.steps",
                 "org.eclipse.kapua.service.device.registry.steps"
-               },
-        plugin = {"pretty", 
-                  "html:target/cucumber/BrokerACLI9n",
-                  "json:target/BrokerACLI9n_cucumber.json"
-                 },
+        },
+        plugin = {"pretty",
+                "html:target/cucumber/BrokerACLI9n",
+                "json:target/BrokerACLI9n_cucumber.json"
+        },
         strict = true,
         monochrome = true )
+@CucumberProperty(key="kapua.config.url", value="")
+@CucumberProperty(key="DOCKER_HOST", value= "")
+@CucumberProperty(key="DOCKER_CERT_PATH", value= "")
+@CucumberProperty(key="commons.db.schema.update", value= "")
+@CucumberProperty(key="commons.db.connection.host", value= "")
+@CucumberProperty(key="commons.db.connection.port", value= "")
+@CucumberProperty(key="datastore.elasticsearch.nodes", value= "")
+@CucumberProperty(key="datastore.elasticsearch.port", value= "")
+@CucumberProperty(key="datastore.client.class", value= "")
+@CucumberProperty(key="commons.eventbus.url", value= "")
+@CucumberProperty(key="certificate.jwt.private.key", value= "")
+@CucumberProperty(key="certificate.jwt.certificate", value= "")
 @CucumberProperty(key="org.eclipse.kapua.qa.broker.extraStartupDelay", value="3")
 @CucumberProperty(key="broker.ip", value="192.168.33.10")
-@CucumberProperty(key="kapua.config.url", value="")
 public class RunBrokerACLI9nTest {
 }

--- a/qa/integration/src/test/resources/features/docker/broker.feature
+++ b/qa/integration/src/test/resources/features/docker/broker.feature
@@ -1,0 +1,57 @@
+###############################################################################
+# Copyright (c) 2019 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@docker
+Feature: Testing docker steps
+  Test that documents functionality of docker steps.
+
+  Scenario: Execute possible docker steps to show its usage
+    For now it only lists docker images
+
+    Given List images by name "kapua/kapua-broker:1.1.0-SNAPSHOT"
+    #And Pull image "kapua/kapua-sql:1.1.0-SNAPSHOT"
+    And Pull image "elasticsearch:5.4.0"
+    Then Create network
+    And Start DB container with name "db"
+    And Start ES container with name "es"
+    And Start EventBroker container with name "events-broker"
+    Then I wait 15 seconds
+    And Start Message Broker container
+      | name     | brokerAddress  | brokerIp | clusterName  | mqttPort | mqttHostPort | mqttsPort | mqttsHostPort | webPort | webHostPort | debugPort | debugHostPort | brokerInternalDebugPort| dockerImage |
+      | broker-1 | broker1         | 0.0.0.0  | test-cluster | 1883     | 1883         | 8883      | 8883          | 8161    | 8161        | 9999      | 9999          | 9991                   | kapua/kapua-broker:1.1.0-SNAPSHOT |
+    And Start Message Broker container
+      | name     | brokerAddress  | brokerIp | clusterName  | mqttPort | mqttHostPort | mqttsPort | mqttsHostPort | webPort | webHostPort | debugPort | debugHostPort | brokerInternalDebugPort| dockerImage |
+      | broker-2 | broker2        | 0.0.0.0  | test-cluster | 1883     | 1884         | 8883      | 8884          | 8161    | 8162        | 9999      | 9998          | 9991                   | kapua/kapua-broker:1.1.0-SNAPSHOT |
+    Then I wait 30 seconds
+    And Create mqtt "client-1" client for broker "0.0.0.0" on port 1883 with user "kapua-sys" and pass "kapua-password"
+    And Connect to mqtt client "client-1"
+    And Subscribe mqtt client "client-1" to topic "#"
+    And Create mqtt "client-2" client for broker "0.0.0.0" on port 1884 with user "kapua-sys" and pass "kapua-password"
+    And Connect to mqtt client "client-2"
+    And Subscribe mqtt client "client-2" to topic "#"
+    And Publish string "foo" to topic "$EDC/kapua-sys/kapua-sys/topic/1" as client "client-1"
+    And I wait 5 seconds
+    Then Client "client-1" has 1 message
+    # Uncomment this step to prove broker cluster is working.
+    #And Client "client-2" has 1 message
+    And Disconnect mqtt client "client-1"
+    And I wait 15 seconds
+    Then Stop container with name "broker-2"
+    And Remove container with name "broker-2"
+    And Stop container with name "broker-1"
+    And Remove container with name "broker-1"
+    And Stop container with name "events-broker"
+    And Remove container with name "events-broker"
+    And Stop container with name "es"
+    And Remove container with name "es"
+    And Stop container with name "db"
+    And Remove container with name "db"
+    And Remove network


### PR DESCRIPTION
This feature provides functionality of starting / stopping - managing
docker containers during integration test execution.

Example is broker.feature scenario where multiple docker containers are
started for broker.

Signed-off-by: Uros Mesaric Kunst <uros.mesaric-kunst@comtrade.com>

**Related Issue**
This is new feature proposal and has no issue opened.
Kapua CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20482

**Description of the solution adopted**
Cucumber steps are provided to manage external docker host, so that containers can
be started and stopped during testing scenarios.

**Screenshots**
Not applicable.

**Any side note on the changes made**
I introduced new dependency that has to be checked and possible CQ opened.
```
        <dependency>
            <groupId>com.spotify</groupId>
            <artifactId>docker-client</artifactId>
            <version>8.15.1</version>
       </dependency>
```