### PR TITLE
Remove createdBy column in Device Event CSV Export

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterCsv.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterCsv.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.servlet;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.URLEncoder;
@@ -18,22 +20,13 @@ import java.nio.charset.Charset;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.model.query.KapuaListResult;
 import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
-import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
 
 import com.opencsv.CSVWriter;
@@ -44,8 +37,6 @@ public class DeviceEventExporterCsv extends DeviceEventExporter {
     private String clientId;
     private DateFormat dateFormat;
     private CSVWriter writer;
-
-    private final Map<String, String> namesCache = new HashMap<String, String>();
 
     public DeviceEventExporterCsv(HttpServletResponse response) {
         super(response);
@@ -95,25 +86,6 @@ public class DeviceEventExporterCsv extends DeviceEventExporter {
             // Created on
             cols.add(deviceEvent.getCreatedOn() != null ? dateFormat.format(deviceEvent.getCreatedOn()) : BLANK);
 
-            // Created by
-            if (deviceEvent.getCreatedBy().toCompactId() != null) {
-                if (!namesCache.containsKey(deviceEvent.getCreatedBy().toCompactId())) {
-                    try {
-                        User user = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
-                            @Override
-                            public User call() throws Exception {
-                                return userService.find(KapuaEid.parseCompactId(scopeId), deviceEvent.getCreatedBy());
-                            }
-                        });
-                        namesCache.put(user.getId().toCompactId(), user.getName());
-                    } catch (KapuaException kaex) {
-                        namesCache.put(deviceEvent.getCreatedBy().toCompactId(), BLANK);
-                    }
-                }
-                cols.add(namesCache.get(deviceEvent.getCreatedBy().toCompactId()));
-            } else {
-                cols.add(BLANK);
-            }
             // Device id
             cols.add(deviceEvent.getDeviceId() != null ? deviceEvent.getDeviceId().toCompactId() : BLANK);
 


### PR DESCRIPTION
This PR removes the `createdBy` column in the Device Events CSV Export

**Related Issue**
No related issues