### PR TITLE
Filter messages according to metrics in Data view

### DIFF
--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
@@ -64,6 +64,7 @@ import org.eclipse.kapua.service.datastore.model.query.ChannelMatchPredicate;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
+import org.eclipse.kapua.service.datastore.model.query.OrPredicate;
 import org.eclipse.kapua.service.datastore.model.query.RangePredicate;
 import org.eclipse.kapua.service.datastore.model.query.SortDirection;
 import org.eclipse.kapua.service.datastore.model.query.SortField;
@@ -442,6 +443,13 @@ public class GwtDataServiceImpl extends KapuaRemoteServiceServlet implements Gwt
         }
         RangePredicate dateRangePredicate = STORABLE_PREDICATE_FACTORY.newRangePredicate(MessageField.TIMESTAMP.field(), startDate, endDate);
         andPredicate.getPredicates().add(dateRangePredicate);
+        if (headers != null) {
+            OrPredicate metricsPredicate = STORABLE_PREDICATE_FACTORY.newOrPredicate();
+            for (GwtHeader header : headers) {
+                metricsPredicate.getPredicates().add(STORABLE_PREDICATE_FACTORY.newExistsPredicate(String.format(MessageSchema.MESSAGE_METRICS + ".%s", header.getName())));
+            }
+            andPredicate.getPredicates().add(metricsPredicate);
+        }
         query.setPredicate(andPredicate);
         if (!StringUtils.isEmpty(loadConfig.getSortField())) {
             String sortField = loadConfig.getSortField();

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/OrPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/OrPredicate.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.model.query;
+
+import java.util.List;
+
+/**
+ * Query "or" aggregation definition
+ *
+ * @since 1.0
+ */
+public interface OrPredicate extends StorablePredicate {
+
+    /**
+     * Get the {@link StorablePredicate} list
+     *
+     * @return
+     */
+    List<StorablePredicate> getPredicates();
+}

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
@@ -77,4 +77,7 @@ public interface StorablePredicateFactory extends KapuaObjectFactory {
      * @return The newly instantiated {@link ExistsPredicate}.
      */
     ExistsPredicate newExistsPredicate(String fieldName);
+
+    OrPredicate newOrPredicate();
+
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/OrPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/OrPredicateImpl.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal.model.query;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.kapua.service.datastore.client.DatamodelMappingException;
+import org.eclipse.kapua.service.datastore.internal.schema.SchemaUtil;
+import org.eclipse.kapua.service.datastore.model.query.OrPredicate;
+import org.eclipse.kapua.service.datastore.model.query.StorablePredicate;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Implementation of query "or" aggregation
+ *
+ * @since 1.0
+ */
+public class OrPredicateImpl implements OrPredicate {
+
+    private List<StorablePredicate> predicates = new ArrayList<StorablePredicate>();
+
+    /**
+     * Default constructor
+     */
+    public OrPredicateImpl() {
+    }
+
+    /**
+     * Creates an "or" predicate for the given predicates collection
+     *
+     * @param predicates
+     */
+    public OrPredicateImpl(Collection<StorablePredicate> predicates) {
+        predicates.addAll(predicates);
+    }
+
+    @Override
+    public List<StorablePredicate> getPredicates() {
+        return this.predicates;
+    }
+
+    /**
+     * Add the storable predicate to the predicates collection
+     *
+     * @param predicate
+     * @return
+     */
+    public OrPredicate addPredicate(StorablePredicate predicate) {
+        this.predicates.add(predicate);
+        return this;
+
+    }
+
+    /**
+     * Clear the predicates collection
+     *
+     * @return
+     */
+    public OrPredicate clearPredicates() {
+        this.predicates.clear();
+        return this;
+    }
+
+    @Override
+    public ObjectNode toSerializedMap() throws DatamodelMappingException {
+        ObjectNode rootNode = SchemaUtil.getObjectNode();
+        ObjectNode termNode = SchemaUtil.getObjectNode();
+        ArrayNode conditionsNode = SchemaUtil.getArrayNode();
+        for (StorablePredicate predicate : predicates) {
+            conditionsNode.add(predicate.toSerializedMap());
+        }
+        termNode.set(PredicateConstants.SHOULD_KEY, conditionsNode);
+        rootNode.set(PredicateConstants.BOOL_KEY, termNode);
+        return rootNode;
+    }
+
+}

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/PredicateConstants.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/PredicateConstants.java
@@ -44,6 +44,11 @@ public interface PredicateConstants {
     String MUST_KEY = "must";
 
     /**
+     * Must term
+     */
+    String SHOULD_KEY = "should";
+
+    /**
      * Prefix term
      */
     String PREFIX_KEY = "prefix";

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorablePredicateFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorablePredicateFactoryImpl.java
@@ -16,6 +16,7 @@ import org.eclipse.kapua.service.datastore.model.query.AndPredicate;
 import org.eclipse.kapua.service.datastore.model.query.ChannelMatchPredicate;
 import org.eclipse.kapua.service.datastore.model.query.ExistsPredicate;
 import org.eclipse.kapua.service.datastore.model.query.MetricPredicate;
+import org.eclipse.kapua.service.datastore.model.query.OrPredicate;
 import org.eclipse.kapua.service.datastore.model.query.RangePredicate;
 import org.eclipse.kapua.service.datastore.model.query.StorableField;
 import org.eclipse.kapua.service.datastore.model.query.StorablePredicateFactory;
@@ -52,6 +53,11 @@ public class StorablePredicateFactoryImpl implements StorablePredicateFactory {
     @Override
     public ExistsPredicate newExistsPredicate(String fieldName) {
         return new ExistsPredicateImpl(fieldName);
+    }
+
+    @Override
+    public OrPredicate newOrPredicate() {
+        return new OrPredicateImpl();
     }
 
 }


### PR DESCRIPTION
Currently, messages in Data View are not filtered by metrics: when selecting only some of the checkboxes, while only the selected metrics are correctly added as columns in the result grid, the the messages are not filtered according to them -- meaning that non relevant messages (i.e. messages without the desired metrics) are added to the results anyway. This PR adds the missing metrics filter.

**Related Issue**
This PR fixes #1687 

**Description of the solution adopted**
A new `OrPredicate` has been implemented for Storable queries