### PR TITLE
Added test scenarios for data store service

### DIFF
--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
@@ -181,4 +181,24 @@ public class BasicSteps extends TestBase {
         stepData.put("ExceptionExpected", true);
         stepData.put("ExceptionName", name);
     }
+
+    @Then("^An assertion error was thrown$")
+    public void anAssertionErrorWasThrown() {
+        String assertErrorName = stepData.contains("AssertErrorName") ? (String) stepData.get("AssertErrorName") : "Unknown";
+        boolean assertErrorCaught = stepData.contains("AssertErrorCaught") ? (boolean) stepData.get("AssertErrorCaught") : false;
+        assertTrue(String.format("Assert error was expected but was not raised.", assertErrorName), assertErrorCaught);
+    }
+
+    @And("^I expect the assertion error \"([^\"]*)\" with the text \"([^\"]*)\"$")
+    public void iExpectTheAssertErrorWithTheText(String name, String text) {
+        stepData.put("AssertErrorExpected", true);
+        stepData.put("AssertErrorName", name);
+        stepData.put("AssertErrorMessage", text);
+    }
+
+    @And("^No assertion error was thrown$")
+    public void noAssertionErrorWasThrown() {
+        boolean assertErrorCaught = stepData.contains("AssertErrorCaught") ? (boolean) stepData.get("AssertErrorCaught") : false;
+        assertFalse("An unexpected assert error was raised!", assertErrorCaught);
+    }
 }

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestBase.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -157,6 +157,26 @@ public class TestBase extends Assert {
         stepData.put("ExceptionCaught", true);
         stepData.put("Exception", ex);
     }
+
+    public void verifyAssertionError(AssertionError assetError)
+            throws AssertionError {
+
+        boolean assertErrorExpected = stepData.contains("AssertErrorExpected") ? (boolean)stepData.get("AssertErrorExpected") : false;
+        String assertErrorName = stepData.contains("AssertErrorName") ? ((String)stepData.get("AssertErrorName")).trim() : "";
+        String assertErrorMessage = stepData.contains("AssertErrorMessage") ? ((String)stepData.get("AssertErrorMessage")).trim() : "";
+
+        if (!assertErrorExpected ||
+                (!assertErrorName.isEmpty() && !assetError.getClass().toGenericString().contains(assertErrorName)) ||
+                (!assertErrorMessage.isEmpty() && !assertErrorMessage.trim().contentEquals("*") && !assetError.getMessage().contains(assertErrorMessage))) {
+            scenario.write("An unexpected assert error was raised!");
+            throw(assetError);
+        }
+
+        scenario.write("Assert error raised as expected: " + assetError.getClass().getCanonicalName() + ", " + assetError.getMessage());
+        stepData.put("AssertErrorCaught", true);
+        stepData.put("AssertError", assetError);
+    }
+
 
     public Date parseDateString(String date) {
         DateFormat df = new SimpleDateFormat("dd/mm/yyyy");

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucMetric.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,6 +18,8 @@ public class CucMetric {
     private String type;
 
     private String value;
+
+    private int message;
 
     public String getMetric() {
         return metric;
@@ -41,5 +43,13 @@ public class CucMetric {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public int getMessage() {
+        return message;
+    }
+
+    public void setMessage(int message) {
+        this.message = message;
     }
 }

--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -748,6 +748,231 @@ Feature: Datastore tests
       |tba_2/1/1/2 |
       |tba_2/1/1/3 |
     And I delete all indices
+
+  Scenario: Find correct number of messages by corresponding metric
+    Checking of the number of messages that are associated with the correct metrics.
+    Searching for messages is done by one metric.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait for 1 seconds
+    Then Device status is "CONNECTED"
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/3 |
+    And I set the following metrics with messages from the list "TestMessages"
+      | message | metric       | type   | value |
+      | 0       | tst-metric-1 | double | 123   |
+      | 1       | tst-metric-1 | double | 123   |
+      | 2       | tst-metric-1 | double | 123   |
+      | 3       | tst-metric-2 | int    | 123   |
+      | 4       | tst-metric-2 | int    | 123   |
+      | 5       | tst-metric-2 | int    | 123   |
+      | 6       | tst-metric-3 | bool   | 123   |
+      | 7       | tst-metric-3 | bool   | 123   |
+      | 8       | tst-metric-4 | string | 123   |
+      | 9       | tst-metric-4 | string | 123   |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics and store them as "AccountMetrics"
+    Then There are exactly 4 metrics in the list "AccountMetrics"
+    When I create message query for metric "tst-metric-1"
+    And I count for data message
+    Then I get message count 3
+    When I create message query for metric "tst-metric-2"
+    And I count for data message
+    Then I get message count 3
+    When I create message query for metric "tst-metric-3"
+    And I count for data message
+    Then I get message count 2
+    When I create message query for metric "tst-metric-4"
+    And I count for data message
+    Then I get message count 2
+    And No assertion error was thrown
+    Then I logout
+
+  Scenario: Finding correct number of messages by corresponding two metrics
+    Checking of the number of messages that are associated with the correct metrics.
+    Searching for messages is done by two metrics.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait for 1 seconds
+    Then Device status is "CONNECTED"
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/3 |
+    And I set the following metrics with messages from the list "TestMessages"
+      | message | metric       | type   | value |
+      | 0       | tst-metric-1 | double | 123   |
+      | 1       | tst-metric-1 | double | 123   |
+      | 2       | tst-metric-1 | double | 123   |
+      | 3       | tst-metric-2 | int    | 123   |
+      | 4       | tst-metric-2 | int    | 123   |
+      | 5       | tst-metric-2 | int    | 123   |
+      | 6       | tst-metric-3 | bool   | 123   |
+      | 7       | tst-metric-3 | bool   | 123   |
+      | 8       | tst-metric-4 | string | 123   |
+      | 9       | tst-metric-4 | string | 123   |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics and store them as "AccountMetrics"
+    Then There are exactly 4 metrics in the list "AccountMetrics"
+    When I create message query for following metrics
+      | tst-metric-1 |
+      | tst-metric-2 |
+    And I count data messages for more metrics
+    Then I count 6 data messages
+    When I create message query for following metrics
+      | tst-metric-3 |
+      | tst-metric-4 |
+    And I count data messages for more metrics
+    Then I count 4 data messages
+    When I create message query for following metrics
+      | tst-metric-1 |
+      | tst-metric-3 |
+    And I count data messages for more metrics
+    Then I count 5 data messages
+    And No assertion error was thrown
+    And I logout
+
+  Scenario: Finding all messages by selecting all metrics
+    Checking of the number of messages that are associated with the correct metrics.
+    Searching for messages is done by all metrics.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait for 1 seconds
+    Then Device status is "CONNECTED"
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/3 |
+    And I set the following metrics with messages from the list "TestMessages"
+      | message | metric       | type   | value |
+      | 0       | tst-metric-1 | double | 123   |
+      | 1       | tst-metric-1 | double | 123   |
+      | 2       | tst-metric-1 | double | 123   |
+      | 3       | tst-metric-2 | int    | 123   |
+      | 4       | tst-metric-2 | int    | 123   |
+      | 5       | tst-metric-2 | int    | 123   |
+      | 6       | tst-metric-3 | bool   | 123   |
+      | 7       | tst-metric-3 | bool   | 123   |
+      | 8       | tst-metric-4 | string | 123   |
+      | 9       | tst-metric-4 | string | 123   |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics and store them as "AccountMetrics"
+    Then There are exactly 4 metrics in the list "AccountMetrics"
+    When I create message query for following metrics
+      | tst-metric-1 |
+      | tst-metric-2 |
+      | tst-metric-3 |
+      | tst-metric-4 |
+    And I count data messages for more metrics
+    Then I count 10 data messages
+    And No assertion error was thrown
+    And I logout
+
+  Scenario: Finding messages with incorrect metric parameters
+  Checking of the number of messages that are associated with the incorrect metrics.
+  Searching for messages is done by one metric.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait for 1 seconds
+    Then Device status is "CONNECTED"
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/3 |
+    And I set the following metrics with messages from the list "TestMessages"
+      | message | metric       | type   | value |
+      | 0       | tst-metric-1 | double | 123   |
+      | 1       | tst-metric-1 | double | 123   |
+      | 2       | tst-metric-1 | double | 123   |
+      | 3       | tst-metric-2 | int    | 123   |
+      | 4       | tst-metric-2 | int    | 123   |
+      | 5       | tst-metric-2 | int    | 123   |
+      | 6       | tst-metric-3 | bool   | 123   |
+      | 7       | tst-metric-3 | bool   | 123   |
+      | 8       | tst-metric-4 | string | 123   |
+      | 9       | tst-metric-4 | string | 123   |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics and store them as "AccountMetrics"
+    Then There are exactly 4 metrics in the list "AccountMetrics"
+    When I create message query for metric "tst-metric-1"
+    And I count for data message
+    And I expect the assertion error "AssertionError" with the text "This two values are not equal"
+    And I get message count 2
+    Then An assertion error was thrown
+    When I create message query for metric "tst-metric-2"
+    And I count for data message
+    And I expect the assertion error "AssertionError" with the text "This two values are not equal"
+    And I get message count 2
+    Then An assertion error was thrown
+    When I create message query for metric "tst-metric-3"
+    And I count for data message
+    And I expect the assertion error "AssertionError" with the text "This two values are not equal"
+    And I get message count 1
+    Then An assertion error was thrown
+    When I create message query for metric "tst-metric-4"
+    And I count for data message
+    And I expect the assertion error "AssertionError" with the text "This two values are not equal"
+    And I get message count 1
+    Then An assertion error was thrown
+    And I logout
 
   Scenario: Stop broker after all scenarios
 


### PR DESCRIPTION
Signed-off-by: ana.albic.comtrade <Ana.Albic@comtrade.com>

Brief description of the PR.
Added integration test scenarios for data store service.

**Related Issue**
This PR represents test scenarios for changes which are made on PR #2674 

**Description of the solution adopted**
In this PR, test scenarios are added for `newExistPredicate`. With this added predicate, message filter only finds messages which are connected with chosen metric. Messages are searched by one metric, two metrics, all metric and in last scenario number of messages are incorrect, and Assertion Error is thrown. Added scenarios in DataStore.feature file are:

_1. Find correct number of messages by corresponding metric
2. Finding correct number of messages by corresponding two metrics
3. Finding all messages by selecting all metrics
4. Finding messages with incorrect metric parameters_

**Screenshots**
/

**Any side note on the changes made**
/
