### PR TITLE
Added second part of jobEngineService integration tests

### DIFF
--- a/qa/integration/src/test/resources/features/job/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -12,8 +12,9 @@
   @integration
   @jobs
   @jobEngineService
+  @jobEngineStartOfflineDevice
 
-  Feature: JobEngineService tests with offline device
+  Feature: JobEngineService tests for starting job with offline device
 
     Scenario: Set environment variables
       Given System property "broker.ip" with value "localhost"
@@ -36,7 +37,7 @@
       be 0 and the status PROCESS_FAILED.
 
       Given I start the Kura Mock
-      When Device is connected
+      When Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
@@ -83,7 +84,7 @@
       be 0 and the status PROCESS_FAILED.
 
       Given I start the Kura Mock
-      When Device is connected
+      When Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
@@ -132,7 +133,7 @@
       Given I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       And I get the KuraMock device
@@ -171,7 +172,7 @@
       And I search for the last job target in the database
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
@@ -188,7 +189,7 @@
       Given I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And I wait 1 seconds
       And I get the KuraMock device
       And Bundles are requested
@@ -227,7 +228,7 @@
       And I search for the last job target in the database
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And Bundles are requested
       And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
       When KuraMock is disconnected
@@ -242,7 +243,7 @@
       be 0 and the status PROCESS_FAILED
 
       Given I start the Kura Mock
-      When Device is connected
+      When Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
@@ -291,7 +292,7 @@
       Given I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       And I get the KuraMock device
@@ -330,7 +331,7 @@
       And I search for the last job target in the database
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And Packages are requested
       Then Number of received packages is 1
       When KuraMock is disconnected
@@ -347,7 +348,7 @@
       Given I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       Then I start the Kura Mock
-      When Device is connected
+      When Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       And I get the KuraMock device
@@ -385,9 +386,10 @@
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
+      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And Packages are requested
       Then Number of received packages is 1
       When KuraMock is disconnected
@@ -531,7 +533,7 @@
       Given I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       And I get the KuraMock device
@@ -577,7 +579,7 @@
       And I search for the last job target in the database
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
@@ -595,7 +597,7 @@
       Given I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And I wait 1 seconds
       And I get the KuraMock device
       And Bundles are requested
@@ -640,7 +642,7 @@
       And I search for the last job target in the database
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And Bundles are requested
       And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
       And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
@@ -719,7 +721,7 @@
       Given I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       And I get the KuraMock device
@@ -766,7 +768,7 @@
       And I search for the last job target in the database
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
       And Packages are requested
       Then Number of received packages is 1
       And Bundles are requested
@@ -785,7 +787,7 @@
       Given I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       Then I start the Kura Mock
-      When Device is connected
+      When Device "is" connected
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       And I get the KuraMock device
@@ -833,14 +835,767 @@
       And I search for the last job target in the database
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
-      And Device is connected
+      And Device "is" connected
+      And Packages are requested
+      Then Number of received packages is 1
+      And KuraMock is disconnected
+      And I logout
+
+    # *****************************************************
+    # * Starting a job with multiple Targets and one Step *
+    # *****************************************************
+
+    Scenario: Starting job with Bundle Start step and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Bundle Start step to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 136   |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Bundle Stop step and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Bundle Stop step to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Bundle Stop"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 136   |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Package Download/Install step and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Package Install step to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      And I get the KuraMock devices
+      And Packages are requested
+      And Number of received packages is 1
+      When KuraMock is disconnected
+      And I wait 5 seconds
+      Then Device status is "DISCONNECTED"
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Package Download / Install"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
+        | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
+        | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I add 2 devices to Kura Mock
+      And Devices "are" connected
+      And Packages are requested
+      Then Number of received packages is 1
+      And KuraMock is disconnected
+      And I logout
+
+    Scenario: Starting job with Package Uninstall step and multiple device
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Package Uninstall step to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Package Uninstall"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name                    | type                                                                                               | value                                                                                                                                                                         |
+        | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>heater</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>30000</rebootDelay></uninstallRequest> |
+        | timeout                 | java.lang.Long                                                                                     | 30000                                                                                                                                                                         |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 15 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 15 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Asset Write step and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Asset Write step to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Asset Write"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name    | type                                                           | value                                                                                                                                                                                                                                                   |
+        | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
+        | timeout | java.lang.Long                                                 | 50000                                                                                                                                                                                                                                                   |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Configuration Put step and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Configuration Put step to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Configuration Put"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+        | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
+        | timeout       | java.lang.Long                                                                | 50000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Command Execution step and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Command Execution step to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Command Execution"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name         | type                                                                   | value                                                                                                                                         |
+        | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+        | timeout      | java.lang.Long                                                         | 50000                                                                                                                                         |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    # ***********************************************************
+    # * Starting a job with multiple Targets and multiple Steps *
+    # ***********************************************************
+
+    Scenario: Starting job with two Bundle Start steps and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a two Bundle Start steps to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 136   |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep1" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 36    |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And I search the database for created job steps and I find 2
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Bundle Stop and Bundle Start step and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Bundle Stop and Bundle Start step to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Bundle Stop"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 136   |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep1" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 36    |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And I search the database for created job steps and I find 2
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Package Download/Install and Bundle Start steps and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Package Install and Bundle Start steps to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      And I get the KuraMock devices
+      And Packages are requested
+      And Number of received packages is 1
+      When KuraMock is disconnected
+      And I wait 5 seconds
+      Then Device status is "DISCONNECTED"
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Package Download / Install"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
+        | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
+        | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
+      When I create a new step entity from the existing creator
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep1" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 36    |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And I search the database for created job steps and I find 2
+      Then No exception was thrown
+      And I start a job
+      And I wait 5 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I add 2 devices to Kura Mock
+      And Device "are" connected
       And Packages are requested
       Then Number of received packages is 1
       And Bundles are requested
-      And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+      And I logout
+
+    Scenario: Starting job with Package Uninstall and Bundle start steps and multiple device
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Package Uninstall and Bundle Start steps to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
       When KuraMock is disconnected
-      And I wait 1 seconds
-      And Device status is "DISCONNECTED"
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Package Uninstall"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name                    | type                                                                                               | value                                                                                                                                                                         |
+        | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>heater</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>30000</rebootDelay></uninstallRequest> |
+        | timeout                 | java.lang.Long                                                                                     | 30000                                                                                                                                                                         |
+      When I create a new step entity from the existing creator
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep1" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 36    |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And I search the database for created job steps and I find 2
+      Then No exception was thrown
+      And I start a job
+      And I wait 15 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 15 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Asset Write and Bundle Start steps and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Asset Write and Bundle Start steps to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Asset Write"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name    | type                                                           | value                                                                                                                                                                                                                                                   |
+        | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
+        | timeout | java.lang.Long                                                 | 50000                                                                                                                                                                                                                                                   |
+      When I create a new step entity from the existing creator
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep1" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 36    |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And I search the database for created job steps and I find 2
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Configuration Put and Bundle Start steps and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Configuration Put and BundleStart steps to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Configuration Put"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+        | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
+        | timeout       | java.lang.Long                                                                | 50000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+      When I create a new step entity from the existing creator
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep1" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 36    |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And I search the database for created job steps and I find 2
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
+      And I logout
+
+    Scenario: Starting job with Command Execution and Bundle Start steps and multiple devices
+    Create a new job. Set a disconnected Kura Mock devices as a job targets.
+    Add a new Command Execution and Bundle Start steps to the created job. Start the job.
+    After the executed job is finished, the step index of executed targets should
+    be 0 and the status PROCESS_FAILED
+
+      Given I add 2 devices to Kura Mock
+      When Devices "are" connected
+      And I wait 5 seconds
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      Then Device status is "DISCONNECTED"
+      And I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock devices
+      And I configure the job service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job target service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      And I configure the job step service
+        | type    | name                   | value |
+        | boolean | infiniteChildEntities  | true  |
+        | integer | maxNumberChildEntities | 5     |
+      Given I create a job with the name "TestJob"
+      And I add targets to job
+      When I count the targets in the current scope
+      Then I count 2
+      And Search for step definition with the name "Command Execution"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name         | type                                                                   | value                                                                                                                                         |
+        | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+        | timeout      | java.lang.Long                                                         | 50000                                                                                                                                         |
+      When I create a new step entity from the existing creator
+      And Search for step definition with the name "Bundle Start"
+      And A regular step creator with the name "TestStep1" and the following properties
+        | name     | type             | value |
+        | bundleId | java.lang.String | 36    |
+        | timeout  | java.lang.Long   | 50000 |
+      When I create a new step entity from the existing creator
+      And I search the database for created job steps and I find 2
+      Then No exception was thrown
+      And I start a job
+      And I wait 3 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 1
+      And I confirm the executed job is finished
+      And I search for the last job target in the database
+      And I wait 3 seconds
+      And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
     Scenario: Stop broker after all scenarios


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Added second part of JobEngineService integration tests.

**Related Issue**
This PR fixes/closes part of issue #2662

**Description of the solution adopted**
This PR represents the second part of JobEngineService integration tests.
In this PR Kura Mock is changed and can get more than one device. Also, all methods with device are changed to be configurable for more devices.
Existing file` JobEngineServiceOfflineDeviceI9n.feature` is renamed to `JobEngineServiceStartOfflineDeviceI9n.feature`. In this feature file, two group of scenarios are added, and methods/steps are implemented in `BrokerSteps`, and `JobServiceSteps `classes.

First group of scenarios (_starting job with multiple targets and one step_):
1. Starting job with Bundle Start step and multiple devices
2. Starting job with Bundle Stop step and multiple devices
3. Starting job with Package Download/Install step and multiple devices
4. Starting job with Package Uninstall step and multiple device
5. Starting job with Asset Write step and multiple devices
6. Starting job with Configuration Put step and multiple devices
7. Starting job with Command Execution step and multiple devices

Second group of scenarios (_starting job with multiple targets and multiple steps_):
1. Starting job with two Bundle Start steps and multiple devices
2. Starting job with Bundle Stop and Bundle Start step and multiple devices
3. Starting job with Package Download/Install and Bundle Start steps and multiple devices
4. Starting job with Package Uninstall and Bundle start steps and multiple device
5. Starting job with Asset Write and Bundle Start steps and multiple devices
6. Starting job with Configuration Put and Bundle Start steps and multiple devices
7. Starting job with Command Execution and Bundle Start steps and multiple devices

**Screenshots**
/

**Any side note on the changes made**
/
