### PR TITLE
Added tests for starting job with multiple online devices

### DIFF
--- a/qa/integration/src/test/resources/features/job/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -12,6 +12,7 @@
 @integration
 @jobs
 @jobEngineService
+@jobEngineStartOnlineDevice
 
 Feature: JobEngineService start job tests with online device
 
@@ -363,10 +364,142 @@ Feature: JobEngineService start job tests with online device
     And I wait 1 seconds
     And Device status is "DISCONNECTED"
     And I logout
-
+#
     # *****************************************************
     # * Starting a job with one Target and multiple Steps *
     # *****************************************************
+
+  Scenario: Starting job with valid Command Execution and Bundle Start steps
+  Create a new job. Set a disconnected Kura Mock device as a job target.
+  Add a new valid Command Execution and Bundle Start steps to the created job. Start the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And I get the KuraMock device
+    And Command "pwd" is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When I search for events from device "rpione3" in account "kapua-sys"
+    And The type of the last event is "BUNDLE"
+    Then I find 3 device event
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                   | value                                                                                                                                                 |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                 |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 128   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    And The type of the last event is "BUNDLE"
+    Then I find 5 device event
+    When Command pwd is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting job with invalid Command Execution and Bundle Start steps
+  Create a new job. Set a disconnected Kura Mock device as a job target.
+  Add a new invalid Command Execution and Bundle Start steps to the created job. Start the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And I get the KuraMock device
+    And Command "pwd" is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When I search for events from device "rpione3" in account "kapua-sys"
+    And The type of the last event is "BUNDLE"
+    Then I find 3 device event
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                   | value                                                                                                                                                 |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandTag>pwd</commandTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                 |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #128  |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device event
+    And The type of the last event is "BUNDLE"
+    When Command pwd is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
 
   Scenario: Starting a job with two valid Bundle Start steps
   Create a new job and set a connected KuraMock device as the job target.
@@ -618,6 +751,746 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+    # *****************************************************
+    # * Starting a job with multiple Targets and one Step *
+    # *****************************************************
+
+  Scenario: Starting job with valid Command Execution step and multiple devices
+  Create a new job. Set a disconnected Kura Mock devices as a job targets.
+  Add a new valid Command Execution step to the created job. Start the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I get the KuraMock devices
+    And Command "pwd" is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "COMMAND"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                   | value                                                                                                                                                 |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    When Command pwd is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device event
+    And The type of the last event is "COMMAND"
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting job with invalid Command Execution step and multiple devices
+  Create a new job. Set a disconnected Kura Mock devices as a job targets.
+  Add a new invalid Command Execution step to the created job. Start the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I get the KuraMock devices
+    And Command "pwd" is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "COMMAND"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                   | value                                                                                                                                                 |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandTag>pwd</commandTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When Command pwd is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device event
+    And The type of the last event is "COMMAND"
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting job with valid Bundle Start step and multiple devices
+  Create a new job. Set a disconnected Kura Mock devices as a job targets.
+  Add a new Bundle Start step to the created job. Start the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Device "are" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I get the KuraMock devices
+    And Bundles are requested
+    Then Bundles are received
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 128   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting job with invalid Bundle Start step and multiple devices
+  Create a new job. Set a disconnected Kura Mock devices as a job targets.
+  Add a new Bundle Start step to the created job. Start the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Device "are" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I get the KuraMock devices
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | *34   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting a job with valid Bundle Stop step and multiple devices
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a new valid Bundle Stop step to the created job. Start the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    And I get the KuraMock devices
+    And Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    Then Device status is "CONNECTED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Stop"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 77    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device event
+    And The type of the last event is "BUNDLE"
+    Then KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+
+  Scenario: Starting a job with invalid Bundle Stop step and multiple devices
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a new invalid Bundle Stop step to the created job. Start the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    And I get the KuraMock devices
+    And Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    Then Device status is "CONNECTED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Stop"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | *77   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+    # ***********************************************************
+    # * Starting a job with multiple Targets and multiple Steps *
+    # ***********************************************************
+
+  Scenario: Starting job with valid Command Execution, valid Bundle Start steps and multiple devices
+  Create a new job. Set a disconnected Kura Mock devices as a job targets.
+  Add a new valid Command Execution and Bundle Start steps to the created job. Start the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I get the KuraMock devices
+    And Command "pwd" is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When I search for events from device "device0" in account "kapua-sys"
+    And The type of the last event is "BUNDLE"
+    Then I find 3 device event
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                   | value                                                                                                                                                 |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                 |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 128   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "device0" in account "kapua-sys"
+    And The type of the last event is "BUNDLE"
+    Then I find 3 device event
+    When Command pwd is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting job with invalid Command Execution, invalid Bundle Start steps and multiple devices
+  Create a new job. Set a disconnected Kura Mock devices as a job targets.
+  Add a new invalid Command Execution and Bundle Start steps to the created job. Start the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I get the KuraMock devices
+    And Command "pwd" is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When I search for events from device "device0" in account "kapua-sys"
+    And The type of the last event is "BUNDLE"
+    Then I find 3 device event
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                   | value                                                                                                                                                 |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandTag>pwd</commandTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                 |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | *128  |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device event
+    And The type of the last event is "BUNDLE"
+    When Command pwd is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting a job with two valid Bundle Start steps and multiple devices
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add two new valid Bundle Start steps to the created job. Start the job.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I get the KuraMock devices
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 95    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting a job with two invalid Bundle Start steps and multiple devices
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add two new invalid Bundle Start steps to the created job. Start the job.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When  I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I get the KuraMock devices
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting a job with valid Bundle Stop and Bundle Start steps and multiple devices
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a new valid Bundle Stop and Bundle Start steps to the created job. Start the job.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    And I get the KuraMock devices
+    And Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    Then Device status is "CONNECTED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Stop"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 77    |
+      | timeout  | java.lang.Long   | 10000 |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 128   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Starting a job with invalid Bundle Stop and Bundle Start steps and multiple devices
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a new invalid Bundle Stop and Bundle Start steps to the created job. Start the job.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 seconds
+    And I get the KuraMock devices
+    And Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    Then Device status is "CONNECTED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "BUNDLE"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job target service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the job step service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Stop"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #77   |
+      | timeout  | java.lang.Long   | 10000 |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #128  |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    And I start a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "device0" in account "kapua-sys"
     Then I find 2 device event
     And The type of the last event is "BUNDLE"
     Then Bundles are requested

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/KuraDevice.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/KuraDevice.java
@@ -48,6 +48,7 @@ public class KuraDevice implements MqttCallback {
     private String deployV2ExecStart34;
     private String deployV2ExecStart95;
     private String deployV2ExecStop77;
+    private String deployV2ExecStart128;
 
     /**
      * URI of mqtt broker.
@@ -121,6 +122,8 @@ public class KuraDevice implements MqttCallback {
         deployV2ExecStart95 = "$EDC/kapua-sys/rpione3/DEPLOY-V2/EXEC/start/95";
 
         deployV2ExecStop77 = "$EDC/kapua-sys/rpione3/DEPLOY-V2/EXEC/stop/77";
+
+        deployV2ExecStart128 = "$EDC/kapua-sys/rpione3/DEPLOY-V2/EXEC/start/128";
         clientId = "rpione3";
 
         mqttClientSetup();
@@ -211,6 +214,8 @@ public class KuraDevice implements MqttCallback {
             deployV2ExecStart95 = "$EDC/kapua-sys/" + clientId + "/DEPLOY-V2/EXEC/start/95";
 
             deployV2ExecStop77 = "$EDC/kapua-sys/" + clientId + "/DEPLOY-V2/EXEC/stop/77";
+
+            deployV2ExecStart128 = "$EDC/kapua-sys/" + clientId + "/DEPLOY-V2/EXEC/start/128";
 
             mqttClient = new MqttClient(BROKER_URI, clientId,
                     new MemoryPersistence());
@@ -335,7 +340,7 @@ public class KuraDevice implements MqttCallback {
             responsePayload = Files.readAllBytes(Paths.get(getClass().getResource("/mqtt/KapuaPool-client-id_CMD-V1_REPLY_req-id_command.mqtt").toURI()));
 
             mqttClient.publish(responseTopic, responsePayload, 0, false);
-        } else if (topic.equals(deployV2ExecStart34) || topic.equals(deployV2ExecStart95)) {
+        } else if (topic.equals(deployV2ExecStart34) || topic.equals(deployV2ExecStart95) || topic.equals(deployV2ExecStart128)) {
             callbackParam = extractCallback(payload);
 
             responseTopic = "$EDC/" + CLIENT_ACCOUNT + "/" + callbackParam.getClientId() + "/DEPLOY-V2/REPLY/" + callbackParam.getRequestId();


### PR DESCRIPTION
Signed-off-by: ct-anaalbic <Ana.Albic@comtrade.com>

Brief description of the PR.
Added tests for starting job with multiple online devices

**Related Issue**
This PR fixes/closes part of issue #2662

**Description of the solution adopted**
This PR represents part of JobEngineService integration tests for starting job with multiple online devices. In feature file JobEngineServiceStartOnlineDeviceI9n.feature the following scenarios have been added:

_1. Starting job with valid Command Execution step and multiple devices_
_2. Starting job with invalid Command Execution step and multiple devices
3. Starting job with valid Bundle Start step and multiple devices
4. Starting job with invalid Bundle Start step and multiple devices
5. Starting a job with valid Bundle Stop step and multiple devices
6. Starting a job with invalid Bundle Stop step and multiple devices_

_7. Starting job with valid Command Execution, valid Bundle Start steps and multiple devices
8. Starting job with invalid Command Execution, invalid Bundle Start steps and multiple devices
9. Starting a job with two valid Bundle Start steps and multiple devices
10. Starting a job with two invalid Bundle Start steps and multiple devices
11. Starting a job with valid Bundle Stop and Bundle Start steps and multiple devices
12. Starting a job with invalid Bundle Stop and Bundle Start steps and multiple devices_

**Screenshots**
/

**Any side note on the changes made**
/
