### PR TITLE
Add useSsl and additional options to MariaDB connection string

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/DefaultConfigurableJdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/DefaultConfigurableJdbcConnectionUrlResolver.java
@@ -55,6 +55,11 @@ public class DefaultConfigurableJdbcConnectionUrlResolver implements JdbcConnect
             dbConnectionString.deleteCharAt(dbConnectionString.length() - 1);
 
         }
+        String additionalOptions = config.getString(SystemSettingKey.DB_CONNECTION_ADDITIONAL_OPTIONS);
+        if (StringUtils.isNotBlank(additionalOptions)) {
+            dbConnectionString.append(additionalOptions)
+                    .append(";");
+        }
         return dbConnectionString.toString();
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/H2JdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/H2JdbcConnectionUrlResolver.java
@@ -13,6 +13,8 @@
 package org.eclipse.kapua.commons.jpa;
 
 import com.google.common.base.MoreObjects;
+import org.apache.commons.lang.StringUtils;
+
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 
@@ -32,7 +34,10 @@ public class H2JdbcConnectionUrlResolver implements JdbcConnectionUrlResolver {
         if (schema != null) {
             connectionUrl += ";INIT=CREATE SCHEMA IF NOT EXISTS " + schema + "\\;SET SCHEMA " + schema;
         }
-
+        String additionalOptions = config.getString(SystemSettingKey.DB_CONNECTION_ADDITIONAL_OPTIONS);
+        if (StringUtils.isNotBlank(additionalOptions)) {
+            connectionUrl += ";" + additionalOptions;
+        }
         return connectionUrl;
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolvers.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolvers.java
@@ -28,14 +28,15 @@ public final class JdbcConnectionUrlResolvers {
         SystemSetting config = SystemSetting.getInstance();
         String connectionUrlResolverType = config.getString(SystemSettingKey.DB_JDBC_CONNECTION_URL_RESOLVER, "DEFAULT");
         LOG.debug("The following JDBC connection URL resolver type will be used: {}", connectionUrlResolverType);
-        if (connectionUrlResolverType.equals("DEFAULT")) {
-            return new DefaultConfigurableJdbcConnectionUrlResolver().connectionUrl();
-        } else if ("H2".equals(connectionUrlResolverType)) {
-            return new H2JdbcConnectionUrlResolver().connectionUrl();
-        } else if ("MariaDB".equals(connectionUrlResolverType)) {
-            return new MariaDBJdbcConnectionUrlResolver().connectionUrl();
-        } else {
-            throw new IllegalArgumentException("Unknown JDBC connection URL resolver type: " + connectionUrlResolverType);
+        switch (connectionUrlResolverType) {
+            case "DEFAULT":
+                return new DefaultConfigurableJdbcConnectionUrlResolver().connectionUrl();
+            case "H2":
+                return new H2JdbcConnectionUrlResolver().connectionUrl();
+            case "MariaDB":
+                return new MariaDBJdbcConnectionUrlResolver().connectionUrl();
+            default:
+                throw new IllegalArgumentException("Unknown JDBC connection URL resolver type: " + connectionUrlResolverType);
         }
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/MariaDBJdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/MariaDBJdbcConnectionUrlResolver.java
@@ -15,6 +15,8 @@ package org.eclipse.kapua.commons.jpa;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  * MariaDB Jdbc url connection resolver implementation
  *
@@ -31,6 +33,10 @@ public class MariaDBJdbcConnectionUrlResolver implements JdbcConnectionUrlResolv
         String dbConnectionScheme = config.getString(SystemSettingKey.DB_CONNECTION_SCHEME);
         String dbConnectionHost = config.getString(SystemSettingKey.DB_CONNECTION_HOST);
         String dbConnectionPort = config.getString(SystemSettingKey.DB_CONNECTION_PORT);
+        boolean useSsl = config.getBoolean(SystemSettingKey.DB_CONNECTION_USE_SSL,false);
+        String trustStore = config.getString(SystemSettingKey.DB_CONNECTION_TRUSTSTORE_URL);
+        String trustStorePwd = config.getString(SystemSettingKey.DB_CONNECTION_TRUSTSTORE_PWD);
+        String additionalOptions = config.getString(SystemSettingKey.DB_CONNECTION_ADDITIONAL_OPTIONS);
 
         StringBuilder dbConnectionString = new StringBuilder().append(dbConnectionScheme)
                 .append("://")
@@ -67,6 +73,27 @@ public class MariaDBJdbcConnectionUrlResolver implements JdbcConnectionUrlResolv
         if (characterEncoding != null) {
             dbConnectionString.append("characterEncoding=")
                     .append(characterEncoding)
+                    .append("&");
+        }
+
+        dbConnectionString.append("useSSL=")
+                .append(useSsl)
+                .append("&");
+
+        if (StringUtils.isNotBlank(trustStore)) {
+            dbConnectionString.append("trustStore=")
+                    .append(trustStore)
+                    .append("&");
+        }
+
+        if (StringUtils.isNotBlank(trustStorePwd)) {
+            dbConnectionString.append("trustStorePassword=")
+                    .append(trustStorePwd)
+                    .append("&");
+        }
+
+        if (StringUtils.isNotBlank(additionalOptions)) {
+            dbConnectionString.append(additionalOptions)
                     .append("&");
         }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -89,11 +89,7 @@ public enum SystemSettingKey implements SettingKey {
     /**
      * Database use ssl connection
      */
-    DB_CONNECTION_USESSL("commons.db.connection.useSsl"),
-    /**
-     * Database verify ssl connection (trust server/client certificates)
-     */
-    DB_CONNECTION_VERIFYSSL("commons.db.connection.sslVerify"),
+    DB_CONNECTION_USE_SSL("commons.db.connection.useSsl"),
     /**
      * Database truststore url
      */
@@ -102,7 +98,10 @@ public enum SystemSettingKey implements SettingKey {
      * Database truststore password
      */
     DB_CONNECTION_TRUSTSTORE_PWD("commons.db.connection.trust.store.pwd"),
-
+    /**
+     * Any additional option that can be passed to the JDBC connection string
+     */
+    DB_CONNECTION_ADDITIONAL_OPTIONS("commons.db.connection.additionalOptions"),
     /**
      * Database schema name
      */


### PR DESCRIPTION
According to #2681, the `commons.db.connection.useSsl` option is not honored from the MariaDB connector. This PR fixes it, and it also adds a generic `commons.db.connection.additionalOptions` to use as a last resort if other options are needed, also in other `JdbcConnectionUrlResolver`s.

**Related Issue**
This PR fixes #2681 
